### PR TITLE
Observability reporter - move JSON serialization step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing descriptions to order module - #14845 by @DevilsAutumn
 - Unify how undiscounted prices are handled in orders and checkouts - #14780 by @jakubkuc
 - Drop demo - #14835 by @fowczarek
+- Add JSON serialization immediately after creating observability events to eliminate extra cPickle serialization and deserialization steps - #14992 by @przlada
 
 # 3.18.0
 

--- a/saleor/plugins/webhook/tests/test_observability.py
+++ b/saleor/plugins/webhook/tests/test_observability.py
@@ -4,7 +4,6 @@ from celery.canvas import Signature
 
 from ....core import EventDeliveryStatus
 from ....webhook.event_types import WebhookEventAsyncType
-from ....webhook.observability import dump_payload
 from ....webhook.transport.asynchronous.transport import (
     observability_reporter_task,
     observability_send_events,
@@ -24,7 +23,7 @@ def test_observability_reporter_task(
     observability_webhook_data,
     settings,
 ):
-    events, batch_count = ["event", "event"], 5
+    events, batch_count = [b"event", b"event"], 5
     webhooks = [observability_webhook_data]
     mock_pop_events_with_remaining_size.return_value = events, batch_count
     mock_get_webhooks.return_value = webhooks
@@ -50,7 +49,7 @@ def test_observability_send_events(
     mock_send_observability_events,
     observability_webhook_data,
 ):
-    events, batch_count = ["event", "event"], 5
+    events, batch_count = [b"event", b"event"], 5
     webhooks = [observability_webhook_data]
     mock_pop_events_with_remaining_size.return_value = events, batch_count
     mock_get_webhooks.return_value = webhooks
@@ -66,7 +65,7 @@ def test_observability_send_events(
 def test_send_observability_events(
     mock_send_webhook_using_scheme_method, observability_webhook_data
 ):
-    events = [{"event": "data"}, {"event": "data"}]
+    events = [b'{"event": "data"}', b'{"event": "data"}']
 
     send_observability_events([observability_webhook_data], events)
 
@@ -75,17 +74,17 @@ def test_send_observability_events(
         observability_webhook_data.saleor_domain,
         observability_webhook_data.secret_key,
         WebhookEventAsyncType.OBSERVABILITY,
-        dump_payload(events),
+        events,
     )
 
 
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
 )
-def test_send_observability_events_when_reposnse_failed(
+def test_send_observability_events_when_response_failed(
     mock_send_webhook_using_scheme_method, observability_webhook_data
 ):
-    events = [{"event": "data"}, {"event": "data"}]
+    events = [b'{"event": "data"}', b'{"event": "data"}']
     response = Mock()
     response.status = EventDeliveryStatus.FAILED
     mock_send_webhook_using_scheme_method.return_value = response
@@ -104,7 +103,7 @@ def test_send_observability_events_to_google_pub_sub(
         "gcpubsub://cloud.google.com/projects/saleor/topics/test"
     )
     webhooks = [observability_webhook_data]
-    events = [{"event": "data"}, {"event": "data"}]
+    events = [b'{"event": "data"}', b'{"event": "data"}']
 
     send_observability_events(webhooks, events)
 
@@ -114,20 +113,20 @@ def test_send_observability_events_to_google_pub_sub(
         observability_webhook_data.saleor_domain,
         observability_webhook_data.secret_key,
         WebhookEventAsyncType.OBSERVABILITY,
-        dump_payload(events[-1]),
+        events[-1],
     )
 
 
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
 )
-def test_send_observability_events_to_google_pub_sub_when_reposnse_failed(
+def test_send_observability_events_to_google_pub_sub_when_response_failed(
     mock_send_webhook_using_scheme_method, observability_webhook_data
 ):
     observability_webhook_data.target_url = (
         "gcpubsub://cloud.google.com/projects/saleor/topics/test"
     )
-    events = [{"event": "data"}, {"event": "data"}]
+    events = [b'{"event": "data"}', b'{"event": "data"}']
     response = Mock()
     response.status = EventDeliveryStatus.FAILED
     mock_send_webhook_using_scheme_method.return_value = response

--- a/saleor/plugins/webhook/tests/test_observability.py
+++ b/saleor/plugins/webhook/tests/test_observability.py
@@ -4,6 +4,7 @@ from celery.canvas import Signature
 
 from ....core import EventDeliveryStatus
 from ....webhook.event_types import WebhookEventAsyncType
+from ....webhook.observability import concatenate_json_events
 from ....webhook.transport.asynchronous.transport import (
     observability_reporter_task,
     observability_send_events,
@@ -23,7 +24,7 @@ def test_observability_reporter_task(
     observability_webhook_data,
     settings,
 ):
-    events, batch_count = [b"event", b"event"], 5
+    events, batch_count = [b'{"event": "data"}', b'{"event": "data"}'], 5
     webhooks = [observability_webhook_data]
     mock_pop_events_with_remaining_size.return_value = events, batch_count
     mock_get_webhooks.return_value = webhooks
@@ -49,7 +50,7 @@ def test_observability_send_events(
     mock_send_observability_events,
     observability_webhook_data,
 ):
-    events, batch_count = [b"event", b"event"], 5
+    events, batch_count = [b'{"event": "data"}', b'{"event": "data"}'], 5
     webhooks = [observability_webhook_data]
     mock_pop_events_with_remaining_size.return_value = events, batch_count
     mock_get_webhooks.return_value = webhooks
@@ -74,7 +75,7 @@ def test_send_observability_events(
         observability_webhook_data.saleor_domain,
         observability_webhook_data.secret_key,
         WebhookEventAsyncType.OBSERVABILITY,
-        events,
+        concatenate_json_events(events),
     )
 
 

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -1,6 +1,6 @@
 from .buffers import get_buffer
 from .exceptions import ObservabilityError
-from .payloads import dump_payload
+from .payloads import concatenate_json_events, dump_payload
 from .tracing import opentracing_trace
 from .utils import (
     WebhookData,
@@ -28,4 +28,5 @@ __all__ = [
     "task_next_retry_date",
     "report_view",
     "opentracing_trace",
+    "concatenate_json_events",
 ]

--- a/saleor/webhook/observability/buffers.py
+++ b/saleor/webhook/observability/buffers.py
@@ -1,7 +1,6 @@
 import math
-import pickle
 import zlib
-from typing import Any, Optional
+from typing import Optional
 
 from asgiref.local import Local
 from django.conf import settings
@@ -16,7 +15,6 @@ _local = Local()
 
 class BaseBuffer:
     _compressor_preset = 6
-    _pickle_version = 5
 
     def __init__(
         self,
@@ -34,42 +32,40 @@ class BaseBuffer:
         self.connection_timeout = connection_timeout
         self.timeout = timeout
 
-    def decode(self, value: bytes) -> Any:
-        return pickle.loads(zlib.decompress(value))
+    def decode(self, value: bytes) -> bytes:
+        return zlib.decompress(value)
 
-    def encode(self, value: Any) -> bytes:
-        return zlib.compress(
-            pickle.dumps(value, self._pickle_version), self._compressor_preset
-        )
+    def encode(self, value: bytes) -> bytes:
+        return zlib.compress(value, self._compressor_preset)
 
-    def put_event(self, event: Any) -> int:
+    def put_event(self, event: bytes) -> int:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a put_event() method"
         )
 
-    def put_events(self, events: list[Any]) -> int:
+    def put_events(self, events: list[bytes]) -> int:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a put_events() method"
         )
 
     def put_multi_key_events(
-        self, events_dict: dict[KEY_TYPE, list[Any]]
+        self, events_dict: dict[KEY_TYPE, list[bytes]]
     ) -> dict[KEY_TYPE, int]:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a put_events_multi_buffer() method"
         )
 
-    def pop_event(self) -> Any:
+    def pop_event(self) -> Optional[bytes]:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a pop_events() method"
         )
 
-    def pop_events(self) -> list[Any]:
+    def pop_events(self) -> list[bytes]:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a pop_events() method"
         )
 
