### PR TITLE
Recalculate variant prices only when PromotionRule has reward_value set

### DIFF
--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -176,12 +176,15 @@ def update_products_discounted_prices_for_promotion_task(
     rules = (
         PromotionRule.objects.order_by("id")
         .using(settings.DATABASE_CONNECTION_REPLICA_NAME)
-        .filter(Exists(promotions.filter(id=OuterRef("promotion_id"))), **kwargs)[
+        .filter(Exists(promotions.filter(id=OuterRef("promotion_id"))), **kwargs)
+        .exclude(Q(reward_value__isnull=True) | Q(reward_value=0))[
             :PROMOTION_RULE_BATCH_SIZE
         ]
     )
     if ids := list(rules.values_list("pk", flat=True)):
-        qs = PromotionRule.objects.filter(pk__in=ids)
+        qs = PromotionRule.objects.filter(pk__in=ids).exclude(
+            Q(reward_value__isnull=True) | Q(reward_value=0)
+        )
         fetch_variants_for_promotion_rules(rules=qs)
         update_products_discounted_prices_for_promotion_task.delay(
             product_ids, ids[-1], rule_ids=rule_ids

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -128,6 +128,42 @@ def test_update_products_discounted_prices_for_promotion_task_with_rules_id(
     ) == {rule_id}
 
 
+@patch("saleor.product.tasks.PROMOTION_RULE_BATCH_SIZE", 1)
+@patch("saleor.product.tasks.update_discounted_prices_task.delay")
+@patch("saleor.product.utils.variants.fetch_variants_for_promotion_rules")
+def test_update_products_discounted_prices_for_promotion_task_with_empty_reward_value(
+    fetch_variants_for_promotion_rules_mock,
+    update_discounted_prices_task_mock,
+    promotion_list,
+    collection,
+    product_list,
+):
+    # given
+    Promotion.objects.update(start_date=timezone.now() - timedelta(days=1))
+    PromotionRuleVariant = PromotionRule.variants.through
+    PromotionRuleVariant.objects.all().delete()
+
+    collection.products.add(*product_list[1:])
+
+    rule = PromotionRule.objects.first()
+    rule.reward_value = 0
+    rule.save(update_fields=["reward_value"])
+    rule_id = PromotionRule.objects.first().id
+    product_ids = [product.id for product in product_list]
+
+    # when
+    update_products_discounted_prices_for_promotion_task(
+        product_ids, rule_ids=[rule_id]
+    )
+
+    # then
+    update_discounted_prices_task_mock.assert_called_once_with(product_ids)
+    assert (
+        set(PromotionRuleVariant.objects.values_list("promotionrule_id", flat=True))
+        == set()
+    )
+
+
 @patch("saleor.product.tasks.DISCOUNTED_PRODUCT_BATCH", 1)
 def test_update_discounted_prices_task(
     product_list,

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import graphene
+import pytest
 from django.utils import timezone
 
 from ...discount import RewardValueType
@@ -128,12 +129,14 @@ def test_update_products_discounted_prices_for_promotion_task_with_rules_id(
     ) == {rule_id}
 
 
+@pytest.mark.parametrize("reward_value", [None, 0])
 @patch("saleor.product.tasks.PROMOTION_RULE_BATCH_SIZE", 1)
 @patch("saleor.product.tasks.update_discounted_prices_task.delay")
 @patch("saleor.product.utils.variants.fetch_variants_for_promotion_rules")
 def test_update_products_discounted_prices_for_promotion_task_with_empty_reward_value(
     fetch_variants_for_promotion_rules_mock,
     update_discounted_prices_task_mock,
+    reward_value,
     promotion_list,
     collection,
     product_list,
@@ -146,7 +149,7 @@ def test_update_products_discounted_prices_for_promotion_task_with_empty_reward_
     collection.products.add(*product_list[1:])
 
     rule = PromotionRule.objects.first()
-    rule.reward_value = 0
+    rule.reward_value = reward_value
     rule.save(update_fields=["reward_value"])
     rule_id = PromotionRule.objects.first().id
     product_ids = [product.id for product in product_list]


### PR DESCRIPTION
I want to merge this change because it improves `update_products_discounted_prices_for_promotion_task` to not recalculate variant prices when `PromotionRule.reward_value` is set to `0` or `null`.

Resolves #15144
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
