### PR TITLE
Fix attributes save performance

### DIFF
--- a/saleor/attribute/tests/test_utils.py
+++ b/saleor/attribute/tests/test_utils.py
@@ -10,7 +10,10 @@ def test_associate_attribute_to_non_product_instance(color_attribute):
     value = color_attribute.values.first()
 
     with pytest.raises(AssertionError) as exc:
-        associate_attribute_values_to_instance(instance, attribute, value)  # noqa
+        associate_attribute_values_to_instance(
+            instance,
+            {attribute.id: [value]},
+        )  # noqa
 
     assert exc.value.args == ("ProductType is unsupported",)
 
@@ -26,7 +29,10 @@ def test_associate_attribute_to_product_instance_from_different_attribute(
     value = size_attribute.values.first()
 
     with pytest.raises(AssertionError) as exc:
-        associate_attribute_values_to_instance(instance, attribute, value)
+        associate_attribute_values_to_instance(
+            instance,
+            {attribute.id: [value]},
+        )
 
     assert exc.value.args == ("Some values are not from the provided attribute.",)
 
@@ -40,7 +46,8 @@ def test_associate_attribute_to_product_instance_without_values(product):
     attribute = old_assignment.attribute
 
     # Clear the values
-    new_assignment = associate_attribute_values_to_instance(product, attribute)
+    associate_attribute_values_to_instance(product, {attribute.id: []})
+    new_assignment = product.attributes.last()
 
     # Ensure the values were cleared and no new assignment entry was created
     assert new_assignment.pk == old_assignment.pk
@@ -63,9 +70,10 @@ def test_associate_attribute_to_product_instance_multiple_values(
     values = attribute.values.all()
 
     # Assign new values
-    new_assignment = associate_attribute_values_to_instance(
-        product, attribute, values[1], values[0]
+    associate_attribute_values_to_instance(
+        product, {attribute.id: [values[1], values[0]]}
     )
+    new_assignment = product.attributes.last()
 
     # Ensure the new assignment was created and ordered correctly
     assert new_assignment.pk == old_assignment.pk
@@ -85,9 +93,8 @@ def test_associate_attribute_to_page_instance_multiple_values(page):
     values = attribute.values.all()
 
     # Clear the values
-    new_assignment = associate_attribute_values_to_instance(
-        page, attribute, values[1], values[0]
-    )
+    associate_attribute_values_to_instance(page, {attribute.id: [values[1], values[0]]})
+    new_assignment = page.attributes.last()
 
     # Ensure the new assignment was created and ordered correctly
     assert new_assignment.pk == old_assignment.pk
@@ -109,10 +116,11 @@ def test_associate_attribute_to_variant_instance_multiple_values(
     )
     values = attribute.values.all()
 
-    new_assignment = associate_attribute_values_to_instance(
-        variant, attribute, values[0], values[1]
+    associate_attribute_values_to_instance(
+        variant, {attribute.id: [values[0], values[1]]}
     )
 
+    new_assignment = variant.attributes.last()
     # Ensure the new assignment was created and ordered correctly
     assert new_assignment.values.count() == 2
     assert list(
@@ -132,9 +140,10 @@ def test_associate_attribute_to_product_copies_data_over_to_new_field(
     values = color_attribute.values.all()
 
     # Assign new values
-    new_assignment = associate_attribute_values_to_instance(
-        product, color_attribute, values[0], values[1]
+    associate_attribute_values_to_instance(
+        product, {color_attribute.id: [values[0], values[1]]}
     )
+    new_assignment = product.attributes.last()
 
     # Ensure the new assignment was created
     assert new_assignment.values.count() == 2

--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -294,41 +294,36 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     # add boolean attribute
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
-        boolean_attribute,
-        boolean_attribute.values.first(),
+        {boolean_attribute.pk: [boolean_attribute.values.first()]},
     )
     associate_attribute_values_to_instance(
-        product, boolean_attribute, boolean_attribute.values.first()
+        product, {boolean_attribute.pk: [boolean_attribute.values.first()]}
     )
 
     # add date attribute
     associate_attribute_values_to_instance(
-        variant_with_many_stocks,
-        date_attribute,
-        date_attribute.values.first(),
+        variant_with_many_stocks, {date_attribute.pk: [date_attribute.values.first()]}
     )
     associate_attribute_values_to_instance(
-        product, date_attribute, date_attribute.values.first()
+        product, {date_attribute.pk: [date_attribute.values.first()]}
     )
 
     # add date time attribute
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
-        date_time_attribute,
-        date_time_attribute.values.first(),
+        {date_time_attribute.pk: [date_time_attribute.values.first()]},
     )
     associate_attribute_values_to_instance(
-        product, date_time_attribute, date_time_attribute.values.first()
+        product, {date_time_attribute.pk: [date_time_attribute.values.first()]}
     )
 
     # add rich text attribute
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
-        rich_text_attribute,
-        rich_text_attribute.values.first(),
+        {rich_text_attribute.pk: [rich_text_attribute.values.first()]},
     )
     associate_attribute_values_to_instance(
-        product, rich_text_attribute, rich_text_attribute.values.first()
+        product, {rich_text_attribute.pk: [rich_text_attribute.values.first()]}
     )
 
     # add page reference attribute
@@ -346,11 +341,10 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     )
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
-        product_type_page_reference_attribute,
-        variant_page_ref_value,
+        {product_type_page_reference_attribute.pk: [variant_page_ref_value]},
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, product_page_ref_value
+        product, {product_type_page_reference_attribute.pk: [product_page_ref_value]}
     )
 
     # add product reference attribute
@@ -371,11 +365,11 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     )
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
-        product_type_product_reference_attribute,
-        variant_product_ref_value,
+        {product_type_product_reference_attribute.pk: [variant_product_ref_value]},
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, product_product_ref_value
+        product,
+        {product_type_product_reference_attribute.pk: [product_product_ref_value]},
     )
 
     # add variant reference attribute
@@ -393,11 +387,11 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     )
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
-        product_type_variant_reference_attribute,
-        variant_variant_ref_value,
+        {product_type_variant_reference_attribute.pk: [variant_variant_ref_value]},
     )
     associate_attribute_values_to_instance(
-        product, product_type_variant_reference_attribute, product_variant_ref_value
+        product,
+        {product_type_variant_reference_attribute.pk: [product_variant_ref_value]},
     )
 
     # add numeric attribute
@@ -405,13 +399,15 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     numeric_value_2 = numeric_attribute.values.last()
 
     associate_attribute_values_to_instance(
-        variant_with_many_stocks, numeric_attribute, numeric_value_1
+        variant_with_many_stocks, {numeric_attribute.pk: [numeric_value_1]}
     )
-    associate_attribute_values_to_instance(product, numeric_attribute, numeric_value_2)
+    associate_attribute_values_to_instance(
+        product, {numeric_attribute.pk: [numeric_value_2]}
+    )
 
     # create assigned product without values
     associate_attribute_values_to_instance(
-        product, color_attribute, color_attribute.values.first()
+        product, {color_attribute.pk: [color_attribute.values.first()]}
     )
     assigned_product = product.attributes.get(assignment__attribute=color_attribute)
     assigned_product.values.clear()
@@ -421,9 +417,11 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     swatch_value_2 = swatch_attribute.values.last()
 
     associate_attribute_values_to_instance(
-        variant_with_many_stocks, swatch_attribute, swatch_value_1
+        variant_with_many_stocks, {swatch_attribute.pk: [swatch_value_1]}
     )
-    associate_attribute_values_to_instance(product, swatch_attribute, swatch_value_2)
+    associate_attribute_values_to_instance(
+        product, {swatch_attribute.pk: [swatch_value_2]}
+    )
 
     products = Product.objects.all()
     export_fields = {"id", "variants__sku"}

--- a/saleor/csv/tests/export/products_data/test_handle_relations_data.py
+++ b/saleor/csv/tests/export/products_data/test_handle_relations_data.py
@@ -91,7 +91,8 @@ def test_get_products_relations_data_attribute_ids(
         product_type_product_reference_attribute,
     )
     associate_attribute_values_to_instance(
-        product, file_attribute, file_attribute.values.first()
+        product,
+        {file_attribute.id: [file_attribute.values.first()]},
     )
     page_ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
