### PR TITLE
Add missing checkout resolver to transactionItem

### DIFF
--- a/saleor/graphql/payment/tests/queries/test_transaction.py
+++ b/saleor/graphql/payment/tests/queries/test_transaction.py
@@ -76,6 +76,9 @@ TRANSACTION_QUERY = """
             order {
                 id
             }
+            checkout {
+                id
+            }
             createdBy{
                 ... on User {
                     id
@@ -520,6 +523,42 @@ def test_transaction_with_pending_amount(
     data = content["data"]["transaction"]
     pending_money = data[api_field]
     assert pending_money["amount"] == expected_value
+
+
+def test_transaction_with_checkout(
+    staff_api_client,
+    checkout_with_items,
+    transaction_item_generator,
+    permission_manage_payments,
+    permission_manage_staff,
+):
+    # given
+    charged_amount = Decimal("10.00")
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout_with_items.pk,
+        charged_value=charged_amount,
+    )
+
+    event = transaction_item.events.filter(
+        type=TransactionEventType.CHARGE_SUCCESS
+    ).get()
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token)
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        TRANSACTION_QUERY,
+        variables,
+        permissions=[permission_manage_payments, permission_manage_staff],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    _assert_transaction_fields(content, transaction_item, event)
+    data = content["data"]["transaction"]
+    assert data["checkout"]["id"] == to_global_id_or_none(checkout_with_items)
 
 
 def test_transaction_event_by_user(

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -479,6 +479,10 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         "saleor.graphql.order.types.Order",
         description="The related order." + ADDED_IN_36,
     )
+    checkout = graphene.Field(
+        "saleor.graphql.checkout.types.Checkout",
+        description="The related checkout." + ADDED_IN_314,
+    )
     events = NonNullList(
         TransactionEvent, required=True, description="List of all transaction's events."
     )
@@ -546,6 +550,12 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         if not root.order_id:
             return
         return OrderByIdLoader(info.context).load(root.order_id)
+
+    @staticmethod
+    def resolve_checkout(root: models.TransactionItem, info):
+        if not root.checkout_id:
+            return
+        return CheckoutByTokenLoader(info.context).load(root.checkout_id)
 
     @staticmethod
     def resolve_events(root: models.TransactionItem, info):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11220,6 +11220,13 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   """
   order: Order
 
