### PR TITLE
[TEST] Unable to create promotion rule with mixed predicates CORE_2125

### DIFF
--- a/saleor/tests/e2e/promotions/test_promotions_query_with_different_parameters.py
+++ b/saleor/tests/e2e/promotions/test_promotions_query_with_different_parameters.py
@@ -88,7 +88,7 @@ def test_step_3_query_promotions_first_10_start_date_before_CORE_2118(
             promotion_name = f"Promotion start date before {i + 1}"
             start_date = (base_date - timedelta(days=i + 1)).isoformat() + "+00:00"
             promotion = create_promotion(
-                e2e_staff_api_client, promotion_name, start_date
+                e2e_staff_api_client, promotion_name, start_date=start_date
             )
             assert promotion["startDate"] == start_date
 

--- a/saleor/tests/e2e/promotions/test_unable_to_have_promotion_rule_with_mixed_predicates.py
+++ b/saleor/tests/e2e/promotions/test_unable_to_have_promotion_rule_with_mixed_predicates.py
@@ -1,0 +1,113 @@
+import pytest
+
+from ..product.utils import (
+    create_collection,
+    create_collection_channel_listing,
+)
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..utils import assign_permissions
+from .utils import create_promotion, raw_create_promotion, raw_update_promotion_rule
+
+
+def prepare_collection(
+    e2e_staff_api_client,
+):
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+
+    collection_data = create_collection(e2e_staff_api_client)
+    collection_id = collection_data["id"]
+
+    create_collection_channel_listing(e2e_staff_api_client, collection_id, channel_id)
+
+    return channel_id, collection_id
+
+
+@pytest.mark.e2e
+def test_unable_to_have_promotion_rule_with_mixed_predicates_CORE_2125(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        channel_id,
+        collection_id,
+    ) = prepare_collection(
+        e2e_staff_api_client,
+    )
+
+    # Step 1- Create promotion with rule with mixed predicates
+    invalid_promotion_name = "Promotion with mixed predicates"
+    invalid_promotion_reward_value = "20"
+    invalid_promotion_rules = [
+        {
+            "name": "rule for promotion with mixed predicates",
+            "channels": [channel_id],
+            "cataloguePredicate": {"collectionPredicate": {"ids": [collection_id]}},
+            "checkoutAndOrderPredicate": {
+                "discountedObjectPredicate": {"totalPrice": {"eq": "10"}}
+            },
+            "rewardType": "SUBTOTAL_DISCOUNT",
+            "rewardValue": invalid_promotion_reward_value,
+            "rewardValueType": "PERCENTAGE",
+        }
+    ]
+    data = raw_create_promotion(
+        e2e_staff_api_client, invalid_promotion_name, invalid_promotion_rules
+    )
+    errors = data["errors"]
+    assert (
+        errors[0]["message"]
+        == "Only one of predicates can be provided: 'cataloguePredicate' or 'checkoutAndOrderPredicate'."
+    )
+    assert errors[0]["code"] == "MIXED_PREDICATES"
+    assert errors[0]["field"] == "cataloguePredicate"
+
+    assert (
+        errors[1]["message"]
+        == "Only one of predicates can be provided: 'cataloguePredicate' or 'checkoutAndOrderPredicate'."
+    )
+    assert errors[1]["code"] == "MIXED_PREDICATES"
+    assert errors[1]["field"] == "checkoutAndOrderPredicate"
+
+    # Step 2- Create promotion with rule with checkout and order predicate
+    promotion_name = "Promotion"
+    reward_value = "20"
+    rules = [
+        {
+            "name": "rule for promotion with checkout and order predicate",
+            "channels": [channel_id],
+            "checkoutAndOrderPredicate": {
+                "discountedObjectPredicate": {"totalPrice": {"eq": "10"}}
+            },
+            "rewardType": "SUBTOTAL_DISCOUNT",
+            "rewardValue": reward_value,
+            "rewardValueType": "PERCENTAGE",
+        }
+    ]
+    promotion_data = create_promotion(e2e_staff_api_client, promotion_name, rules)
+    promotion_rule_id = promotion_data["rules"][0]["id"]
+
+    # Step 3 - Check the promotion rule cannot be updated with catalogue predicate
+    update_input = {
+        "cataloguePredicate": {"collectionPredicate": {"ids": [collection_id]}}
+    }
+    data = raw_update_promotion_rule(
+        e2e_staff_api_client, promotion_rule_id, update_input
+    )
+    error = data["errors"][0]
+    assert (
+        error["message"]
+        == "Only one of predicates can be provided: 'cataloguePredicate' or 'checkoutAndOrderPredicate'."
+    )
+    assert error["code"] == "MIXED_PREDICATES"
+    assert error["field"] == "cataloguePredicate"

--- a/saleor/tests/e2e/promotions/utils/__init__.py
+++ b/saleor/tests/e2e/promotions/utils/__init__.py
@@ -1,16 +1,18 @@
-from .promotion_create import create_promotion
+from .promotion_create import create_promotion, raw_create_promotion
 from .promotion_delete import delete_promotion
 from .promotion_query import promotion_query
 from .promotion_rule_create import create_promotion_rule
 from .promotion_rule_translate import translate_promotion_rule
-from .promotion_rule_update import update_promotion_rule
+from .promotion_rule_update import raw_update_promotion_rule, update_promotion_rule
 from .promotion_translate import translate_promotion
 from .promotions_query import promotions_query
 
 __all__ = [
     "create_promotion",
+    "raw_create_promotion",
     "create_promotion_rule",
     "update_promotion_rule",
+    "raw_update_promotion_rule",
     "delete_promotion",
     "promotion_query",
     "promotions_query",

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
@@ -24,7 +24,7 @@ mutation promotionRuleCreate($id: ID!, $input: PromotionRuleUpdateInput!) {
 """
 
 
-def update_promotion_rule(
+def raw_update_promotion_rule(
     staff_api_client,
     promotion_rule_id,
     input,
@@ -37,7 +37,23 @@ def update_promotion_rule(
     )
     content = get_graphql_content(response)
 
-    assert content["data"]["promotionRuleUpdate"]["errors"] == []
+    raw_data = content["data"]["promotionRuleUpdate"]
 
-    data = content["data"]["promotionRuleUpdate"]["promotionRule"]
+    return raw_data
+
+
+def update_promotion_rule(
+    staff_api_client,
+    promotion_rule_id,
+    input,
+):
+    response = raw_update_promotion_rule(
+        staff_api_client,
+        promotion_rule_id,
+        input,
+    )
+
+    assert response["errors"] == []
+
+    data = response["promotionRule"]
     return data


### PR DESCRIPTION
I want to merge this change because it covers [CORE_2125](https://saleor.testmo.net/repositories/5?group_id=391&case_id=7962)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
