### PR TITLE
Fix visible_to_user makes unnecessary calls when the channel is not passed.

### DIFF
--- a/saleor/graphql/product/tests/benchmark/test_collection.py
+++ b/saleor/graphql/product/tests/benchmark/test_collection.py
@@ -1,7 +1,6 @@
 import graphene
 import pytest
 
-from .....product.models import Collection
 from ....tests.utils import get_graphql_content
 
 
@@ -386,26 +385,11 @@ def test_collection_bulk_delete(
 @pytest.mark.count_queries(autouse=False)
 def test_collections_for_federation_query_count(
     api_client,
+    published_collections,
+    channel_USD,
     django_assert_num_queries,
     count_queries,
 ):
-    collections = Collection.objects.bulk_create(
-        [
-            Collection(
-                name="collection 1",
-                slug="collection-1",
-            ),
-            Collection(
-                name="collection 2",
-                slug="collection-2",
-            ),
-            Collection(
-                name="collection 3",
-                slug="collection-3",
-            ),
-        ]
-    )
-
     query = """
         query GetCollectionInFederation($representations: [_Any]) {
             _entities(representations: $representations) {
@@ -422,27 +406,35 @@ def test_collections_for_federation_query_count(
         "representations": [
             {
                 "__typename": "Collection",
-                "id": graphene.Node.to_global_id("Collection", collections[0].pk),
+                "id": graphene.Node.to_global_id(
+                    "Collection", published_collections[0].pk
+                ),
+                "channel": channel_USD.slug,
             },
         ],
     }
 
-    with django_assert_num_queries(2):
+    with django_assert_num_queries(3):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
+        for collection_data in content["data"]["_entities"]:
+            assert collection_data is not None
 
     variables = {
         "representations": [
             {
                 "__typename": "Collection",
                 "id": graphene.Node.to_global_id("Collection", collection.pk),
+                "channel": channel_USD.slug,
             }
-            for collection in collections
+            for collection in published_collections
         ],
     }
 
-    with django_assert_num_queries(2):
+    with django_assert_num_queries(3):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 3
+        for collection_data in content["data"]["_entities"]:
+            assert collection_data is not None

--- a/saleor/product/tests/test_collections_availability.py
+++ b/saleor/product/tests/test_collections_availability.py
@@ -1,0 +1,75 @@
+from .. import models
+
+
+def test_visible_to_customer_user(customer_user, published_collections, channel_USD):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        customer_user, channel_USD.slug
+    )
+
+    # then
+    assert available_collections.count() == len(published_collections) - 1
+
+
+def test_visible_to_customer_user_without_channel_slug(
+    customer_user,
+    published_collections,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        customer_user, None
+    )
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_collections.count() == 0
+
+
+def test_visible_to_staff_user(
+    staff_user,
+    published_collections,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(staff_user, None)
+
+    # then
+    assert available_collections.count() == len(published_collections)
+
+
+def test_visible_to_staff_user_with_channel(
+    staff_user,
+    published_collections,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    collection = published_collections[0]
+    collection.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_collections = models.Collection.objects.visible_to_user(
+        staff_user, channel_USD.slug
+    )
+
+    # then
+    assert available_collections.count() == len(published_collections) - 1

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -273,28 +273,75 @@ def test_available_products_with_variants_in_many_channels_pln(
 
 
 def test_visible_to_customer_user(customer_user, product_list, channel_USD):
+    # given
     product = product_list[0]
-    product.variants.all().delete()
+    product.channel_listings.all().delete()
 
+    # when
     available_products = models.Product.objects.visible_to_user(
         customer_user, channel_USD.slug
     )
-    assert available_products.count() == 2
+
+    # then
+    assert available_products.count() == len(product_list) - 1
+
+
+def test_visible_to_customer_user_without_channel_slug(
+    customer_user,
+    product_list,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    # when
+    available_products = models.Product.objects.visible_to_user(customer_user, None)
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_products.count() == 0
 
 
 def test_visible_to_staff_user(
-    staff_user, product_list, channel_USD, permission_manage_products
+    staff_user,
+    product_list,
+    permission_manage_products,
+    channel_USD,
 ):
+    # given
     product = product_list[0]
-    product.variants.all().delete()
+    product.channel_listings.all().delete()
 
     staff_user.user_permissions.add(permission_manage_products)
 
+    # when
+    available_products = models.Product.objects.visible_to_user(staff_user, None)
+
+    # then
+    assert available_products.count() == len(product_list)
+
+
+def test_visible_to_staff_user_with_channel(
+    staff_user,
+    product_list,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
     available_products = models.Product.objects.visible_to_user(
-        staff_user,
-        channel_USD.slug,
+        staff_user, channel_USD.slug
     )
-    assert available_products.count() == 3
+
+    # then
+    assert available_products.count() == len(product_list) - 1
 
 
 def test_filter_not_published_product_is_unpublished(product, channel_USD):

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -45,6 +45,9 @@ AUTH_PASSWORD_VALIDATORS = []
 
 PASSWORD_HASHERS = ["saleor.tests.dummy_password_hasher.DummyHasher"]
 
+OBSERVABILITY_ACTIVE = False
+OBSERVABILITY_REPORT_ALL_API_CALLS = False
+
 PLUGINS = []
 
 PATTERNS_IGNORED_IN_QUERY_CAPTURES: list[Union[Pattern, SimpleLazyObject]] = [


### PR DESCRIPTION
I want to merge this change because of fix visible_to_user makes unnecessary calls when the channel is not passed.

I have disabled observablity by default for testing.

Port https://github.com/saleor/saleor/pull/15053

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