+  """
+  The related checkout.
+  
+  Added in Saleor 3.14.
+  """
+  checkout: Checkout
+
   """List of all transaction's events."""
   events: [TransactionEvent!]!
 

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -522,5 +522,16 @@ fragment TransactionFragment on TransactionItem {
   order {
     id
   }
+  checkout {
+    id
+    channel {
+      slug
+    }
+    totalPrice {
+      gross {
+        amount
+      }
+    }
+  }
 }
 """

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
@@ -37,7 +38,9 @@ subscription {
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_transaction_cancel_request(order, webhook_app, permission_manage_payments):
+def test_order_transaction_cancel_request(
+    order, webhook_app, permission_manage_payments
+):
     # given
     authorized_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)
@@ -94,7 +97,92 @@ def test_transaction_cancel_request(order, webhook_app, permission_manage_paymen
                 {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
             ],
             "pspReference": "PSP ref",
-            "order": {"id": graphene.Node.to_global_id("Order", order.id)},
+            "order": {
+                "id": graphene.Node.to_global_id("Order", order.id),
+            },
+            "checkout": None,
+        },
+        "action": {"actionType": "CANCEL", "amount": None, "currency": order.currency},
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_transaction_cancel_request(
+    checkout_with_items, webhook_app, permission_manage_payments
+):
+    # given
+    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.save()
+    authorized_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["cancel"],
+        currency="USD",
+        checkout_id=checkout_with_items.pk,
+        authorized_value=authorized_value,
+    )
+
+    request_event = transaction.events.create(
+        currency=transaction.currency,
+        type=TransactionEventType.CANCEL_REQUEST,
+    )
+
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_CANCELATION_REQUESTED_SUBSCRIPTION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_CANCELATION_REQUESTED
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.CANCEL,
+        event=request_event,
+        transaction_app_owner=None,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["CANCEL"],
+            "authorizedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(authorized_value, "USD"),
+            },
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "canceledAmount": {"currency": "USD", "amount": 0.0},
+            "chargedAmount": {"currency": "USD", "amount": 0.0},
+            "events": [
+                {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
+            ],
+            "pspReference": "PSP ref",
+            "order": None,
+            "checkout": {
+                "channel": {
+                    "slug": checkout_with_items.channel.slug,
+                },
+                "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+                "totalPrice": {
+                    "gross": {
+                        "amount": quantize_price(
+                            checkout_with_items.total_gross_amount, "USD"
+                        )
+                    }
+                },
+            },
         },
         "action": {"actionType": "CANCEL", "amount": None, "currency": "USD"},
     }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
@@ -37,7 +38,9 @@ subscription {
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_transaction_charge_request(order, webhook_app, permission_manage_payments):
+def test_order_transaction_charge_request(
+    order, webhook_app, permission_manage_payments
+):
     # given
     authorized_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)
@@ -96,7 +99,98 @@ def test_transaction_charge_request(order, webhook_app, permission_manage_paymen
                 {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
             ],
             "pspReference": "PSP ref",
-            "order": {"id": graphene.Node.to_global_id("Order", order.id)},
+            "order": {
+                "id": graphene.Node.to_global_id("Order", order.id),
+            },
+            "checkout": None,
+        },
+        "action": {
+            "actionType": "CHARGE",
+            "amount": quantize_price(action_value, "USD"),
+            "currency": order.currency,
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_transaction_charge_request(
+    checkout_with_items, webhook_app, permission_manage_payments
+):
+    # given
+    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.save()
+    authorized_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["charge"],
+        currency="USD",
+        checkout_id=checkout_with_items.pk,
+        authorized_value=authorized_value,
+    )
+
+    action_value = Decimal("5.00")
+    request_event = transaction.events.create(
+        amount_value=action_value,
+        currency=transaction.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_CHARGE_REQUESTED_SUBSCRIPTION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_CHARGE_REQUESTED
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.CHARGE,
+        action_value=action_value,
+        event=request_event,
+        transaction_app_owner=None,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["CHARGE"],
+            "authorizedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(authorized_value, "USD"),
+            },
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "canceledAmount": {"currency": "USD", "amount": 0.0},
+            "chargedAmount": {"currency": "USD", "amount": 0.0},
+            "events": [
+                {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
+            ],
+            "pspReference": "PSP ref",
+            "order": None,
+            "checkout": {
+                "channel": {
+                    "slug": checkout_with_items.channel.slug,
+                },
+                "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+                "totalPrice": {
+                    "gross": {
+                        "amount": quantize_price(
+                            checkout_with_items.total_gross_amount, "USD"
+                        )
+                    }
+                },
+            },
         },
         "action": {
             "actionType": "CHARGE",

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
@@ -73,7 +74,9 @@ subscription {
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_transaction_refund_request(order, webhook_app, permission_manage_payments):
+def test_order_transaction_refund_request(
+    order, webhook_app, permission_manage_payments
+):
     # given
     charged_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)
@@ -132,7 +135,98 @@ def test_transaction_refund_request(order, webhook_app, permission_manage_paymen
                 {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
             ],
             "pspReference": "PSP ref",
-            "order": {"id": graphene.Node.to_global_id("Order", order.id)},
+            "order": {
+                "id": graphene.Node.to_global_id("Order", order.id),
+            },
+            "checkout": None,
+        },
+        "action": {
+            "actionType": "REFUND",
+            "amount": quantize_price(action_value, "USD"),
+            "currency": order.currency,
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_transaction_refund_request(
+    checkout_with_items, webhook_app, permission_manage_payments
+):
+    # given
+    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.save()
+    charged_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        checkout_id=checkout_with_items.pk,
+        charged_value=charged_value,
+    )
+
+    action_value = Decimal("5.00")
+    request_event = transaction.events.create(
+        amount_value=action_value,
+        currency=transaction.currency,
+        type=TransactionEventType.REFUND_REQUEST,
+    )
+
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_REFUND_REQUESTED_SUBSCRIPTION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.REFUND,
+        action_value=action_value,
+        event=request_event,
+        transaction_app_owner=None,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["REFUND"],
+            "authorizedAmount": {"currency": "USD", "amount": 0.0},
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "canceledAmount": {"currency": "USD", "amount": 0.0},
+            "chargedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(charged_value, "USD"),
+            },
+            "events": [
+                {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
+            ],
+            "pspReference": "PSP ref",
+            "order": None,
+            "checkout": {
+                "channel": {
+                    "slug": checkout_with_items.channel.slug,
+                },
+                "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+                "totalPrice": {
+                    "gross": {
+                        "amount": quantize_price(
+                            checkout_with_items.total_gross_amount, "USD"
+                        )
+                    }
+                },
+            },
         },
         "action": {
             "actionType": "REFUND",
@@ -219,6 +313,7 @@ def test_transaction_refund_request_with_granted_refund(
             ],
             "pspReference": "PSP ref",
             "order": {"id": graphene.Node.to_global_id("Order", order_with_lines.id)},
+            "checkout": None,
         },
         "grantedRefund": {
             "amount": {"amount": 12.3},


### PR DESCRIPTION
I want to merge this change because it adds checkout resolver to TransactionItem.
Some payment app could not be able to handle the release the funds for abandoned checkouts without access to checkout.
This PR adds a missing field for transaction - checkout
The field is accessible from transactionItem object via query and subscription webhook.

Port of changes from: #15027 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