-    def pop_events_get_size(self) -> tuple[list[Any], int]:
+    def pop_events_get_size(self) -> tuple[list[bytes], int]:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a pop_events_get_size() method"
         )
@@ -121,7 +117,7 @@ class RedisBuffer(BaseBuffer):
         return self._client
 
     def _put_events(
-        self, key: KEY_TYPE, events: list[Any], client: Optional[Redis] = None
+        self, key: KEY_TYPE, events: list[bytes], client: Optional[Redis] = None
     ) -> int:
         start_index = -self.max_size
         events_data = [self.encode(event) for event in events[start_index:]]
@@ -132,17 +128,17 @@ class RedisBuffer(BaseBuffer):
         client.expire(key, self.timeout)
         return max(0, len(events) - self.max_size)
 
-    def put_events(self, events: list[Any]) -> int:
+    def put_events(self, events: list[bytes]) -> int:
         with self.client.pipeline(transaction=False) as pipe:
             dropped = self._put_events(self.key, events, client=pipe)
             result = pipe.execute()
         return dropped + max(0, result[0] - self.max_size)
 
-    def put_event(self, event: Any) -> int:
+    def put_event(self, event: bytes) -> int:
         return self.put_events([event])
 
     def put_multi_key_events(
-        self, events_dict: dict[KEY_TYPE, list[Any]]
+        self, events_dict: dict[KEY_TYPE, list[bytes]]
     ) -> dict[KEY_TYPE, int]:
         keys = list(events_dict.keys())
         trimmed: dict[KEY_TYPE, int] = {}
