### PR TITLE
fix: Renamed DiscountType.PROMOTION to DiscountType.CATALOGUE_PROMOTION

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -59,7 +59,7 @@ class CheckoutLineInfo:
         return [
             discount
             for discount in self.discounts
-            if discount.type == DiscountType.PROMOTION
+            if discount.type == DiscountType.CATALOGUE_PROMOTION
         ]
 
 

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1314,7 +1314,7 @@ def test_recalculate_checkout_discount_with_promotion(
 
     line_discount = CheckoutLineDiscount.objects.create(
         line=line_info.line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         amount_value=reward_value * line_info.line.quantity,
         currency=line_info.channel.currency_code,

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -75,7 +75,7 @@ def test_create_fixed_discount(
     discount_from_db = line_info1.line.discounts.get()
     assert discount_from_info.line == discount_from_db.line == line_info1.line
     assert discount_from_info.created_at == discount_from_db.created_at == now
-    assert discount_from_info.type == discount_from_db.type == DiscountType.PROMOTION
+    assert discount_from_info.type == discount_from_db.type == DiscountType.CATALOGUE_PROMOTION
     assert (
         discount_from_info.value_type
         == discount_from_db.value_type
@@ -159,7 +159,7 @@ def test_create_fixed_discount_multiple_quantity_in_lines(
     discount_from_db = line_info1.line.discounts.get()
     assert discount_from_info.line == discount_from_db.line == line_info1.line
     assert discount_from_info.created_at == discount_from_db.created_at == now
-    assert discount_from_info.type == discount_from_db.type == DiscountType.PROMOTION
+    assert discount_from_info.type == discount_from_db.type == DiscountType.CATALOGUE_PROMOTION
     assert (
         discount_from_info.value_type
         == discount_from_db.value_type
@@ -237,7 +237,7 @@ def test_create_fixed_discount_multiple_quantity_in_lines_discount_bigger_than_t
     discount_from_info = line_info1.discounts[0]
     discount_from_db = line_info1.line.discounts.get()
     assert discount_from_info.line == discount_from_db.line == line_info1.line
-    assert discount_from_info.type == discount_from_db.type == DiscountType.PROMOTION
+    assert discount_from_info.type == discount_from_db.type == DiscountType.CATALOGUE_PROMOTION
     assert (
         discount_from_info.value_type
         == discount_from_db.value_type
@@ -306,7 +306,7 @@ def test_create_percentage_discount(checkout_lines_info, promotion_without_rules
     discount_from_db = line_info1.line.discounts.get()
     assert discount_from_info.line == discount_from_db.line == line_info1.line
     assert discount_from_info.created_at == discount_from_db.created_at == now
-    assert discount_from_info.type == discount_from_db.type == DiscountType.PROMOTION
+    assert discount_from_info.type == discount_from_db.type == DiscountType.CATALOGUE_PROMOTION
     assert (
         discount_from_info.value_type
         == discount_from_db.value_type
@@ -390,7 +390,7 @@ def test_create_percentage_discount_multiple_quantity_in_lines(
     discount_from_db = line_info1.line.discounts.get()
     assert discount_from_info.line == discount_from_db.line == line_info1.line
     assert discount_from_info.created_at == discount_from_db.created_at == now
-    assert discount_from_info.type == discount_from_db.type == DiscountType.PROMOTION
+    assert discount_from_info.type == discount_from_db.type == DiscountType.CATALOGUE_PROMOTION
     assert (
         discount_from_info.value_type
         == discount_from_db.value_type
@@ -510,8 +510,8 @@ def test_create_discount_multiple_rules_applied(
     assert discount_for_rule_1.line == line_info1.line
     assert discount_for_rule_2.line == line_info1.line
 
-    assert discount_for_rule_1.type == DiscountType.PROMOTION
-    assert discount_for_rule_2.type == DiscountType.PROMOTION
+    assert discount_for_rule_1.type == DiscountType.CATALOGUE_PROMOTION
+    assert discount_for_rule_2.type == DiscountType.CATALOGUE_PROMOTION
 
     assert discount_for_rule_1.value_type == RewardValueType.FIXED
     assert discount_for_rule_2.value_type == RewardValueType.PERCENTAGE
@@ -632,7 +632,7 @@ def test_two_promotions_applied_to_two_different_lines(
     discount_from_db_1 = line_info1.line.discounts.get()
     assert discount_from_info_1.line == discount_from_db_1.line == line_info1.line
     assert (
-        discount_from_info_1.type == discount_from_db_1.type == DiscountType.PROMOTION
+        discount_from_info_1.type == discount_from_db_1.type == DiscountType.CATALOGUE_PROMOTION
     )
     assert (
         discount_from_info_1.value_type
@@ -663,7 +663,7 @@ def test_two_promotions_applied_to_two_different_lines(
     discount_from_db_2 = line_info2.line.discounts.get()
     assert discount_from_info_2.line == discount_from_db_2.line == line_info2.line
     assert (
-        discount_from_info_2.type == discount_from_db_2.type == DiscountType.PROMOTION
+        discount_from_info_2.type == discount_from_db_2.type == DiscountType.CATALOGUE_PROMOTION
     )
     assert (
         discount_from_info_2.value_type
@@ -755,7 +755,7 @@ def test_create_percentage_discount_1_cent_variant_on_10_percentage_discount(
     discount_from_db = line_info1.line.discounts.get()
     assert discount_from_info.line == discount_from_db.line == line_info1.line
     assert discount_from_info.created_at == discount_from_db.created_at == now
-    assert discount_from_info.type == discount_from_db.type == DiscountType.PROMOTION
+    assert discount_from_info.type == discount_from_db.type == DiscountType.CATALOGUE_PROMOTION
     assert (
         discount_from_info.value_type
         == discount_from_db.value_type
@@ -808,7 +808,7 @@ def test_promotion_not_valid_anymore(checkout_lines_info, promotion_without_rule
         value_type=RewardValueType.FIXED,
         value=reward_value,
         currency=line_info1.channel.currency_code,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         promotion_rule=rule,
     )
 
@@ -885,7 +885,7 @@ def test_one_of_promotion_rule_not_valid_anymore_one_updated(
                 value_type=RewardValueType.PERCENTAGE,
                 value=Decimal("10"),
                 currency=line_info1.channel.currency_code,
-                type=DiscountType.PROMOTION,
+                type=DiscountType.CATALOGUE_PROMOTION,
                 promotion_rule=rule_1,
             ),
             CheckoutLineDiscount(
@@ -893,7 +893,7 @@ def test_one_of_promotion_rule_not_valid_anymore_one_updated(
                 value_type=RewardValueType.FIXED,
                 value=reward_value_2,
                 currency=line_info1.channel.currency_code,
-                type=DiscountType.PROMOTION,
+                type=DiscountType.CATALOGUE_PROMOTION,
                 promotion_rule=rule_2,
             ),
         ]
@@ -922,7 +922,7 @@ def test_one_of_promotion_rule_not_valid_anymore_one_updated(
     discount_from_info = line_info1.discounts[0]
     line_discount_1.refresh_from_db()
     assert discount_from_info.line == line_discount_1.line == line_info1.line
-    assert discount_from_info.type == line_discount_1.type == DiscountType.PROMOTION
+    assert discount_from_info.type == line_discount_1.type == DiscountType.CATALOGUE_PROMOTION
     assert (
         discount_from_info.value_type
         == line_discount_1.value_type

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -387,7 +387,7 @@ def create_or_update_discount_objects_from_promotion_for_checkout(
             if not discount_to_update:
                 line_discount = CheckoutLineDiscount(
                     line=line,
-                    type=DiscountType.PROMOTION,
+                    type=DiscountType.CATALOGUE_PROMOTION,
                     value_type=rule.reward_value_type,
                     value=rule.reward_value,
                     amount_value=rule_discount_amount,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -1095,7 +1095,7 @@ def test_checkout_with_voucher_complete_product_on_promotion(
     )
     CheckoutLineDiscount.objects.create(
         line=checkout_line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         amount_value=reward_value,
         currency=channel.currency_code,
@@ -1451,7 +1451,7 @@ def test_checkout_complete_product_on_promotion(
     )
     CheckoutLineDiscount.objects.create(
         line=checkout_line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         amount_value=reward_value,
         currency=channel.currency_code,
@@ -1596,7 +1596,7 @@ def test_checkout_complete_product_on_old_sale(
     )
     CheckoutLineDiscount.objects.create(
         line=checkout_line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         amount_value=reward_value,
         currency=channel.currency_code,
@@ -1776,7 +1776,7 @@ def test_checkout_complete_multiple_rules_applied(
         [
             CheckoutLineDiscount(
                 line=checkout_line,
-                type=DiscountType.PROMOTION,
+                type=DiscountType.CATALOGUE_PROMOTION,
                 value_type=DiscountValueType.FIXED,
                 amount_value=reward_value_1,
                 currency=channel.currency_code,
@@ -1784,7 +1784,7 @@ def test_checkout_complete_multiple_rules_applied(
             ),
             CheckoutLineDiscount(
                 line=checkout_line,
-                type=DiscountType.PROMOTION,
+                type=DiscountType.CATALOGUE_PROMOTION,
                 value_type=DiscountValueType.FIXED,
                 amount_value=discount_amount_2,
                 currency=channel.currency_code,
@@ -1923,7 +1923,7 @@ def test_checkout_with_voucher_on_specific_product_complete_with_product_on_prom
     )
     line_discount = CheckoutLineDiscount.objects.create(
         line=checkout_line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         amount_value=reward_value,
         currency=channel.currency_code,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1905,7 +1905,7 @@ def test_checkout_with_voucher_complete_product_on_sale(
     )
     CheckoutLineDiscount.objects.create(
         line=checkout_line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         amount_value=reward_value,
         currency=channel.currency_code,
@@ -2100,7 +2100,7 @@ def test_checkout_complete_product_on_promotion(
     )
     CheckoutLineDiscount.objects.create(
         line=checkout_line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         amount_value=reward_value,
         currency=channel.currency_code,
@@ -2247,7 +2247,7 @@ def test_checkout_complete_multiple_rules_applied(
         [
             CheckoutLineDiscount(
                 line=checkout_line,
-                type=DiscountType.PROMOTION,
+                type=DiscountType.CATALOGUE_PROMOTION,
                 value_type=DiscountValueType.FIXED,
                 amount_value=reward_value_1,
                 currency=channel.currency_code,
@@ -2255,7 +2255,7 @@ def test_checkout_complete_multiple_rules_applied(
             ),
             CheckoutLineDiscount(
                 line=checkout_line,
-                type=DiscountType.PROMOTION,
+                type=DiscountType.CATALOGUE_PROMOTION,
                 value_type=DiscountValueType.FIXED,
                 amount_value=discount_amount_2,
                 currency=channel.currency_code,

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -1049,7 +1049,7 @@ def test_order_from_checkout_multiple_rules_applied(
     )
     CheckoutLineDiscount.objects.create(
         line=line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.PERCENTAGE,
         amount_value=discount_amount_2,
         currency=channel.currency_code,

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -636,7 +636,7 @@ def test_order_lines_create_variant_on_promotion(
     discount = line.discounts.first()
     assert discount.promotion_rule == rule
     assert discount.amount_value == reward_value
-    assert discount.type == DiscountType.PROMOTION
+    assert discount.type == DiscountType.CATALOGUE_PROMOTION
     assert discount.name == f"{promotion_without_rules.name}: {rule.name}"
     assert (
         discount.translated_name

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -638,7 +638,7 @@ def test_create_order_line_discounts(
 
     for discount in [discount_1, discount_2]:
         assert discount.line == order_line
-        assert discount.type == DiscountType.PROMOTION
+        assert discount.type == DiscountType.CATALOGUE_PROMOTION
         assert discount.currency == order.currency
         assert discount.reason is None
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -338,7 +338,7 @@ def create_order_line_discounts(
         line_discounts_to_create.append(
             OrderLineDiscount(
                 line=line,
-                type=DiscountType.PROMOTION,
+                type=DiscountType.CATALOGUE_PROMOTION,
                 value_type=rule.reward_value_type,
                 value=rule.reward_value,
                 amount_value=rule_discount_amount,

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -1536,7 +1536,7 @@ def test_calculate_checkout_total_for_JPY_with_promotion(
     )
     CheckoutLineDiscount.objects.create(
         line=line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         value=reward_value,
         amount_value=reward_value * line.quantity,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -393,7 +393,7 @@ def checkout_with_item_on_promotion(checkout_with_item):
     )
     CheckoutLineDiscount.objects.create(
         line=line,
-        type=DiscountType.PROMOTION,
+        type=DiscountType.CATALOGUE_PROMOTION,
         value_type=DiscountValueType.FIXED,
         value=reward_value,
         amount_value=reward_value * line.quantity,

--- a/saleor/webhook/tests/test_webhook_serializers.py
+++ b/saleor/webhook/tests/test_webhook_serializers.py
@@ -390,7 +390,7 @@ def test_serialize_checkout_lines_for_tax_calculation_with_promotion(
         }
 
         discount = line_info.discounts[0]
-        assert discount.type == DiscountType.PROMOTION
+        assert discount.type == DiscountType.CATALOGUE_PROMOTION
         undiscounted_unit_price = variant.get_base_price(
             line_info.channel_listing,
             line_info.line.price_override,


### PR DESCRIPTION
I want to merge this change because...

fixes #15253

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
