### PR TITLE
Fix multiple db queries in dataloaders

### DIFF
--- a/saleor/graphql/plugins/dataloaders.py
+++ b/saleor/graphql/plugins/dataloaders.py
@@ -55,9 +55,8 @@ def plugin_manager_promise(context: SaleorContext, app) -> Promise[PluginsManage
 
 
 def get_plugin_manager_promise(context: SaleorContext) -> Promise[PluginsManager]:
-    return get_app_promise(context).then(
-        partial(plugin_manager_promise, context)  # type: ignore[arg-type] # mypy incorrectly assumes the return type to be a promise of a promise # noqa: E501
-    )
+    app = get_app_promise(context).get()
+    return plugin_manager_promise(context, app)
 
 
 def plugin_manager_promise_callback(func):

--- a/saleor/graphql/warehouse/tests/benchmark/test_stock_bulk_update.py
+++ b/saleor/graphql/warehouse/tests/benchmark/test_stock_bulk_update.py
@@ -15,6 +15,12 @@ STOCKS_BULK_UPDATE_MUTATION = """
                     code
                 }
                 stock{
+                    warehouse{
+                        id
+                    }
+                    productVariant{
+                        id
+                    }
                     id
                     quantity
                 }
@@ -71,7 +77,7 @@ def test_stocks_bulk_update_queries_count(
     ]
 
     # test number of queries when single object is updated
-    with django_assert_num_queries(10):
+    with django_assert_num_queries(12):
         staff_api_client.user.user_permissions.add(permission_manage_products)
         response = staff_api_client.post_graphql(
             STOCKS_BULK_UPDATE_MUTATION, {"stocks": stocks_input}
@@ -107,7 +113,7 @@ def test_stocks_bulk_update_queries_count(
     ]
 
     # Test number of queries when multiple objects are updated
-    with django_assert_num_queries(10):
+    with django_assert_num_queries(12):
         staff_api_client.user.user_permissions.add(permission_manage_products)
         response = staff_api_client.post_graphql(
             STOCKS_BULK_UPDATE_MUTATION, {"stocks": stocks_input}


### PR DESCRIPTION
Fix incorrect logic for fetching the app and manager, which caused dataloaders in mutations to be called multiple times.

Port of changes https://github.com/saleor/saleor/pull/15116

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
