### PR TITLE
Optimize collection update and delete

### DIFF
--- a/saleor/graphql/product/mutations/collection/collection_create.py
+++ b/saleor/graphql/product/mutations/collection/collection_create.py
@@ -112,13 +112,23 @@ class CollectionCreate(ModelMutation):
         clean_seo_fields(cleaned_input)
         return cleaned_input
 
+    @staticmethod
+    def batch_product_ids(ids):
+        # Batch size of 25k ids, assuming their pks are at least 7 digits each
+        # after json serialization, weights 225kB of payload.
+        BATCH_SIZE = 25000
+        _length = len(ids)
+        for i in range(0, _length, BATCH_SIZE):
+            yield ids[i : min(i + BATCH_SIZE, _length)]
+
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.collection_created, instance)
 
         product_ids = list(instance.products.values_list("id", flat=True))
-        collection_run_product_updated_task.delay(product_ids)
+        for ids_batch in cls.batch_product_ids(product_ids):
+            collection_run_product_updated_task.delay(ids_batch)
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **kwargs):

--- a/saleor/graphql/product/mutations/collection/collection_create.py
+++ b/saleor/graphql/product/mutations/collection/collection_create.py
@@ -8,7 +8,7 @@ from .....core.utils.date_time import convert_to_utc_date_time
 from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.error_codes import CollectionErrorCode
-from .....product.tasks import collection_run_product_updated_task
+from .....product.tasks import collection_product_updated_task
 from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_38, DEPRECATED_IN_3X_INPUT, RICH_CONTENT
@@ -128,7 +128,7 @@ class CollectionCreate(ModelMutation):
 
         product_ids = list(instance.products.values_list("id", flat=True))
         for ids_batch in cls.batch_product_ids(product_ids):
-            collection_run_product_updated_task.delay(ids_batch)
+            collection_product_updated_task.delay(ids_batch)
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **kwargs):

--- a/saleor/graphql/product/mutations/collection/collection_delete.py
+++ b/saleor/graphql/product/mutations/collection/collection_delete.py
@@ -3,7 +3,7 @@ import graphene
 from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.tasks import (
-    collection_run_product_updated_task,
+    collection_product_updated_task,
     update_products_discounted_prices_for_promotion_task,
 )
 from ....channel import ChannelContext
@@ -47,7 +47,7 @@ class CollectionDelete(ModelDeleteMutation):
         cls.call_event(manager.collection_deleted, instance)
 
         for ids_batch in cls.batch_product_ids(product_ids):
-            collection_run_product_updated_task.delay(ids_batch)
+            collection_product_updated_task.delay(ids_batch)
         update_products_discounted_prices_for_promotion_task.delay(product_ids)
 
         return CollectionDelete(

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -15,6 +15,8 @@ from ..discount.models import Promotion
 from ..plugins.manager import get_plugins_manager
 from ..product.models import Category, CollectionProduct
 from ..warehouse.management import deactivate_preorder_for_variant
+from ..webhook.event_types import WebhookEventAsyncType
+from ..webhook.utils import get_webhooks_for_event
 from .models import Product, ProductType, ProductVariant
 from .search import PRODUCTS_BATCH_SIZE, update_products_search_vector
 from .utils.variant_prices import update_discounted_prices_for_promotion
@@ -194,5 +196,6 @@ def collection_run_product_updated_task(product_ids):
             single_object=False
         )
     )
+    webhooks = get_webhooks_for_event(WebhookEventAsyncType.PRODUCT_UPDATED)
     for product in products:
-        manager.product_updated(product)
+        manager.product_updated(product, webhooks=webhooks)

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -189,7 +189,7 @@ def update_products_search_vector_task():
 
 
 @app.task(queue=settings.COLLECTION_PRODUCT_UPDATED_QUEUE_NAME)
-def collection_run_product_updated_task(product_ids):
+def collection_product_updated_task(product_ids):
     manager = get_plugins_manager()
     products = list(
         Product.objects.filter(id__in=product_ids).prefetched_for_webhook(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -856,6 +856,11 @@ UPDATE_SEARCH_VECTOR_INDEX_QUEUE_NAME = os.environ.get(
 # Queue name for "async webhook" events
 WEBHOOK_CELERY_QUEUE_NAME = os.environ.get("WEBHOOK_CELERY_QUEUE_NAME", None)
 
+# Queue name for execution of collection product_updated events
+COLLECTION_PRODUCT_UPDATED_QUEUE_NAME = os.environ.get(
+    "COLLECTION_PRODUCT_UPDATED_QUEUE_NAME", None
+)
+
 # Lock time for request password reset mutation per user (seconds)
 RESET_PASSWORD_LOCK_TIME = parse(
     os.environ.get("RESET_PASSWORD_LOCK_TIME", "15 minutes")


### PR DESCRIPTION
I want to merge this change because it optimizes collection create and delete mutations.
There is a big prefetch going on in these, which doesn't necessary needs to extend the mutation time.

QA tips: create a webhook for product_updated event, create / delete a collection, webhooks should fire for all products inside.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
