### PR TITLE
Fix test for clearing promotion rule variants

### DIFF
--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -195,8 +195,9 @@ def test_handle_promotion_toggle(
 def test_clear_promotion_rule_variants_task(promotion_list):
     # given
     expired_promotion = promotion_list[-1]
+    expired_promotion.start_date = timezone.now() - timedelta(days=5)
     expired_promotion.end_date = timezone.now() - timedelta(days=1)
-    expired_promotion.save(update_fields=["end_date"])
+    expired_promotion.save(update_fields=["start_date", "end_date"])
 
     PromotionRuleVariant = PromotionRule.variants.through
     expired_rules = PromotionRule.objects.filter(promotion_id=expired_promotion.id)
@@ -204,6 +205,7 @@ def test_clear_promotion_rule_variants_task(promotion_list):
     expired_rule_variants_count = PromotionRuleVariant.objects.filter(
         Exists(expired_rules.filter(pk=OuterRef("promotionrule_id")))
     ).count()
+    assert expired_rule_variants_count > 0
 
     # when
     clear_promotion_rule_variants_task()

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5523,6 +5523,7 @@ def promotion_with_single_rule(catalogue_predicate, channel_USD):
 
 @pytest.fixture
 def promotion_list(channel_USD, product, collection):
+    collection.products.add(product)
     promotions = Promotion.objects.bulk_create(
         [
             Promotion(


### PR DESCRIPTION
Fix `test_clear_promotion_rule_variants_task`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
