### PR TITLE
Make allow_replica argument required in get_plugins_manager function

### DIFF
--- a/saleor/core/auth_backend.py
+++ b/saleor/core/auth_backend.py
@@ -109,7 +109,7 @@ class PluginBackend(JSONWebTokenBackend):
         # as many Promise are waiting.
 
         allow_replica = getattr(request, "allow_replica", True)
-        manager = get_plugins_manager(None, allow_replica)
+        manager = get_plugins_manager(allow_replica, None)
 
         # Store created manager in request to be used in other Dataloader.
         plugin_loader = AnonymousPluginManagerLoader(request)

--- a/saleor/graphql/plugins/dataloaders.py
+++ b/saleor/graphql/plugins/dataloaders.py
@@ -32,7 +32,7 @@ class PluginManagerByRequestorDataloader(DataLoader):
 
     def batch_load(self, keys):
         allow_replica = getattr(self.context, "allow_replica", True)
-        return [get_plugins_manager(lambda: key, allow_replica) for key in keys]
+        return [get_plugins_manager(allow_replica, lambda: user) for user in keys]
 
 
 class AnonymousPluginManagerLoader(DataLoader):
@@ -43,7 +43,7 @@ class AnonymousPluginManagerLoader(DataLoader):
         # in `saleor.core.auth_backend.PluginBackend.authenticate`
 
         allow_replica = getattr(self.context, "allow_replica", True)
-        return [get_plugins_manager(None, allow_replica) for key in keys]
+        return [get_plugins_manager(allow_replica, None) for key in keys]
 
 
 def plugin_manager_promise(context: SaleorContext, app) -> Promise[PluginsManager]:

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2119,10 +2119,8 @@ class PluginsManager(PaymentInterface):
 
 
 def get_plugins_manager(
+    allow_replica: bool,
     requestor_getter: Optional[Callable[[], "Requestor"]] = None,
-    allow_replica: Optional[bool] = None,
 ) -> PluginsManager:
-    if allow_replica is None:
-        raise ValueError("Please pass an allow_replica argument explicitly.")
     with opentracing.global_tracer().start_active_span("get_plugins_manager"):
         return PluginsManager(settings.PLUGINS, requestor_getter, allow_replica)

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1590,7 +1590,7 @@ def test_notify_user(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager(lambda: customer_user, True)
+    manager = get_plugins_manager(True, lambda: customer_user)
     timestamp = timezone.make_aware(
         datetime.strptime("2020-03-18 12:00", "%Y-%m-%d %H:%M"), timezone.utc
     ).isoformat()


### PR DESCRIPTION
I want to merge this change because it fixes the `get_plugins_manager`, `allow_replica` parameter and mypy.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
