### PR TITLE
Do not re-calculate the promotions when catalogue predicate is empty

### DIFF
--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -122,9 +122,9 @@ def update_products_discounted_prices_for_promotion_task(
         PromotionRule.objects.order_by("id")
         .using(settings.DATABASE_CONNECTION_REPLICA_NAME)
         .filter(Exists(promotions.filter(id=OuterRef("promotion_id"))), **kwargs)
-        .exclude(Q(reward_value__isnull=True) | Q(reward_value=0))[
-            :PROMOTION_RULE_BATCH_SIZE
-        ]
+        .exclude(
+            Q(reward_value__isnull=True) | Q(reward_value=0) | Q(catalogue_predicate={})
+        )[:PROMOTION_RULE_BATCH_SIZE]
     )
     if ids := list(rules.values_list("pk", flat=True)):
         qs = PromotionRule.objects.filter(pk__in=ids).exclude(

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -97,6 +97,34 @@ def test_update_products_discounted_prices_for_promotion_task(
     ) == set(PromotionRule.objects.values_list("id", flat=True))
 
 
+@patch(
+    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
+)
+@patch("saleor.product.tasks.PROMOTION_RULE_BATCH_SIZE", 1)
+@patch("saleor.product.tasks.update_discounted_prices_task.delay")
+def test_update_products_discounted_prices_for_promotion_task_with_order_predicate(
+    update_discounted_prices_task_mock,
+    update_products_discounted_prices_for_promotion_task_delay_mocked,
+    promotion_list,
+    product_list,
+):
+    # given
+    Promotion.objects.update(start_date=timezone.now() - timedelta(days=1))
+    product_ids = [product.id for product in product_list]
+    PromotionRule.objects.update(catalogue_predicate={})
+    PromotionRuleVariant = PromotionRule.variants.through
+
+    # when
+    update_products_discounted_prices_for_promotion_task(product_ids)
+
+    # then
+    assert not update_products_discounted_prices_for_promotion_task_delay_mocked.called
+    update_discounted_prices_task_mock.assert_called_once_with(product_ids)
+    assert set(
+        PromotionRuleVariant.objects.values_list("promotionrule_id", flat=True)
+    ) == set(PromotionRule.objects.values_list("id", flat=True))
+
+
 @patch("saleor.product.tasks.PROMOTION_RULE_BATCH_SIZE", 1)
 @patch("saleor.product.tasks.update_discounted_prices_task.delay")
 @patch("saleor.product.utils.variants.fetch_variants_for_promotion_rules")


### PR DESCRIPTION
I want to merge this change because it covers: https://github.com/saleor/saleor/issues/15234

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
