### PR TITLE
Add missing checkout resolver to transactionItem

### DIFF
--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -498,6 +498,10 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         "saleor.graphql.order.types.Order",
         description="The related order." + ADDED_IN_36,
     )
+    checkout = graphene.Field(
+        "saleor.graphql.checkout.types.Checkout",
+        description="The related checkout." + ADDED_IN_314,
+    )
     events = NonNullList(
         TransactionEvent, required=True, description="List of all transaction's events."
     )
@@ -569,6 +573,12 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         if not root.order_id:
             return
         return OrderByIdLoader(info.context).load(root.order_id)
+
+    @staticmethod
+    def resolve_checkout(root: models.TransactionItem, info):
+        if not root.checkout_id:
+            return
+        return CheckoutByTokenLoader(info.context).load(root.checkout_id)
 
     @staticmethod
     def resolve_events(root: models.TransactionItem, info):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10193,6 +10193,13 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   """
   order: Order
 
+  """
+  The related checkout.
+  
+  Added in Saleor 3.14.
+  """
+  checkout: Checkout
+
   """List of all transaction's events."""
   events: [TransactionEvent!]!
 

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -482,5 +482,16 @@ fragment TransactionFragment on TransactionItem {
       }
     }
   }
+  checkout {
+    id
+    channel {
+      slug
+    }
+    totalPrice {
+      gross {
+        amount
+      }
+    }
+  }
 }
 """

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
@@ -34,7 +35,7 @@ subscription {
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_transaction_void_request(order, webhook_app, permission_manage_payments):
+def test_order_transaction_void_request(order, webhook_app, permission_manage_payments):
     # given
     authorized_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)
@@ -99,6 +100,93 @@ def test_transaction_void_request(order, webhook_app, permission_manage_payments
                 "id": graphene.Node.to_global_id("Order", order.id),
                 "total": {
                     "gross": {"amount": quantize_price(order.total.gross.amount, "USD")}
+                },
+            },
+            "checkout": None,
+        },
+        "action": {"actionType": "VOID", "amount": None},
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_transaction_void_request(
+    checkout_with_items, webhook_app, permission_manage_payments
+):
+    # given
+    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.save()
+    authorized_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["void"],
+        currency="USD",
+        checkout_id=checkout_with_items.pk,
+        authorized_value=authorized_value,
+    )
+
+    request_event = transaction.events.create(
+        currency=transaction.currency,
+        type=TransactionEventType.CANCEL_REQUEST,
+    )
+
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_CANCELATION_REQUESTED_SUBSCRIPTION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_CANCELATION_REQUESTED
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.VOID,
+        event=request_event,
+        transaction_app_owner=None,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["VOID"],
+            "authorizedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(authorized_value, "USD"),
+            },
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "voidedAmount": {"currency": "USD", "amount": 0.0},
+            "chargedAmount": {"currency": "USD", "amount": 0.0},
+            "events": [
+                {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
+            ],
+            "status": "Captured",
+            "type": "Credit card",
+            "reference": "PSP ref",
+            "pspReference": "PSP ref",
+            "order": None,
+            "checkout": {
+                "channel": {
+                    "slug": checkout_with_items.channel.slug,
+                },
+                "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+                "totalPrice": {
+                    "gross": {
+                        "amount": quantize_price(
+                            checkout_with_items.total_gross_amount, "USD"
+                        )
+                    }
                 },
             },
         },

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
@@ -34,7 +35,9 @@ subscription {
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_transaction_charge_request(order, webhook_app, permission_manage_payments):
+def test_order_transaction_charge_request(
+    order, webhook_app, permission_manage_payments
+):
     # given
     authorized_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)
@@ -101,6 +104,98 @@ def test_transaction_charge_request(order, webhook_app, permission_manage_paymen
                 "id": graphene.Node.to_global_id("Order", order.id),
                 "total": {
                     "gross": {"amount": quantize_price(order.total.gross.amount, "USD")}
+                },
+            },
+            "checkout": None,
+        },
+        "action": {
+            "actionType": "CHARGE",
+            "amount": quantize_price(action_value, "USD"),
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_transaction_charge_request(
+    checkout_with_items, webhook_app, permission_manage_payments
+):
+    # given
+    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.save()
+    authorized_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["charge"],
+        currency="USD",
+        checkout_id=checkout_with_items.pk,
+        authorized_value=authorized_value,
+    )
+
+    action_value = Decimal("5.00")
+    request_event = transaction.events.create(
+        amount_value=action_value,
+        currency=transaction.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_CHARGE_REQUESTED_SUBSCRIPTION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_CHARGE_REQUESTED
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.CHARGE,
+        action_value=action_value,
+        event=request_event,
+        transaction_app_owner=None,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["CHARGE"],
+            "authorizedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(authorized_value, "USD"),
+            },
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "voidedAmount": {"currency": "USD", "amount": 0.0},
+            "chargedAmount": {"currency": "USD", "amount": 0.0},
+            "events": [
+                {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
+            ],
+            "status": "Authorized",
+            "type": "Credit card",
+            "reference": "PSP ref",
+            "pspReference": "PSP ref",
+            "order": None,
+            "checkout": {
+                "channel": {
+                    "slug": checkout_with_items.channel.slug,
+                },
+                "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+                "totalPrice": {
+                    "gross": {
+                        "amount": quantize_price(
+                            checkout_with_items.total_gross_amount, "USD"
+                        )
+                    }
                 },
             },
         },

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
@@ -34,7 +35,9 @@ subscription {
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_transaction_refund_request(order, webhook_app, permission_manage_payments):
+def test_order_transaction_refund_request(
+    order, webhook_app, permission_manage_payments
+):
     # given
     charged_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)
@@ -101,6 +104,98 @@ def test_transaction_refund_request(order, webhook_app, permission_manage_paymen
                 "id": graphene.Node.to_global_id("Order", order.id),
                 "total": {
                     "gross": {"amount": quantize_price(order.total.gross.amount, "USD")}
+                },
+            },
+            "checkout": None,
+        },
+        "action": {
+            "actionType": "REFUND",
+            "amount": quantize_price(action_value, "USD"),
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_transaction_refund_request(
+    checkout_with_items, webhook_app, permission_manage_payments
+):
+    # given
+    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.save()
+    charged_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        checkout_id=checkout_with_items.pk,
+        charged_value=charged_value,
+    )
+
+    action_value = Decimal("5.00")
+    request_event = transaction.events.create(
+        amount_value=action_value,
+        currency=transaction.currency,
+        type=TransactionEventType.REFUND_REQUEST,
+    )
+
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_REFUND_REQUESTED_SUBSCRIPTION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.REFUND,
+        action_value=action_value,
+        event=request_event,
+        transaction_app_owner=None,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["REFUND"],
+            "authorizedAmount": {"currency": "USD", "amount": 0.0},
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "voidedAmount": {"currency": "USD", "amount": 0.0},
+            "chargedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(charged_value, "USD"),
+            },
+            "events": [
+                {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
+            ],
+            "status": "Captured",
+            "type": "Credit card",
+            "reference": "PSP ref",
+            "pspReference": "PSP ref",
+            "order": None,
+            "checkout": {
+                "channel": {
+                    "slug": checkout_with_items.channel.slug,
+                },
+                "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+                "totalPrice": {
+                    "gross": {
+                        "amount": quantize_price(
+                            checkout_with_items.total_gross_amount, "USD"
+                        )
+                    }
                 },
             },
         },


### PR DESCRIPTION
I want to merge this change because it adds `checkout` resolver to `TransactionItem`. 
Some payment app could not be able to handle the release the funds for abandoned checkouts without access to `checkout`. 
This PR adds a missing field for `transaction` - `checkout`
The field is accessible from `transactionItem` object via query and subscription webhook.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
