### PR TITLE
Fix `promotionCreate` mutation to allow creating rules with no channels specified.

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -182,7 +182,8 @@ class PromotionCreate(ModelMutation):
             models.PromotionRule.objects.bulk_create(rules)
 
         for rule, channels in rules_with_channels_to_add:
-            rule.channels.set(channels)
+            if channels:
+                rule.channels.set(channels)
 
         return rules
 

--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -1184,6 +1184,52 @@ def test_promotion_create_invalid_catalogue_predicate(
     assert errors[0]["index"] == 1
 
 
+@patch("saleor.product.tasks.update_products_discounted_prices_of_promotion_task.delay")
+@patch("saleor.plugins.manager.PluginsManager.promotion_started")
+@patch("saleor.plugins.manager.PluginsManager.promotion_created")
+def test_promotion_create_rules_without_channels_and_percentage_reward(
+    promotion_created_mock,
+    promotion_started_mock,
+    update_products_discounted_prices_of_promotion_task_mock,
+    staff_api_client,
+    permission_group_manage_discounts,
+    variant,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+    catalogue_predicate = {
+        "variantPredicate": {
+            "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
+        }
+    }
+    variables = {
+        "input": {
+            "name": "test promotion",
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": "test promotion rule 1",
+                    "rewardValueType": RewardValueTypeEnum.PERCENTAGE.name,
+                    "rewardValue": Decimal("10"),
+                    "cataloguePredicate": catalogue_predicate,
+                }
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    assert not data["errors"]
+    assert data["promotion"]["rules"]
+
+
 PROMOTION_CREATE_WITH_EVENTS = """
     mutation promotionCreate($input: PromotionCreateInput!) {
         promotionCreate(input: $input) {


### PR DESCRIPTION
Port to: https://github.com/saleor/saleor/pull/15220
Issue: https://github.com/saleor/saleor/issues/15215

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
