### PR TITLE
Handle invalid image MIME type during thumbnail generation

### DIFF
--- a/saleor/graphql/core/tests/test_file_validation.py
+++ b/saleor/graphql/core/tests/test_file_validation.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -137,10 +137,9 @@ def test_clean_image_file():
     image.save(img_data, format="JPEG")
     field = "image"
 
-    # when
     img = SimpleUploadedFile("product.jpg", img_data.getvalue(), "image/jpeg")
 
-    # then
+    # when & then
     clean_image_file({field: img}, field, ProductErrorCode)
 
 
@@ -267,4 +266,25 @@ def test_clean_image_file_exif_validation_raising_error(monkeypatch):
         clean_image_file({field: img}, field, ProductErrorCode)
 
     # then
+    assert error_msg in exc.value.args[0][field].message
+
+
+@patch("saleor.thumbnail.utils.magic.from_buffer")
+def test_clean_image_file_invalid_image_mime_type(from_buffer_mock):
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="WEBP")
+    field = "image"
+
+    invalid_mime_type = "application/x-empty"
+    from_buffer_mock.return_value = invalid_mime_type
+    img = SimpleUploadedFile("product.webp", img_data.getvalue(), "image/webp")
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: img}, field, ProductErrorCode)
+
+    # then
+    error_msg = f"Unsupported image MIME type: {invalid_mime_type}"
     assert error_msg in exc.value.args[0][field].message

--- a/saleor/graphql/core/validators/file.py
+++ b/saleor/graphql/core/validators/file.py
@@ -6,6 +6,7 @@ from PIL import Image, UnidentifiedImageError
 
 from ....core.http_client import HTTPClient
 from ....thumbnail import MIME_TYPE_TO_PIL_IDENTIFIER
+from ....thumbnail.utils import ProcessedImage
 from ..utils import add_hash_to_file_name
 
 Image.init()
@@ -76,6 +77,7 @@ def clean_image_file(cleaned_input, img_field_name, error_class):
     try:
         with Image.open(img_file) as image:
             _validate_image_exif(image, img_field_name, error_class)
+            img_file.seek(0)
     except (SyntaxError, TypeError, UnidentifiedImageError) as e:
         raise ValidationError(
             {
@@ -85,6 +87,14 @@ def clean_image_file(cleaned_input, img_field_name, error_class):
                     code=error_class.INVALID.value,
                 )
             }
+        )
+
+    try:
+        # validate if the image MIME type is supported
+        ProcessedImage.get_image_metadata_from_file(img_file)
+    except ValueError as e:
+        raise ValidationError(
+            {img_field_name: ValidationError(str(e), code=error_class.INVALID.value)}
         )
 
     add_hash_to_file_name(img_file)

--- a/saleor/thumbnail/utils.py
+++ b/saleor/thumbnail/utils.py
@@ -133,7 +133,8 @@ class ProcessedImage:
         image_format = self.get_image_metadata_from_file(image)
         return (Image.open(image), image_format)
 
-    def get_image_metadata_from_file(self, file_like):
+    @classmethod
+    def get_image_metadata_from_file(cls, file_like):
         """Return a image format and InMemoryUploadedFile-friendly save format.
 
         Receive a valid image file and returns a 2-tuple of two strings:
@@ -143,6 +144,8 @@ class ProcessedImage:
         """
         mime_type = magic.from_buffer(file_like.read(1024), mime=True)
         file_like.seek(0)
+        if mime_type not in MIME_TYPE_TO_PIL_IDENTIFIER:
+            raise ValueError(f"Unsupported image MIME type: {mime_type}")
         image_format = MIME_TYPE_TO_PIL_IDENTIFIER[mime_type]
         return image_format
 


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/15084

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
