### PR TITLE
lowercase file extension before validation

### DIFF
--- a/saleor/graphql/core/tests/test_file_validation.py
+++ b/saleor/graphql/core/tests/test_file_validation.py
@@ -288,3 +288,16 @@ def test_clean_image_file_invalid_image_mime_type(from_buffer_mock):
     # then
     error_msg = f"Unsupported image MIME type: {invalid_mime_type}"
     assert error_msg in exc.value.args[0][field].message
+
+
+def test_clean_image_file_with_captialized_extension():
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    field = "image"
+
+    img = SimpleUploadedFile("product.JPG", img_data.getvalue(), "image/jpeg")
+
+    # when & then
+    clean_image_file({field: img}, field, ProductErrorCode)

--- a/saleor/graphql/core/validators/file.py
+++ b/saleor/graphql/core/validators/file.py
@@ -113,7 +113,7 @@ def _validate_image_format(file, field_name, error_class):
                 )
             }
         )
-    elif format not in allowed_extensions:
+    elif format.lower() not in allowed_extensions:
         raise ValidationError(
             {
                 field_name: ValidationError(


### PR DESCRIPTION
valid extensions are already being loaded as lower case added test for capitalised extension

I want to merge this change because resolves https://github.com/saleor/saleor/issues/15033

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
