### PR TITLE
[TEST] Promotion applied on checkout with specified total/subtotal CORE_2132_2133_2134

### DIFF
--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
@@ -53,14 +53,17 @@ def test_checkout_products_on_fixed_promotion_core_2102(
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
 
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": "FIXED",
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
@@ -53,15 +53,16 @@ def test_checkout_products_on_percentage_promotion_core_2104(
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
 
-    promotion_rule = create_promotion_rule(
-        e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
-    )
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
+
+    promotion_rule = create_promotion_rule(e2e_staff_api_client, input)
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id
     assert product_predicate[0] == product_id

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price.py
@@ -54,14 +54,17 @@ def test_checkout_with_fixed_promotion_should_not_result_in_negative_price_CORE_
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
 
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_promotion_applied_on_checkout_with_specific_subtotal.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_promotion_applied_on_checkout_with_specific_subtotal.py
@@ -1,0 +1,155 @@
+import pytest
+
+from ....product.utils.preparing_product import prepare_product
+from ....promotions.utils import create_promotion, create_promotion_rule
+from ....shop.utils.preparing_shop import prepare_default_shop
+from ....utils import assign_permissions
+from ...utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+    checkout_lines_update,
+)
+
+
+def prepare_promotion(e2e_staff_api_client):
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    promotion_name = "Promotion"
+
+    promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
+    promotion_id = promotion_data["id"]
+    discount_value = 2.99
+    order_predicate_subtotal_value = "21"
+    order_predicate = {
+        "discountedObjectPredicate": {
+            "baseSubtotalPrice": {"eq": order_predicate_subtotal_value}
+        }
+    }
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": "test rule",
+        "orderPredicate": order_predicate,
+        "rewardType": "SUBTOTAL_DISCOUNT",
+        "rewardValue": discount_value,
+        "rewardValueType": "FIXED",
+    }
+
+    promotion_rule = create_promotion_rule(e2e_staff_api_client, input)
+    assert promotion_rule["orderPredicate"] == order_predicate
+    assert promotion_rule["channels"][0]["id"] == channel_id
+
+    return (
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        warehouse_id,
+        promotion_id,
+        discount_value,
+        order_predicate_subtotal_value,
+    )
+
+
+@pytest.mark.e2e
+def test_promotion_applied_on_checkout_with_specific_subtotal_CORE_2133(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        warehouse_id,
+        promotion_id,
+        discount_value,
+        order_predicate_subtotal_value,
+    ) = prepare_promotion(e2e_staff_api_client)
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(e2e_staff_api_client, warehouse_id, channel_id, variant_price=7)
+
+    # Step 1 - Create checkout with 5 product variants
+    lines = [{"variantId": product_variant_id, "quantity": 5}]
+    data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = data["id"]
+    total = data["totalPrice"]["gross"]["amount"]
+    subtotal = data["subtotalPrice"]["gross"]["amount"]
+    assert data["billingAddress"] is not None
+    assert data["shippingAddress"] is not None
+    assert checkout_id is not None
+    assert data["lines"][0]["variant"]["id"] == product_variant_id
+    assert data["discount"]["amount"] == 0.00
+    assert subtotal != order_predicate_subtotal_value
+
+    # Step 2 - Add shipping method
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    shipping_price = checkout_data["shippingPrice"]["gross"]["amount"]
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+
+    # Step 3 - Update checkout lines to only 3 product variants
+    lines = [{"variantId": product_variant_id, "quantity": 3}]
+    checkout_lines = checkout_lines_update(
+        e2e_not_logged_api_client, checkout_id, lines
+    )
+    discounted_subtotal = checkout_lines["checkout"]["subtotalPrice"]["gross"]["amount"]
+    total_gross = checkout_lines["checkout"]["totalPrice"]["gross"]["amount"]
+    undiscounted_subtotal = checkout_lines["checkout"]["lines"][0][
+        "undiscountedTotalPrice"
+    ]["amount"]
+    discounted_subtotal = checkout_lines["checkout"]["lines"][0]["totalPrice"]["gross"][
+        "amount"
+    ]
+    unit_price = checkout_lines["checkout"]["lines"][0]["unitPrice"]["gross"]["amount"]
+    assert unit_price == round((float(undiscounted_subtotal) - discount_value) / 3, 2)
+    undiscounted_unit_price = checkout_lines["checkout"]["lines"][0][
+        "undiscountedUnitPrice"
+    ]["amount"]
+    assert undiscounted_unit_price == float(product_variant_price)
+    assert discounted_subtotal == round(
+        float(undiscounted_subtotal - discount_value), 2
+    )
+    discounted_total = discounted_subtotal + shipping_price
+    assert checkout_lines["checkout"]["discount"]["amount"] == discount_value
+    assert total_gross != total
+    assert total_gross == discounted_total
+    assert undiscounted_subtotal == float(order_predicate_subtotal_value)
+
+    # Step 4 - Create payment
+    checkout_dummy_payment_create(e2e_not_logged_api_client, checkout_id, total_gross)
+
+    # Step 5 - Complete the checkout
+    order_data = checkout_complete(e2e_not_logged_api_client, checkout_id)
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == discounted_total

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_promotion_discount_applied_on_checkout_with_specific_total_and_subtotal.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_promotion_discount_applied_on_checkout_with_specific_total_and_subtotal.py
@@ -1,0 +1,158 @@
+import pytest
+
+from ....product.utils.preparing_product import prepare_product
+from ....promotions.utils import create_promotion, create_promotion_rule
+from ....shop.utils.preparing_shop import prepare_default_shop
+from ....utils import assign_permissions
+from ...utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+    checkout_lines_update,
+)
+
+
+def prepare_promotion(e2e_staff_api_client):
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    promotion_name = "Promotion"
+
+    promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
+
+    promotion_id = promotion_data["id"]
+    discount_value = 25
+    order_predicate_subtotal_value = "79.96"
+    order_predicate_total_value = "89.96"
+    order_predicate = {
+        "discountedObjectPredicate": {
+            "baseSubtotalPrice": {"eq": order_predicate_subtotal_value},
+            "baseTotalPrice": {"eq": order_predicate_total_value},
+        }
+    }
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": "test rule",
+        "orderPredicate": order_predicate,
+        "rewardType": "SUBTOTAL_DISCOUNT",
+        "rewardValue": discount_value,
+        "rewardValueType": "PERCENTAGE",
+    }
+
+    promotion_rule = create_promotion_rule(e2e_staff_api_client, input)
+    promotion_rule_id = promotion_rule["id"]
+    assert promotion_rule["orderPredicate"] == order_predicate
+    assert promotion_rule["channels"][0]["id"] == channel_id
+
+    return (
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        warehouse_id,
+        promotion_id,
+        promotion_rule_id,
+        discount_value,
+        order_predicate_total_value,
+        order_predicate_subtotal_value,
+    )
+
+
+@pytest.mark.e2e
+def test_promotion_discount_applied_on_checkout_with_specific_total_and_subtotal_CORE_2134(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        warehouse_id,
+        promotion_id,
+        promotion_rule_id,
+        discount_value,
+        order_predicate_total_value,
+        order_predicate_subtotal_value,
+    ) = prepare_promotion(e2e_staff_api_client)
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=19.99
+    )
+
+    # Step 1 - Create checkout with 1 product variant
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = data["id"]
+    total = data["totalPrice"]["gross"]["amount"]
+    subtotal = data["subtotalPrice"]["gross"]["amount"]
+    assert data["billingAddress"] is not None
+    assert data["shippingAddress"] is not None
+    assert checkout_id is not None
+    assert data["lines"][0]["variant"]["id"] == product_variant_id
+    assert data["discount"]["amount"] == 0.00
+    assert total != order_predicate_total_value
+    assert subtotal != order_predicate_subtotal_value
+
+    # Step 2 - Add shipping method
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    shipping_price = checkout_data["shippingPrice"]["gross"]["amount"]
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+
+    # Step 3 - Update checkout lines to 4 product variants
+    lines = [{"variantId": product_variant_id, "quantity": 4}]
+    checkout_lines = checkout_lines_update(
+        e2e_not_logged_api_client, checkout_id, lines
+    )
+    discounted_subtotal = checkout_lines["checkout"]["subtotalPrice"]["gross"]["amount"]
+    total_gross = checkout_lines["checkout"]["totalPrice"]["gross"]["amount"]
+    undiscounted_subtotal = checkout_lines["checkout"]["lines"][0][
+        "undiscountedTotalPrice"
+    ]["amount"]
+    undiscounted_total = undiscounted_subtotal + shipping_price
+    discount = round(float(undiscounted_subtotal) * discount_value / 100, 2)
+    discounted_total = discounted_subtotal + shipping_price
+    assert discounted_subtotal == undiscounted_subtotal - discount
+    assert checkout_lines["checkout"]["discount"]["amount"] == discount
+    assert total_gross != total
+    assert total_gross == discounted_total
+    assert undiscounted_total == float(order_predicate_total_value)
+    assert undiscounted_subtotal == float(order_predicate_subtotal_value)
+
+    # Step 4 - Create payment
+    checkout_dummy_payment_create(e2e_not_logged_api_client, checkout_id, total_gross)
+
+    # Step 5 - Complete the checkout
+    order_data = checkout_complete(e2e_not_logged_api_client, checkout_id)
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == discounted_total

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
@@ -41,15 +41,17 @@ def prepare_promotion(
     catalogue_predicate = {
         "productPredicate": {"ids": [product_id]},
     }
-
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": promotion_value,
+        "rewardValueType": promotion_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        promotion_type,
-        promotion_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/checkout/utils/checkout_complete.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_complete.py
@@ -78,6 +78,8 @@ mutation CheckoutComplete($checkoutId: ID!) {
         }
       }
       discounts {
+        id
+        name
         type
         value
       }

