### PR TITLE
Fix return value type in `send_webhook_using_aws_sqs`

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -468,7 +468,7 @@ def send_webhook_using_http(
 
 def send_webhook_using_aws_sqs(
     target_url, message, domain, signature, event_type, **kwargs
-):
+) -> WebhookResponse:
     parts = urlparse(target_url)
     region = "us-east-1"
     hostname_parts = parts.hostname.split(".")
@@ -517,7 +517,7 @@ def send_webhook_using_aws_sqs(
         message_kwargs["MessageGroupId"] = domain
     with catch_duration_time() as duration:
         try:
-            response = client.send_message(**message_kwargs)
+            response = json.dumps(client.send_message(**message_kwargs))
         except (ClientError,) as e:
             return WebhookResponse(
                 content=str(e), status=EventDeliveryStatus.FAILED, duration=duration()

--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -8,9 +9,120 @@ from django.core.serializers import serialize
 from google.cloud.pubsub_v1 import PublisherClient
 from requests_hardened import HTTPSession
 
+from ....core import EventDeliveryStatus
 from ....webhook.event_types import WebhookEventAsyncType
 from ...webhook import signature_for_payload
-from ...webhook.tasks import trigger_webhooks_async
+from ...webhook.tasks import send_webhook_using_aws_sqs, trigger_webhooks_async
+
+
+@pytest.fixture
+def mocked_boto3_client_constructor():
+    with patch("saleor.plugins.webhook.tasks.boto3.client") as mocked_constructor:
+        yield mocked_constructor
+
+
+@pytest.fixture
+def sqs_response():
+    return {
+        "MD5OfMessageBody": "message-body-hash",
+        "MD5OfMessageAttributes": "message-attributes-hash",
+        "MD5OfMessageSystemAttributes": "message-system-attributes-hash",
+        "MessageId": "message-id",
+        "SequenceNumber": "sequence-number",
+    }
+
+
+@pytest.fixture
+def mocked_boto3_client(mocked_boto3_client_constructor, sqs_response):
+    mocked_client = MagicMock()
+    mocked_client.send_message.return_value = sqs_response
+    mocked_boto3_client_constructor.return_value = mocked_client
+    return mocked_client
+
+
+@pytest.mark.parametrize(
+    (
+        "target_url",
+        "expected_access_key_id",
+        "expected_secret_access_key",
+        "expected_region",
+        "expected_queue_url",
+    ),
+    [
+        (
+            "awssqs://key_id:secret%2B%2Faccess@sqs.eu-west-1.amazonaws.com/account_id/queue_name",
+            "key_id",
+            "secret+/access",
+            "eu-west-1",
+            "https://sqs.eu-west-1.amazonaws.com/account_id/queue_name",
+        ),
+        (
+            "awssqs://key_id:secret@sqs.example.com/account_id/queue_name",
+            "key_id",
+            "secret",
+            "us-east-1",
+            "https://sqs.example.com/account_id/queue_name",
+        ),
+    ],
+)
+def test_send_webhook_using_aws_sqs(
+    mocked_boto3_client_constructor,
+    mocked_boto3_client,
+    sqs_response,
+    target_url,
+    expected_access_key_id,
+    expected_secret_access_key,
+    expected_region,
+    expected_queue_url,
+):
+    # given
+    message, signature, domain = "payload", "signature", "example.com"
+    event_type = WebhookEventAsyncType.ORDER_CREATED
+
+    # when
+    webhook_response = send_webhook_using_aws_sqs(
+        target_url, message.encode("utf-8"), domain, signature, event_type
+    )
+
+    # then
+    mocked_boto3_client_constructor.assert_called_once_with(
+        "sqs",
+        region_name=expected_region,
+        aws_access_key_id=expected_access_key_id,
+        aws_secret_access_key=expected_secret_access_key,
+    )
+    expected_call_args = {
+        "QueueUrl": expected_queue_url,
+        "MessageAttributes": {
+            "SaleorDomain": {"DataType": "String", "StringValue": domain},
+            "SaleorApiUrl": {
+                "DataType": "String",
+                "StringValue": f"http://{domain}/graphql/",
+            },
+            "EventType": {"DataType": "String", "StringValue": event_type},
+            "Signature": {"DataType": "String", "StringValue": signature},
+        },
+        "MessageBody": message,
+    }
+    mocked_boto3_client.send_message.assert_called_once_with(**expected_call_args)
+    assert webhook_response.status == EventDeliveryStatus.SUCCESS
+    assert webhook_response.content == json.dumps(sqs_response)
+
+
+def test_send_webhook_using_aws_sqs_with_fifo_queue(mocked_boto3_client):
+    # given
+    domain = "example.com"
+    event_type = WebhookEventAsyncType.ORDER_CREATED
+    target_url = (
+        "awssqs://key_id:secret@sqs.us-east-1.amazonaws.com/account_id/queue_name.fifo"
+    )
+
+    # when
+    send_webhook_using_aws_sqs(target_url, b"payload", domain, "signature", event_type)
+
+    # then
+    _, send_message_kwargs = mocked_boto3_client.send_message.call_args
+    assert send_message_kwargs["MessageGroupId"] == domain
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Port of #15150

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
