### PR TITLE
Fix `OrderDiscount.type` when converting checkout to order.

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1058,16 +1058,10 @@ def _create_order_discount(order: "Order", checkout_info: "CheckoutInfo"):
     if checkout.discount:
         checkout_discount = checkout.discounts.first()
         if checkout_discount and checkout_discount.type == DiscountType.ORDER_PROMOTION:
-            order.discounts.create(
-                type=checkout_discount.type,
-                value_type=checkout_discount.value_type,
-                value=checkout_discount.value,
-                name=checkout_discount.name,
-                translated_name=checkout_discount.translated_name,
-                currency=checkout_discount.currency,
-                amount_value=checkout_discount.amount_value,
-                promotion_rule=checkout_discount.promotion_rule,
-            )
+            discount_data = model_to_dict(checkout_discount)
+            discount_data["promotion_rule"] = checkout_discount.promotion_rule
+            del discount_data["checkout"]
+            order.discounts.create(**discount_data)
 
         if not checkout_discount:
             # store voucher as a fixed value as it this the simplest solution for now.

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1081,8 +1081,8 @@ def _create_order_discount(order: "Order", checkout_info: "CheckoutInfo"):
                 translated_name=checkout.translated_discount_name,
                 currency=checkout.currency,
                 amount_value=checkout.discount_amount,
-                # voucher=checkout_info.voucher,
-                # voucher_code=checkout_info.voucher_code,
+                voucher=checkout_info.voucher,
+                voucher_code=checkout_info.voucher_code.code,
             )
 
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1082,7 +1082,9 @@ def _create_order_discount(order: "Order", checkout_info: "CheckoutInfo"):
                 currency=checkout.currency,
                 amount_value=checkout.discount_amount,
                 voucher=checkout_info.voucher,
-                voucher_code=checkout_info.voucher_code.code,
+                voucher_code=checkout_info.voucher_code.code
+                if checkout_info.voucher_code
+                else None,
             )
 
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -26,7 +26,7 @@ from ..core.tracing import traced_atomic_transaction
 from ..core.transactions import transaction_with_commit_on_errors
 from ..core.utils.url import validate_storefront_url
 from ..discount import DiscountType, DiscountValueType
-from ..discount.models import NotApplicable, OrderLineDiscount
+from ..discount.models import CheckoutDiscount, NotApplicable, OrderLineDiscount
 from ..discount.utils import (
     get_sale_id,
     increase_voucher_usage,
@@ -1062,6 +1062,7 @@ def _create_order_discount(order: "Order", checkout_info: "CheckoutInfo"):
     )
 
     if is_promotion_discount:
+        checkout_discount = cast(CheckoutDiscount, checkout_discount)
         discount_data = model_to_dict(checkout_discount)
         discount_data["promotion_rule"] = checkout_discount.promotion_rule
         del discount_data["checkout"]

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -770,6 +770,9 @@ def test_order_from_checkout_with_voucher(
         order_discount.amount_value
         == (order.undiscounted_total - order.total).gross.amount
     )
+    assert order_discount.type == DiscountType.VOUCHER
+    assert order_discount.voucher == voucher_percentage
+    assert order_discount.voucher_code == code.code
 
     code.refresh_from_db()
     assert code.used == voucher_used_count + 1
@@ -847,6 +850,9 @@ def test_order_from_checkout_with_voucher_apply_once_per_order(
         order_discount.amount_value
         == (order.undiscounted_total - order.total).gross.amount
     )
+    assert order_discount.type == DiscountType.VOUCHER
+    assert order_discount.voucher == voucher_percentage
+    assert order_discount.voucher_code == code.code
 
     code.refresh_from_db()
     assert code.used == voucher_used_count + 1
@@ -911,6 +917,9 @@ def test_order_from_checkout_with_specific_product_voucher(
         order_discount.amount_value
         == (order.undiscounted_total - order.total).gross.amount
     )
+    assert order_discount.type == DiscountType.VOUCHER
+    assert order_discount.voucher == voucher_specific_product_type
+    assert order_discount.voucher_code == code.code
 
     code.refresh_from_db()
     assert code.used == voucher_used_count + 1


### PR DESCRIPTION
I want to merge this change because it fixes https://github.com/saleor/saleor/issues/15233.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
