### PR TITLE
Add replica usage to more DB queries

### DIFF
--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -226,7 +226,7 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
                 )
                 .values("warehouse_id")
             )
-            warehouses = Warehouse.objects.filter(
+            warehouses = Warehouse.objects.using(self.database_connection_name).filter(
                 Exists(warehouse_channels.filter(warehouse_id=OuterRef("id"))),
                 click_and_collect_option__in=[
                     WarehouseClickAndCollectOption.LOCAL_STOCK,

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1607,9 +1607,11 @@ class PluginsManager(PaymentInterface):
     def _get_all_plugin_configs(self):
         with opentracing.global_tracer().start_active_span("_get_all_plugin_configs"):
             if not hasattr(self, "_plugin_configs"):
-                plugin_configurations = PluginConfiguration.objects.prefetch_related(
-                    "channel"
-                ).all()
+                plugin_configurations = (
+                    PluginConfiguration.objects.using(self.database)
+                    .prefetch_related("channel")
+                    .all()
+                )
                 self._plugin_configs_per_channel: DefaultDict[
                     Channel, Dict
                 ] = defaultdict(dict)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -203,7 +203,9 @@ class ProductsQueryset(models.QuerySet["Product"]):
     def published(self, channel_slug: str):
         today = datetime.datetime.now(pytz.UTC)
         if channel := (
-            Channel.objects.filter(slug=str(channel_slug), is_active=True).first()
+            Channel.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+            .filter(slug=str(channel_slug), is_active=True)
+            .first()
         ):
             channel_listings = ProductChannelListing.objects.filter(
                 Q(published_at__lte=today) | Q(published_at__isnull=True),


### PR DESCRIPTION
Add more usages of replica DB in places that are often used in GraphQL queries.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
