### PR TITLE
add collections handling for product bulk create

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -19,6 +19,7 @@ from ....core.utils.validators import get_oembed_data
 from ....permission.enums import ProductPermissions
 from ....product import ProductMediaTypes, models
 from ....product.error_codes import ProductBulkCreateErrorCode
+from ....product.models import CollectionProduct
 from ....product.tasks import update_products_discounted_prices_task
 from ....thumbnail.utils import get_filename_from_url
 from ....warehouse.models import Warehouse
@@ -761,6 +762,27 @@ class ProductBulkCreate(BaseMutation):
         return variants, updated_channels
 
     @classmethod
+    def _save_m2m(cls, _info, instances_data):
+        product_collections_map = []
+        for instance_data in instances_data:
+            product = instance_data["instance"]
+            cleaned_input = instance_data["cleaned_input"]
+            if collections := cleaned_input.get("collections"):
+                for collection in collections:
+                    product_collections_map.append(
+                        {"product": product, "collection": collection}
+                    )
+
+        CollectionProduct.objects.bulk_create(
+            [
+                CollectionProduct(
+                    product=pair["product"], collection=pair["collection"]
+                )
+                for pair in product_collections_map
+            ]
+        )
+
+    @classmethod
     def prepare_products_channel_listings(
         cls, product, listings_input, listings_to_create, updated_channels
     ):
@@ -879,6 +901,9 @@ class ProductBulkCreate(BaseMutation):
 
         # save all objects
         variants, updated_channels = cls.save(info, instances_data_with_errors_list)
+
+        # save m2m fields
+        cls._save_m2m(info, instances_data_with_errors_list)
 
         # prepare and return data
         results = get_results(instances_data_with_errors_list)

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -763,24 +763,17 @@ class ProductBulkCreate(BaseMutation):
 
     @classmethod
     def _save_m2m(cls, _info, instances_data):
-        product_collections_map = []
+        product_collections = []
         for instance_data in instances_data:
             product = instance_data["instance"]
             cleaned_input = instance_data["cleaned_input"]
             if collections := cleaned_input.get("collections"):
                 for collection in collections:
-                    product_collections_map.append(
-                        {"product": product, "collection": collection}
+                    product_collections.append(
+                        CollectionProduct(product=product, collection=collection)
                     )
 
-        CollectionProduct.objects.bulk_create(
-            [
-                CollectionProduct(
-                    product=pair["product"], collection=pair["collection"]
-                )
-                for pair in product_collections_map
-            ]
-        )
+        CollectionProduct.objects.bulk_create(product_collections)
 
     @classmethod
     def prepare_products_channel_listings(


### PR DESCRIPTION
I want to merge this change because it fixes the lack of collection handling in `ProductBulkUpdate`
fixes: #14012

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
