### PR TITLE
Fix visible_to_user makes unnecessary calls when the channel is not passed.

### DIFF
--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -80,6 +80,8 @@ class ProductsQueryset(models.QuerySet):
                     Exists(channel_listings.filter(product_id=OuterRef("pk")))
                 )
             return self.all()
+        if not channel_slug:
+            return self.none()
         return self.published_with_variants(channel_slug)
 
     def annotate_publication_info(self, channel_slug: str):
@@ -326,6 +328,8 @@ class CollectionsQueryset(models.QuerySet):
             if channel_slug:
                 return self.filter(channel_listings__channel__slug=str(channel_slug))
             return self.all()
+        if not channel_slug:
+            return self.none()
         return self.published(channel_slug)
 
 

--- a/saleor/product/tests/test_collections_availability.py
+++ b/saleor/product/tests/test_collections_availability.py
@@ -1,0 +1,75 @@
+from .. import models
+
+
+def test_visible_to_customer_user(customer_user, published_collections, channel_USD):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        customer_user, channel_USD.slug
+    )
+
+    # then
+    assert available_collections.count() == len(published_collections) - 1
+
+
+def test_visible_to_customer_user_without_channel_slug(
+    customer_user,
+    published_collections,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        customer_user, None
+    )
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_collections.count() == 0
+
+
+def test_visible_to_staff_user(
+    staff_user,
+    published_collections,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(staff_user, None)
+
+    # then
+    assert available_collections.count() == len(published_collections)
+
+
+def test_visible_to_staff_user_with_channel(
+    staff_user,
+    published_collections,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        staff_user, channel_USD.slug
+    )
+
+    # then
+    assert available_collections.count() == len(published_collections) - 1

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -273,28 +273,75 @@ def test_available_products_with_variants_in_many_channels_pln(
 
 
 def test_visible_to_customer_user(customer_user, product_list, channel_USD):
+    # given
     product = product_list[0]
-    product.variants.all().delete()
+    product.channel_listings.all().delete()
 
+    # when
     available_products = models.Product.objects.visible_to_user(
         customer_user, channel_USD.slug
     )
-    assert available_products.count() == 2
+
+    # then
+    assert available_products.count() == len(product_list) - 1
+
+
+def test_visible_to_customer_user_without_channel_slug(
+    customer_user,
+    product_list,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    # when
+    available_products = models.Product.objects.visible_to_user(customer_user, None)
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_products.count() == 0
 
 
 def test_visible_to_staff_user(
-    staff_user, product_list, channel_USD, permission_manage_products
+    staff_user,
+    product_list,
+    permission_manage_products,
+    channel_USD,
 ):
+    # given
     product = product_list[0]
-    product.variants.all().delete()
+    product.channel_listings.all().delete()
 
     staff_user.user_permissions.add(permission_manage_products)
 
+    # when
+    available_products = models.Product.objects.visible_to_user(staff_user, None)
+
+    # then
+    assert available_products.count() == len(product_list)
+
+
+def test_visible_to_staff_user_with_channel(
+    staff_user,
+    product_list,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
     available_products = models.Product.objects.visible_to_user(
-        staff_user,
-        channel_USD.slug,
+        staff_user, channel_USD.slug
     )
-    assert available_products.count() == 3
+
+    # then
+    assert available_products.count() == len(product_list) - 1
 
 
 def test_filter_not_published_product_is_unpublished(product, channel_USD):

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -44,6 +44,9 @@ AUTH_PASSWORD_VALIDATORS = []
 
 PASSWORD_HASHERS = ["saleor.tests.dummy_password_hasher.DummyHasher"]
 
+OBSERVABILITY_ACTIVE = False
+OBSERVABILITY_REPORT_ALL_API_CALLS = False
+
 PLUGINS = []
 
 PATTERNS_IGNORED_IN_QUERY_CAPTURES: List[Union[Pattern, SimpleLazyObject]] = [


### PR DESCRIPTION
I want to merge this change because of fix visible_to_user makes unnecessary calls when the channel is not passed.

I have disabled observablity by default for testing.

Port https://github.com/saleor/saleor/pull/15053

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
