### PR TITLE
Adjust batch size of removed apps in task

### DIFF
--- a/saleor/app/tasks.py
+++ b/saleor/app/tasks.py
@@ -82,7 +82,7 @@ def remove_apps_task():
         # Saleor use batch size here to prevent timeous on database.
         # Batch size determine how many deliveries will be removed,
         # each delivery contains attempts and payloads.
-        batch_size = 10000
+        batch_size = 1000
         last_id = 0
         while True:
             deliveries_ids = list(


### PR DESCRIPTION
I want to merge this change because I am adjusting the batch size of removed apps in the task.

This change was introduced in the [patch for 3.17.](https://github.com/saleor/saleor-multitenant/pull/1057/files)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
