### PR TITLE
Get rid of total discount

### DIFF
--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1395,7 +1395,7 @@ def test_recalculate_checkout_discount_with_checkout_discount_voucher_not_applic
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=reward_value,
-        reward_type=RewardType.TOTAL_DISCOUNT,
+        reward_type=RewardType.SUBTOTAL_DISCOUNT,
     )
     rule.channels.add(line_info.channel)
 

--- a/saleor/discount/__init__.py
+++ b/saleor/discount/__init__.py
@@ -54,11 +54,9 @@ class RewardValueType:
 
 class RewardType:
     SUBTOTAL_DISCOUNT = "subtotal_discount"
-    TOTAL_DISCOUNT = "total_discount"
 
     CHOICES = [
         (SUBTOTAL_DISCOUNT, "subtotal_discount"),
-        (TOTAL_DISCOUNT, "total_discount"),
     ]
 
 

--- a/saleor/discount/migrations/0074_promotionrule_order_predicate.py
+++ b/saleor/discount/migrations/0074_promotionrule_order_predicate.py
@@ -27,7 +27,6 @@ class Migration(migrations.Migration):
                 blank=True,
                 choices=[
                     ("subtotal_discount", "subtotal_discount"),
-                    ("total_discount", "total_discount"),
                 ],
                 max_length=255,
                 null=True,

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -1380,7 +1380,7 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
 
 @patch("saleor.discount.utils.base_checkout_delivery_price")
 @patch("saleor.discount.utils.base_checkout_subtotal")
-def test_create_or_update_discount_objects_from_promotion_total_price_discount(
+def test_create_or_update_discount_objects_from_promotion_subtotal_price_discount(
     subtotal_mock,
     delivery_price_mock,
     checkout_info,
@@ -1419,7 +1419,7 @@ def test_create_or_update_discount_objects_from_promotion_total_price_discount(
                 },
                 reward_value_type=RewardValueType.PERCENTAGE,
                 reward_value=Decimal("50"),
-                reward_type=RewardType.TOTAL_DISCOUNT,
+                reward_type=RewardType.SUBTOTAL_DISCOUNT,
             ),
         ]
     )
@@ -1436,11 +1436,7 @@ def test_create_or_update_discount_objects_from_promotion_total_price_discount(
     assert len(checkout_info.discounts) == 1
     assert checkout_info.discounts[0].promotion_rule == rules[0]
     discount = checkout_info.discounts[0]
-    assert (
-        discount.amount_value
-        == checkout.base_total.amount * Decimal("0.5")
-        == (delivery_price + price).amount * Decimal("0.5")
-    )
+    assert discount.amount_value == checkout.base_subtotal.amount * Decimal("0.5")
 
 
 def test_create_or_update_discount_from_promotion_voucher_code_set_checkout_discount(
@@ -1641,7 +1637,7 @@ def test_create_discount_objects_for_order_promotions_race_condition(
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=reward_value,
-        reward_type=RewardType.TOTAL_DISCOUNT,
+        reward_type=RewardType.SUBTOTAL_DISCOUNT,
     )
     rule.channels.add(channel)
 
@@ -1655,7 +1651,7 @@ def test_create_discount_objects_for_order_promotions_race_condition(
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=Decimal("1"),
-        reward_type=RewardType.TOTAL_DISCOUNT,
+        reward_type=RewardType.SUBTOTAL_DISCOUNT,
     )
     rule0.channels.add(channel)
 
@@ -1705,7 +1701,7 @@ def test_create_or_update_checkout_discount_race_condition(
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=reward_value,
-        reward_type=RewardType.TOTAL_DISCOUNT,
+        reward_type=RewardType.SUBTOTAL_DISCOUNT,
     )
     rule.channels.add(channel)
 

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -546,7 +546,6 @@ def create_discount_objects_for_order_promotions(
         _clear_checkout_discount(checkout_info, save)
         return
     subtotal = checkout.base_subtotal
-    total = checkout.base_total
 
     rules = fetch_promotion_rules_for_checkout(checkout)
     if not rules:
@@ -559,8 +558,6 @@ def create_discount_objects_for_order_promotions(
         price = zero_money(currency_code)
         if rule.reward_type == RewardType.SUBTOTAL_DISCOUNT:
             price = subtotal
-        elif rule.reward_type == RewardType.TOTAL_DISCOUNT:
-            price = total
         discount_amount = price - discount(price)
         rule_with_discount_amount.append((rule, discount_amount))
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14313,7 +14313,6 @@ enum RewardValueTypeEnum @doc(category: "Discounts") {
 """An enumeration."""
 enum RewardTypeEnum @doc(category: "Discounts") {
   SUBTOTAL_DISCOUNT
-  TOTAL_DISCOUNT
 }
 
 union PromotionEvent = PromotionCreatedEvent | PromotionUpdatedEvent | PromotionStartedEvent | PromotionEndedEvent | PromotionRuleCreatedEvent | PromotionRuleUpdatedEvent | PromotionRuleDeletedEvent

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1142,7 +1142,7 @@ def test_checkout_payload_includes_order_promotion_discount(
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=reward_value,
-        reward_type=RewardType.TOTAL_DISCOUNT,
+        reward_type=RewardType.SUBTOTAL_DISCOUNT,
     )
     rule.channels.add(channel_listing.channel)
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -422,7 +422,7 @@ def checkout_with_item_and_order_discount(checkout_with_item, promotion_without_
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=reward_value,
-        reward_type=RewardType.TOTAL_DISCOUNT,
+        reward_type=RewardType.SUBTOTAL_DISCOUNT,
     )
     rule.channels.add(channel)
 


### PR DESCRIPTION
Get rid of `TOTAL_DISCOUNT` reward type for now.
Will be added later: https://github.com/saleor/saleor/issues/15230.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
