### PR TITLE
Fix `visible_to_user` makes unnecessary calls when the channel is not passed. 

### DIFF
--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -251,6 +251,8 @@ class ProductsQueryset(models.QuerySet["Product"]):
                     )
                 return self.none()
             return self.all()
+        if not channel_slug:
+            return self.none()
         return self.published_with_variants(channel_slug)
 
     def annotate_publication_info(self, channel_slug: str):
@@ -927,6 +929,8 @@ class CollectionsQueryset(models.QuerySet["Collection"]):
             if channel_slug:
                 return self.filter(channel_listings__channel__slug=str(channel_slug))
             return self.all()
+        if not channel_slug:
+            return self.none()
         return self.published(channel_slug)
 
 

--- a/saleor/product/tests/test_collections_availability.py
+++ b/saleor/product/tests/test_collections_availability.py
@@ -1,0 +1,75 @@
+from .. import models
+
+
+def test_visible_to_customer_user(customer_user, published_collections, channel_USD):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        customer_user, channel_USD.slug
+    )
+
+    # then
+    assert available_collections.count() == len(published_collections) - 1
+
+
+def test_visible_to_customer_user_without_channel_slug(
+    customer_user,
+    published_collections,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        customer_user, None
+    )
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_collections.count() == 0
+
+
+def test_visible_to_staff_user(
+    staff_user,
+    published_collections,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(staff_user, None)
+
+    # then
+    assert available_collections.count() == len(published_collections)
+
+
+def test_visible_to_staff_user_with_channel(
+    staff_user,
+    published_collections,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        staff_user, channel_USD.slug
+    )
+
+    # then
+    assert available_collections.count() == len(published_collections) - 1

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -44,6 +44,9 @@ AUTH_PASSWORD_VALIDATORS = []
 
 PASSWORD_HASHERS = ["saleor.tests.dummy_password_hasher.DummyHasher"]
 
+OBSERVABILITY_ACTIVE = False
+OBSERVABILITY_REPORT_ALL_API_CALLS = False
+
 PLUGINS = []
 
 PATTERNS_IGNORED_IN_QUERY_CAPTURES: List[Union[Pattern, SimpleLazyObject]] = [


### PR DESCRIPTION
I want to merge this change because of fix `visible_to_user` makes unnecessary calls when the channel is not passed. 

I have disabled observablity by default for testing.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
