### PR TITLE
Fix INSUFFICIENT_STOCK error not returning order lines ids

### DIFF
--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -145,7 +145,11 @@ def validate_order_lines(order: "Order", country: str, errors: T_ERRORS):
         elif line.variant.track_inventory:
             try:
                 check_stock_and_preorder_quantity(
-                    line.variant, country, order.channel.slug, line.quantity
+                    line.variant,
+                    country,
+                    order.channel.slug,
+                    line.quantity,
+                    order_line=line,
                 )
             except InsufficientStock as exc:
                 errors["lines"].extend(
@@ -307,7 +311,6 @@ def prepare_insufficient_stock_order_validation_errors(exc):
             if item.warehouse_pk
             else None
         )
-
         errors.append(
             ValidationError(
                 "Insufficient product stock.",

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -25,6 +25,7 @@ from .reservations import get_listings_reservations
 if TYPE_CHECKING:
     from ..checkout.fetch import CheckoutLineInfo
     from ..checkout.models import CheckoutLine
+    from ..order.models import OrderLine
     from ..product.models import Product, ProductVariant
 
 
@@ -68,6 +69,7 @@ def check_stock_and_preorder_quantity(
     quantity: int,
     checkout_lines: Optional[List["CheckoutLine"]] = None,
     check_reservations: bool = False,
+    order_line: Optional["OrderLine"] = None,
 ):
     """Validate if there is stock/preorder available for given variant.
 
@@ -86,6 +88,7 @@ def check_stock_and_preorder_quantity(
             quantity,
             checkout_lines,
             check_reservations,
+            order_line,
         )
 
 
@@ -96,6 +99,7 @@ def check_stock_quantity(
     quantity: int,
     checkout_lines: Optional[List["CheckoutLine"]] = None,
     check_reservations: bool = False,
+    order_line: Optional["OrderLine"] = None,
 ):
     """Validate if there is stock available for given variant in given country.
 
@@ -108,7 +112,11 @@ def check_stock_quantity(
         )
         if not stocks:
             raise InsufficientStock(
-                [InsufficientStockData(variant=variant, available_quantity=0)]
+                [
+                    InsufficientStockData(
+                        variant=variant, available_quantity=0, order_line=order_line
+                    )
+                ]
             )
 
         available_quantity = _get_available_quantity(
@@ -116,7 +124,11 @@ def check_stock_quantity(
         )
         if quantity > available_quantity:
             raise InsufficientStock(
-                [InsufficientStockData(variant=variant, available_quantity=0)]
+                [
+                    InsufficientStockData(
+                        variant=variant, available_quantity=0, order_line=order_line
+                    )
+                ]
             )
 
 


### PR DESCRIPTION
Port of  #15065

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
