### PR TITLE
[TEST] Tests for voucher usage in draft orders TC_0913 & TC_0922

### DIFF
--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
@@ -165,8 +165,7 @@ def test_checkout_voucher_is_still_active_when_checkout_fails_core_0918(
     assert order_data["errors"] != []
     assert order_data["errors"][0]["code"] == "INSUFFICIENT_STOCK"
 
-    # Step 7 - Check the voucher code is still active and is assigned to checkout
+    # Step 7 - Check the voucher code is still active
     voucher_data = get_voucher(e2e_staff_api_client, voucher_id)
     assert voucher_data["voucher"]["id"] == voucher_id
     assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 0
-    assert voucher_data["checkouts"]["edges"][0]["node"]["id"] == checkout_id

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
@@ -156,8 +156,7 @@ def test_checkout_voucher_is_still_active_when_payment_fails_core_0919(
         data["errors"][0]["message"] == "Token is required for mirumee.payments.dummy."
     )
 
-    # Step 5 - Check the voucher code is still active and is assigned to checkout
+    # Step 5 - Check the voucher code is still active
     voucher_data = get_voucher(e2e_staff_api_client, voucher_id)
     assert voucher_data["voucher"]["id"] == voucher_id
     assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 0
-    assert voucher_data["checkouts"]["edges"][0]["node"]["id"] == checkout_id

--- a/saleor/tests/e2e/orders/discounts/test_order_voucher_is_released_when_draft_order_is_deleted.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_voucher_is_released_when_draft_order_is_deleted.py
@@ -1,0 +1,119 @@
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_default_shop
+from ...utils import assign_permissions
+from ...vouchers.utils import (
+    create_voucher,
+    create_voucher_channel_listing,
+    get_voucher,
+)
+from ..utils import draft_order_create, draft_order_delete, order_query
+
+
+def prepare_voucher(
+    e2e_staff_api_client,
+    channel_id,
+    voucher_code,
+    voucher_discount_type,
+    voucher_discount_value,
+    voucher_type,
+):
+    input = {
+        "code": voucher_code,
+        "discountValueType": voucher_discount_type,
+        "type": voucher_type,
+        "usageLimit": None,
+        "singleUse": True,
+        "applyOncePerOrder": True,
+    }
+    voucher_data = create_voucher(e2e_staff_api_client, input)
+
+    voucher_id = voucher_data["id"]
+    channel_listing = [
+        {
+            "channelId": channel_id,
+            "discountValue": voucher_discount_value,
+        },
+    ]
+    create_voucher_channel_listing(
+        e2e_staff_api_client,
+        voucher_id,
+        channel_listing,
+    )
+
+    return voucher_code, voucher_id,
+
+@pytest.mark.e2e
+def test_order_voucher_is_released_when_draft_order_is_deleted_CORE_0922(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+    permission_manage_checkouts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+        permission_manage_checkouts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
+    )
+
+    voucher_code, voucher_id = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        voucher_code="voucher",
+        voucher_discount_type="PERCENTAGE",
+        voucher_discount_value=15,
+        voucher_type="ENTIRE_ORDER",
+    )
+
+    # Step 1 - Create draft order with the voucher
+    input = {
+        "channelId": channel_id,
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "shippingMethod": shipping_method_id,
+        "lines": [{"variantId": product_variant_id, "quantity": 2}],
+        "voucherCode": voucher_code,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert order_id is not None
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert data["order"]["lines"] is not None
+    assert data["order"]["voucher"]["id"] == voucher_id
+
+    # Step 2 - Delete order and verify the voucher can be used
+    order = draft_order_delete(
+        e2e_staff_api_client,
+        order_id,
+    )
+    assert order["order"]["status"] is not None
+    order = order_query(e2e_staff_api_client, order_id)
+    assert order is None
+    voucher_data = get_voucher(e2e_staff_api_client, voucher_id)
+    assert voucher_data["voucher"]["id"] == voucher_id
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 0
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["isActive"] is True
+

--- a/saleor/tests/e2e/orders/discounts/test_order_voucher_usage_includes_draft_orders.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_voucher_usage_includes_draft_orders.py
@@ -9,7 +9,11 @@ from ...vouchers.utils import (
     create_voucher_channel_listing,
     get_voucher,
 )
-from ..utils import draft_order_create, draft_order_delete, order_query
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+)
 
 
 def prepare_voucher(
@@ -24,7 +28,7 @@ def prepare_voucher(
         "code": voucher_code,
         "discountValueType": voucher_discount_type,
         "type": voucher_type,
-        "usageLimit": None,
+        "usageLimit": 1,
         "singleUse": True,
         "applyOncePerOrder": True,
     }
@@ -43,20 +47,16 @@ def prepare_voucher(
         channel_listing,
     )
 
-    return (
-        voucher_code,
-        voucher_id,
-    )
+    return voucher_code, voucher_id, voucher_discount_value
 
 
 @pytest.mark.e2e
-def test_order_voucher_is_released_when_draft_order_is_deleted_CORE_0922(
+def test_order_voucher_usage_includes_draft_orders_CORE_0913(
     e2e_staff_api_client,
     shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_checkouts,
 ):
     # Before
     permissions = [
@@ -64,7 +64,6 @@ def test_order_voucher_is_released_when_draft_order_is_deleted_CORE_0922(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_checkouts,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -88,47 +87,68 @@ def test_order_voucher_is_released_when_draft_order_is_deleted_CORE_0922(
     (
         product_id,
         product_variant_id,
-        _product_variant_price,
+        product_variant_price,
     ) = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
     )
 
-    voucher_code, voucher_id = prepare_voucher(
+    voucher_code, voucher_id, voucher_discount_value = prepare_voucher(
         e2e_staff_api_client,
         channel_id,
         voucher_code="voucher",
-        voucher_discount_type="PERCENTAGE",
-        voucher_discount_value=15,
+        voucher_discount_type="FIXED",
+        voucher_discount_value=10,
         voucher_type="ENTIRE_ORDER",
     )
 
     # Step 1 - Create draft order with the voucher
     input = {
         "channelId": channel_id,
-        "userEmail": "test_user@test.com",
         "billingAddress": DEFAULT_ADDRESS,
         "shippingAddress": DEFAULT_ADDRESS,
-        "shippingMethod": shipping_method_id,
+        "userEmail": "test_user@test.com",
         "lines": [{"variantId": product_variant_id, "quantity": 2}],
         "voucherCode": voucher_code,
     }
     data = draft_order_create(e2e_staff_api_client, input)
     order_id = data["order"]["id"]
     assert order_id is not None
+    subtotal_amount = float(product_variant_price)
+    total_without_shipping = data["order"]["lines"][0]["totalPrice"]["gross"]["amount"]
+    assert total_without_shipping == subtotal_amount * 2 - voucher_discount_value
     assert data["order"]["billingAddress"] is not None
     assert data["order"]["shippingAddress"] is not None
     assert data["order"]["lines"] is not None
-    assert data["order"]["voucher"]["id"] == voucher_id
 
-    # Step 2 - Delete order and verify the voucher can be used
-    order = draft_order_delete(
+    # Step 2 - Update the shipping method
+    input = {"shippingMethod": shipping_method_id}
+    draft_order = draft_order_update(
         e2e_staff_api_client,
         order_id,
+        input,
     )
-    assert order["order"]["status"] is not None
-    order = order_query(e2e_staff_api_client, order_id)
-    assert order is None
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    shipping_price = draft_order["order"]["shippingPrice"]["gross"]["amount"]
+    total = draft_order["order"]["total"]["gross"]["amount"]
+    discount_value = draft_order["order"]["voucher"]["discountValue"]
+    assert draft_order["order"]["voucher"]["id"] == voucher_id
+    assert discount_value == voucher_discount_value
+    assert total == shipping_price + total_without_shipping
+    assert order_shipping_id == shipping_method_id
+
+    # Step 3 - Complete the order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"
+    order_total = order["order"]["total"]["gross"]["amount"]
+    assert order["order"]["voucher"]["id"] == voucher_id
+    assert order_total == total
+
+    # Step 4 - Verify the voucher's usage and status
     voucher_data = get_voucher(e2e_staff_api_client, voucher_id)
     assert voucher_data["voucher"]["id"] == voucher_id
-    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 0
-    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["isActive"] is True
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 1
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["isActive"] is False

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -47,6 +47,10 @@ mutation DraftOrderComplete($id: ID!) {
       }
       displayGrossPrices
       status
+      voucher {
+        id
+        code
+      }
       paymentStatus
       isPaid
       channel {

--- a/saleor/tests/e2e/orders/utils/draft_order_create.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_create.py
@@ -16,6 +16,10 @@ mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
           amount
         }
       }
+      voucher {
+        code
+        id
+      }
       billingAddress {
         streetAddress1
       }

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -51,6 +51,11 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
           amount
         }
       }
+      voucher {
+        id
+        code
+        discountValue
+      }
       billingAddress {
         firstName
         lastName

--- a/saleor/tests/e2e/vouchers/utils/query_voucher.py
+++ b/saleor/tests/e2e/vouchers/utils/query_voucher.py
@@ -24,19 +24,6 @@ query voucherQuery ($id:ID!){
       }
     }
   }
-  checkouts(first: 10) {
-    edges {
-      node {
-        id
-        lines {
-          quantity
-          variant {
-            id
-          }
-        }
-      }
-    }
-  }
 }
 """
 


### PR DESCRIPTION
I want to merge this change because it covers:
- [TC 0913](https://saleor.testmo.net/repositories/5?group_id=131&case_id=2915) Should include voucher usage from draft order
- [TC 0922](https://saleor.testmo.net/repositories/5?group_id=131&case_id=4735) Voucher should be released when the draft order is deleted


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
