### PR TITLE
Improve creation of `PromotionRule`-`ProductVariant` relation.

### DIFF
--- a/saleor/discount/tests/test_utils/test_update_rule_variant_relation.py
+++ b/saleor/discount/tests/test_utils/test_update_rule_variant_relation.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+
+import graphene
+
+from ... import RewardValueType
+from ...models import PromotionRule
+from ...utils import update_rule_variant_relation
+
+
+def test_update_rule_variant_relation(
+    promotion_without_rules, channel_USD, product_variant_list
+):
+    # given
+    promotion = promotion_without_rules
+    variants = product_variant_list
+    PromotionRuleVariant = PromotionRule.variants.through
+
+    for i in range(len(variants)):
+        existing_variants = variants[:i]
+        new_variants = variants[-i:]
+        new_variant_global_ids = [
+            graphene.Node.to_global_id("ProductVariant", variant.id)
+            for variant in new_variants
+        ]
+        new_variant_ids = [variant.id for variant in new_variants]
+
+        percentage_reward_value = Decimal("10")
+        rule = promotion.rules.create(
+            name="Percentage promotion rule",
+            catalogue_predicate={"variantPredicate": {"ids": new_variant_global_ids}},
+            reward_value_type=RewardValueType.PERCENTAGE,
+            reward_value=percentage_reward_value,
+        )
+
+        rule.channels.add(channel_USD)
+        rule.variants.add(*existing_variants)
+
+        rules = PromotionRule.objects.filter(id=rule.id)
+        new_variants_rules = [
+            PromotionRuleVariant(promotionrule_id=rule.id, productvariant_id=variant.id)
+            for variant in new_variants
+        ]
+
+        # when
+        update_rule_variant_relation(rules, new_variants_rules)
+
+        # then
+        related_variants = PromotionRuleVariant.objects.filter(
+            promotionrule_id=rule.id
+        ).values_list("productvariant_id", flat=True)
+        assert all([variant in new_variant_ids for variant in related_variants])
+        assert len(related_variants) == len(new_variants)

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -18,6 +18,7 @@ from typing import (
 from uuid import UUID
 
 import graphene
+from django.db import transaction
 from django.db.models import Exists, F, OuterRef, QuerySet
 from prices import Money, TaxedMoney, fixed_discount, percentage_discount
 
@@ -543,3 +544,45 @@ def get_current_products_for_rules(rules: "QuerySet[PromotionRule]"):
         Exists(rule_variants.filter(productvariant_id=OuterRef("id")))
     )
     return Product.objects.filter(Exists(variants.filter(product_id=OuterRef("id"))))
+
+
+def update_rule_variant_relation(
+    rules: QuerySet[PromotionRule], new_rules_variants: list
+):
+    """Update PromotionRule - ProductVariant relation.
+
+    Deletes relations, which are not valid anymore.
+    Adds new relations, if they don't exist already.
+    `new_rules_variants` is a list of PromotionRuleVariant objects.
+    """
+    with transaction.atomic():
+        PromotionRuleVariant = PromotionRule.variants.through
+        existing_rules_variants = PromotionRuleVariant.objects.filter(
+            Exists(rules.filter(pk=OuterRef("promotionrule_id")))
+        ).all()
+        new_rule_variant_set = set(
+            (rv.promotionrule_id, rv.productvariant_id) for rv in new_rules_variants
+        )
+        existing_rule_variant_set = set(
+            (rv.promotionrule_id, rv.productvariant_id)  # type: ignore[attr-defined]
+            for rv in existing_rules_variants
+        )
+
+        # Clear invalid variants assigned to promotion rules
+        rule_variant_to_delete_ids = [
+            rv.id  # type: ignore[attr-defined]
+            for rv in existing_rules_variants
+            if (rv.promotionrule_id, rv.productvariant_id) not in new_rule_variant_set  # type: ignore[attr-defined] # noqa: E501
+        ]
+        PromotionRuleVariant.objects.filter(id__in=rule_variant_to_delete_ids).delete()
+
+        # Assign new variants to promotion rules
+        rules_variants_to_add = [
+            rv
+            for rv in new_rules_variants
+            if (rv.promotionrule_id, rv.productvariant_id)
+            not in existing_rule_variant_set
+        ]
+        PromotionRuleVariant.objects.bulk_create(
+            rules_variants_to_add, ignore_conflicts=True
+        )

--- a/saleor/graphql/discount/mutations/utils.py
+++ b/saleor/graphql/discount/mutations/utils.py
@@ -2,11 +2,10 @@ from collections import defaultdict
 from typing import DefaultDict, Set
 
 import graphene
-from django.db import transaction
-from django.db.models import Exists, OuterRef, QuerySet
+from django.db.models import QuerySet
 
 from ....discount.models import Promotion, PromotionRule
-from ....discount.utils import CatalogueInfo
+from ....discount.utils import CatalogueInfo, update_rule_variant_relation
 from ....product.models import ProductVariant
 
 CATALOGUE_FIELD_TO_TYPE_NAME = {
@@ -53,11 +52,4 @@ def update_variants_for_promotion(
                 for variant in variants
             ]
         )
-    with transaction.atomic():
-        # Clear existing variants assigned to promotion rules
-        PromotionRuleVariant.objects.filter(
-            Exists(rules.filter(id=OuterRef("promotionrule_id")))
-        ).delete()
-        PromotionRuleVariant.objects.bulk_create(
-            promotion_rule_variants, ignore_conflicts=True
-        )
+    update_rule_variant_relation(rules, promotion_rule_variants)

