### PR TITLE
add missing autodiscover for attributer migration tasks.

### DIFF
--- a/saleor/celeryconf.py
+++ b/saleor/celeryconf.py
@@ -42,6 +42,7 @@ app.autodiscover_tasks(
 )
 app.autodiscover_tasks(
     packages=[
+        "saleor.attribute.migrations.tasks",
         "saleor.discount.migrations.tasks",
     ],
     related_name="saleor3_16",


### PR DESCRIPTION
Fixing the following issue:

https://saleor.sentry.io/issues/4730704382/?project=6417854

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
