### PR TITLE
Remove optional field from validation

### DIFF
--- a/saleor/plugins/webhook/shipping.py
+++ b/saleor/plugins/webhook/shipping.py
@@ -80,7 +80,7 @@ def parse_list_shipping_methods_response(
 def validate_shipping_method_data(shipping_method_data):
     if type(shipping_method_data) is not dict:
         return False
-    keys = ["id", "name", "amount", "currency", "maximum_delivery_days"]
+    keys = ["id", "name", "amount", "currency"]
     return all(key in shipping_method_data for key in keys)
 
 


### PR DESCRIPTION
I want to merge this change because `maximum_delivery_days` should not be mandatory when validating shipping method data

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