--- a/saleor/tests/e2e/checkout/utils/checkout_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create.py
@@ -19,6 +19,15 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
       channel {
         slug
       }
+      discountName
+      discount {
+        amount
+      }
+      shippingPrice {
+        gross {
+          amount
+        }
+      }
       totalPrice {
         gross {
           amount
@@ -27,6 +36,11 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
           amount
         }
         tax {
+          amount
+        }
+      }
+      subtotalPrice {
+        gross {
           amount
         }
       }

--- a/saleor/tests/e2e/checkout/utils/checkout_lines_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_lines_update.py
@@ -1,14 +1,44 @@
 from ...utils import get_graphql_content
 
 CHECKOUT_LINES_UPDATE_MUTATION = """
-mutation checkoutLinesUpdate($checkoutId: ID!, $lines: [CheckoutLineUpdateInput!]! ){
+mutation checkoutLinesUpdate($checkoutId: ID!, $lines: [CheckoutLineUpdateInput!]!) {
   checkoutLinesUpdate(lines: $lines, checkoutId: $checkoutId) {
     checkout {
+      discountName
+      discount {
+        amount
+      }
+      subtotalPrice {
+        gross {
+          amount
+        }
+      }
+      totalPrice {
+        gross {
+          amount
+        }
+      }
       lines {
         quantity
+        undiscountedTotalPrice {
+          amount
+        }
         variant {
           id
           quantityLimitPerCustomer
+        }
+        unitPrice {
+          gross {
+            amount
+          }
+        }
+        undiscountedUnitPrice {
+          amount
+        }
+        totalPrice {
+          gross {
+            amount
+          }
         }
       }
     }

--- a/saleor/tests/e2e/checkout/utils/query_checkout.py
+++ b/saleor/tests/e2e/checkout/utils/query_checkout.py
@@ -19,6 +19,17 @@ query Checkout($checkoutId: ID!){
         amount
       }
     }
+    subtotalPrice {
+      gross {
+        amount
+      }
+      net {
+        amount
+      }
+      tax {
+        amount
+      }
+    }
     availablePaymentGateways{
       id
       name

--- a/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
@@ -22,14 +22,17 @@ def prepare_promotion_with_rules(
     promotion_id = promotion["id"]
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
@@ -51,15 +51,17 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     promotion_id = promotion_data["id"]
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
-
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -100,15 +100,17 @@ def prepare_product(
     catalogue_predicate = {
         "categoryPredicate": {"ids": category_ids},
     }
-
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     category_predicate = promotion_rule["cataloguePredicate"]["categoryPredicate"][
         "ids"

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_promotion.py
@@ -53,14 +53,17 @@ def test_order_products_on_fixed_promotion_CORE_2101(
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
 
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
@@ -58,15 +58,17 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
     promotion_id = promotion_data["id"]
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
-
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": promotion_discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        promotion_discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
@@ -70,14 +70,17 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
 
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
@@ -59,15 +59,17 @@ def test_order_promotion_still_applied_to_the_order_when_promotion_is_removed_CO
     promotion_id = promotion_data["id"]
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
-
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/product/test_product_no_longer_on_promotion_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/product/test_product_no_longer_on_promotion_when_promotion_is_removed.py
@@ -50,14 +50,17 @@ def test_product_no_longer_on_promotion_when_promotion_is_removed_CORE_2114(
 
     catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
 
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        catalogue_predicate,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -31,17 +31,20 @@ def prepare_promotion(
     promotion_id = promotion_data["id"]
 
     predicate_input = {"collectionPredicate": {"ids": collection_ids}}
-    promotion_rule_data = create_promotion_rule(
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": predicate_input,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
+    promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        predicate_input,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
-    promotion_rule_id = promotion_rule_data["id"]
-    discount_value = promotion_rule_data["rewardValue"]
+    promotion_rule_id = promotion_rule["id"]
+    discount_value = promotion_rule["rewardValue"]
 
     return promotion_rule_id, discount_value
 

--- a/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
@@ -27,17 +27,18 @@ def prepare_promotion(
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
 
-    promotion_rule_data = create_promotion_rule(
-        e2e_staff_api_client,
-        promotion_id,
-        predicate_input,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
-    )
-    promotion_rule_id = promotion_rule_data["id"]
-    discount_value = promotion_rule_data["rewardValue"]
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": predicate_input,
+        "rewardValue": discount_value,
+        "rewardValueType": "PERCENTAGE",
+    }
+
+    promotion_rule = create_promotion_rule(e2e_staff_api_client, input)
+    promotion_rule_id = promotion_rule["id"]
+    discount_value = promotion_rule["rewardValue"]
 
     return promotion_rule_id
 

--- a/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
@@ -20,17 +20,20 @@ def prepare_promotion(
     promotion_id = promotion_data["id"]
 
     predicate_input = {"variantPredicate": {"ids": variant_ids}}
-    promotion_rule_data = create_promotion_rule(
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": predicate_input,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
+    promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        predicate_input,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
-    promotion_rule_id = promotion_rule_data["id"]
-    discount_value = promotion_rule_data["rewardValue"]
+    promotion_rule_id = promotion_rule["id"]
+    discount_value = promotion_rule["rewardValue"]
 
     return promotion_rule_id, discount_value
 

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -100,14 +100,17 @@ def test_create_promotion_for_collection_core_2109(
 
     collection_ids = [collection_id]
     predicate_input = {"collectionPredicate": {"ids": collection_ids}}
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": predicate_input,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        predicate_input,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
+        input,
     )
 
     collection_predicate = promotion_rule["cataloguePredicate"]["collectionPredicate"]

--- a/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
@@ -37,18 +37,21 @@ def prepare_promotion(
         "blocks": [{"data": {"text": "rule description"}, "type": "paragraph"}],
         "version": "1.0.0",
     }
-    promotion_rule_data = create_promotion_rule(
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": predicate_input,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+        "description": rule_description,
+    }
+    promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
-        promotion_id,
-        predicate_input,
-        discount_type,
-        discount_value,
-        promotion_rule_name,
-        channel_id,
-        description=rule_description,
+        input,
     )
-    promotion_rule_id = promotion_rule_data["id"]
-    discount_value = promotion_rule_data["rewardValue"]
+    promotion_rule_id = promotion_rule["id"]
+    discount_value = promotion_rule["rewardValue"]
 
     return promotion_id, promotion_rule_id
 

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_create.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_create.py
@@ -15,6 +15,7 @@ mutation promotionRuleCreate($input: PromotionRuleCreateInput!) {
       rewardValueType
       rewardValue
       cataloguePredicate
+      orderPredicate
       channels{
         id
       }
@@ -24,30 +25,8 @@ mutation promotionRuleCreate($input: PromotionRuleCreateInput!) {
 """
 
 