@@ -157,7 +153,7 @@ class RedisBuffer(BaseBuffer):
             trimmed[key] += max(0, buffer_len - self.max_size)
         return trimmed
 
-    def _pop_events(self, key: KEY_TYPE, batch_size: int) -> tuple[list[Any], int]:
+    def _pop_events(self, key: KEY_TYPE, batch_size: int) -> tuple[list[bytes], int]:
         events = []
         with self.client.pipeline(transaction=False) as pipe:
             pipe.llen(key)
@@ -171,15 +167,15 @@ class RedisBuffer(BaseBuffer):
             events.append(self.decode(elem))
         return events, size - len(events)
 
-    def pop_event(self) -> Any:
+    def pop_event(self) -> Optional[bytes]:
         events, _ = self._pop_events(self.key, batch_size=1)
         return events[0] if events else None
 
-    def pop_events(self) -> list[Any]:
+    def pop_events(self) -> list[bytes]:
         events, _ = self._pop_events(self.key, self.batch_size)
         return events
 
-    def pop_events_get_size(self) -> tuple[list[Any], int]:
+    def pop_events_get_size(self) -> tuple[list[bytes], int]:
         return self._pop_events(self.key, self.batch_size)
 
     def clear(self) -> int:

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -150,7 +150,7 @@ def generate_api_call_payload(
     response: HttpResponse,
     gql_operations: list["GraphQLOperationResponse"],
     bytes_limit: int,
-) -> ApiCallPayload:
+) -> str:
     payload = ApiCallPayload(
         event_type=ObservabilityEventTypes.API_CALL,
         request=ApiCallRequest(
@@ -182,7 +182,7 @@ def generate_api_call_payload(
     payload["gql_operations"] = serialize_gql_operation_results(
         gql_operations, remaining_bytes
     )
-    return payload
+    return dump_payload(payload)
 
 
 @traced_payload_generator

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -67,8 +67,10 @@ def pretty_json(obj: Any) -> str:
     return json.dumps(obj, indent=2, ensure_ascii=True)
 
 
-def dump_payload(payload: Any) -> str:
-    return json.dumps(to_camel_case(payload), ensure_ascii=True, cls=CustomJsonEncoder)
+def dump_payload(payload: Any) -> bytes:
+    return json.dumps(
+        to_camel_case(payload), ensure_ascii=True, cls=CustomJsonEncoder
+    ).encode("utf-8")
 
 
 TRUNC_PLACEHOLDER = JsonTruncText(truncated=False)
@@ -150,7 +152,7 @@ def generate_api_call_payload(
     response: HttpResponse,
     gql_operations: list["GraphQLOperationResponse"],
     bytes_limit: int,
-) -> str:
+) -> bytes:
     payload = ApiCallPayload(
         event_type=ObservabilityEventTypes.API_CALL,
         request=ApiCallRequest(
@@ -190,7 +192,7 @@ def generate_event_delivery_attempt_payload(
     attempt: "EventDeliveryAttempt",
     next_retry: Optional["datetime"],
     bytes_limit: int,
-) -> str:
+) -> bytes:
     if not attempt.delivery:
         raise ValueError(
             f"EventDeliveryAttempt {attempt.id} is not assigned to delivery. "

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -190,7 +190,7 @@ def generate_event_delivery_attempt_payload(
     attempt: "EventDeliveryAttempt",
     next_retry: Optional["datetime"],
     bytes_limit: int,
-) -> EventDeliveryAttemptPayload:
+) -> str:
     if not attempt.delivery:
         raise ValueError(
             f"EventDeliveryAttempt {attempt.id} is not assigned to delivery. "
@@ -266,4 +266,4 @@ def generate_event_delivery_attempt_payload(
     payload["event_delivery"]["payload"]["body"] = JsonTruncText.truncate(
         pretty_json(event_delivery_payload), remaining
     )
-    return payload
+    return dump_payload(payload)

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -73,6 +73,10 @@ def dump_payload(payload: Any) -> bytes:
     ).encode("utf-8")
 
 
+def concatenate_json_events(events: list[bytes]) -> bytes:
+    return b"[" + b", ".join(events) + b"]"
+
+
 TRUNC_PLACEHOLDER = JsonTruncText(truncated=False)
 EMPTY_TRUNC = JsonTruncText(truncated=True)
 GQL_OPERATION_PLACEHOLDER = GraphQLOperation(

--- a/saleor/webhook/observability/tests/conftest.py
+++ b/saleor/webhook/observability/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 from unittest.mock import patch
 
@@ -72,3 +73,8 @@ def patch_connection_pool(redis_server):
 def buffer(patch_connection_pool):
     buffer = RedisBuffer(BROKER_URL, KEY, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
     return buffer
+
+
+@pytest.fixture
+def event_data():
+    return json.dumps({"event": "data"}).encode("utf-8")

--- a/saleor/webhook/observability/tests/test_buffer.py
+++ b/saleor/webhook/observability/tests/test_buffer.py
@@ -44,46 +44,44 @@ def test_in_batches(buffer):
     assert buffer.in_batches(BATCH_SIZE + BATCH_SIZE // 2) == 2
 
 
-def test_put_event(buffer):
-    event = {"event": "data"}
-    dropped = buffer.put_event(event)
+def test_put_event(buffer, event_data):
+    dropped = buffer.put_event(event_data)
     assert buffer.size() == 1
     assert dropped == 0
 
 
-def test_buffer_put_events_max_size(buffer):
-    event = {"event": "data"}
+def test_buffer_put_events_max_size(buffer, event_data):
     for i in range(MAX_SIZE * 2):
-        buffer.put_event(event)
+        buffer.put_event(event_data)
     assert buffer.size() == MAX_SIZE
 
 
-def test_put_events(buffer):
-    events = [{"event": "data"}] * 2
+def test_put_events(buffer, event_data):
+    events = [event_data] * 2
     dropped = buffer.put_events(events)
     assert buffer.size() == 2
     assert dropped == 0
 
 
-def test_put_events_max_size(buffer):
-    events = [{"event": "data"}] * MAX_SIZE * 2
+def test_put_events_max_size(buffer, event_data):
+    events = [event_data] * MAX_SIZE * 2
     dropped = buffer.put_events(events)
     assert buffer.size() == MAX_SIZE
     assert dropped == MAX_SIZE
 
 
-def test_buffer_drops_events_when_put_events(buffer):
-    events = [{"event": "data"}] * MAX_SIZE
+def test_buffer_drops_events_when_put_events(buffer, event_data):
+    events = [event_data] * MAX_SIZE
     buffer.put_events(events)
     dropped = buffer.put_events(events)
     assert dropped == MAX_SIZE
     assert buffer.size() == MAX_SIZE
 
 
-def test_put_multi_key_events(patch_connection_pool):
-    key_a, events_a = "buffer_a", [{"event": "data"}] * 2
-    key_b, events_b = "buffer_b", [{"event": "data"}] * MAX_SIZE
-    key_c, events_c = "buffer_c", [{"event": "data"}] * MAX_SIZE * 2
+def test_put_multi_key_events(patch_connection_pool, event_data):
+    key_a, events_a = "buffer_a", [event_data] * 2
+    key_b, events_b = "buffer_b", [event_data] * MAX_SIZE
+    key_c, events_c = "buffer_c", [event_data] * MAX_SIZE * 2
     buffer_a, buffer_b, buffer_c = (
         get_buffer(key_a),
         get_buffer(key_b),
@@ -98,11 +96,11 @@ def test_put_multi_key_events(patch_connection_pool):
     assert dropped == {key_a: 0, key_b: 0, key_c: MAX_SIZE}
 
 
-def test_put_multi_key_events_when_buffer_full(patch_connection_pool):
-    max_events = [{"event": "data"}] * MAX_SIZE
-    key_a, events_a = "buffer_a", [{"event": "data"}] * 2
-    key_b, events_b = "buffer_b", [{"event": "data"}] * MAX_SIZE
-    key_c, events_c = "buffer_c", [{"event": "data"}] * MAX_SIZE * 2
+def test_put_multi_key_events_when_buffer_full(patch_connection_pool, event_data):
+    max_events = [event_data] * MAX_SIZE
+    key_a, events_a = "buffer_a", [event_data] * 2
+    key_b, events_b = "buffer_b", [event_data] * MAX_SIZE
+    key_c, events_c = "buffer_c", [event_data] * MAX_SIZE * 2
     buffer_a = get_buffer(key_a)
     buffer_a.put_multi_key_events(
         {key_a: max_events, key_b: max_events, key_c: max_events}
@@ -114,18 +112,17 @@ def test_put_multi_key_events_when_buffer_full(patch_connection_pool):
     assert dropped == {key_a: 2, key_b: MAX_SIZE, key_c: MAX_SIZE * 2}
 
 
-def test_pop_event(buffer):
-    event = "buffer", {"event": "data"}
-    buffer.put_event(event)
+def test_pop_event(buffer, event_data):
+    buffer.put_event(event_data)
     popped_event = buffer.pop_event()
-    assert id(event) != id(popped_event)
-    assert event == popped_event
+    assert id(event_data) != id(popped_event)
+    assert event_data == popped_event
     assert buffer.size() == 0
     assert buffer.pop_event() is None
 
 
-def test_pop_events(buffer):
-    events = [{"event": f"data{i}"} for i in range(MAX_SIZE)]
+def test_pop_events(buffer, event_data):
+    events = [f"event-data-{i}".encode() for i in range(MAX_SIZE)]
     buffer.put_events(events)
     popped_events = buffer.pop_events()
     assert len(popped_events) == BATCH_SIZE
@@ -134,7 +131,7 @@ def test_pop_events(buffer):
 
 
 def test_pop_events_get_size(buffer):
-    events = [{"event": f"data{i}"} for i in range(MAX_SIZE)]
+    events = [f"event-data-{i}".encode() for i in range(MAX_SIZE)]
     buffer.put_events(events)
     popped_events, size = buffer.pop_events_get_size()
     assert len(popped_events) == BATCH_SIZE
@@ -143,8 +140,8 @@ def test_pop_events_get_size(buffer):
     assert buffer.size() == size
 
 
-def test_clear(buffer):
-    events = [{"event": "data"}] * 2
+def test_clear(buffer, event_data):
+    events = [event_data] * 2
     buffer.put_events(events)
     assert buffer.size() == 2
     assert buffer.clear() == 2
@@ -154,7 +151,7 @@ def test_clear(buffer):
 def test_pop_expired_events(buffer):
     push_time = timezone.now()
     with freeze_time(push_time):
-        events = [{"event": f"data{i}"} for i in range(MAX_SIZE)]
+        events = [f"event-data-{i}".encode() for i in range(MAX_SIZE)]
         buffer.put_events(events)
     with freeze_time(push_time + timedelta(seconds=buffer.timeout + 1)):
         popped_events = buffer.pop_events()

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -29,6 +29,7 @@ from ..payload_schema import (
 from ..payloads import (
     GQL_OPERATION_PLACEHOLDER_SIZE,
     JsonTruncText,
+    concatenate_json_events,
     dump_payload,
     generate_api_call_payload,
     generate_event_delivery_attempt_payload,
@@ -76,6 +77,15 @@ from ..utils import GraphQLOperationResponse
 )
 def test_to_camel_case(snake_payload, expected_camel):
     assert to_camel_case(snake_payload) == expected_camel
+
+
+@pytest.mark.parametrize(
+    "events", [[], [b'{"event": "data"}'], [b'{"event": "data"}' for _ in range(10)]]
+)
+def test_concatenate_json_events_with_one_event(events):
+    payload = json.loads(concatenate_json_events(events))
+    assert isinstance(payload, list)
+    assert len(payload) == len(events)
 
 
 def test_serialize_gql_operation_result(gql_operation_factory):

--- a/saleor/webhook/observability/tests/test_utils.py
+++ b/saleor/webhook/observability/tests/test_utils.py
@@ -244,8 +244,8 @@ def test_report_event_delivery_attempt_not_active(
     mock_put_event.assert_not_called()
 
 
-def test_put_event(patch_get_buffer, buffer):
-    put_event(lambda: {"payload": "data"})
+def test_put_event(patch_get_buffer, buffer, event_data):
+    put_event(lambda: event_data)
     assert buffer.size() == 1
 
 
@@ -268,19 +268,19 @@ def test_put_event_catch_exceptions(patch_get_buffer, buffer, error):
 
 
 def test_pop_events_with_remaining_size(patch_get_buffer, buffer):
-    payload = "payload-{}"
-    buffer.put_events([payload.format(i) for i in range(BATCH_SIZE + BATCH_SIZE // 2)])
+    payloads_count = BATCH_SIZE + (BATCH_SIZE // 2)
+    payloads = [f"event-data-{i}".encode() for i in range(payloads_count)]
+    buffer.put_events(payloads)
 
-    events, batch_count = pop_events_with_remaining_size()
+    events, remaining_batch_count = pop_events_with_remaining_size()
 
-    assert events == [payload.format(i) for i in range(BATCH_SIZE)]
-    assert batch_count == 1
+    assert events == [f"event-data-{i}".encode() for i in range(BATCH_SIZE)]
+    assert remaining_batch_count == 1
 
 
 def test_pop_events_with_remaining_size_catch_exceptions(
     redis_server, buffer, patch_get_buffer
 ):
-    payload = "payload-{}"
-    buffer.put_events([payload.format(i) for i in range(BATCH_SIZE)])
+    buffer.put_events([f"event-data-{i}".encode() for i in range(BATCH_SIZE)])
     redis_server.connected = False
     assert pop_events_with_remaining_size() == ([], 0)

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -46,7 +46,7 @@ class WebhookData:
 
 
 def get_buffer_name() -> str:
-    return cache.make_key(BUFFER_KEY)
+    return cache.make_key(BUFFER_KEY, version=2)
 
 
 _webhooks_mem_cache: dict[str, tuple[list[WebhookData], float]] = {}
@@ -90,7 +90,7 @@ def task_next_retry_date(retry_error: "Retry") -> Optional[datetime]:
     return None
 
 
-def put_event(generate_payload: Callable[[], Any]):
+def put_event(generate_payload: Callable[[], bytes]):
     try:
         payload = generate_payload()
         with opentracing_trace("put_event", "buffer"):

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import partial
 from time import monotonic
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from asgiref.local import Local
 from django.conf import settings
@@ -102,7 +102,7 @@ def put_event(generate_payload: Callable[[], bytes]):
         logger.error("Observability event dropped.", exc_info=True)
 
 
-def pop_events_with_remaining_size() -> tuple[list[Any], int]:
+def pop_events_with_remaining_size() -> tuple[list[bytes], int]:
     with opentracing_trace("pop_events", "buffer"):
         try:
             buffer = get_buffer(get_buffer_name())

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -250,7 +250,7 @@ def send_observability_events(webhooks: list[WebhookData], events: list[bytes]):
                     webhook.saleor_domain,
                     webhook.secret_key,
                     event_type,
-                    events,
+                    observability.concatenate_json_events(events),
                 )
                 if response.status == EventDeliveryStatus.FAILED:
                     failed = len(events)

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from celery import group
@@ -222,7 +222,7 @@ def send_webhook_request_async(self, event_delivery_id):
     clear_successful_delivery(delivery)
 
 
-def send_observability_events(webhooks: list[WebhookData], events: list[Any]):
+def send_observability_events(webhooks: list[WebhookData], events: list[bytes]):
     event_type = WebhookEventAsyncType.OBSERVABILITY
     for webhook in webhooks:
         scheme = urlparse(webhook.target_url).scheme.lower()
@@ -240,7 +240,7 @@ def send_observability_events(webhooks: list[WebhookData], events: list[Any]):
                         webhook.saleor_domain,
                         webhook.secret_key,
                         event_type,
-                        observability.dump_payload(event),
+                        event,
                     )
                     if response.status == EventDeliveryStatus.FAILED:
                         failed += 1
@@ -250,7 +250,7 @@ def send_observability_events(webhooks: list[WebhookData], events: list[Any]):
                     webhook.saleor_domain,
                     webhook.secret_key,
                     event_type,
-                    observability.dump_payload(events),
+                    events,
                 )
                 if response.status == EventDeliveryStatus.FAILED:
                     failed = len(events)

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -267,7 +267,7 @@ def send_webhook_using_scheme_method(
     custom_headers=None,
 ) -> WebhookResponse:
     parts = urlparse(target_url)
-    message = data.encode("utf-8")
+    message = data if isinstance(data, bytes) else data.encode("utf-8")
     signature = signature_for_payload(message, secret)
     scheme_matrix: dict[WebhookSchemes, Callable] = {
         WebhookSchemes.HTTP: send_webhook_using_http,


### PR DESCRIPTION
I want to merge this change because it adds a JSON serialization step to observability events creation functions. It aims to achieve the following benefits:
- Eliminate an extra serialization/deserialization step when storing events in the buffer.
- Drop the usage of the cPickle library.

While Pickle offers faster serialization than JSON, the simple data structure and small size (max limit of 25 kB) of observability events result in negligible performance impact. Local tests indicate a maximal increase of approximately 0.14 milliseconds per event, with the potential for further reduction through the integration of faster JSON serialization libraries.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
