### PR TITLE
Fix INSUFFICIENT_STOCK error not returning order lines ids

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -27,6 +27,7 @@ DRAFT_ORDER_COMPLETE_MUTATION = """
                 code
                 message
                 variants
+                orderLines
             }
             order {
                 status
@@ -748,6 +749,7 @@ def test_draft_order_complete_with_not_excluded_shipping_method(
 def test_draft_order_complete_out_of_stock_variant(
     staff_api_client, permission_group_manage_orders, staff_user, draft_order
 ):
+    # given
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = draft_order
 
@@ -761,15 +763,19 @@ def test_draft_order_complete_out_of_stock_variant(
 
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
+
+    # when
     response = staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, variables)
     content = get_graphql_content(response)
     error = content["data"]["draftOrderComplete"]["errors"][0]
     order.refresh_from_db()
+
+    # then
     assert order.status == OrderStatus.DRAFT
     assert order.origin == OrderOrigin.DRAFT
-
     assert error["field"] == "lines"
     assert error["code"] == OrderErrorCode.INSUFFICIENT_STOCK.name
+    assert error["orderLines"] == [graphene.Node.to_global_id("OrderLine", line_1.id)]
 
 
 def test_draft_order_complete_existing_user_email_updates_user_field(

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -148,7 +148,11 @@ def validate_order_lines(order: "Order", country: str, errors: T_ERRORS):
         elif line.variant.track_inventory:
             try:
                 check_stock_and_preorder_quantity(
-                    line.variant, country, order.channel.slug, line.quantity
+                    line.variant,
+                    country,
+                    order.channel.slug,
+                    line.quantity,
+                    order_line=line,
                 )
             except InsufficientStock as exc:
                 errors["lines"].extend(
@@ -326,7 +330,6 @@ def prepare_insufficient_stock_order_validation_errors(exc):
             if item.warehouse_pk
             else None
         )
-
         errors.append(
             ValidationError(
                 "Insufficient product stock.",

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -22,6 +22,7 @@ from .reservations import get_listings_reservations
 if TYPE_CHECKING:
     from ..checkout.fetch import CheckoutLineInfo
     from ..checkout.models import CheckoutLine
+    from ..order.models import OrderLine
     from ..product.models import Product, ProductVariant
 
 
@@ -65,6 +66,7 @@ def check_stock_and_preorder_quantity(
     quantity: int,
     checkout_lines: Optional[list["CheckoutLine"]] = None,
     check_reservations: bool = False,
+    order_line: Optional["OrderLine"] = None,
 ):
     """Validate if there is stock/preorder available for given variant.
 
@@ -83,6 +85,7 @@ def check_stock_and_preorder_quantity(
             quantity,
             checkout_lines,
             check_reservations,
+            order_line,
         )
 
 
@@ -93,6 +96,7 @@ def check_stock_quantity(
     quantity: int,
     checkout_lines: Optional[list["CheckoutLine"]] = None,
     check_reservations: bool = False,
+    order_line: Optional["OrderLine"] = None,
 ):
     """Validate if there is stock available for given variant in given country.
 
@@ -105,7 +109,11 @@ def check_stock_quantity(
         )
         if not stocks:
             raise InsufficientStock(
-                [InsufficientStockData(variant=variant, available_quantity=0)]
+                [
+                    InsufficientStockData(
+                        variant=variant, available_quantity=0, order_line=order_line
+                    )
+                ]
             )
 
         available_quantity = _get_available_quantity(
@@ -113,7 +121,11 @@ def check_stock_quantity(
         )
         if quantity > available_quantity:
             raise InsufficientStock(
-                [InsufficientStockData(variant=variant, available_quantity=0)]
+                [
+                    InsufficientStockData(
+                        variant=variant, available_quantity=0, order_line=order_line
+                    )
+                ]
             )
 
 


### PR DESCRIPTION
Port of  #15065

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
