### PR TITLE
Unify the timouts for webhooks (#15141)

### DIFF
--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -233,6 +233,7 @@ def test_trigger_webhooks_with_http(
     permission_manage_orders,
     permission_manage_users,
     permission_manage_products,
+    settings,
 ):
     mock_request.return_value = MagicMock(
         text="{response: body}",
@@ -274,14 +275,14 @@ def test_trigger_webhooks_with_http(
         webhook.target_url,
         data=bytes(expected_data, "utf-8"),
         headers=expected_headers,
-        timeout=10,
+        timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         allow_redirects=False,
     )
 
 
 @patch.object(HTTPSession, "request")
 def test_trigger_webhooks_with_http_and_secret_key(
-    mock_request, webhook, order_with_lines, permission_manage_orders
+    mock_request, webhook, order_with_lines, permission_manage_orders, settings
 ):
     mock_request.return_value = MagicMock(
         text="{response: body}",
@@ -323,14 +324,14 @@ def test_trigger_webhooks_with_http_and_secret_key(
         webhook.target_url,
         data=bytes(expected_data, "utf-8"),
         headers=expected_headers,
-        timeout=10,
+        timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         allow_redirects=False,
     )
 
 
 @patch.object(HTTPSession, "request")
 def test_trigger_webhooks_with_http_and_secret_key_as_empty_string(
-    mock_request, webhook, order_with_lines, permission_manage_orders
+    mock_request, webhook, order_with_lines, permission_manage_orders, settings
 ):
     mock_request.return_value = MagicMock(
         text="{response: body}",
@@ -376,7 +377,7 @@ def test_trigger_webhooks_with_http_and_secret_key_as_empty_string(
         webhook.target_url,
         data=bytes(expected_data, "utf-8"),
         headers=expected_headers,
-        timeout=10,
+        timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         allow_redirects=False,
     )
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -755,17 +755,6 @@ for entry_point in installed_plugins:
 
 PLUGINS = BUILTIN_PLUGINS + EXTERNAL_PLUGINS
 
-# Default timeout (sec) for establishing a connection when performing external requests.
-REQUESTS_CONN_EST_TIMEOUT = 2
-
-# Default timeout for external requests.
-COMMON_REQUESTS_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
-
-# Timeouts for webhook requests. Sync webhooks (eg. payment webhook) need more time
-# for getting response from the server.
-WEBHOOK_TIMEOUT = 10
-WEBHOOK_SYNC_TIMEOUT = COMMON_REQUESTS_TIMEOUT
-
 # When `True`, HTTP requests made from arbitrary URLs will be rejected (e.g., webhooks).
 # if they try to access private IP address ranges, and loopback ranges (unless
 # `HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS=False`).
@@ -890,3 +879,13 @@ CONFIRMATION_EMAIL_LOCK_TIME = parse(
 OAUTH_UPDATE_LAST_LOGIN_THRESHOLD = parse(
     os.environ.get("OAUTH_UPDATE_LAST_LOGIN_THRESHOLD", "15 minutes")
 )
+
+
+# Default timeout (sec) for establishing a connection when performing external requests.
+REQUESTS_CONN_EST_TIMEOUT = 2
+
+# Default timeout for external requests.
+COMMON_REQUESTS_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
+
+WEBHOOK_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
+WEBHOOK_SYNC_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)


### PR DESCRIPTION
Port https://github.com/saleor/saleor/pull/15141/.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