--- a/saleor/product/tests/test_fetch_variants_for_promotion_rules.py
+++ b/saleor/product/tests/test_fetch_variants_for_promotion_rules.py
@@ -1,14 +1,20 @@
 from decimal import Decimal
 
+import before_after
 import graphene
 
 from ...discount import RewardValueType
 from ...discount.models import PromotionRule
+from ...discount.utils import update_rule_variant_relation
 from ..utils.variants import fetch_variants_for_promotion_rules
 
 
 def test_fetch_variants_for_promotion_rules_discount(
-    promotion_without_rules, product, product_with_two_variants, channel_USD
+    promotion_without_rules,
+    product,
+    product_with_two_variants,
+    channel_USD,
+    product_variant_list,
 ):
     # given
     variant = product.variants.first()
@@ -20,7 +26,12 @@ def test_fetch_variants_for_promotion_rules_discount(
         name="Percentage promotion rule",
         catalogue_predicate={
             "variantPredicate": {
-                "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
+                "ids": [
+                    graphene.Node.to_global_id("ProductVariant", variant.id),
+                    graphene.Node.to_global_id(
+                        "ProductVariant", product_variant_list[0].id
+                    ),
+                ]
             }
         },
         reward_value_type=RewardValueType.PERCENTAGE,
@@ -41,13 +52,19 @@ def test_fetch_variants_for_promotion_rules_discount(
     rule_1.channels.add(channel_USD)
     rule_2.channels.add(channel_USD)
 
+    # Variants not present in rules predicate should be deleted
+    rule_1.variants.add(*product_variant_list)
+    rule_2.variants.add(*product_variant_list)
+
     # when
     fetch_variants_for_promotion_rules(PromotionRule.objects.all())
 
     # then
     rule_1.refresh_from_db()
-    assert rule_1.variants.count() == 1
-    assert rule_1.variants.first() == variant
+    rule_1_variants = rule_1.variants.all()
+    assert len(rule_1_variants) == 2
+    assert variant in rule_1_variants
+    assert product_variant_list[0] in rule_1_variants
 
     rule_2.refresh_from_db()
     assert rule_2.variants.count() == product_with_two_variants.variants.count()
@@ -97,3 +114,43 @@ def test_fetch_variants_for_promotion_rules_relation_already_exist(
     # then
     rule.refresh_from_db()
     assert rule.variants.count() > 0
+
+
+def test_fetch_variants_for_promotion_rules_discount_race_condition(
+    promotion_without_rules,
+    channel_USD,
+    product_variant_list,
+):
+    # given
+    promotion = promotion_without_rules
+    existing_variant = product_variant_list[0]
+    new_variant = product_variant_list[1]
+
+    percentage_reward_value = Decimal("10")
+    rule = promotion.rules.create(
+        name="Percentage promotion rule",
+        catalogue_predicate={
+            "variantPredicate": {
+                "ids": [
+                    graphene.Node.to_global_id("ProductVariant", new_variant.id),
+                ]
+            }
+        },
+        reward_value_type=RewardValueType.PERCENTAGE,
+        reward_value=percentage_reward_value,
+    )
+    rule.channels.add(channel_USD)
+    rule.variants.add(existing_variant)
+
+    # when
+    with before_after.after(
+        "saleor.product.utils.variants.update_rule_variant_relation",
+        update_rule_variant_relation,
+    ):
+        fetch_variants_for_promotion_rules(PromotionRule.objects.all())
+
+    # then
+    rule.refresh_from_db()
+    rule_variants = rule.variants.all()
+    assert len(rule_variants) == 1
+    assert new_variant in rule_variants

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
-from django.db import transaction
-from django.db.models import Exists, OuterRef, QuerySet
+from django.db.models import QuerySet
 
 from ...attribute import AttributeType
 from ...discount.models import PromotionRule
+from ...discount.utils import update_rule_variant_relation
 from ..models import ProductVariant
 
 if TYPE_CHECKING:
@@ -51,16 +51,14 @@ def get_variant_selection_attributes(
     ]
 
 
-def fetch_variants_for_promotion_rules(
-    rules: QuerySet[PromotionRule],
-):
+def fetch_variants_for_promotion_rules(rules: QuerySet[PromotionRule]):
     from ...graphql.discount.utils import get_variants_for_predicate
 
     PromotionRuleVariant = PromotionRule.variants.through
-    promotion_rule_variants = []
+    new_rules_variants = []
     for rule in list(rules.iterator()):
         variants = get_variants_for_predicate(rule.catalogue_predicate)
-        promotion_rule_variants.extend(
+        new_rules_variants.extend(
             [
                 PromotionRuleVariant(
                     promotionrule_id=rule.pk, productvariant_id=variant_id
@@ -68,12 +66,4 @@ def fetch_variants_for_promotion_rules(
                 for variant_id in set(variants.values_list("pk", flat=True))
             ]
         )
-
-    with transaction.atomic():
-        # Clear existing variants assigned to promotion rules
-        PromotionRuleVariant.objects.filter(
-            Exists(rules.filter(pk=OuterRef("promotionrule_id")))
-        ).delete()
-        PromotionRuleVariant.objects.bulk_create(
-            promotion_rule_variants, ignore_conflicts=True
-        )
+    update_rule_variant_relation(rules, new_rules_variants)


### PR DESCRIPTION
Port to: https://github.com/saleor/saleor/pull/15176

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
