### PR TITLE
Fix Deprecation: datetime.datetime.utcnow()

### DIFF
--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 import graphene
@@ -31,7 +31,7 @@ JWT_OWNER_FIELD = "owner"
 def jwt_base_payload(
     exp_delta: Optional[timedelta], token_owner: str
 ) -> dict[str, Any]:
-    utc_now = datetime.utcnow()
+    utc_now = datetime.now(timezone.utc)
 
     payload = {
         "iat": utc_now,

--- a/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
@@ -56,15 +56,15 @@ def test_create_token(api_client, customer_user, settings):
     payload = jwt_decode(token)
     assert payload["email"] == customer_user.email
     assert payload["user_id"] == graphene.Node.to_global_id("User", customer_user.id)
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_ACCESS
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_ACCESS
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_ACCESS_TYPE
 
     payload = jwt_decode(refreshToken)
     assert payload["email"] == customer_user.email
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_REFRESH
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_REFRESH
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_REFRESH_TYPE
     assert payload["token"] == customer_user.jwt_token_key
@@ -94,16 +94,16 @@ def test_create_token_with_audience(api_client, customer_user, settings):
     payload = jwt_decode(token)
     assert payload["email"] == customer_user.email
     assert payload["user_id"] == graphene.Node.to_global_id("User", customer_user.id)
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_ACCESS
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_ACCESS
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_ACCESS_TYPE
     assert payload["aud"] == f"custom:{audience}"
 
     payload = jwt_decode(refreshToken)
     assert payload["email"] == customer_user.email
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_REFRESH
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_REFRESH
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_REFRESH_TYPE
     assert payload["token"] == customer_user.jwt_token_key
@@ -125,7 +125,7 @@ def test_create_token_sets_cookie(api_client, customer_user, settings, monkeypat
     )
     refresh_token = response.cookies["refreshToken"]
     assert refresh_token.value == expected_refresh_token
-    expected_expires = datetime.utcnow() + settings.JWT_TTL_REFRESH
+    expected_expires = datetime.now(timezone.utc) + settings.JWT_TTL_REFRESH
     expected_expires += timedelta(seconds=1)
     expires = datetime.strptime(refresh_token["expires"], "%a, %d %b %Y  %H:%M:%S %Z")
     assert expires == expected_expires
@@ -198,15 +198,15 @@ def test_create_token_unconfirmed_user_unconfirmed_login_enabled(
     payload = jwt_decode(token)
     assert payload["email"] == customer_user.email
     assert payload["user_id"] == graphene.Node.to_global_id("User", customer_user.id)
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_ACCESS
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_ACCESS
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_ACCESS_TYPE
 
     payload = jwt_decode(refreshToken)
     assert payload["email"] == customer_user.email
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_REFRESH
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_REFRESH
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_REFRESH_TYPE
     assert payload["token"] == customer_user.jwt_token_key
@@ -252,15 +252,15 @@ def test_create_token_active_user_logged_before(api_client, customer_user, setti
     payload = jwt_decode(token)
     assert payload["email"] == customer_user.email
     assert payload["user_id"] == graphene.Node.to_global_id("User", customer_user.id)
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_ACCESS
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_ACCESS
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_ACCESS_TYPE
 
     payload = jwt_decode(refreshToken)
     assert payload["email"] == customer_user.email
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
-    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_REFRESH
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
+    expected_expiration_datetime = datetime.now(timezone.utc) + settings.JWT_TTL_REFRESH
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_REFRESH_TYPE
     assert payload["token"] == customer_user.jwt_token_key

--- a/saleor/graphql/account/tests/mutations/authentication/test_token_refresh.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_token_refresh.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.urls import reverse
 from freezegun import freeze_time
@@ -50,10 +50,10 @@ def test_refresh_token_with_audience(api_client, customer_user, settings):
     assert token
     payload = jwt_decode(token)
     assert payload["email"] == customer_user.email
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
     assert (
         datetime.fromtimestamp(payload["exp"])
-        == datetime.utcnow() + settings.JWT_TTL_ACCESS
+        == datetime.now(timezone.utc) + settings.JWT_TTL_ACCESS
     )
     assert payload["type"] == JWT_ACCESS_TYPE
     assert payload["token"] == customer_user.jwt_token_key
@@ -82,10 +82,10 @@ def test_refresh_token_get_token_from_cookie(api_client, customer_user, settings
     assert token
     payload = jwt_decode(token)
     assert payload["email"] == customer_user.email
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
     assert (
         datetime.fromtimestamp(payload["exp"])
-        == datetime.utcnow() + settings.JWT_TTL_ACCESS
+        == datetime.now(timezone.utc) + settings.JWT_TTL_ACCESS
     )
     assert payload["type"] == JWT_ACCESS_TYPE
     assert payload["token"] == customer_user.jwt_token_key
@@ -108,10 +108,10 @@ def test_refresh_token_get_token_from_input(api_client, customer_user, settings)
     assert token
     payload = jwt_decode(token)
     assert payload["email"] == customer_user.email
-    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.now(timezone.utc)
     assert (
         datetime.fromtimestamp(payload["exp"])
-        == datetime.utcnow() + settings.JWT_TTL_ACCESS
+        == datetime.now(timezone.utc) + settings.JWT_TTL_ACCESS
     )
     assert payload["type"] == JWT_ACCESS_TYPE
 

--- a/saleor/graphql/product/tests/queries/test_products_query.py
+++ b/saleor/graphql/product/tests/queries/test_products_query.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import graphene
@@ -562,12 +562,12 @@ SORT_PRODUCTS_QUERY = """
 
 
 def test_sort_products(user_api_client, product, channel_USD):
-    product.updated_at = datetime.utcnow()
+    product.updated_at = datetime.now(timezone.utc)
     product.save()
 
     product.pk = None
     product.slug = "second-product"
-    product.updated_at = datetime.utcnow()
+    product.updated_at = datetime.now(timezone.utc)
     product.save()
     ProductChannelListing.objects.create(
         product=product,
@@ -586,7 +586,7 @@ def test_sort_products(user_api_client, product, channel_USD):
     )
     product.pk = None
     product.slug = "third-product"
-    product.updated_at = datetime.utcnow()
+    product.updated_at = datetime.now(timezone.utc)
     product.save()
     ProductChannelListing.objects.create(
         product=product,
@@ -672,13 +672,13 @@ def test_sort_products(user_api_client, product, channel_USD):
 def test_sort_products_by_price_as_staff(
     staff_api_client, product, channel_USD, permission_manage_products
 ):
-    product.updated_at = datetime.utcnow()
+    product.updated_at = datetime.now(timezone.utc)
     product.save()
     staff_api_client.user.user_permissions.add(permission_manage_products)
 
     product.pk = None
     product.slug = "second-product"
-    product.updated_at = datetime.utcnow()
+    product.updated_at = datetime.now(timezone.utc)
     product.save()
     ProductChannelListing.objects.create(
         product=product,
@@ -697,7 +697,7 @@ def test_sort_products_by_price_as_staff(
     )
     product.pk = None
     product.slug = "third-product"
-    product.updated_at = datetime.utcnow()
+    product.updated_at = datetime.now(timezone.utc)
     product.save()
     ProductChannelListing.objects.create(
         product=product,

--- a/saleor/webhook/transport/tests/test_utils.py
+++ b/saleor/webhook/transport/tests/test_utils.py
@@ -48,7 +48,7 @@ def test_webhook_retry(webhook, event_delivery):
     # given
     attempt = EventDeliveryAttempt(
         id=1,
-        created_at=datetime.datetime.utcnow(),
+        created_at=datetime.datetime.now(datetime.timezone.utc),
         delivery=event_delivery,
         request_headers="",
         task_id="123",
@@ -68,7 +68,7 @@ def test_webhook_retry_404(webhook, event_delivery):
     # given
     attempt = EventDeliveryAttempt(
         id=1,
-        created_at=datetime.datetime.utcnow(),
+        created_at=datetime.datetime.now(datetime.timezone.utc),
         delivery=event_delivery,
         request_headers="",
         task_id="123",
@@ -88,7 +88,7 @@ def test_webhook_retry_redirect(webhook, event_delivery):
     # given
     attempt = EventDeliveryAttempt(
         id=1,
-        created_at=datetime.datetime.utcnow(),
+        created_at=datetime.datetime.now(datetime.timezone.utc),
         delivery=event_delivery,
         request_headers="",
         task_id="123",


### PR DESCRIPTION
I want to merge this change because...

As of python 3.12, datetime.utcnow is deprecated (since it returns a naive datetime rather than a timezone-aware datetime).
The suggested fix is to use datetime.now with a specific timezone info of UTC instead.\
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs
This is an internal code change I think we don't need to update the documentation.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
