### PR TITLE
Process `handle-promotion-toggle` task in batches.

### DIFF
--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from uuid import UUID
 
 task_logger = get_task_logger(__name__)
+# Batch of size 100 takes ~1 sec and consumes ~3mb at peak
+PROMOTION_TOGGLE_BATCH_SIZE = 100
 
 
 # DEPRECATED: To remove in 3.18
@@ -35,19 +37,24 @@ def handle_promotion_toggle():
     """
     manager = get_plugins_manager()
 
-    staring_promotions = get_starting_promotions()
-    ending_promotions = get_ending_promotions()
-
-    if not staring_promotions and not ending_promotions:
-        return
-
-    promotions = staring_promotions | ending_promotions
+    starting_promotions = get_starting_promotions(batch=True)
+    ending_promotions = get_ending_promotions(batch=True)
+    promotion_ids = [
+        promotion.id for promotion in starting_promotions | ending_promotions
+    ][:PROMOTION_TOGGLE_BATCH_SIZE]
+    starting_promotions = [
+        promotion for promotion in starting_promotions if promotion.id in promotion_ids
+    ]
+    ending_promotions = [
+        promotion for promotion in ending_promotions if promotion.id in promotion_ids
+    ]
+    promotions = Promotion.objects.filter(id__in=promotion_ids).all()
     promotion_id_to_variants, product_ids = fetch_promotion_variants_and_product_ids(
         promotions
     )
 
-    for staring_promo in staring_promotions:
-        manager.promotion_started(staring_promo)
+    for starting_promo in starting_promotions:
+        manager.promotion_started(starting_promo)
 
     for ending_promo in ending_promotions:
         manager.promotion_ended(ending_promo)
@@ -72,16 +79,16 @@ def handle_promotion_toggle():
         update_products_discounted_prices_for_promotion_task.delay(product_ids)
 
     starting_promotion_ids = ", ".join(
-        [str(staring_promo.id) for staring_promo in staring_promotions]
+        [str(staring_promo.id) for staring_promo in starting_promotions]
     )
     ending_promotions_ids = ", ".join(
         [str(ending_promo.id) for ending_promo in ending_promotions]
     )
+
     # DEPRECATED: will be removed in Saleor 4.0.
-    promotion_ids = ", ".join([str(promo.id) for promo in promotions])
+    promotion_ids_str = ", ".join([str(promo.id) for promo in promotions])
 
     promotions.update(last_notification_scheduled_at=datetime.now(pytz.UTC))
-
     if starting_promotion_ids:
         task_logger.info(
             "The promotion_started webhook sent for Promotions with ids: %s",
@@ -95,11 +102,11 @@ def handle_promotion_toggle():
 
     # DEPRECATED: will be removed in Saleor 4.0.
     task_logger.info(
-        "The sale_toggle webhook sent for sales with ids: %s", promotion_ids
+        "The sale_toggle webhook sent for sales with ids: %s", promotion_ids_str
     )
 
 
-def get_starting_promotions():
+def get_starting_promotions(batch=False):
     """Return promotions for which the notify about starting should be sent.
 
     The notification should be sent for promotions for which the start date has passed
@@ -116,10 +123,12 @@ def get_starting_promotions():
             & Q(start_date__lte=now)
         )
     )
+    if batch:
+        return promotions.all()[:PROMOTION_TOGGLE_BATCH_SIZE]
     return promotions
 
 
-def get_ending_promotions():
+def get_ending_promotions(batch=False):
     """Return promotions for which the notify about ending should be sent.
 
     The notification should be sent for promotions for which the end date has passed
@@ -136,6 +145,8 @@ def get_ending_promotions():
             & Q(end_date__lte=now)
         )
     )
+    if batch:
+        return promotions[:PROMOTION_TOGGLE_BATCH_SIZE]
     return promotions
 
 


### PR DESCRIPTION
Port of: https://github.com/saleor/saleor/pull/14982
I want to merge this change because it processes handle-promotion-toggle task in batches, what prevents Celery queue getting stuck in case of big number of starting/ending promotions.