### PR TITLE
Add order promotions when populating database with dummy data.

### DIFF
--- a/saleor/core/management/commands/populatedb.py
+++ b/saleor/core/management/commands/populatedb.py
@@ -9,17 +9,18 @@ from django.db import connection
 from ....account.utils import create_superuser
 from ...utils.random_data import (
     add_address_to_admin,
+    create_catalogue_promotions,
     create_channels,
     create_checkout_with_custom_prices,
     create_checkout_with_preorders,
     create_checkout_with_same_variant_in_multiple_lines,
     create_gift_cards,
     create_menus,
+    create_order_promotions,
     create_orders,
     create_page_type,
     create_pages,
     create_permission_groups,
-    create_product_promotions,
     create_products_by_schema,
     create_shipping_zones,
     create_staffs,
@@ -100,7 +101,9 @@ class Command(BaseCommand):
             self.stdout.write(msg)
         create_products_by_schema(self.placeholders_dir, create_images)
         self.stdout.write("Created products")
-        for msg in create_product_promotions(2):
+        for msg in create_catalogue_promotions(2):
+            self.stdout.write(msg)
+        for msg in create_order_promotions(2):
             self.stdout.write(msg)
         for msg in create_vouchers():
             self.stdout.write(msg)

--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -148,12 +148,23 @@ def test_create_fake_order(db, monkeypatch, image, media_root, warehouse):
     assert Order.objects.all().count() == how_many_orders
 
 
-def test_create_product_promotions(db):
+def test_create_catalogue_promotions(db):
     how_many = 5
     channel_count = 0
     for _ in random_data.create_channels():
         channel_count += 1
-    for _ in random_data.create_product_promotions(how_many):
+    for _ in random_data.create_catalogue_promotions(how_many):
+        pass
+    assert Promotion.objects.all().count() == how_many
+    assert PromotionRule.objects.all().count() == how_many * 2
+
+
+def test_create_order_promotions(db):
+    how_many = 5
+    channel_count = 0
+    for _ in random_data.create_channels():
+        channel_count += 1
+    for _ in random_data.create_order_promotions(how_many):
         pass
     assert Promotion.objects.all().count() == how_many
     assert PromotionRule.objects.all().count() == how_many * 2


### PR DESCRIPTION
I want to merge this change because I want to add order promotions when populating database with dummy data.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