-def create_promotion_rule(
-    staff_api_client,
-    promotion_id,
-    catalogue_predicate,
-    reward_value_type="PERCENTAGE",
-    reward_value=5.00,
-    promotion_rule_name="Test rule",
-    channel_id=None,
-    description=None,
-):
-    if not channel_id:
-        channel_id = []
-
-    variables = {
-        "input": {
-            "promotion": promotion_id,
-            "name": promotion_rule_name,
-            "rewardValueType": reward_value_type,
-            "rewardValue": reward_value,
-            "channels": channel_id,
-            "cataloguePredicate": catalogue_predicate,
-            "description": description,
-        }
-    }
+def create_promotion_rule(staff_api_client, input):
+    variables = {"input": input}
 
     response = staff_api_client.post_graphql(
         PROMOTION_RULE_CREATE_MUTATION,
@@ -59,7 +38,5 @@ def create_promotion_rule(
 
     data = content["data"]["promotionRuleCreate"]["promotionRule"]
     assert data["id"] is not None
-    assert data["name"] == promotion_rule_name
-    assert data["rewardValueType"] == reward_value_type
-    assert data["rewardValue"] == reward_value
+
     return data

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
@@ -15,6 +15,7 @@ mutation promotionRuleCreate($id: ID!, $input: PromotionRuleUpdateInput!) {
       rewardValueType
       rewardValue
       cataloguePredicate
+      orderPredicate
       channels {
         id
       }


### PR DESCRIPTION
I want to merge this change because it covers applying promotion on checkout based on orderPredicate eq a value:

- [CORE_2133](https://saleor.testmo.net/repositories/5?group_id=133&sort_column=repository_cases:custom_automated&sort_direction=desc&case_id=7974)
- [CORE_2134](https://saleor.testmo.net/repositories/5?group_id=133&sort_column=repository_cases:custom_automated&sort_direction=desc&case_id=7975)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
