### PR TITLE
Adjust checkout discounted object where filter

### DIFF
--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1387,7 +1387,7 @@ def test_recalculate_checkout_discount_with_checkout_discount_voucher_not_applic
     rule = promotion_without_rules.rules.create(
         name="Fixed promotion rule",
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 20,
                 }

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1409,11 +1409,11 @@ def test_recalculate_checkout_discount_with_checkout_discount_voucher_not_applic
 
 
 def test_recalculate_checkout_discount_with_checkout_discount_voucher_added(
-    checkout_with_item_with_checkout_and_order_discount,
+    checkout_with_item_and_order_discount,
     voucher_percentage,
 ):
     # given
-    checkout = checkout_with_item_with_checkout_and_order_discount
+    checkout = checkout_with_item_and_order_discount
     checkout_discount = checkout.discounts.first()
     channel = checkout.channel
     discount_value = voucher_percentage.channel_listings.get(
@@ -1799,10 +1799,10 @@ def test_add_voucher_to_checkout_fail(
 
 
 def test_add_voucher_to_checkout_clears_checkout_and_order_promotion_discount(
-    checkout_with_item_with_checkout_and_order_discount, voucher
+    checkout_with_item_and_order_discount, voucher
 ):
     # given
-    checkout = checkout_with_item_with_checkout_and_order_discount
+    checkout = checkout_with_item_and_order_discount
     checkout_discount = checkout.discounts.first()
     assert checkout.voucher_code is None
     manager = get_plugins_manager(allow_replica=False)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -750,7 +750,7 @@ def add_voucher_to_checkout(
     # with vouchers
     CheckoutDiscount.objects.filter(
         checkout=checkout_info.checkout,
-        type=DiscountType.CHECKOUT_AND_ORDER_PROMOTION,
+        type=DiscountType.ORDER_PROMOTION,
     ).delete()
 
 

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -1324,7 +1324,7 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
                 name="Order promotion rule 2",
                 promotion=promotion,
                 order_predicate={
-                    "total_price": {
+                    "subtotal_price": {
                         "range": {
                             "gte": 20,
                         }

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -1235,7 +1235,7 @@ def test_create_or_update_discount_objects_from_promotion(
                 name="Order promotion rule 1",
                 promotion=promotion,
                 order_predicate={
-                    "total_price": {
+                    "base_total_price": {
                         "range": {
                             "gte": 10,
                         }
@@ -1249,7 +1249,7 @@ def test_create_or_update_discount_objects_from_promotion(
                 name="Order promotion rule 2",
                 promotion=promotion,
                 order_predicate={
-                    "total_price": {
+                    "base_total_price": {
                         "range": {
                             "gte": 20,
                         }
@@ -1310,7 +1310,7 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
                 name="Order promotion rule 1",
                 promotion=promotion,
                 order_predicate={
-                    "total_price": {
+                    "base_total_price": {
                         "range": {
                             "gte": 10,
                         }
@@ -1324,7 +1324,7 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
                 name="Order promotion rule 2",
                 promotion=promotion,
                 order_predicate={
-                    "subtotal_price": {
+                    "base_subtotal_price": {
                         "range": {
                             "gte": 20,
                         }
@@ -1338,7 +1338,7 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
                 name="Order promotion rule 1",
                 promotion=promotion,
                 order_predicate={
-                    "total_price": {
+                    "base_total_price": {
                         "range": {
                             "gte": 100,
                         }
@@ -1406,7 +1406,7 @@ def test_create_or_update_discount_objects_from_promotion_total_price_discount(
                 name="Order promotion rule 2",
                 promotion=promotion,
                 order_predicate={
-                    "total_price": {
+                    "base_total_price": {
                         "range": {
                             "gte": 20,
                         }
@@ -1466,7 +1466,7 @@ def test_create_or_update_discount_from_promotion_voucher_code_set_checkout_disc
         name="Order promotion rule 1",
         promotion=promotion,
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 10,
                 }
@@ -1522,7 +1522,7 @@ def test_create_or_update_discount_from_promotion_checkout_discount_updated(
         name="Order promotion rule 1",
         promotion=promotion,
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 10,
                 }
@@ -1585,7 +1585,7 @@ def test_create_or_update_discount_from_promotion_rule_not_applies_anymore(
         name="Order promotion rule 1",
         promotion=promotion,
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 200,
                 }

--- a/saleor/graphql/checkout/filters.py
+++ b/saleor/graphql/checkout/filters.py
@@ -16,12 +16,10 @@ from ..core.filters import (
     MetadataFilter,
     MetadataFilterBase,
     ObjectTypeFilter,
-    OperationObjectTypeWhereFilter,
-    WhereFilterSet,
 )
 from ..core.types import DateRangeInput, FilterInputObjectType
-from ..core.types.filter_input import DecimalFilterInput
 from ..core.utils import from_global_id_or_error
+from ..discount.filters import DiscountedObjectWhere
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_range_field, filter_where_by_numeric_field
 from .enums import CheckoutAuthorizeStatusEnum, CheckoutChargeStatusEnum
@@ -155,29 +153,16 @@ class CheckoutFilterInput(FilterInputObjectType):
         filterset_class = CheckoutFilter
 
 
-class CheckoutDiscountedObjectWhere(WhereFilterSet):
-    subtotal_price = OperationObjectTypeWhereFilter(
-        input_class=DecimalFilterInput,
-        method="filter_subtotal_price",
-        field_name="filter_subtotal_price",
-        help_text="Filter by the checkout base subtotal price.",
-    )
-    total_price = OperationObjectTypeWhereFilter(
-        input_class=DecimalFilterInput,
-        method="filter_total_price",
-        field_name="filter_total_price",
-        help_text="Filter by the checkout base total price.",
-    )
-
+class CheckoutDiscountedObjectWhere(DiscountedObjectWhere):
     class Meta:
         model = Checkout
-        fields = ["subtotal_price", "total_price"]
+        fields = ["base_subtotal_price", "base_total_price"]
 
-    def filter_subtotal_price(self, queryset, name, value):
+    def filter_base_subtotal_price(self, queryset, name, value):
         currency = get_currency_from_filter_data(self.data)
         return _filter_price(queryset, name, "base_subtotal_amount", value, currency)
 
-    def filter_total_price(self, queryset, name, value):
+    def filter_base_total_price(self, queryset, name, value):
         currency = get_currency_from_filter_data(self.data)
         return _filter_price(queryset, name, "base_total_amount", value, currency)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -796,10 +796,10 @@ def test_checkout_add_category_code_checkout_on_promotion(
 
 
 def test_checkout_add_voucher_code_checkout_on_checkout_promotion_discount(
-    api_client, checkout_with_item_with_checkout_and_order_discount, voucher
+    api_client, checkout_with_item_and_order_discount, voucher
 ):
     # given
-    checkout = checkout_with_item_with_checkout_and_order_discount
+    checkout = checkout_with_item_and_order_discount
     checkout_discount = checkout.discounts.first()
     variables = {
         "id": to_global_id_or_none(checkout),

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -287,7 +287,7 @@ def test_add_to_existing_line_catalogue_and_order_discount_applies(
     # create order promotion discount
     rule = promotion_without_rules.rules.create(
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 20,
                 }
@@ -394,7 +394,7 @@ def test_add_to_existing_line_on_promotion_with_voucher_checkout_promotion_not_a
     # create order promotion discount
     rule = promotion_without_rules.rules.create(
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 20,
                 }

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -303,16 +303,14 @@ def test_checkout_remove_voucher_code_invalidates_price(
 
 
 def test_checkout_remove_voucher_code_checkout_promotion_discount_applied(
-    api_client, checkout_with_voucher, checkout_and_order_promotion_rule
+    api_client, checkout_with_voucher, order_promotion_rule
 ):
     # given
     checkout = checkout_with_voucher
     reward_value = Decimal("5")
-    checkout_and_order_promotion_rule.reward_value = reward_value
-    checkout_and_order_promotion_rule.reward_value_type = RewardValueType.FIXED
-    checkout_and_order_promotion_rule.save(
-        update_fields=["reward_value", "reward_value_type"]
-    )
+    order_promotion_rule.reward_value = reward_value
+    order_promotion_rule.reward_value_type = RewardValueType.FIXED
+    order_promotion_rule.save(update_fields=["reward_value", "reward_value_type"])
 
     assert checkout.voucher_code is not None
     previous_checkout_last_change = checkout.last_change

--- a/saleor/graphql/checkout/tests/test_checkout_filters.py
+++ b/saleor/graphql/checkout/tests/test_checkout_filters.py
@@ -4,14 +4,18 @@ from decimal import Decimal
 
 import graphene
 import pytest
+from django.core.exceptions import ValidationError
 from freezegun import freeze_time
+from prices import Money
 
 from ....account.models import User
 from ....checkout.models import Checkout
 from ....checkout.payment_utils import update_checkout_payment_statuses
 from ....payment.models import ChargeStatus, Payment
+from ...core.connection import where_filter_qs
 from ...tests.utils import get_graphql_content
 from ..enums import CheckoutAuthorizeStatusEnum, CheckoutChargeStatusEnum
+from ..filters import CheckoutDiscountedObjectWhere
 
 
 @pytest.fixture
@@ -608,3 +612,130 @@ def test_checkouts_query_with_filter_charge_status(
     # then
     content = get_graphql_content(response)
     assert content["data"]["checkouts"]["totalCount"] == expected_count
+
+
+def test_filtering_checkout_discounted_object_where_by_total_price_range(
+    checkout_with_item,
+):
+    # given
+    checkout = checkout_with_item
+
+    currency = checkout.currency
+    subtotal_price = Money("20", currency)
+    total_price = Money("30", currency)
+    checkout.base_total = total_price
+    checkout.base_subtotal = subtotal_price
+    checkout.save(update_fields=["base_total_amount", "base_subtotal_amount"])
+
+    Checkout.objects.create(
+        currency=currency,
+        user=checkout.user,
+        channel=checkout.channel,
+        base_total=Money("15", currency),
+        base_subtotal=Money("10", currency),
+    )
+
+    qs = Checkout.objects.all()
+    predicate_data = {
+        "currency": currency,
+        "total_price": {
+            "range": {
+                "gte": 20,
+            }
+        },
+    }
+
+    # when
+    result = where_filter_qs(
+        qs,
+        {},
+        CheckoutDiscountedObjectWhere,
+        predicate_data,
+        None,
+    )
+
+    # then
+    assert result.count() == 1
+    assert result.first() == checkout
+
+
+def test_filtering_checkout_discounted_object_where_by_total_price_one_of(
+    checkout_with_item,
+):
+    # given
+    checkout = checkout_with_item
+
+    currency = checkout.currency
+    subtotal_price = Money("20", currency)
+    total_price = Money("30", currency)
+    checkout.base_total = total_price
+    checkout.base_subtotal = subtotal_price
+    checkout.save(update_fields=["base_total_amount", "base_subtotal_amount"])
+
+    another_checkout = Checkout.objects.create(
+        currency=currency,
+        user=checkout.user,
+        channel=checkout.channel,
+        base_total=Money("15", currency),
+        base_subtotal=Money("10", currency),
+    )
+
+    qs = Checkout.objects.all()
+    predicate_data = {"currency": currency, "total_price": {"one_of": [15, 40]}}
+
+    # when
+    result = where_filter_qs(
+        qs,
+        {},
+        CheckoutDiscountedObjectWhere,
+        predicate_data,
+        None,
+    )
+
+    # then
+    assert result.count() == 1
+    assert result.first() == another_checkout
+
+
+def test_filtering_checkout_discounted_object_where_currency_not_given(
+    checkout_with_item,
+):
+    # given
+    checkout = checkout_with_item
+
+    currency = checkout.currency
+    subtotal_price = Money("20", currency)
+    total_price = Money("30", currency)
+    checkout.base_total = total_price
+    checkout.base_subtotal = subtotal_price
+    checkout.save(update_fields=["base_total_amount", "base_subtotal_amount"])
+
+    Checkout.objects.create(
+        currency=currency,
+        user=checkout.user,
+        channel=checkout.channel,
+        base_total=Money("15", currency),
+        base_subtotal=Money("10", currency),
+    )
+
+    qs = Checkout.objects.all()
+    predicate_data = {
+        "total_price": {
+            "range": {
+                "gte": 20,
+            }
+        }
+    }
+
+    # when
+    with pytest.raises(ValidationError) as validation_error:
+        where_filter_qs(
+            qs,
+            {},
+            CheckoutDiscountedObjectWhere,
+            predicate_data,
+            None,
+        )
+
+    # then
+    assert validation_error.value.code == "required"

--- a/saleor/graphql/checkout/tests/test_checkout_filters.py
+++ b/saleor/graphql/checkout/tests/test_checkout_filters.py
@@ -614,7 +614,7 @@ def test_checkouts_query_with_filter_charge_status(
     assert content["data"]["checkouts"]["totalCount"] == expected_count
 
 
-def test_filtering_checkout_discounted_object_where_by_total_price_range(
+def test_filtering_checkout_discounted_object_where_by_base_total_price_range(
     checkout_with_item,
 ):
     # given
@@ -638,7 +638,7 @@ def test_filtering_checkout_discounted_object_where_by_total_price_range(
     qs = Checkout.objects.all()
     predicate_data = {
         "currency": currency,
-        "total_price": {
+        "base_total_price": {
             "range": {
                 "gte": 20,
             }
@@ -659,7 +659,7 @@ def test_filtering_checkout_discounted_object_where_by_total_price_range(
     assert result.first() == checkout
 
 
-def test_filtering_checkout_discounted_object_where_by_total_price_one_of(
+def test_filtering_checkout_discounted_object_where_by_base_total_price_one_of(
     checkout_with_item,
 ):
     # given
@@ -681,7 +681,7 @@ def test_filtering_checkout_discounted_object_where_by_total_price_one_of(
     )
 
     qs = Checkout.objects.all()
-    predicate_data = {"currency": currency, "total_price": {"one_of": [15, 40]}}
+    predicate_data = {"currency": currency, "base_total_price": {"one_of": [15, 40]}}
 
     # when
     result = where_filter_qs(
@@ -697,7 +697,7 @@ def test_filtering_checkout_discounted_object_where_by_total_price_one_of(
     assert result.first() == another_checkout
 
 
-def test_filtering_checkout_discounted_object_where_by_total_currency_not_given(
+def test_filtering_checkout_discounted_object_where_by_base_total_currency_not_given(
     checkout_with_item,
 ):
     # given
@@ -720,7 +720,7 @@ def test_filtering_checkout_discounted_object_where_by_total_currency_not_given(
 
     qs = Checkout.objects.all()
     predicate_data = {
-        "total_price": {
+        "base_total_price": {
             "range": {
                 "gte": 20,
             }
@@ -741,7 +741,7 @@ def test_filtering_checkout_discounted_object_where_by_total_currency_not_given(
     assert validation_error.value.code == "required"
 
 
-def test_filtering_checkout_discounted_object_where_by_subtotal_price_range(
+def test_filtering_checkout_discounted_object_where_by_base_subtotal_price_range(
     checkout_with_item,
 ):
     # given
@@ -765,7 +765,7 @@ def test_filtering_checkout_discounted_object_where_by_subtotal_price_range(
     qs = Checkout.objects.all()
     predicate_data = {
         "currency": currency,
-        "subtotal_price": {
+        "base_subtotal_price": {
             "range": {
                 "lte": 12,
             }
@@ -786,7 +786,7 @@ def test_filtering_checkout_discounted_object_where_by_subtotal_price_range(
     assert result.first() == another_checkout
 
 
-def test_filtering_checkout_discounted_object_where_by_subtotal_price_one_of(
+def test_filtering_checkout_discounted_object_where_by_base_subtotal_price_one_of(
     checkout_with_item,
 ):
     # given
@@ -808,7 +808,7 @@ def test_filtering_checkout_discounted_object_where_by_subtotal_price_one_of(
     )
 
     qs = Checkout.objects.all()
-    predicate_data = {"currency": currency, "subtotal_price": {"one_of": [15, 20]}}
+    predicate_data = {"currency": currency, "base_subtotal_price": {"one_of": [15, 20]}}
 
     # when
     result = where_filter_qs(
@@ -824,7 +824,7 @@ def test_filtering_checkout_discounted_object_where_by_subtotal_price_one_of(
     assert result.first() == checkout
 
 
-def test_filtering_checkout_discounted_object_where_by_subtotal_currency_not_given(
+def test_filtering_checkout_discounted_object_where_by_base_subtotal_currency_not_given(
     checkout_with_item,
 ):
     # given
@@ -847,7 +847,7 @@ def test_filtering_checkout_discounted_object_where_by_subtotal_currency_not_giv
 
     qs = Checkout.objects.all()
     predicate_data = {
-        "subtotal_price": {
+        "base_subtotal_price": {
             "range": {
                 "gte": 20,
             }

--- a/saleor/graphql/discount/filters.py
+++ b/saleor/graphql/discount/filters.py
@@ -23,14 +23,16 @@ from ..core.filters import (
     ObjectTypeFilter,
     ObjectTypeWhereFilter,
     OperationObjectTypeWhereFilter,
+    WhereFilterSet,
 )
 from ..core.types import (
     DateTimeFilterInput,
     DateTimeRangeInput,
+    FilterInputObjectType,
     IntRangeInput,
     StringFilterInput,
 )
-from ..core.types.filter_input import WhereInputObjectType
+from ..core.types.filter_input import DecimalFilterInput, WhereInputObjectType
 from ..utils.filters import (
     filter_by_id,
     filter_by_ids,
@@ -190,3 +192,25 @@ class PromotionWhereInput(WhereInputObjectType):
     class Meta:
         doc_category = DOC_CATEGORY_DISCOUNTS
         filterset_class = PromotionWhere
+
+
+class DiscountedObjectWhere(WhereFilterSet):
+    base_subtotal_price = OperationObjectTypeWhereFilter(
+        input_class=DecimalFilterInput,
+        method="filter_base_subtotal_price",
+        help_text="Filter by the base subtotal price.",
+    )
+    base_total_price = OperationObjectTypeWhereFilter(
+        input_class=DecimalFilterInput,
+        method="filter_base_total_price",
+        help_text="Filter by the base total price.",
+    )
+
+    class Meta:
+        abstract = True
+
+
+class DiscountedObjectWhereInput(FilterInputObjectType):
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+        filterset_class = DiscountedObjectWhere

--- a/saleor/graphql/discount/inputs.py
+++ b/saleor/graphql/discount/inputs.py
@@ -4,7 +4,7 @@ from ..core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ..core.scalars import JSON, PositiveDecimal
 from ..core.types import BaseInputObjectType, NonNullList
-from ..core.types.filter_input import DecimalFilterInput
+from ..discount.filters import DiscountedObjectWhereInput
 from ..product.filters import (
     CategoryWhereInput,
     CollectionWhereInput,
@@ -65,21 +65,9 @@ class CataloguePredicateInput(PredicateInputObjectType):
         doc_category = DOC_CATEGORY_DISCOUNTS
 
 
-class DiscountedObjectPredicateInput(PredicateInputObjectType):
-    subtotal_price = graphene.Field(
-        DecimalFilterInput, description="Subtotal price range condition."
-    )
-    total_price = graphene.Field(
-        DecimalFilterInput, description="Total price range condition."
-    )
-
-    class Meta:
-        doc_category = DOC_CATEGORY_DISCOUNTS
-
-
-class orderPredicateInput(PredicateInputObjectType):
+class OrderPredicateInput(PredicateInputObjectType):
     discounted_object_predicate = graphene.Field(
-        DiscountedObjectPredicateInput,
+        DiscountedObjectWhereInput,
         description="Defines the conditions related to checkout and order objects.",
     )
 
@@ -97,7 +85,7 @@ class PromotionRuleBaseInput(BaseInputObjectType):
         ),
     )
     order_predicate = graphene.Field(
-        orderPredicateInput,
+        OrderPredicateInput,
         description=(
             "Defines the conditions on the checkout/draft order level that must be met "
             "for the reward to be applied." + ADDED_IN_319 + PREVIEW_FEATURE

--- a/saleor/graphql/discount/mutations/promotion/validators.py
+++ b/saleor/graphql/discount/mutations/promotion/validators.py
@@ -203,7 +203,12 @@ def _clean_order_predicate(
 
     price_based_predicate = any(
         field in str(order_predicate)
-        for field in ["subtotal_price", "subtotalPrice", "total_price", "totalPrice"]
+        for field in [
+            "base_subtotal_price",
+            "baseSubtotalPrice",
+            "base_total_price",
+            "baseTotalPrice",
+        ]
     )
     if len(channel_currencies) > 1 and price_based_predicate:
         error_field = "channels"

--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -320,7 +320,7 @@ def test_promotion_create_with_order_rule(
 
     promotion_name = "test promotion"
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     rule_name = "test promotion rule 1"
     reward_value = Decimal("10")
@@ -1052,7 +1052,7 @@ def test_promotion_create_mixed_catalogue_and_order_rules(
         "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
     }
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     rule_1_name = "test promotion rule 1"
     rule_2_name = "test promotion rule 2"
@@ -1118,7 +1118,7 @@ def test_promotion_create_mixed_currencies_for_price_based_predicate(
 
     promotion_name = "test promotion"
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     rule_name = "test promotion rule 1"
     reward_value = Decimal("10")

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
@@ -550,11 +550,13 @@ def test_promotion_rule_invalid_order_predicate(
     order_predicate = {
         "OR": [
             {
-                "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}},
+                "discountedObjectPredicate": {
+                    "baseSubtotalPrice": {"range": {"gte": 100}}
+                },
                 "AND": [
                     {
                         "discountedObjectPredicate": {
-                            "subtotalPrice": {"range": {"lte": 500}}
+                            "baseSubtotalPrice": {"range": {"lte": 500}}
                         }
                     }
                 ],
@@ -1022,7 +1024,7 @@ def test_promotion_rule_create_multiple_predicates(
         "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
     }
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     rules_count = promotion.rules.count()
 
@@ -1080,7 +1082,7 @@ def test_promotion_rule_create_mixed_predicates_order(
     reward_type = RewardTypeEnum.SUBTOTAL_DISCOUNT.name
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     rules_count = promotion.rules.count()
 
@@ -1184,7 +1186,7 @@ def test_promotion_rule_create_missing_reward_type(
     reward_value_type = RewardValueTypeEnum.FIXED.name
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     rules_count = promotion.rules.count()
 
@@ -1287,7 +1289,7 @@ def test_promotion_rule_create_order_predicate(
     reward_type = RewardTypeEnum.SUBTOTAL_DISCOUNT.name
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": "100"}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": "100"}}}
     }
 
     rules_count = promotion.rules.count()
@@ -1342,7 +1344,7 @@ def test_promotion_rule_create_mixed_currencies_for_price_based_predicate(
     reward_type = RewardTypeEnum.SUBTOTAL_DISCOUNT.name
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": "100"}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": "100"}}}
     }
     channel_ids = [
         graphene.Node.to_global_id("Channel", channel.pk)

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
@@ -797,7 +797,7 @@ def test_promotion_rule_update_mix_predicates_invalid_order_predicate(
     rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
 
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
 
     variables = {
@@ -876,7 +876,7 @@ def test_promotion_rule_update_mix_predicates_both_predicate_types_given(
     rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
 
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     catalogue_predicate = {
         "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}

--- a/saleor/graphql/discount/tests/test_validators.py
+++ b/saleor/graphql/discount/tests/test_validators.py
@@ -69,7 +69,7 @@ def test_clean_predicate_invalid_predicate(predicate):
 def test_clean_predicates_both_catalogue_and_order_provided(product):
     # given
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     catalogue_predicate = {
         "product_predicate": {
@@ -178,7 +178,7 @@ def test_clean_predicates_mixed_promotion_predicates_invalid_order(
 ):
     # given
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,
@@ -237,7 +237,7 @@ def test_clean_catalogue_predicate_reward_type_provided():
 def test_clean_order_predicate_missing_reward_type():
     # given
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,
@@ -267,7 +267,7 @@ def test_clean_order_predicate_reward_type_in_instance(
     # given
     rule = promotion_with_order_rule.rules.first()
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,
@@ -292,7 +292,7 @@ def test_clean_order_predicate_reward_type_in_instance(
 def test_clean_order_predicate_price_based_predicate_mixed_currencies():
     # given
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,
@@ -327,7 +327,7 @@ def test_clean_order_mixed_currencies_instance_given_invalid_predicate(
     # given
     rule = promotion_with_order_rule.rules.first()
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,
@@ -361,7 +361,7 @@ def test_clean_order_mixed_currencies_instance_given_invalid_channels(
     # given
     rule = promotion_with_order_rule.rules.first()
     order_predicate = {
-        "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "add_channels": ["AB", "CD"],
@@ -392,7 +392,7 @@ def test_clean_order_mixed_currencies_instance_given_invalid_channels(
 def test_clean_reward_lack_of_reward_value_type():
     # given
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,
@@ -423,7 +423,7 @@ def test_clean_reward_lack_of_reward_value_type():
 def test_clean_reward_no_reward_value():
     # given
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,
@@ -452,7 +452,7 @@ def test_clean_reward_no_reward_value():
 def test_clean_reward_lack_of_reward_value_and_reward_value_type():
     # given
     order_predicate = {
-        "discounted_object_predicate": {"subtotal_price": {"range": {"gte": 100}}}
+        "discounted_object_predicate": {"base_subtotal_price": {"range": {"gte": 100}}}
     }
     cleaned_input = {
         "order_predicate": order_predicate,

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -318,7 +318,7 @@ def _handle_checkout_predicate(
     if currency:
         predicate_data["currency"] = currency
 
-    orders = where_filter_qs(
+    checkouts = where_filter_qs(
         Checkout.objects.filter(pk__in=base_qs.values("pk")),
         {},
         CheckoutDiscountedObjectWhere,
@@ -326,9 +326,9 @@ def _handle_checkout_predicate(
         None,
     )
     if operator == Operators.AND:
-        result_qs &= orders
+        result_qs &= checkouts
     else:
-        result_qs |= orders
+        result_qs |= checkouts
     return result_qs
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27465,7 +27465,7 @@ input PromotionRuleInput @doc(category: "Discounts") {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
-  orderPredicate: orderPredicateInput
+  orderPredicate: OrderPredicateInput
 
   """
   Defines the promotion rule reward value type. Must be provided together with reward value.
@@ -27510,29 +27510,23 @@ input CataloguePredicateInput @doc(category: "Discounts") {
   OR: [CataloguePredicateInput!]
 }
 
-input orderPredicateInput @doc(category: "Discounts") {
+input OrderPredicateInput @doc(category: "Discounts") {
   """Defines the conditions related to checkout and order objects."""
-  discountedObjectPredicate: DiscountedObjectPredicateInput
+  discountedObjectPredicate: DiscountedObjectWhereInput
 
   """List of conditions that must be met."""
-  AND: [orderPredicateInput!]
+  AND: [OrderPredicateInput!]
 
   """A list of conditions of which at least one must be met."""
-  OR: [orderPredicateInput!]
+  OR: [OrderPredicateInput!]
 }
 
-input DiscountedObjectPredicateInput @doc(category: "Discounts") {
-  """Subtotal price range condition."""
-  subtotalPrice: DecimalFilterInput
+input DiscountedObjectWhereInput @doc(category: "Discounts") {
+  """Filter by the base subtotal price."""
+  baseSubtotalPrice: DecimalFilterInput
 
-  """Total price range condition."""
-  totalPrice: DecimalFilterInput
-
-  """List of conditions that must be met."""
-  AND: [DiscountedObjectPredicateInput!]
-
-  """A list of conditions of which at least one must be met."""
-  OR: [DiscountedObjectPredicateInput!]
+  """Filter by the base total price."""
+  baseTotalPrice: DecimalFilterInput
 }
 
 """
@@ -27687,7 +27681,7 @@ input PromotionRuleCreateInput {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
-  orderPredicate: orderPredicateInput
+  orderPredicate: OrderPredicateInput
 
   """
   Defines the promotion rule reward value type. Must be provided together with reward value.
@@ -27780,7 +27774,7 @@ input PromotionRuleUpdateInput {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
-  orderPredicate: orderPredicateInput
+  orderPredicate: OrderPredicateInput
 
   """
   Defines the promotion rule reward value type. Must be provided together with reward value.

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1134,7 +1134,7 @@ def test_checkout_payload_includes_order_promotion_discount(
     rule = promotion_without_rules.rules.create(
         name="Fixed promotion rule",
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 20,
                 }

--- a/saleor/tests/e2e/promotions/test_unable_to_have_promotion_rule_with_mixed_predicates.py
+++ b/saleor/tests/e2e/promotions/test_unable_to_have_promotion_rule_with_mixed_predicates.py
@@ -54,7 +54,7 @@ def test_unable_to_have_promotion_rule_with_mixed_predicates_CORE_2125(
             "channels": [channel_id],
             "cataloguePredicate": {"collectionPredicate": {"ids": [collection_id]}},
             "orderPredicate": {
-                "discountedObjectPredicate": {"totalPrice": {"eq": "10"}}
+                "discountedObjectPredicate": {"baseTotalPrice": {"eq": "10"}}
             },
             "rewardType": "SUBTOTAL_DISCOUNT",
             "rewardValue": invalid_promotion_reward_value,
@@ -87,7 +87,7 @@ def test_unable_to_have_promotion_rule_with_mixed_predicates_CORE_2125(
             "name": "rule for promotion with checkout and order predicate",
             "channels": [channel_id],
             "orderPredicate": {
-                "discountedObjectPredicate": {"totalPrice": {"eq": "10"}}
+                "discountedObjectPredicate": {"baseTotalPrice": {"eq": "10"}}
             },
             "rewardType": "SUBTOTAL_DISCOUNT",
             "rewardValue": reward_value,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -414,7 +414,7 @@ def checkout_with_item_and_order_discount(checkout_with_item, promotion_without_
 
     rule = promotion_without_rules.rules.create(
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 20,
                 }
@@ -5643,7 +5643,7 @@ def promotion_with_order_rule(catalogue_predicate, channel_USD):
         name="Promotion rule",
         promotion=promotion,
         order_predicate={
-            "discountedObjectPredicate": {"subtotalPrice": {"range": {"gte": 100}}}
+            "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 100}}}
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=Decimal(5),
@@ -5768,7 +5768,7 @@ def order_promotion_rule(channel_USD, promotion, product):
         name="Order promotion rule",
         promotion=promotion,
         order_predicate={
-            "total_price": {
+            "base_total_price": {
                 "range": {
                     "gte": 20,
                 }


### PR DESCRIPTION
Resolves https://github.com/saleor/saleor/issues/14943

- [x] Finish `total_price` filtering.
- [x] Add `subtotal_price` filtering similar to `total_price` filtering.
- [x] Add test for `create_or_update_discount_objects_from_promotion_for_checkout` with the scenario when one promotion rule has a subtotal based predicate, and the second one has a total base predicate.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
