### PR TITLE
Handle invalid image MIME type during thumbnail generation

### DIFF
--- a/saleor/thumbnail/utils.py
+++ b/saleor/thumbnail/utils.py
@@ -133,7 +133,8 @@ class ProcessedImage:
         image_format = self.get_image_metadata_from_file(image)
         return (Image.open(image), image_format)
 
-    def get_image_metadata_from_file(self, file_like):
+    @classmethod
+    def get_image_metadata_from_file(cls, file_like):
         """Return a image format and InMemoryUploadedFile-friendly save format.
 
         Receive a valid image file and returns a 2-tuple of two strings:
@@ -143,6 +144,8 @@ class ProcessedImage:
         """
         mime_type = magic.from_buffer(file_like.read(1024), mime=True)
         file_like.seek(0)
+        if mime_type not in MIME_TYPE_TO_PIL_IDENTIFIER:
+            raise ValueError(f"Unsupported image MIME type: {mime_type}")
         image_format = MIME_TYPE_TO_PIL_IDENTIFIER[mime_type]
         return image_format
 


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/15084

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
