### PR TITLE
Update pspReference when recieving different event than success

### DIFF
--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -17,7 +17,10 @@ from django.utils import timezone
 from ..account.models import User
 from ..app.models import App
 from ..channel import TransactionFlowStrategy
-from ..checkout.actions import transaction_amounts_for_checkout_updated
+from ..checkout.actions import (
+    transaction_amounts_for_checkout_updated,
+    update_last_transaction_modified_at_for_checkout,
+)
 from ..checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ..checkout.models import Checkout
 from ..checkout.payment_utils import update_refundable_for_checkout
@@ -1228,13 +1231,13 @@ def create_transaction_event_for_transaction_session(
     if request_event_update_fields:
         request_event.save(update_fields=request_event_update_fields)
 
+    transaction_item = event.transaction
     if event.type in [
         TransactionEventType.AUTHORIZATION_REQUEST,
         TransactionEventType.AUTHORIZATION_SUCCESS,
         TransactionEventType.CHARGE_REQUEST,
         TransactionEventType.CHARGE_SUCCESS,
     ]:
-        transaction_item = event.transaction
         previous_authorized_value = transaction_item.authorized_value
         previous_charged_value = transaction_item.charged_value
         previous_refunded_value = transaction_item.refunded_value
@@ -1279,6 +1282,13 @@ def create_transaction_event_for_transaction_session(
             )
         elif transaction_item.checkout_id:
             transaction_amounts_for_checkout_updated(transaction_item, manager)
+    elif event.psp_reference and transaction_item.psp_reference != event.psp_reference:
+        transaction_item.psp_reference = event.psp_reference
+        transaction_item.save(update_fields=["psp_reference", "modified_at"])
+        if transaction_item.checkout_id:
+            checkout = cast(Checkout, transaction_item.checkout)
+            update_last_transaction_modified_at_for_checkout(checkout, transaction_item)
+
     return event
 
 


### PR DESCRIPTION
I want to merge this change because it updates the psp-reference based on the response from app, when psp-reference is related to non-success event

Port of changes from #15100

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
