### PR TITLE
Optimize products filtering

### DIFF
--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -721,7 +721,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(6):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
@@ -743,7 +743,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(6):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 2

--- a/saleor/graphql/product/tests/benchmark/test_variant.py
+++ b/saleor/graphql/product/tests/benchmark/test_variant.py
@@ -384,7 +384,7 @@ def test_products_variants_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(5):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
@@ -400,7 +400,7 @@ def test_products_variants_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(5):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 4

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -32,15 +32,18 @@ class ProductsQueryset(models.QuerySet):
         from .models import ProductChannelListing
 
         today = datetime.datetime.now(pytz.UTC)
-        channels = Channel.objects.filter(
-            slug=str(channel_slug), is_active=True
-        ).values("id")
-        channel_listings = ProductChannelListing.objects.filter(
-            Q(published_at__lte=today) | Q(published_at__isnull=True),
-            Exists(channels.filter(pk=OuterRef("channel_id"))),
-            is_published=True,
-        ).values("id")
-        return self.filter(Exists(channel_listings.filter(product_id=OuterRef("pk"))))
+        if channel := (
+            Channel.objects.filter(slug=str(channel_slug), is_active=True).first()
+        ):
+            channel_listings = ProductChannelListing.objects.filter(
+                Q(published_at__lte=today) | Q(published_at__isnull=True),
+                channel_id=channel.id,
+                is_published=True,
+            ).values("id")
+            return self.filter(
+                Exists(channel_listings.filter(product_id=OuterRef("pk")))
+            )
+        return self.none()
 
     def not_published(self, channel_slug: str):
         today = datetime.datetime.now(pytz.UTC)
@@ -53,31 +56,34 @@ class ProductsQueryset(models.QuerySet):
     def published_with_variants(self, channel_slug: str):
         from .models import ProductVariant, ProductVariantChannelListing
 
-        published = self.published(channel_slug)
-        channels = Channel.objects.filter(
-            slug=str(channel_slug), is_active=True
-        ).values("id")
-        variant_channel_listings = ProductVariantChannelListing.objects.filter(
-            Exists(channels.filter(pk=OuterRef("channel_id"))),
-            price_amount__isnull=False,
-        ).values("id")
-        variants = ProductVariant.objects.filter(
-            Exists(variant_channel_listings.filter(variant_id=OuterRef("pk")))
-        )
-        return published.filter(Exists(variants.filter(product_id=OuterRef("pk"))))
+        if channel := (
+            Channel.objects.filter(slug=str(channel_slug), is_active=True).first()
+        ):
+            variant_channel_listings = ProductVariantChannelListing.objects.filter(
+                channel_id=channel.id,
+                price_amount__isnull=False,
+            ).values("id")
+            variants = ProductVariant.objects.filter(
+                Exists(variant_channel_listings.filter(variant_id=OuterRef("pk")))
+            )
+            return self.published(channel_slug).filter(
+                Exists(variants.filter(product_id=OuterRef("pk")))
+            )
+        return self.none()
 
     def visible_to_user(self, requestor: Union["User", "App", None], channel_slug: str):
         from .models import ALL_PRODUCTS_PERMISSIONS, ProductChannelListing
 
         if has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
             if channel_slug:
-                channels = Channel.objects.filter(slug=str(channel_slug)).values("id")
-                channel_listings = ProductChannelListing.objects.filter(
-                    Exists(channels.filter(pk=OuterRef("channel_id")))
-                ).values("id")
-                return self.filter(
-                    Exists(channel_listings.filter(product_id=OuterRef("pk")))
-                )
+                if channel := Channel.objects.filter(slug=str(channel_slug)).first():
+                    channel_listings = ProductChannelListing.objects.filter(
+                        channel_id=channel.id
+                    ).values("id")
+                    return self.filter(
+                        Exists(channel_listings.filter(product_id=OuterRef("pk")))
+                    )
+                return self.none()
             return self.all()
         return self.published_with_variants(channel_slug)
 


### PR DESCRIPTION
I want to merge this change because it optimizes product filtering in various places.

1. It no longer makes an exist within exist just to join a channel while explicitly assuming there exists one.
2. Handles a case where there is no channel so further filtering by ProductChannelListing is redundant and can be skipped entirely.

The number of queries in benchmarks rises but it's expected, the extra query is worth it.
This is a port of https://github.com/saleor/saleor/pull/14945

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
