### PR TITLE
Fix return value type in `send_webhook_using_aws_sqs`

### DIFF
--- a/saleor/webhook/transport/tests/test_utils.py
+++ b/saleor/webhook/transport/tests/test_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from unittest.mock import MagicMock
 
 import boto3
@@ -163,4 +164,4 @@ def test_send_webhook_using_aws_sqs(
         expected_call_args.update({"MessageGroupId": domain})
     mocked_client.send_message.assert_called_once_with(**expected_call_args)
     assert webhook_response.status == EventDeliveryStatus.SUCCESS
-    assert webhook_response.content == str(sqs_response)
+    assert webhook_response.content == json.dumps(sqs_response)

--- a/saleor/webhook/transport/tests/test_utils.py
+++ b/saleor/webhook/transport/tests/test_utils.py
@@ -1,5 +1,7 @@
 import datetime
+from unittest.mock import MagicMock
 
+import boto3
 import pytest
 from celery import Task
 from celery.exceptions import Retry
@@ -7,7 +9,8 @@ from celery.utils.threads import LocalStack
 
 from ....core import EventDeliveryStatus
 from ....core.models import EventDeliveryAttempt
-from ..utils import WebhookResponse, handle_webhook_retry
+from ...event_types import WebhookEventAsyncType
+from ..utils import WebhookResponse, handle_webhook_retry, send_webhook_using_aws_sqs
 
 
 class DummyTask(Task):
@@ -74,3 +77,90 @@ def test_webhook_retry_redirect(webhook, event_delivery):
     # then
     retry = handle_webhook_retry(task, webhook, response, event_delivery, attempt)
     assert retry is False
+
+
+@pytest.mark.parametrize(
+    (
+        "target_url",
+        "expected_access_key_id",
+        "expected_secret_access_key",
+        "expected_region",
+        "is_fifo",
+        "expected_queue_url",
+    ),
+    [
+        (
+            "awssqs://key_id:secret%2B%2Faccess@sqs.eu-west-1.amazonaws.com/account_id/queue_name",
+            "key_id",
+            "secret+/access",
+            "eu-west-1",
+            False,
+            "https://sqs.eu-west-1.amazonaws.com/account_id/queue_name",
+        ),
+        (
+            "awssqs://key_id:secret@sqs.example.com/account_id/queue_name.fifo",
+            "key_id",
+            "secret",
+            "us-east-1",
+            True,
+            "https://sqs.example.com/account_id/queue_name.fifo",
+        ),
+    ],
+)
+def test_send_webhook_using_aws_sqs(
+    target_url,
+    expected_access_key_id,
+    expected_secret_access_key,
+    expected_region,
+    is_fifo,
+    expected_queue_url,
+    monkeypatch,
+):
+    # given
+    message, signature, domain = "payload", "signature", "example.com"
+    event_type = WebhookEventAsyncType.ORDER_CREATED
+    sqs_response = {
+        "MD5OfMessageBody": "message-body-hash",
+        "MD5OfMessageAttributes": "message-attributes-hash",
+        "MD5OfMessageSystemAttributes": "message-system-attributes-hash",
+        "MessageId": "message-id",
+        "SequenceNumber": "sequence-number",
+    }
+    mocked_client = MagicMock()
+    mocked_client.send_message.return_value = sqs_response
+    mocked_client_constructor = MagicMock(spec=boto3.client, return_value=mocked_client)
+    monkeypatch.setattr(
+        "saleor.webhook.transport.utils.boto3.client",
+        mocked_client_constructor,
+    )
+
+    # when
+    webhook_response = send_webhook_using_aws_sqs(
+        target_url, message.encode("utf-8"), domain, signature, event_type
+    )
+
+    # then
+    mocked_client_constructor.assert_called_once_with(
+        "sqs",
+        region_name=expected_region,
+        aws_access_key_id=expected_access_key_id,
+        aws_secret_access_key=expected_secret_access_key,
+    )
+    expected_call_args = {
+        "QueueUrl": expected_queue_url,
+        "MessageAttributes": {
+            "SaleorDomain": {"DataType": "String", "StringValue": domain},
+            "SaleorApiUrl": {
+                "DataType": "String",
+                "StringValue": f"http://{domain}/graphql/",
+            },
+            "EventType": {"DataType": "String", "StringValue": event_type},
+            "Signature": {"DataType": "String", "StringValue": signature},
+        },
+        "MessageBody": message,
+    }
+    if is_fifo:
+        expected_call_args.update({"MessageGroupId": domain})
+    mocked_client.send_message.assert_called_once_with(**expected_call_args)
+    assert webhook_response.status == EventDeliveryStatus.SUCCESS
+    assert webhook_response.content == str(sqs_response)

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -182,7 +182,7 @@ def send_webhook_using_http(
 
 def send_webhook_using_aws_sqs(
     target_url, message, domain, signature, event_type, **kwargs
-):
+) -> WebhookResponse:
     parts = urlparse(target_url)
     region = "us-east-1"
     hostname_parts = parts.hostname.split(".")
@@ -236,7 +236,7 @@ def send_webhook_using_aws_sqs(
             return WebhookResponse(
                 content=str(e), status=EventDeliveryStatus.FAILED, duration=duration()
             )
-        return WebhookResponse(content=response, duration=duration())
+        return WebhookResponse(content=str(response), duration=duration())
 
 
 def send_webhook_using_google_cloud_pubsub(

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -231,12 +231,12 @@ def send_webhook_using_aws_sqs(
         message_kwargs["MessageGroupId"] = domain
     with catch_duration_time() as duration:
         try:
-            response = client.send_message(**message_kwargs)
+            response = json.dumps(client.send_message(**message_kwargs))
         except (ClientError,) as e:
             return WebhookResponse(
                 content=str(e), status=EventDeliveryStatus.FAILED, duration=duration()
             )
-        return WebhookResponse(content=str(response), duration=duration())
+        return WebhookResponse(content=response, duration=duration())
 
 
 def send_webhook_using_google_cloud_pubsub(


### PR DESCRIPTION
I want to merge this change because it addresses the issue related to the return value type from the `send_webhook_using_aws_sqs` function. The problem is resolved by JSON encoding the SQS response.

As it is [described in the docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs/client/send_message.html#send-message), the Boto3 SQS client's `send_message` method returns a dictionary, which was incorrectly treated in `send_webhook_using_aws_sqs` function as a string. This resulted in a failure in the Observability reporter, which went previously undetected as Django's `TextField` automatically converted the dictionary to a string under the hood.

This change should not be a breaking-change, as we do not store successful `EventDeliverAttempt`s (so SQS responses weren't accessible through GraphQL API), and Observability events failed to be created due to the type mismatch.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