@@ -99,7 +100,8 @@ def test_get_products_relations_data_attribute_ids(
         name=page.title,
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, page_ref_value
+        product,
+        {product_type_page_reference_attribute.id: [page_ref_value]},
     )
     product_ref_value = AttributeValue.objects.create(
         attribute=product_type_product_reference_attribute,
@@ -107,7 +109,8 @@ def test_get_products_relations_data_attribute_ids(
         name=product_list[1].name,
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, product_ref_value
+        product,
+        {product_type_product_reference_attribute.id: [product_ref_value]},
     )
 
     qs = Product.objects.all()
@@ -165,7 +168,8 @@ def test_prepare_products_relations_data(
         file_attribute, product_type_page_reference_attribute
     )
     associate_attribute_values_to_instance(
-        product_with_image, file_attribute, file_attribute.values.first()
+        product_with_image,
+        {file_attribute.id: [file_attribute.values.first()]},
     )
     ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
@@ -175,7 +179,8 @@ def test_prepare_products_relations_data(
         date_time=None,
     )
     associate_attribute_values_to_instance(
-        product_with_image, product_type_page_reference_attribute, ref_value
+        product_with_image,
+        {product_type_page_reference_attribute.id: [ref_value]},
     )
 
     collection_list[0].products.add(product_with_image)
@@ -386,7 +391,8 @@ def test_get_variants_relations_data_attribute_ids(
     )
     variant = product.variants.first()
     associate_attribute_values_to_instance(
-        variant, file_attribute, file_attribute.values.first()
+        variant,
+        {file_attribute.id: [file_attribute.values.first()]},
     )
     # add page reference attribute
     page_ref_value = AttributeValue.objects.create(
@@ -395,7 +401,8 @@ def test_get_variants_relations_data_attribute_ids(
         name=page.title,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, page_ref_value
+        variant,
+        {product_type_page_reference_attribute.id: [page_ref_value]},
     )
     # add product reference attribute
     product_ref_value = AttributeValue.objects.create(
@@ -404,7 +411,8 @@ def test_get_variants_relations_data_attribute_ids(
         name=product_list[1].name,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_product_reference_attribute, product_ref_value
+        variant,
+        {product_type_product_reference_attribute.id: [product_ref_value]},
     )
 
     qs = Product.objects.all()
@@ -523,7 +531,8 @@ def test_prepare_variants_relations_data(
     )
     variant = product_1.variants.first()
     associate_attribute_values_to_instance(
-        variant, file_attribute, file_attribute.values.first()
+        variant,
+        {file_attribute.id: [file_attribute.values.first()]},
     )
     # add page reference attribute
     page_ref_value = AttributeValue.objects.create(
@@ -533,7 +542,8 @@ def test_prepare_variants_relations_data(
         name=page.title,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, page_ref_value
+        variant,
+        {product_type_page_reference_attribute.id: [page_ref_value]},
     )
     # add prodcut reference attribute
     product_ref_value = AttributeValue.objects.create(
@@ -543,7 +553,8 @@ def test_prepare_variants_relations_data(
         name=product.name,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_product_reference_attribute, product_ref_value
+        variant,
+        {product_type_product_reference_attribute.id: [product_ref_value]},
     )
 
     qs = Product.objects.all()

--- a/saleor/graphql/attribute/tests/benchmark/test_attribute.py
+++ b/saleor/graphql/attribute/tests/benchmark/test_attribute.py
@@ -170,7 +170,7 @@ def test_attribute_value_translation(
 
     product.product_type.product_attributes.add(rich_text_attribute_with_many_values)
     associate_attribute_values_to_instance(
-        product, rich_text_attribute_with_many_values, *attribute_values
+        product, {rich_text_attribute_with_many_values.pk: attribute_values}
     )
 
     variables = {"slug": product.slug}

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -177,7 +177,7 @@ def test_delete_attribute_value_product_search_document_updated(
     product_type = product.product_type
     product_type.product_attributes.add(attribute)
 
-    associate_attribute_values_to_instance(product, attribute, value)
+    associate_attribute_values_to_instance(product, {attribute.pk: [value]})
 
     query = ATTRIBUTE_VALUE_DELETE_MUTATION
     node_id = graphene.Node.to_global_id("AttributeValue", value.id)
@@ -208,7 +208,7 @@ def test_delete_attribute_value_product_search_document_updated_variant_attribut
     product_type = product.product_type
     product_type.variant_attributes.add(attribute)
 
-    associate_attribute_values_to_instance(variant, attribute, value)
+    associate_attribute_values_to_instance(variant, {attribute.pk: [value]})
 
     query = ATTRIBUTE_VALUE_DELETE_MUTATION
     node_id = graphene.Node.to_global_id("AttributeValue", value.id)

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -259,7 +259,7 @@ def test_update_attribute_value_product_search_document_updated(
     product_type = product.product_type
     product_type.product_attributes.add(attribute)
 
-    associate_attribute_values_to_instance(product, attribute, value)
+    associate_attribute_values_to_instance(product, {attribute.pk: [value]})
 
     node_id = graphene.Node.to_global_id("AttributeValue", value.id)
     name = "Crimson name"
@@ -296,7 +296,7 @@ def test_update_attribute_value_product_search_document_updated_variant_attribut
     product_type = product.product_type
     product_type.variant_attributes.add(attribute)
 
-    associate_attribute_values_to_instance(variant, attribute, value)
+    associate_attribute_values_to_instance(variant, {attribute.pk: [value]})
 
     node_id = graphene.Node.to_global_id("AttributeValue", value.id)
     name = "Crimson name"

--- a/saleor/graphql/attribute/tests/mutations/test_bulk_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_bulk_delete.py
@@ -117,12 +117,18 @@ def test_delete_attributes_products_search_document_updated(
     attr_3_name = "attr 3 value"
     attr_3_value = AttributeValue.objects.create(name=attr_3_name, attribute=attr_3)
 
-    associate_attribute_values_to_instance(product_1, attr_1, attr_1_value)
     associate_attribute_values_to_instance(
-        product_1, color_attribute, color_attribute_value
+        product_1,
+        {attr_1.id: [attr_1_value], color_attribute.id: [color_attribute_value]},
     )
-    associate_attribute_values_to_instance(product_2, attr_2, attr_2_value)
-    associate_attribute_values_to_instance(variant_1, attr_3, attr_3_value)
+    associate_attribute_values_to_instance(
+        product_2,
+        {attr_2.id: [attr_2_value]},
+    )
+    associate_attribute_values_to_instance(
+        variant_1,
+        {attr_3.id: [attr_3_value]},
+    )
 
     variables = {
         "ids": [
@@ -231,9 +237,18 @@ def test_delete_attribute_values_search_document_updated(
     product_type.product_attributes.add(attribute)
     product_type.variant_attributes.add(attribute)
 
-    associate_attribute_values_to_instance(product_1, attribute, value_1, value_4)
-    associate_attribute_values_to_instance(product_2, attribute, value_2)
-    associate_attribute_values_to_instance(variant_1, attribute, value_3)
+    associate_attribute_values_to_instance(
+        product_1,
+        {attribute.id: [value_1, value_4]},
+    )
+    associate_attribute_values_to_instance(
+        product_2,
+        {attribute.id: [value_2]},
+    )
+    associate_attribute_values_to_instance(
+        variant_1,
+        {attribute.id: [value_3]},
+    )
 
     variables = {
         "ids": [

--- a/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
@@ -187,7 +187,7 @@ def test_filter_attributes_in_category_invalid_category_id(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     variables = {
@@ -229,7 +229,7 @@ def test_filter_attributes_in_category_object_with_given_id_does_not_exist(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     variables = {
@@ -266,7 +266,7 @@ def test_filter_attributes_in_category_not_visible_in_listings_by_customer(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -316,7 +316,7 @@ def test_filter_attributes_in_category_not_visible_in_listings_by_staff_with_per
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -360,7 +360,7 @@ def test_filter_attributes_in_category_not_in_listings_by_staff_without_manage_p
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -407,7 +407,7 @@ def test_filter_attributes_in_category_not_visible_in_listings_by_app_with_perm(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -451,7 +451,7 @@ def test_filter_attributes_in_category_not_in_listings_by_app_without_manage_pro
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -492,7 +492,7 @@ def test_filter_attributes_in_category_not_published_by_customer(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -542,7 +542,7 @@ def test_filter_attributes_in_category_not_published_by_staff_with_perm(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -586,7 +586,7 @@ def test_filter_attributes_in_category_not_published_by_staff_without_manage_pro
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -633,7 +633,7 @@ def test_filter_attributes_in_category_not_published_by_app_with_perm(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -677,7 +677,7 @@ def test_filter_attributes_in_category_not_published_by_app_without_manage_produ
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -721,7 +721,7 @@ def test_filter_attributes_in_collection_invalid_category_id(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     variables = {
@@ -766,7 +766,7 @@ def test_filter_attributes_in_collection_object_with_given_id_does_not_exist(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     variables = {
@@ -806,7 +806,7 @@ def test_filter_attributes_in_collection_not_visible_in_listings_by_customer(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -849,7 +849,7 @@ def test_filter_in_collection_not_published_by_customer(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -902,7 +902,7 @@ def test_filter_in_collection_not_published_by_staff_with_perm(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -949,7 +949,7 @@ def test_filter_in_collection_not_published_by_staff_without_manage_products(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -999,7 +999,7 @@ def test_filter_in_collection_not_published_by_app_with_perm(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()
@@ -1046,7 +1046,7 @@ def test_filter_in_collection_not_published_by_app_without_manage_products(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], {weight_attribute.pk: [weight_attribute.values.first()]}
     )
 
     attribute_count = Attribute.objects.count()

--- a/saleor/graphql/attribute/tests/queries/test_attribute_where.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_where.py
@@ -487,7 +487,8 @@ def test_attributes_filter_attributes_in_collection_not_visible_in_listings_by_c
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -530,7 +531,8 @@ def test_attributes_filter_in_collection_not_published_by_customer(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -583,7 +585,8 @@ def test_attributes_filter_in_collection_not_published_by_staff_with_perm(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -630,7 +633,8 @@ def test_attributes_filter_in_collection_not_published_by_staff_without_manage_p
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -680,7 +684,8 @@ def test_attributes_filter_in_collection_not_published_by_app_with_perm(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -727,7 +732,8 @@ def test_attributes_filter_in_collection_not_published_by_app_without_manage_pro
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -770,7 +776,8 @@ def test_attributes_filter_attributes_in_collection_invalid_collection_id(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     variables = {
@@ -815,7 +822,8 @@ def test_attributes_filter_attributes_in_collection_object_with_given_id_does_no
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     variables = {
@@ -862,7 +870,8 @@ def test_attributes_filter_in_collection_empty_value(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     variables = {
@@ -900,7 +909,8 @@ def test_attributes_filter_in_category_not_visible_in_listings_by_customer(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -950,7 +960,8 @@ def test_attributes_filter_in_category_not_visible_in_listings_by_staff_with_per
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -994,7 +1005,8 @@ def test_attributes_filter_in_category_not_in_listings_by_staff_without_manage_p
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1041,7 +1053,8 @@ def test_attributes_filter_in_category_not_visible_in_listings_by_app_with_perm(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1085,7 +1098,8 @@ def test_attributes_filter_in_category_not_in_listings_by_app_without_manage_pro
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1126,7 +1140,8 @@ def test_attributes_filter_in_category_not_published_by_customer(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1176,7 +1191,8 @@ def test_attributes_filter_in_category_not_published_by_staff_with_perm(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1220,7 +1236,8 @@ def test_attributes_filter_in_category_not_published_by_staff_without_manage_pro
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1267,7 +1284,8 @@ def test_attributes_filter_in_category_not_published_by_app_with_perm(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1311,7 +1329,8 @@ def test_attributes_filter_in_category_not_published_by_app_without_manage_produ
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     attribute_count = Attribute.objects.count()
@@ -1352,7 +1371,8 @@ def test_attributes_filter_in_category_invalid_category_id(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     variables = {
@@ -1394,7 +1414,8 @@ def test_attributes_filter_in_category_object_with_given_id_does_not_exist(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     variables = {
@@ -1437,7 +1458,8 @@ def test_attributes_filter_in_category_empty_value(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1],
+        {weight_attribute.pk: [weight_attribute.values.first()]},
     )
 
     variables = {

--- a/saleor/graphql/attribute/tests/queries/test_attributes_sort.py
+++ b/saleor/graphql/attribute/tests/queries/test_attributes_sort.py
@@ -114,7 +114,7 @@ def test_attributes_of_products_are_sorted(
     node = variant if is_variant else product  # type: Union[Product, ProductVariant]
     node.attributesrelated.clear()
     associate_attribute_values_to_instance(
-        node, color_attribute, color_attribute.values.first()
+        node, {color_attribute.id: [color_attribute.values.first()]}
     )
 
     # Sort the database attributes by their sort order and ID (when None)

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -397,6 +397,7 @@ class AttributeAssignmentMixin:
             AttributeInputType.RICH_TEXT: cls._pre_save_rich_text_values,
         }
         clean_assignment = []
+        attr_val_map = defaultdict(list)
 
         for attribute, attr_values in cleaned_input:
             is_handled_by_values_field = (
@@ -414,11 +415,12 @@ class AttributeAssignmentMixin:
                 pre_save_func = pre_save_methods_mapping[attribute.input_type]
                 attribute_values = pre_save_func(instance, attribute, attr_values)
 
-            associate_attribute_values_to_instance(
-                instance, attribute, *attribute_values
-            )
             if not attribute_values:
                 clean_assignment.append(attribute.pk)
+            else:
+                attr_val_map[attribute.pk].extend(attribute_values)
+
+        associate_attribute_values_to_instance(instance, attr_val_map)
 
         # drop attribute assignment model when values are unassigned from instance
         if clean_assignment:

--- a/saleor/graphql/page/tests/mutations/test_page_bulk_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_bulk_delete.py
@@ -50,7 +50,7 @@ def test_page_bulk_delete_with_file_attribute(
 
     value = page_file_attribute.values.first()
     page_type.page_attributes.add(page_file_attribute)
-    associate_attribute_values_to_instance(page, page_file_attribute, value)
+    associate_attribute_values_to_instance(page, {page_file_attribute.pk: [value]})
 
     variables = {
         "ids": [graphene.Node.to_global_id("Page", page.pk) for page in page_list]
@@ -93,7 +93,7 @@ def test_page_delete_removes_reference_to_product(
     )
 
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value
+        product, {product_type_page_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Page", page.pk)
@@ -133,7 +133,7 @@ def test_page_delete_removes_reference_to_product_variant(
     )
 
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, attr_value
+        variant, {product_type_page_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Page", page.pk)
@@ -175,7 +175,7 @@ def test_page_delete_removes_reference_to_page(
     )
 
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, attr_value
+        page, {page_type_page_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Page", page_ref.pk)

--- a/saleor/graphql/page/tests/mutations/test_page_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_delete.py
@@ -87,7 +87,9 @@ def test_page_delete_with_file_attribute(
     page_type = page.page_type
     page_type.page_attributes.add(page_file_attribute)
     existing_value = page_file_attribute.values.first()
-    associate_attribute_values_to_instance(page, page_file_attribute, existing_value)
+    associate_attribute_values_to_instance(
+        page, {page_file_attribute.pk: [existing_value]}
+    )
 
     variables = {"id": graphene.Node.to_global_id("Page", page.id)}
 
@@ -126,7 +128,7 @@ def test_page_delete_removes_reference_to_product(
     )
 
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value
+        product, {product_type_page_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Page", page.pk)
@@ -166,7 +168,7 @@ def test_page_delete_removes_reference_to_product_variant(
     )
 
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, attr_value
+        variant, {product_type_page_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Page", page.pk)
@@ -208,7 +210,7 @@ def test_page_delete_removes_reference_to_page(
     )
 
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, attr_value
+        page, {page_type_page_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Page", page_ref.pk)

--- a/saleor/graphql/page/tests/mutations/test_page_reorder_attribute_values.py
+++ b/saleor/graphql/page/tests/mutations/test_page_reorder_attribute_values.py
@@ -77,7 +77,7 @@ def test_sort_page_attribute_values(
         ]
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, *attr_values
+        page, {page_type_page_reference_attribute.id: attr_values}
     )
 
     variables = {
@@ -147,7 +147,7 @@ def test_sort_page_attribute_values_invalid_attribute_id(
         ]
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, *attr_values
+        page, {page_type_page_reference_attribute.id: attr_values}
     )
 
     variables = {
@@ -208,7 +208,7 @@ def test_sort_page_attribute_values_invalid_value_id(
         ]
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, *attr_values
+        page, {page_type_page_reference_attribute.id: attr_values}
     )
 
     invalid_value_id = graphene.Node.to_global_id(

--- a/saleor/graphql/page/tests/mutations/test_page_type_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_type_delete.py
@@ -194,7 +194,7 @@ def test_page_type_delete_with_file_attributes(
     page_type.page_attributes.add(page_file_attribute)
 
     value = page_file_attribute.values.first()
-    associate_attribute_values_to_instance(page, page_file_attribute, value)
+    associate_attribute_values_to_instance(page, {page_file_attribute.pk: [value]})
     page_type_id = graphene.Node.to_global_id("PageType", page_type.pk)
 
     variables = {"id": page_type_id}

--- a/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
@@ -179,7 +179,7 @@ def test_page_type_bulk_delete_with_file_attribute(
 
     value = page_file_attribute.values.first()
     page_type.page_attributes.add(page_file_attribute)
-    associate_attribute_values_to_instance(page, page_file_attribute, value)
+    associate_attribute_values_to_instance(page, {page_file_attribute.pk: [value]})
 
     pages_pks = list(
         Page.objects.filter(page_type__in=page_type_list).values_list("pk", flat=True)

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -313,7 +313,9 @@ def test_update_page_with_file_attribute_new_value_is_not_created(
         "Attribute", page_file_attribute.pk
     )
     existing_value = page_file_attribute.values.first()
-    associate_attribute_values_to_instance(page, page_file_attribute, existing_value)
+    associate_attribute_values_to_instance(
+        page, {page_file_attribute.pk: [existing_value]}
+    )
 
     page_id = graphene.Node.to_global_id("Page", page.id)
     domain = site_settings.site.domain
@@ -465,7 +467,7 @@ def test_update_page_with_page_reference_attribute_existing_value(
         reference_page=ref_page,
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, attr_value
+        page, {page_type_page_reference_attribute.pk: [attr_value]}
     )
 
     values_count = page_type_page_reference_attribute.values.count()
@@ -747,7 +749,7 @@ def test_update_page_with_product_reference_attribute_existing_value(
         reference_product=product,
     )
     associate_attribute_values_to_instance(
-        page, page_type_product_reference_attribute, attr_value
+        page, {page_type_product_reference_attribute.pk: [attr_value]}
     )
 
     values_count = page_type_product_reference_attribute.values.count()
@@ -867,7 +869,7 @@ def test_update_page_with_variant_reference_attribute_existing_value(
         reference_variant=variant,
     )
     associate_attribute_values_to_instance(
-        page, page_type_variant_reference_attribute, attr_value
+        page, {page_type_variant_reference_attribute.pk: [attr_value]}
     )
 
     values_count = page_type_variant_reference_attribute.values.count()
@@ -1086,10 +1088,13 @@ def test_update_page_change_attribute_values_ordering(
 
     associate_attribute_values_to_instance(
         page,
-        page_type_product_reference_attribute,
-        attr_value_3,
-        attr_value_2,
-        attr_value_1,
+        {
+            page_type_product_reference_attribute.pk: [
+                attr_value_3,
+                attr_value_2,
+                attr_value_1,
+            ]
+        },
     )
 
     assert list(

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -291,7 +291,7 @@ def test_get_page_with_sorted_attribute_values(
 
     attr_values = [attr_value_2, attr_value_1, attr_value_3]
     associate_attribute_values_to_instance(
-        page, page_type_product_reference_attribute, *attr_values
+        page, {page_type_product_reference_attribute.pk: attr_values}
     )
 
     page_id = graphene.Node.to_global_id("Page", page.id)

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -601,7 +601,7 @@ def test_filter_products_by_numeric_attributes(
     product = product_list[0]
     product.product_type.product_attributes.add(numeric_attribute)
     associate_attribute_values_to_instance(
-        product, numeric_attribute, *numeric_attribute.values.all()
+        product, {numeric_attribute.id: list(numeric_attribute.values.all())}
     )
     variables = {
         "channel": channel_USD.slug,
@@ -628,7 +628,7 @@ def test_filter_products_by_boolean_attributes(
     product = product_list[0]
     product.product_type.product_attributes.add(boolean_attribute)
     associate_attribute_values_to_instance(
-        product, boolean_attribute, *boolean_attribute.values.all()
+        product, {boolean_attribute.id: list(boolean_attribute.values.all())}
     )
     variables = {
         "channel": channel_USD.slug,

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -465,6 +465,9 @@ def test_update_product(
     non_default_category,
     collection_list,
     product_with_variant_with_two_attributes,
+    color_attribute,
+    size_attribute,
+    boolean_attribute,
     other_description_json,
     permission_manage_products,
     monkeypatch,
@@ -529,6 +532,24 @@ def test_update_product(
     product_slug = "updated-product"
     product_charge_taxes = True
     product_tax_rate = "STANDARD"
+    product.product_type.product_attributes.add(size_attribute)
+    product.product_type.product_attributes.add(color_attribute)
+    product.product_type.product_attributes.add(boolean_attribute)
+
+    attributes = [
+        {
+            "id": graphene.Node.to_global_id("Attribute", color_attribute.pk),
+            "values": ["newValue"],
+        },
+        {
+            "id": graphene.Node.to_global_id("Attribute", size_attribute.pk),
+            "values": ["newValue"],
+        },
+        {
+            "id": graphene.Node.to_global_id("Attribute", boolean_attribute.pk),
+            "values": ["False"],
+        },
+    ]
 
     # Mock tax interface with fake response from tax gateway
     monkeypatch.setattr(
@@ -546,6 +567,7 @@ def test_update_product(
             "description": other_description_json,
             "chargeTaxes": product_charge_taxes,
             "taxCode": product_tax_rate,
+            "attributes": attributes,
         },
     }
 

--- a/saleor/graphql/product/tests/mutations/test_product_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_delete.py
@@ -161,7 +161,9 @@ def test_delete_product_with_file_attribute(
     product_type = product.product_type
     product_type.product_attributes.add(file_attribute)
     existing_value = file_attribute.values.first()
-    associate_attribute_values_to_instance(product, file_attribute, existing_value)
+    associate_attribute_values_to_instance(
+        product, {file_attribute.pk: [existing_value]}
+    )
 
     node_id = graphene.Node.to_global_id("Product", product.id)
     variables = {"id": node_id}
@@ -323,7 +325,7 @@ def test_product_delete_removes_reference_to_product(
         reference_product=product_ref,
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, attr_value
+        product, {product_type_product_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Product", product_ref.pk)
@@ -363,9 +365,7 @@ def test_product_delete_removes_reference_to_product_variant(
     )
 
     associate_attribute_values_to_instance(
-        variant,
-        product_type_product_reference_attribute,
-        attr_value,
+        variant, {product_type_product_reference_attribute.pk: [attr_value]}
     )
     reference_id = graphene.Node.to_global_id("Product", product_list[0].pk)
 
@@ -404,7 +404,7 @@ def test_product_delete_removes_reference_to_page(
         reference_product=product,
     )
     associate_attribute_values_to_instance(
-        page, page_type_product_reference_attribute, attr_value
+        page, {page_type_product_reference_attribute.pk: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Product", product.pk)

--- a/saleor/graphql/product/tests/mutations/test_product_type_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_type_delete.py
@@ -73,8 +73,7 @@ def test_product_type_delete_with_file_attributes(
     product_type.product_attributes.add(file_attribute)
     associate_attribute_values_to_instance(
         product_with_variant_with_file_attribute,
-        file_attribute,
-        file_attribute.values.last(),
+        {file_attribute.pk: [file_attribute.values.last()]},
     )
     values = list(file_attribute.values.all())
 

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -579,7 +579,9 @@ def test_update_product_with_file_attribute_value_new_value_is_not_created(
     attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
     product_type.product_attributes.add(file_attribute)
     existing_value = file_attribute.values.first()
-    associate_attribute_values_to_instance(product, file_attribute, existing_value)
+    associate_attribute_values_to_instance(
+        product, {file_attribute.pk: [existing_value]}
+    )
 
     values_count = file_attribute.values.count()
     domain = site_settings.site.domain
@@ -704,7 +706,7 @@ def test_update_product_with_numeric_attribute_value_new_value_is_not_created(
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0"
     )
-    associate_attribute_values_to_instance(product, numeric_attribute, value)
+    associate_attribute_values_to_instance(product, {numeric_attribute.pk: [value]})
 
     value_count = AttributeValue.objects.count()
 
@@ -809,7 +811,7 @@ def test_update_product_clean_boolean_attribute_value(
 
     product_type.product_attributes.add(boolean_attribute)
     associate_attribute_values_to_instance(
-        product, boolean_attribute, boolean_attribute.values.first()
+        product, {boolean_attribute.pk: [boolean_attribute.values.first()]}
     )
 
     product_attr = product.attributes.get(assignment__attribute_id=boolean_attribute.id)
@@ -855,7 +857,7 @@ def test_update_product_clean_file_attribute_value(
 
     product_type.product_attributes.add(file_attribute)
     associate_attribute_values_to_instance(
-        product, file_attribute, file_attribute.values.first()
+        product, {file_attribute.pk: [file_attribute.values.first()]}
     )
 
     product_attr = product.attributes.get(assignment__attribute_id=file_attribute.id)
@@ -1296,7 +1298,7 @@ def test_update_product_with_page_reference_attribute_existing_value(
         reference_page=page,
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value
+        product, {product_type_page_reference_attribute.pk: [attr_value]}
     )
 
     values_count = product_type_page_reference_attribute.values.count()
@@ -1583,7 +1585,7 @@ def test_update_product_with_product_reference_attribute_existing_value(
         reference_product=product_ref,
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, attr_value
+        product, {product_type_product_reference_attribute.pk: [attr_value]}
     )
 
     values_count = product_type_product_reference_attribute.values.count()
@@ -1712,7 +1714,8 @@ def test_update_product_change_values_ordering(
     )
 
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value_2, attr_value_1
+        product,
+        {product_type_page_reference_attribute.pk: [attr_value_2, attr_value_1]},
     )
 
     assert list(
@@ -2214,7 +2217,7 @@ def test_update_product_with_numeric_attribute_by_numeric_field_null_value(
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0"
     )
-    associate_attribute_values_to_instance(product, numeric_attribute, value)
+    associate_attribute_values_to_instance(product, {numeric_attribute.pk: [value]})
 
     variables = {
         "productId": product_id,
@@ -2251,7 +2254,7 @@ def test_update_product_with_numeric_attribute_by_numeric_field_new_value_not_cr
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0"
     )
-    associate_attribute_values_to_instance(product, numeric_attribute, value)
+    associate_attribute_values_to_instance(product, {numeric_attribute.pk: [value]})
 
     value_count = AttributeValue.objects.count()
 
@@ -2567,7 +2570,7 @@ def test_update_product_with_multiselect_attribute_existing_values(
     attr_value_id_2 = graphene.Node.to_global_id("AttributeValue", attr_value_2.pk)
     attr_value_name_2 = product.attributes.first().values.all()[1].name
 
-    associate_attribute_values_to_instance(product, attribute, attr_value_1)
+    associate_attribute_values_to_instance(product, {attribute.pk: [attr_value_1]})
     assert len(product.attributes.first().values.all()) == 1
 
     variables = {

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -878,7 +878,8 @@ def test_update_variant_with_boolean_attribute(
     }
 
     associate_attribute_values_to_instance(
-        variant, boolean_attribute, boolean_attribute.values.first()
+        variant,
+        {boolean_attribute.id: [boolean_attribute.values.first()]},
     )
 
     response = staff_api_client.post_graphql(
@@ -1113,7 +1114,7 @@ def test_update_variant_with_rich_text_attribute(
     rich_text_attribute_value.save()
     values_count = rich_text_attribute.values.count()
     associate_attribute_values_to_instance(
-        variant, rich_text_attribute, rich_text_attribute.values.first()
+        variant, {rich_text_attribute.id: [rich_text_attribute_value]}
     )
 
     response = staff_api_client.post_graphql(
@@ -1161,7 +1162,7 @@ def test_update_variant_with_plain_text_attribute(
     plain_text_attribute_value.save()
     values_count = plain_text_attribute.values.count()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, plain_text_attribute.values.first()
+        variant, {plain_text_attribute.id: [plain_text_attribute_value]}
     )
 
     # when
@@ -1216,7 +1217,7 @@ def test_update_variant_with_plain_text_attribute_value_required(
 
     values_count = plain_text_attribute.values.count()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, plain_text_attribute.values.first()
+        variant, {plain_text_attribute.id: [plain_text_attribute_value]}
     )
 
     # when
@@ -1259,7 +1260,7 @@ def test_update_variant_with_required_plain_text_attribute_no_value(
     plain_text_attribute_value.save()
 
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, plain_text_attribute.values.first()
+        variant, {plain_text_attribute.id: [plain_text_attribute_value]}
     )
 
     plain_text_attribute.value_required = True
@@ -1439,7 +1440,9 @@ def test_update_variant_with_numeric_attribute(
     attribute_value.slug = f"{variant.id}_{numeric_attribute.id}"
     attribute_value.save()
     values_count = numeric_attribute.values.count()
-    associate_attribute_values_to_instance(variant, numeric_attribute, attribute_value)
+    associate_attribute_values_to_instance(
+        variant, {numeric_attribute.id: [attribute_value]}
+    )
 
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]
@@ -1557,10 +1560,11 @@ def test_update_product_variant_with_duplicated_attribute(
     variant2.sku = str(uuid4())[:12]
     variant2.save()
     associate_attribute_values_to_instance(
-        variant2, color_attribute, color_attribute.values.last()
-    )
-    associate_attribute_values_to_instance(
-        variant2, size_attribute, size_attribute.values.last()
+        variant2,
+        {
+            color_attribute.id: [color_attribute.values.last()],
+            size_attribute.id: [size_attribute.values.last()],
+        },
     )
 
     assert variant.attributes.first().values.first().slug == "red"
@@ -1660,7 +1664,9 @@ def test_update_product_variant_with_duplicated_file_attribute(
     variant2.sku = str(uuid4())[:12]
     variant2.save()
     file_attr_value = file_attribute.values.last()
-    associate_attribute_values_to_instance(variant2, file_attribute, file_attr_value)
+    associate_attribute_values_to_instance(
+        variant2, {file_attribute.id: [file_attr_value]}
+    )
 
     sku = str(uuid4())[:12]
     assert not variant.sku == sku
@@ -1952,10 +1958,13 @@ def test_update_product_variant_change_attribute_values_ordering(
 
     associate_attribute_values_to_instance(
         variant,
-        product_type_product_reference_attribute,
-        attr_value_3,
-        attr_value_2,
-        attr_value_1,
+        {
+            product_type_product_reference_attribute.id: [
+                attr_value_3,
+                attr_value_2,
+                attr_value_1,
+            ]
+        },
     )
 
     assert list(

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -1563,7 +1563,8 @@ def test_get_product_with_sorted_attribute_values(
     )
 
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value_2, attr_value_1
+        product,
+        {product_type_page_reference_attribute.pk: [attr_value_2, attr_value_1]},
     )
 
     product_id = graphene.Node.to_global_id("Product", product.id)

--- a/saleor/graphql/product/tests/queries/test_products_query_with_filter.py
+++ b/saleor/graphql/product/tests/queries/test_products_query_with_filter.py
@@ -66,7 +66,10 @@ def test_products_query_with_filter_attributes(
     second_product.product_type = product_type
     second_product.slug = "second-product"
     second_product.save()
-    associate_attribute_values_to_instance(second_product, attribute, attr_value)
+    associate_attribute_values_to_instance(
+        second_product,
+        {attribute.id: [attr_value]},
+    )
 
     variables = {
         "filter": {
@@ -112,7 +115,8 @@ def test_products_query_with_filter_numeric_attributes(
 ):
     product.product_type.product_attributes.add(numeric_attribute)
     associate_attribute_values_to_instance(
-        product, numeric_attribute, *numeric_attribute.values.all()
+        product,
+        {numeric_attribute.id: list(numeric_attribute.values.all())},
     )
 
     product_type = ProductType.objects.create(
@@ -135,7 +139,8 @@ def test_products_query_with_filter_numeric_attributes(
     )
 
     associate_attribute_values_to_instance(
-        second_product, numeric_attribute, attr_value
+        second_product,
+        {numeric_attribute.id: [attr_value]},
     )
 
     third_product = Product.objects.create(
@@ -148,7 +153,10 @@ def test_products_query_with_filter_numeric_attributes(
         attribute=numeric_attribute, name="5", slug="5_X"
     )
 
-    associate_attribute_values_to_instance(third_product, numeric_attribute, attr_value)
+    associate_attribute_values_to_instance(
+        third_product,
+        {numeric_attribute.id: [attr_value]},
+    )
 
     second_product.refresh_from_db()
     third_product.refresh_from_db()
@@ -203,7 +211,8 @@ def test_products_query_with_filter_boolean_attributes(
     product.product_type.product_attributes.add(boolean_attribute)
 
     associate_attribute_values_to_instance(
-        product, boolean_attribute, boolean_attribute.values.get(boolean=filter_value)
+        product,
+        {boolean_attribute.id: [boolean_attribute.values.get(boolean=filter_value)]},
     )
 
     product_type = ProductType.objects.create(
@@ -222,7 +231,8 @@ def test_products_query_with_filter_boolean_attributes(
         category=category,
     )
     associate_attribute_values_to_instance(
-        second_product, boolean_attribute, boolean_attribute.values.get(boolean=False)
+        second_product,
+        {boolean_attribute.id: [boolean_attribute.values.get(boolean=False)]},
     )
 
     second_product.refresh_from_db()
@@ -263,7 +273,8 @@ def test_products_query_with_filter_by_attributes_values_and_range(
     attr_value_1 = product_attr.values.first()
     product.product_type.product_attributes.add(numeric_attribute)
     associate_attribute_values_to_instance(
-        product, numeric_attribute, *numeric_attribute.values.all()
+        product,
+        {numeric_attribute.id: list(numeric_attribute.values.all())},
     )
 
     product_type = ProductType.objects.create(
@@ -286,7 +297,8 @@ def test_products_query_with_filter_by_attributes_values_and_range(
     )
 
     associate_attribute_values_to_instance(
-        second_product, numeric_attribute, attr_value_2
+        second_product,
+        {numeric_attribute.id: [attr_value_2]},
     )
 
     second_product.refresh_from_db()
@@ -322,7 +334,8 @@ def test_products_query_with_filter_swatch_attributes(
 ):
     product.product_type.product_attributes.add(swatch_attribute)
     associate_attribute_values_to_instance(
-        product, swatch_attribute, *swatch_attribute.values.all()
+        product,
+        {swatch_attribute.id: list(swatch_attribute.values.all())},
     )
 
     product_type = ProductType.objects.create(
@@ -343,7 +356,10 @@ def test_products_query_with_filter_swatch_attributes(
         attribute=swatch_attribute, name="Dark", slug="dark"
     )
 
-    associate_attribute_values_to_instance(second_product, swatch_attribute, attr_value)
+    associate_attribute_values_to_instance(
+        second_product,
+        {swatch_attribute.id: [attr_value]},
+    )
 
     second_product.refresh_from_db()
 
@@ -395,13 +411,16 @@ def test_products_query_with_filter_date_range_date_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0], date_attribute, attr_value_1
+        product_list[0],
+        {date_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1], date_attribute, attr_value_2
+        product_list[1],
+        {date_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2], date_attribute, attr_value_3
+        product_list[2],
+        {date_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -459,13 +478,16 @@ def test_products_query_with_filter_date_range_date_variant_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0].variants.first(), date_attribute, attr_value_1
+        product_list[0].variants.first(),
+        {date_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1].variants.first(), date_attribute, attr_value_2
+        product_list[1].variants.first(),
+        {date_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2].variants.first(), date_attribute, attr_value_3
+        product_list[2].variants.first(),
+        {date_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -526,13 +548,16 @@ def test_products_query_with_filter_date_range_date_time_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0], date_time_attribute, attr_value_1
+        product_list[0],
+        {date_time_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1], date_time_attribute, attr_value_2
+        product_list[1],
+        {date_time_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2], date_time_attribute, attr_value_3
+        product_list[2],
+        {date_time_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -593,13 +618,16 @@ def test_products_query_with_filter_date_range_date_time_variant_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0].variants.first(), date_time_attribute, attr_value_1
+        product_list[0].variants.first(),
+        {date_time_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1].variants.first(), date_time_attribute, attr_value_2
+        product_list[1].variants.first(),
+        {date_time_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2].variants.first(), date_time_attribute, attr_value_3
+        product_list[2].variants.first(),
+        {date_time_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -664,13 +692,16 @@ def test_products_query_with_filter_date_time_range_date_time_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0], date_time_attribute, attr_value_1
+        product_list[0],
+        {date_time_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1].variants.first(), date_time_attribute, attr_value_2
+        product_list[1].variants.first(),
+        {date_time_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2].variants.first(), date_time_attribute, attr_value_3
+        product_list[2].variants.first(),
+        {date_time_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -1040,7 +1071,8 @@ def test_products_query_with_filter_search_by_dropdown_attribute_value(
     dropdown_attr_value.save(update_fields=["name"])
 
     associate_attribute_values_to_instance(
-        product_with_dropdown_attr, color_attribute, dropdown_attr_value
+        product_with_dropdown_attr,
+        {color_attribute.id: [dropdown_attr_value]},
     )
 
     product_with_dropdown_attr.refresh_from_db()
@@ -1101,9 +1133,7 @@ def test_products_query_with_filter_search_by_multiselect_attribute_value(
 
     associate_attribute_values_to_instance(
         product_with_multiselect_attr,
-        multiselect_attribute,
-        multiselect_attr_val_1,
-        multiselect_attr_val_2,
+        {multiselect_attribute.id: [multiselect_attr_val_1, multiselect_attr_val_2]},
     )
 
     product_with_multiselect_attr.refresh_from_db()
@@ -1151,7 +1181,8 @@ def test_products_query_with_filter_search_by_rich_text_attribute(
     rich_text_value.save(update_fields=["rich_text"])
 
     associate_attribute_values_to_instance(
-        product_with_rich_text_attr, rich_text_attribute, rich_text_value
+        product_with_rich_text_attr,
+        {rich_text_attribute.id: [rich_text_value]},
     )
 
     product_with_rich_text_attr.refresh_from_db()
@@ -1199,7 +1230,8 @@ def test_products_query_with_filter_search_by_plain_text_attribute(
     plain_text_value.save(update_fields=["plain_text"])
 
     associate_attribute_values_to_instance(
-        product_with_plain_text_attr, plain_text_attribute, plain_text_value
+        product_with_plain_text_attr,
+        {plain_text_attribute.id: [plain_text_value]},
     )
 
     product_with_plain_text_attr.refresh_from_db()
@@ -1250,7 +1282,8 @@ def test_products_query_with_filter_search_by_numeric_attribute_value(
     numeric_attr_value.save(update_fields=["name"])
 
     associate_attribute_values_to_instance(
-        product_with_numeric_attr, numeric_attribute, numeric_attr_value
+        product_with_numeric_attr,
+        {numeric_attribute.id: [numeric_attr_value]},
     )
 
     product_with_numeric_attr.refresh_from_db()
@@ -1297,7 +1330,8 @@ def test_products_query_with_filter_search_by_numeric_attribute_value_without_un
     numeric_attr_value.save(update_fields=["name"])
 
     associate_attribute_values_to_instance(
-        product_with_numeric_attr, numeric_attribute, numeric_attr_value
+        product_with_numeric_attr,
+        {numeric_attribute.id: [numeric_attr_value]},
     )
 
     product_with_numeric_attr.refresh_from_db()
@@ -1345,7 +1379,8 @@ def test_products_query_with_filter_search_by_date_attribute_value(
     date_attr_value.save(update_fields=["date_time"])
 
     associate_attribute_values_to_instance(
-        product_with_date_attr, date_attribute, date_attr_value
+        product_with_date_attr,
+        {date_attribute.id: [date_attr_value]},
     )
 
     product_with_date_attr.refresh_from_db()
@@ -1393,7 +1428,8 @@ def test_products_query_with_filter_search_by_date_time_attribute_value(
     date_time_attr_value.save(update_fields=["date_time"])
 
     associate_attribute_values_to_instance(
-        product_with_date_time_attr, date_time_attribute, date_time_attr_value
+        product_with_date_time_attr,
+        {date_time_attribute.id: [date_time_attr_value]},
     )
 
     product_with_date_time_attr.refresh_from_db()

--- a/saleor/graphql/product/tests/queries/test_products_query_with_where.py
+++ b/saleor/graphql/product/tests/queries/test_products_query_with_where.py
@@ -667,7 +667,10 @@ def test_products_filter_by_attributes(
     product = product_list[0]
     product.product_type = product_type
     product.save()
-    associate_attribute_values_to_instance(product, attribute, attr_value)
+    associate_attribute_values_to_instance(
+        product,
+        {attribute.id: [attr_value]},
+    )
 
     variables = {
         "channel": channel_USD.slug,
@@ -710,7 +713,10 @@ def test_products_filter_by_attributes_empty_list(
     product = product_list[0]
     product.product_type = product_type
     product.save()
-    associate_attribute_values_to_instance(product, attribute, attr_value)
+    associate_attribute_values_to_instance(
+        product,
+        {attribute.id: [attr_value]},
+    )
 
     variables = {
         "channel": channel_USD.slug,
@@ -754,7 +760,8 @@ def test_products_filter_by_numeric_attributes(
     # given
     product_list[0].product_type.product_attributes.add(numeric_attribute)
     associate_attribute_values_to_instance(
-        product_list[0], numeric_attribute, *numeric_attribute.values.all()
+        product_list[0],
+        {numeric_attribute.id: list(numeric_attribute.values.all())},
     )
 
     product_type = ProductType.objects.create(
@@ -771,7 +778,8 @@ def test_products_filter_by_numeric_attributes(
         attribute=numeric_attribute, name="5", slug="5"
     )
     associate_attribute_values_to_instance(
-        product_list[1], numeric_attribute, attr_value
+        product_list[1],
+        {numeric_attribute.id: [attr_value]},
     )
 
     attr_value = AttributeValue.objects.create(
@@ -779,7 +787,8 @@ def test_products_filter_by_numeric_attributes(
     )
     product_list[2].product_type = product_type
     associate_attribute_values_to_instance(
-        product_list[2], numeric_attribute, attr_value
+        product_list[2],
+        {numeric_attribute.id: [attr_value]},
     )
 
     variables = {
@@ -815,8 +824,7 @@ def test_products_filter_by_boolean_attributes(
     product_list[0].product_type.product_attributes.add(boolean_attribute)
     associate_attribute_values_to_instance(
         product_list[0],
-        boolean_attribute,
-        boolean_attribute.values.get(boolean=filter_value),
+        {boolean_attribute.id: [boolean_attribute.values.get(boolean=filter_value)]},
     )
 
     product_type = ProductType.objects.create(
@@ -830,7 +838,8 @@ def test_products_filter_by_boolean_attributes(
 
     product_list[1].product_type = product_type
     associate_attribute_values_to_instance(
-        product_list[1], boolean_attribute, boolean_attribute.values.get(boolean=False)
+        product_list[1],
+        {boolean_attribute.id: [boolean_attribute.values.get(boolean=False)]},
     )
 
     variables = {
@@ -863,7 +872,8 @@ def test_products_filter_by_attributes_values_and_range(
     attr_value_1 = product_attr.values.first()
     product_list[0].product_type.product_attributes.add(numeric_attribute)
     associate_attribute_values_to_instance(
-        product_list[0], numeric_attribute, *numeric_attribute.values.all()
+        product_list[0],
+        {numeric_attribute.id: list(numeric_attribute.values.all())},
     )
 
     product_type = ProductType.objects.create(
@@ -880,7 +890,8 @@ def test_products_filter_by_attributes_values_and_range(
         attribute=numeric_attribute, name="1.2", slug="1_2"
     )
     associate_attribute_values_to_instance(
-        product_list[1], numeric_attribute, attr_value_2
+        product_list[1],
+        {numeric_attribute.id: [attr_value_2]},
     )
     variables = {
         "channel": channel_USD.slug,
@@ -914,7 +925,8 @@ def test_products_filter_by_swatch_attributes(
     # given
     product_list[0].product_type.product_attributes.add(swatch_attribute)
     associate_attribute_values_to_instance(
-        product_list[0], swatch_attribute, *swatch_attribute.values.all()
+        product_list[0],
+        {swatch_attribute.id: list(swatch_attribute.values.all())},
     )
 
     product_type = ProductType.objects.create(
@@ -930,7 +942,8 @@ def test_products_filter_by_swatch_attributes(
         attribute=swatch_attribute, name="Dark", slug="dark"
     )
     associate_attribute_values_to_instance(
-        product_list[1], swatch_attribute, attr_value
+        product_list[1],
+        {swatch_attribute.id: [attr_value]},
     )
 
     variables = {
@@ -977,13 +990,16 @@ def test_products_filter_by_date_range_date_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0], date_attribute, attr_value_1
+        product_list[0],
+        {date_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1], date_attribute, attr_value_2
+        product_list[1],
+        {date_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2], date_attribute, attr_value_3
+        product_list[2],
+        {date_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -1038,13 +1054,16 @@ def test_products_filter_by_date_range_date_variant_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0].variants.first(), date_attribute, attr_value_1
+        product_list[0].variants.first(),
+        {date_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1].variants.first(), date_attribute, attr_value_2
+        product_list[1].variants.first(),
+        {date_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2].variants.first(), date_attribute, attr_value_3
+        product_list[2].variants.first(),
+        {date_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -1102,13 +1121,16 @@ def test_products_filter_by_date_range_date_time_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0], date_time_attribute, attr_value_1
+        product_list[0],
+        {date_time_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1], date_time_attribute, attr_value_2
+        product_list[1],
+        {date_time_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2], date_time_attribute, attr_value_3
+        product_list[2],
+        {date_time_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -1166,13 +1188,16 @@ def test_products_filter_by_date_range_date_time_variant_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0].variants.first(), date_time_attribute, attr_value_1
+        product_list[0].variants.first(),
+        {date_time_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1].variants.first(), date_time_attribute, attr_value_2
+        product_list[1].variants.first(),
+        {date_time_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2].variants.first(), date_time_attribute, attr_value_3
+        product_list[2].variants.first(),
+        {date_time_attribute.id: [attr_value_3]},
     )
 
     variables = {
@@ -1234,13 +1259,16 @@ def test_products_filter_by_date_time_range_date_time_attributes(
     )
 
     associate_attribute_values_to_instance(
-        product_list[0], date_time_attribute, attr_value_1
+        product_list[0],
+        {date_time_attribute.id: [attr_value_1]},
     )
     associate_attribute_values_to_instance(
-        product_list[1].variants.first(), date_time_attribute, attr_value_2
+        product_list[1].variants.first(),
+        {date_time_attribute.id: [attr_value_2]},
     )
     associate_attribute_values_to_instance(
-        product_list[2].variants.first(), date_time_attribute, attr_value_3
+        product_list[2].variants.first(),
+        {date_time_attribute.id: [attr_value_3]},
     )
 
     variables = {

--- a/saleor/graphql/product/tests/queries/test_variant_query.py
+++ b/saleor/graphql/product/tests/queries/test_variant_query.py
@@ -534,9 +534,12 @@ def test_get_variant_by_id_with_variant_selection_filter(
     )
 
     _associate_attribute_to_instance(
-        variant, file_attribute_with_file_input_type_without_values.pk
+        variant,
+        {
+            file_attribute_with_file_input_type_without_values.pk: [],
+            size_attribute.pk: [],
+        },
     )
-    _associate_attribute_to_instance(variant, size_attribute.pk)
 
     # when
     response = staff_api_client.post_graphql(
@@ -592,7 +595,7 @@ def test_get_variant_with_sorted_attribute_values(
 
     attr_values = [attr_value_2, attr_value_1, attr_value_3]
     associate_attribute_values_to_instance(
-        variant, product_type_product_reference_attribute, *attr_values
+        variant, {product_type_product_reference_attribute.pk: attr_values}
     )
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -1055,7 +1055,10 @@ def test_unassign_attributes_from_product_type(
     product_attr_value = AttributeValue.objects.create(
         attribute=attribute, name="Test value", slug="test-value"
     )
-    associate_attribute_values_to_instance(product, attribute, product_attr_value)
+    associate_attribute_values_to_instance(
+        product,
+        {attribute.pk: [product_attr_value]},
+    )
 
     remaining_attribute_global_id = graphene.Node.to_global_id(
         "Attribute", product_attributes[1].pk
@@ -1391,7 +1394,7 @@ def test_sort_product_attribute_values(
         ]
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, *attr_values
+        product, {product_type_page_reference_attribute.pk: attr_values}
     )
 
     variables = {
@@ -1458,7 +1461,7 @@ def test_sort_product_attribute_values_invalid_attribute_id(
         ]
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, *attr_values
+        product, {product_type_page_reference_attribute.pk: attr_values}
     )
 
     variables = {
@@ -1521,7 +1524,7 @@ def test_sort_product_attribute_values_invalid_value_id(
         ]
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, *attr_values
+        product, {product_type_page_reference_attribute.pk: attr_values}
     )
 
     invalid_value_id = graphene.Node.to_global_id(
@@ -1626,7 +1629,7 @@ def test_sort_product_variant_attribute_values(
         ]
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, *attr_values
+        variant, {product_type_page_reference_attribute.pk: attr_values}
     )
 
     variables = {
@@ -1696,7 +1699,7 @@ def test_sort_product_variant_attribute_values_invalid_attribute_id(
         ]
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, *attr_values
+        variant, {product_type_page_reference_attribute.pk: attr_values}
     )
 
     variables = {
@@ -1760,7 +1763,7 @@ def test_sort_product_variant_attribute_values_invalid_value_id(
         ]
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, *attr_values
+        variant, {product_type_page_reference_attribute.pk: attr_values}
     )
 
     invalid_value_id = graphene.Node.to_global_id(

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -737,7 +737,9 @@ def test_delete_products_with_file_attributes(
         product_type = product.product_type
         product_type.product_attributes.add(file_attribute)
         existing_value = values[i]
-        associate_attribute_values_to_instance(product, file_attribute, existing_value)
+        associate_attribute_values_to_instance(
+            product, {file_attribute.pk: [existing_value]}
+        )
 
     variables = {
         "ids": [
@@ -909,7 +911,9 @@ def test_delete_product_types_with_file_attributes(
         product.product_type = product_type
         product.save()
         existing_value = values[i]
-        associate_attribute_values_to_instance(product, file_attribute, existing_value)
+        associate_attribute_values_to_instance(
+            product, {file_attribute.pk: [existing_value]}
+        )
 
     variables = {
         "ids": [
@@ -1340,7 +1344,7 @@ def test_product_delete_removes_reference_to_product(
         reference_product=product_ref,
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, attr_value
+        product, {product_type_product_reference_attribute.id: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Product", product_ref.pk)
@@ -1380,9 +1384,7 @@ def test_product_delete_removes_variant_reference_to_product(
     )
 
     associate_attribute_values_to_instance(
-        variant,
-        product_type_product_reference_attribute,
-        attr_value,
+        variant, {product_type_product_reference_attribute.id: [attr_value]}
     )
     reference_id = graphene.Node.to_global_id("Product", product_list[0].pk)
 
@@ -1423,7 +1425,7 @@ def test_product_delete_removes_reference_to_variant(
         reference_variant=variant_ref,
     )
     associate_attribute_values_to_instance(
-        product, product_type_variant_reference_attribute, attr_value
+        product, {product_type_variant_reference_attribute.id: [attr_value]}
     )
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1466,7 +1468,7 @@ def test_product_delete_removes_reference_to_page(
         reference_product=product,
     )
     associate_attribute_values_to_instance(
-        page, page_type_product_reference_attribute, attr_value
+        page, {page_type_product_reference_attribute.id: [attr_value]}
     )
 
     reference_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1520,7 +1522,9 @@ def test_delete_product_variants_with_file_attribute(
         product_type = variant.product.product_type
         product_type.variant_attributes.add(file_attribute)
         existing_value = values[i]
-        associate_attribute_values_to_instance(variant, file_attribute, existing_value)
+        associate_attribute_values_to_instance(
+            variant, {file_attribute.id: [existing_value]}
+        )
 
     variables = {
         "ids": [

--- a/saleor/graphql/product/tests/test_product_pagination.py
+++ b/saleor/graphql/product/tests/test_product_pagination.py
@@ -377,10 +377,10 @@ def products_for_pagination(
 
     product_attrib_values = color_attribute.values.all()
     associate_attribute_values_to_instance(
-        products[1], color_attribute, product_attrib_values[0]
+        products[1], {color_attribute.id: [product_attrib_values[0]]}
     )
     associate_attribute_values_to_instance(
-        products[3], color_attribute, product_attrib_values[1]
+        products[3], {color_attribute.id: [product_attrib_values[1]]}
     )
 
     variants = ProductVariant.objects.bulk_create(

--- a/saleor/graphql/product/tests/test_product_sorting_attributes.py
+++ b/saleor/graphql/product/tests/test_product_sorting_attributes.py
@@ -208,17 +208,24 @@ def products_structures(category, channel_USD):
         currency=channel_USD.currency_code,
     )
     dummy_attr_value = attr_value(dummy_attr, DUMMIES[0])
-    associate_attribute_values_to_instance(dummy, dummy_attr, *dummy_attr_value)
+    associate_attribute_values_to_instance(
+        dummy,
+        {dummy_attr.pk: dummy_attr_value},
+    )
 
     for products in (apples, oranges):
         for product, attr_values in zip(products, COLORS):
             attr_values = attr_value(colors_attr, *attr_values)
-            associate_attribute_values_to_instance(product, colors_attr, *attr_values)
+            associate_attribute_values_to_instance(
+                product,
+                {colors_attr.pk: attr_values},
+            )
 
         for product, attr_values in zip(products, TRADEMARKS):
             attr_values = attr_value(trademark_attr, attr_values)
             associate_attribute_values_to_instance(
-                product, trademark_attr, *attr_values
+                product,
+                {trademark_attr.pk: attr_values},
             )
 
     return colors_attr, trademark_attr, dummy_attr
@@ -577,7 +584,10 @@ def test_sort_product_not_having_attribute_data(api_client, category, count_quer
     product_having_attr_value = product_models.Product.objects.create(
         name="Z", slug="z", product_type=product_type, **product_create_kwargs
     )
-    associate_attribute_values_to_instance(product_having_attr_value, attribute, value)
+    associate_attribute_values_to_instance(
+        product_having_attr_value,
+        {attribute.pk: [value]},
+    )
 
     # Create a product having the same product type but no attribute data
     product_models.Product.objects.create(

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -2196,7 +2196,8 @@ def test_plain_text_attribute_value_create_translation(
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant,
+        {plain_text_attribute.pk: [attribute_value]},
     )
     attribute_value_id = graphene.Node.to_global_id(
         "AttributeValue", attribute_value.id
@@ -2477,7 +2478,8 @@ def test_plain_text_attribute_value_update_translation_only_plain_text(
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant,
+        {plain_text_attribute.pk: [attribute_value]},
     )
 
     text = "Jakiś bazowy opis"
@@ -2516,7 +2518,8 @@ def test_plain_text_attribute_value_update_translation_only_plain_text_long_text
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant,
+        {plain_text_attribute.pk: [attribute_value]},
     )
 
     text = "Jakiś bazowy opis"
@@ -2557,7 +2560,8 @@ def test_plain_text_attribute_value_update_translation_name_set_manually(
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant,
+        {plain_text_attribute.pk: [attribute_value]},
     )
 
     text = "Jakiś bazowy opis"
@@ -2597,7 +2601,8 @@ def test_plain_text_attribute_value_update_translation_empty_name(
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant,
+        {plain_text_attribute.pk: [attribute_value]},
     )
 
     text = "Jakiś bazowy opis"
@@ -2636,7 +2641,8 @@ def test_plain_text_attribute_value_update_translation_name_null(
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant,
+        {plain_text_attribute.pk: [attribute_value]},
     )
 
     text = "Jakiś bazowy opis"
@@ -3821,7 +3827,7 @@ def test_product_attribute_value_plain_text_translation(
 
     product_attr_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        product, plain_text_attribute, product_attr_value
+        product, {plain_text_attribute.id: [product_attr_value]}
     )
 
     text = "Test plain text translation"
@@ -3862,7 +3868,7 @@ def test_nested_product_attribute_translation(
 
     product_attr_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        product, plain_text_attribute, product_attr_value
+        product, {plain_text_attribute.id: [product_attr_value]}
     )
 
     text = "Test attribute translation"
@@ -3970,7 +3976,7 @@ def test_product_variant_attribute_value_plain_text_translation(
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant, {plain_text_attribute.id: [attribute_value]}
     )
 
     text = "Test plain text translation"
@@ -4011,7 +4017,7 @@ def test_nested_product_variant_attribute_translation(
 
     attribute_value = plain_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, plain_text_attribute, attribute_value
+        variant, {plain_text_attribute.id: [attribute_value]}
     )
 
     text = "Test attribute translation"
@@ -4114,7 +4120,7 @@ def test_page_attribute_value_plain_text_translation(
     attribute_value = plain_text_attribute_page_type.values.first()
 
     associate_attribute_values_to_instance(
-        page, plain_text_attribute_page_type, attribute_value
+        page, {plain_text_attribute_page_type.id: [attribute_value]}
     )
 
     text = "Test plain text translation"
@@ -4157,7 +4163,7 @@ def test_nested_page_attribute_translation(
     attribute_value = plain_text_attribute_page_type.values.first()
 
     associate_attribute_values_to_instance(
-        page, plain_text_attribute_page_type, attribute_value
+        page, {plain_text_attribute_page_type.id: [attribute_value]}
     )
 
     text = "Test attribute translation"

--- a/saleor/product/tests/test_generate_and_set_variant_name.py
+++ b/saleor/product/tests/test_generate_and_set_variant_name.py
@@ -71,8 +71,13 @@ def test_generate_and_set_variant_name_different_attributes(
     size = size_attribute.values.get(slug="big")
 
     # Associate the colors and size to variant attributes
-    associate_attribute_values_to_instance(variant, color_attribute, *tuple(colors))
-    associate_attribute_values_to_instance(variant, size_attribute, size)
+    associate_attribute_values_to_instance(
+        variant,
+        {
+            color_attribute.id: colors,
+            size_attribute.id: [size],
+        },
+    )
 
     # Generate the variant name from the attributes
     generate_and_set_variant_name(variant, variant.sku)
@@ -116,8 +121,13 @@ def test_generate_and_set_variant_name_only_variant_selection_attributes(
     size.save(update_fields=["sort_order"])
 
     # Associate the colors and size to variant attributes
-    associate_attribute_values_to_instance(variant, color_attribute, *tuple(colors))
-    associate_attribute_values_to_instance(variant, size_attribute, size)
+    associate_attribute_values_to_instance(
+        variant,
+        {
+            color_attribute.id: colors,
+            size_attribute.id: [size],
+        },
+    )
 
     # Generate the variant name from the attributes
     generate_and_set_variant_name(variant, variant.sku)
@@ -160,8 +170,13 @@ def test_generate_and_set_variant_name_only_not_variant_selection_attributes(
     )
 
     # Associate the colors and size to variant attributes
-    associate_attribute_values_to_instance(variant, color_attribute, *values[:2])
-    associate_attribute_values_to_instance(variant, file_attribute, values[-1])
+    associate_attribute_values_to_instance(
+        variant,
+        {
+            color_attribute.id: values[:2],
+            file_attribute.id: [values[-1]],
+        },
+    )
 
     # Generate the variant name from the attributes
     generate_and_set_variant_name(variant, variant.sku)

--- a/saleor/product/tests/test_product.py
+++ b/saleor/product/tests/test_product.py
@@ -82,8 +82,14 @@ def test_filtering_by_attribute(
     color_2 = color_attribute.values.last()
 
     # Associate color to a product and a variant
-    associate_attribute_values_to_instance(product_a, color_attribute, color)
-    associate_attribute_values_to_instance(variant_b, color_attribute, color)
+    associate_attribute_values_to_instance(
+        product_a,
+        {color_attribute.pk: [color]},
+    )
+    associate_attribute_values_to_instance(
+        variant_b,
+        {color_attribute.pk: [color]},
+    )
 
     product_qs = models.Product.objects.all().values_list("pk", flat=True)
 
@@ -92,7 +98,10 @@ def test_filtering_by_attribute(
     assert product_a.pk in list(filtered)
     assert product_b.pk in list(filtered)
 
-    associate_attribute_values_to_instance(product_a, color_attribute, color_2)
+    associate_attribute_values_to_instance(
+        product_a,
+        {color_attribute.pk: [color_2]},
+    )
 
     filters = {color_attribute.pk: [color.pk]}
     filtered = filter_products_by_attributes_values(product_qs, filters)
@@ -114,7 +123,10 @@ def test_filtering_by_attribute(
     # Associate additional attribute to a product
     size = size_attribute.values.first()
     product_type_a.product_attributes.add(size_attribute)
-    associate_attribute_values_to_instance(product_a, size_attribute, size)
+    associate_attribute_values_to_instance(
+        product_a,
+        {size_attribute.pk: [size]},
+    )
 
     # Filter by multiple attributes
     filters = {color_attribute.pk: [color_2.pk], size_attribute.pk: [size.pk]}
@@ -126,10 +138,16 @@ def test_filtering_by_attribute(
     product_type_b.product_attributes.add(date_attribute)
 
     date = date_attribute.values.first()
-    associate_attribute_values_to_instance(product_a, date_attribute, date)
+    associate_attribute_values_to_instance(
+        product_a,
+        {date_attribute.pk: [date]},
+    )
 
     date_2 = date_attribute.values.last()
-    associate_attribute_values_to_instance(product_b, date_attribute, date_2)
+    associate_attribute_values_to_instance(
+        product_b,
+        {date_attribute.pk: [date_2]},
+    )
 
     filters = {date_attribute.pk: [date.pk]}
     filtered = filter_products_by_attributes_values(product_qs, filters)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2411,7 +2411,7 @@ def categories_tree(db, product_type, channel_USD):  # pylint: disable=W0613
         visible_in_listings=True,
     )
 
-    associate_attribute_values_to_instance(product, product_attr, attr_value)
+    associate_attribute_values_to_instance(product, {product_attr.pk: [attr_value]})
     return parent
 
 
@@ -2623,7 +2623,9 @@ def product(product_type, category, warehouse, channel_USD, default_tax_class):
         available_for_purchase_at=datetime.datetime(1999, 1, 1, tzinfo=pytz.UTC),
     )
 
-    associate_attribute_values_to_instance(product, product_attr, product_attr_value)
+    associate_attribute_values_to_instance(
+        product, {product_attr.pk: [product_attr_value]}
+    )
 
     variant_attr = product_type.variant_attributes.first()
     variant_attr_value = variant_attr.values.first()
@@ -2639,7 +2641,9 @@ def product(product_type, category, warehouse, channel_USD, default_tax_class):
     )
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
 
-    associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
+    associate_attribute_values_to_instance(
+        variant, {variant_attr.pk: [variant_attr_value]}
+    )
 
     return product
 
@@ -2809,7 +2813,9 @@ def product_with_rich_text_attribute(
         available_for_purchase_at=datetime.datetime(1999, 1, 1, tzinfo=pytz.UTC),
     )
 
-    associate_attribute_values_to_instance(product, product_attr, product_attr_value)
+    associate_attribute_values_to_instance(
+        product, {product_attr.pk: [product_attr_value]}
+    )
 
     variant_attr = product_type_with_rich_text_attribute.variant_attributes.first()
     variant_attr_value = variant_attr.values.first()
@@ -2825,7 +2831,9 @@ def product_with_rich_text_attribute(
     )
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
 
-    associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
+    associate_attribute_values_to_instance(
+        variant, {variant_attr.pk: [variant_attr_value]}
+    )
     return [product, variant]
 
 
@@ -2979,10 +2987,10 @@ def product_with_variant_with_two_attributes(
     )
 
     associate_attribute_values_to_instance(
-        variant, color_attribute, color_attribute.values.first()
+        variant, {color_attribute.pk: [color_attribute.values.first()]}
     )
     associate_attribute_values_to_instance(
-        variant, size_attribute, size_attribute.values.first()
+        variant, {size_attribute.pk: [size_attribute.values.first()]}
     )
 
     return product
@@ -3042,10 +3050,10 @@ def product_with_variant_with_external_media(
     )
 
     associate_attribute_values_to_instance(
-        variant, color_attribute, color_attribute.values.first()
+        variant, {color_attribute.pk: [color_attribute.values.first()]}
     )
     associate_attribute_values_to_instance(
-        variant, size_attribute, size_attribute.values.first()
+        variant, {size_attribute.pk: [size_attribute.values.first()]}
     )
 
     return product
@@ -3093,7 +3101,7 @@ def product_with_variant_with_file_attribute(
     )
 
     associate_attribute_values_to_instance(
-        variant, file_attribute, file_attribute.values.first()
+        variant, {file_attribute.pk: [file_attribute.values.first()]}
     )
 
     return product
@@ -3118,7 +3126,9 @@ def product_with_multiple_values_attributes(product, product_type, category) -> 
     product_type.product_attributes.clear()
     product_type.product_attributes.add(attribute)
 
-    associate_attribute_values_to_instance(product, attribute, attr_val_1, attr_val_2)
+    associate_attribute_values_to_instance(
+        product, {attribute.pk: [attr_val_1, attr_val_2]}
+    )
     return product
 
 
@@ -3596,7 +3606,7 @@ def product_list(
     Stock.objects.bulk_create(stocks)
 
     for product in products:
-        associate_attribute_values_to_instance(product, product_attr, attr_value)
+        associate_attribute_values_to_instance(product, {product_attr.pk: [attr_value]})
         product.search_vector = FlatConcatSearchVector(
             *prepare_product_search_vector_value(product)
         )
@@ -3877,7 +3887,9 @@ def unavailable_product_with_variant(
     )
     Stock.objects.create(product_variant=variant, warehouse=warehouse, quantity=10)
 
-    associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
+    associate_attribute_values_to_instance(
+        variant, {variant_attr.pk: [variant_attr_value]}
+    )
     return product
 
 
@@ -6063,7 +6075,7 @@ def page(db, page_type):
     page_attr = page_type.page_attributes.first()
     page_attr_value = page_attr.values.first()
 
-    associate_attribute_values_to_instance(page, page_attr, page_attr_value)
+    associate_attribute_values_to_instance(page, {page_attr.pk: [page_attr_value]})
 
     return page
 
@@ -6083,7 +6095,7 @@ def second_page(page):
     page_attr = page.page_type.page_attributes.first()
     page_attr_value = page_attr.values.first()
 
-    associate_attribute_values_to_instance(page2, page_attr, page_attr_value)
+    associate_attribute_values_to_instance(page2, {page_attr.pk: [page_attr_value]})
 
     attribute = Attribute.objects.create(
         slug="test-attribute",
@@ -6102,7 +6114,7 @@ def second_page(page):
                 slug=f"test-slug-attribute-value-{i}",
             )
         )
-    associate_attribute_values_to_instance(page2, attribute, *attribute_values)
+    associate_attribute_values_to_instance(page2, {attribute.pk: attribute_values})
     return page, page2
 
 
@@ -6121,7 +6133,7 @@ def page_with_rich_text_attribute(db, page_type_with_rich_text_attribute):
     page_attr = page_type_with_rich_text_attribute.page_attributes.first()
     page_attr_value = page_attr.values.first()
 
-    associate_attribute_values_to_instance(page, page_attr, page_attr_value)
+    associate_attribute_values_to_instance(page, {page_attr.pk: [page_attr_value]})
 
     return page
 
@@ -6275,7 +6287,7 @@ def translated_page_unique_attribute_value(page, rich_text_attribute_page_type):
     page_type.page_attributes.add(rich_text_attribute_page_type)
     attribute_value = rich_text_attribute_page_type.values.first()
     associate_attribute_values_to_instance(
-        page, rich_text_attribute_page_type, attribute_value
+        page, {rich_text_attribute_page_type.id: [attribute_value]}
     )
     return AttributeValueTranslation.objects.create(
         language_code="fr",
@@ -6290,7 +6302,7 @@ def translated_product_unique_attribute_value(product, rich_text_attribute):
     product_type.product_attributes.add(rich_text_attribute)
     attribute_value = rich_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        product, rich_text_attribute, attribute_value
+        product, {rich_text_attribute.id: [attribute_value]}
     )
     return AttributeValueTranslation.objects.create(
         language_code="fr",
@@ -6305,7 +6317,7 @@ def translated_variant_unique_attribute_value(variant, rich_text_attribute):
     product_type.variant_attributes.add(rich_text_attribute)
     attribute_value = rich_text_attribute.values.first()
     associate_attribute_values_to_instance(
-        variant, rich_text_attribute, attribute_value
+        variant, {rich_text_attribute.id: [attribute_value]}
     )
     return AttributeValueTranslation.objects.create(
         language_code="fr",


### PR DESCRIPTION
I want to merge this change because it fixes the performance issue of `associate_attribute_values_to_instance`.
Benchmark for product with 3 attributes:
```
  test name             left count      right count     duplicate count
  -------------------   -----------     -----------     ---------------
- update product                 88             112                   6
```

For `productUpdate` with 103 attributes in input queries count dropped from ~960 -> ~340
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
