### PR TITLE
Allow switching channel with the same currency.

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -121,14 +121,14 @@ class PromotionRuleUpdate(ModelMutation):
         channel_currencies = set(
             instance.channels.values_list("currency_code", flat=True)
         )
-        if add_channels := cleaned_input.get("add_channels"):
-            channel_currencies.update(
-                [channel.currency_code for channel in add_channels]
-            )
         if remove_channels := cleaned_input.get("remove_channels"):
             channel_currencies = channel_currencies - {
                 channel.currency_code for channel in remove_channels
             }
+        if add_channels := cleaned_input.get("add_channels"):
+            channel_currencies.update(
+                [channel.currency_code for channel in add_channels]
+            )
 
         if "reward_value" in cleaned_input or "reward_value_type" in cleaned_input:
             reward_value = cleaned_input.get("reward_value") or instance.reward_value


### PR DESCRIPTION
I want to merge this change because it fixes a bug in `promotionRuleUpdate` mutation, when user want to change channels with the same currency.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
