### PR TITLE
Fix collections order in CheckoutLinesInfoByCheckoutTokenLoader

### DIFF
--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -135,7 +135,10 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, List[CheckoutLineIn
                                 ],
                                 product=products_map[line.variant_id],
                                 product_type=product_types_map[line.variant_id],
-                                collections=collections_map[line.variant_id],
+                                collections=sorted(
+                                    collections_map[line.variant_id],
+                                    key=lambda collection: collection.slug,
+                                ),
                                 discounts=checkout_lines_discounts[line.id],
                                 tax_class=tax_class_map[line.variant_id],
                                 channel=channels[checkout.channel_id],


### PR DESCRIPTION
I want to merge this change because it fixes collection order in `CheckoutLinesInfoByCheckoutTokenLoader` to match order returned by `fetch_checkout_lines` to avoid flaky tests like `test_checkout_available_payment_gateways_valid_info_sent`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
