### PR TITLE
Allow to fetch transactions via checkout or order type

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -12,11 +12,7 @@ from ...checkout.calculations import fetch_checkout_data
 from ...checkout.utils import get_valid_collection_points_for_checkout
 from ...core.taxes import zero_money, zero_taxed_money
 from ...core.utils.lazyobjects import unwrap_lazy
-from ...permission.enums import (
-    AccountPermissions,
-    CheckoutPermissions,
-    PaymentPermissions,
-)
+from ...permission.enums import AccountPermissions
 from ...shipping.interface import ShippingMethodData
 from ...tax.utils import get_display_gross_prices
 from ...warehouse import models as warehouse_models
@@ -44,7 +40,6 @@ from ..core.scalars import UUID
 from ..core.tracing import traced_resolver
 from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList, TaxedMoney
 from ..core.utils import str_to_enum
-from ..decorators import one_of_permissions_required
 from ..giftcard.dataloaders import GiftCardsByCheckoutIdLoader
 from ..giftcard.types import GiftCard
 from ..meta import resolvers as MetaResolvers
@@ -479,10 +474,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     transactions = NonNullList(
         TransactionItem,
         description=(
-            "List of transactions for the checkout. Requires one of the "
-            "following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS."
-            + ADDED_IN_34
-            + PREVIEW_FEATURE
+            "List of transactions for the checkout." + ADDED_IN_34 + PREVIEW_FEATURE
         ),
     )
     display_gross_prices = graphene.Boolean(
@@ -744,9 +736,6 @@ class Checkout(ModelObjectType[models.Checkout]):
         )
 
     @staticmethod
-    @one_of_permissions_required(
-        [CheckoutPermissions.MANAGE_CHECKOUTS, PaymentPermissions.HANDLE_PAYMENTS]
-    )
     def resolve_transactions(root: models.Checkout, info: ResolveInfo):
         return TransactionItemsByCheckoutIDLoader(info.context).load(root.pk)
 

--- a/saleor/graphql/meta/tests/test_meta_queries.py
+++ b/saleor/graphql/meta/tests/test_meta_queries.py
@@ -1153,6 +1153,9 @@ def test_query_public_meta_for_transaction_item_as_app_with_permission(
 def test_query_public_meta_for_transaction_item_as_app_without_permission(
     app_api_client, order
 ):
+    # given
+    order.payment_transactions.create(metadata={PUBLIC_KEY: PUBLIC_VALUE})
+
     # when
     response = execute_query_public_metadata_for_transaction_item(app_api_client, order)
 
@@ -2792,7 +2795,7 @@ def test_query_private_meta_for_transaction_item_as_customer(
     order.payment_transactions.create(private_metadata={PRIVATE_KEY: PRIVATE_VALUE})
 
     # when
-    response = execute_query_public_metadata_for_transaction_item(
+    response = execute_query_private_metadata_for_transaction_item(
         user_api_client,
         order,
         permissions=[],
@@ -2864,6 +2867,8 @@ def test_query_private_meta_for_transaction_item_as_app_with_permission(
 def test_query_private_meta_for_transaction_item_as_app_without_permission(
     app_api_client, order
 ):
+    order.payment_transactions.create(private_metadata={PRIVATE_KEY: PRIVATE_VALUE})
+
     # when
     response = execute_query_private_metadata_for_transaction_item(
         app_api_client, order

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -37,7 +37,6 @@ from ...permission.enums import (
     AccountPermissions,
     AppPermission,
     OrderPermissions,
-    PaymentPermissions,
     ProductPermissions,
 )
 from ...permission.utils import has_one_of_permissions
@@ -97,7 +96,6 @@ from ..core.types import (
     Weight,
 )
 from ..core.utils import str_to_enum
-from ..decorators import one_of_permissions_required
 from ..discount.dataloaders import OrderDiscountsByOrderIDLoader, VoucherByIdLoader
 from ..discount.enums import DiscountValueTypeEnum
 from ..discount.types import Voucher
@@ -1116,10 +1114,7 @@ class Order(ModelObjectType[models.Order]):
     )
     transactions = NonNullList(
         TransactionItem,
-        description=(
-            "List of transactions for the order. Requires one of the "
-            "following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS." + ADDED_IN_34
-        ),
+        description=("List of transactions for the order." + ADDED_IN_34),
         required=True,
     )
     payments = NonNullList(
@@ -1763,9 +1758,6 @@ class Order(ModelObjectType[models.Order]):
         return PaymentsByOrderIdLoader(info.context).load(root.id)
 
     @staticmethod
-    @one_of_permissions_required(
-        [OrderPermissions.MANAGE_ORDERS, PaymentPermissions.HANDLE_PAYMENTS]
-    )
     def resolve_transactions(root: models.Order, info):
         return TransactionItemsByOrderIDLoader(info.context).load(root.id)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9674,7 +9674,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   languageCode: LanguageCodeEnum!
 
   """
-  List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
+  List of transactions for the checkout.
   
   Added in Saleor 3.4.
   
@@ -10079,13 +10079,15 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   """
   privateMetafields(keys: [String!]): Metadata
 
-  """List of public metadata items. Can be accessed without permissions."""
+  """
+  List of public metadata items. Requires one of the following permissions: MANAGE_ORDERS, MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
+  """
   metadata: [MetadataItem!]!
 
   """
   A single key from public metadata.
   
-  Tip: Use GraphQL aliases to fetch multiple keys.
+  Tip: Use GraphQL aliases to fetch multiple keys. Requires one of the following permissions: MANAGE_ORDERS, MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   
   Added in Saleor 3.3.
   
@@ -10094,7 +10096,7 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   metafield(key: String!): String
 
   """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything. Requires one of the following permissions: MANAGE_ORDERS, MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   
   Added in Saleor 3.3.
   
@@ -10376,7 +10378,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   taxExemption: Boolean!
 
   """
-  List of transactions for the order. Requires one of the following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS.
+  List of transactions for the order.
   
   Added in Saleor 3.4.
   """


### PR DESCRIPTION
I want to merge this change because it removes permission check on the `checkout.transactions` and `order.transactions`.  The `transactions` data could be useful for frontend implementation to check the current status of the payments.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
