### PR TITLE
Do not choose id for fake users at random

### DIFF
--- a/saleor/core/utils/anonymization.py
+++ b/saleor/core/utils/anonymization.py
@@ -37,7 +37,7 @@ def generate_fake_user() -> "User":
 
     The instance cannot be saved
     """
-    fake_user = create_fake_user(user_password=None, save=False)
+    fake_user = create_fake_user(user_password=None, save=False, generate_id=True)
     # Prevent accidental saving of the instance
     fake_user.save = _fake_save
     return fake_user

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import graphene
 from django.conf import settings
 from django.core.files import File
+from django.db import connection
 from django.db.models import F
 from django.utils import timezone
 from django.utils.text import slugify
@@ -504,7 +505,7 @@ def create_address(save=True, **kwargs):
     return address
 
 
-def create_fake_user(user_password, save=True):
+def create_fake_user(user_password, save=True, generate_id=False):
     address = create_address(save=save)
     email = get_email(address.first_name, address.last_name)
 
@@ -514,15 +515,25 @@ def create_fake_user(user_password, save=True):
     except User.DoesNotExist:
         pass
 
+    user_params = {
+        "first_name": address.first_name,
+        "last_name": address.last_name,
+        "email": email,
+        "default_billing_address": address,
+        "default_shipping_address": address,
+        "is_active": True,
+        "note": fake.paragraph(),
+        "date_joined": fake.date_time(tzinfo=timezone.get_current_timezone()),
+    }
+
+    if generate_id:
+        _, max_user_id = connection.ops.integer_field_range(
+            User.id.field.get_internal_type()
+        )
+        user_params["id"] = fake.random_int(min=1, max=max_user_id)
+
     user = User(
-        first_name=address.first_name,
-        last_name=address.last_name,
-        email=email,
-        default_billing_address=address,
-        default_shipping_address=address,
-        is_active=True,
-        note=fake.paragraph(),
-        date_joined=fake.date_time(tzinfo=timezone.get_current_timezone()),
+        **user_params,
     )
     user.search_document = _prepare_search_document_value(user, address)
 

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 import graphene
 from django.conf import settings
 from django.core.files import File
-from django.db import connection
 from django.db.models import F
 from django.utils import timezone
 from django.utils.text import slugify
@@ -515,11 +514,7 @@ def create_fake_user(user_password, save=True):
     except User.DoesNotExist:
         pass
 
-    _, max_user_id = connection.ops.integer_field_range(
-        User.id.field.get_internal_type()
-    )
     user = User(
-        id=fake.random_int(min=1, max=max_user_id),
         first_name=address.first_name,
         last_name=address.last_name,
         email=email,


### PR DESCRIPTION
I want to merge this change because populating database with sample data poses a risk of setting `userprofile_user_id_seq` to a very high number, effectively significantly limiting number of users that can be created before reaching the maximum value.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
