### PR TITLE
Fix saving attribute values in order

### DIFF
--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -242,23 +242,27 @@ class AttributeValueManager(models.Manager):
         results = []
         objects_not_in_db: List[AttributeValue] = []
 
+        # prepare a list that will save order index of attribute values
+        objects_enumerated = [
+            (index, obj_data) for index, obj_data in enumerate(objects_data)
+        ]
         query = self._prepare_query_for_bulk_operation(objects_data)
 
         # iterate over all records in db and check if they match any of objects data
         for record in query.iterator():
             # iterate over all objects data and check if they match any of records in db
-            for obj in objects_data:
+            for index, obj in objects_enumerated:
                 if self._is_correct_record(record, obj):
                     # upon finding existing record add it to results
-                    results.append(record)
-
-                    # remove it from objects data, so it won't be added to new records
-                    objects_data.remove(obj)
-
-                    break
+                    results.append((index, record))
+                    # remove it from objects list, so it won't be added to new records
+                    objects_enumerated.remove((index, obj))
 
         # add what is left to the list of new records
-        self._add_new_records(objects_data, objects_not_in_db, results)
+        self._add_new_records(objects_enumerated, objects_not_in_db, results)
+        # sort results to keep order of attribute values
+        results.sort()
+        results = [obj for index, obj in results]
 
         if objects_not_in_db:
             self.bulk_create(objects_not_in_db)  # type: ignore[arg-type]
@@ -268,18 +272,19 @@ class AttributeValueManager(models.Manager):
     def bulk_update_or_create(self, objects_data):
         # this method mimics django's queryset.update_or_create method on bulk objects
         # https://docs.djangoproject.com/en/5.0/ref/models/querysets/#update-or-create
-
         results = []
         objects_not_in_db: List[AttributeValue] = []
         objects_to_be_updated = []
         update_fields = set()
-
+        objects_enumerated = [
+            (index, obj_data) for index, obj_data in enumerate(objects_data)
+        ]
         query = self._prepare_query_for_bulk_operation(objects_data)
 
         # iterate over all records in db and check if they match any of objects data
         for record in query.iterator():
             # iterate over all objects data and check if they match any of records in db
-            for obj in objects_data:
+            for index, obj in objects_enumerated:
                 if self._is_correct_record(record, obj):
                     # upon finding a matching record, update it with defaults
                     for key, value in obj["defaults"].items():
@@ -287,18 +292,22 @@ class AttributeValueManager(models.Manager):
                         update_fields.add(key)
 
                     # add it to results and objects to be updated
-                    results.append(record)
+                    results.append((index, record))
 
                     # add it to objects to be updated, so it can be bulk updated later
                     objects_to_be_updated.append(record)
 
                     # remove it from objects data, so it won't be added to new records
-                    objects_data.remove(obj)
+                    objects_enumerated.remove((index, obj))
 
                     break
 
         # add what is left to the list of new records
-        self._add_new_records(objects_data, objects_not_in_db, results)
+        self._add_new_records(objects_enumerated, objects_not_in_db, results)
+
+        # sort results by index
+        results.sort()
+        results = [obj for index, obj in results]
 
         if objects_not_in_db:
             self.bulk_create(objects_not_in_db)  # type: ignore[arg-type]
@@ -310,8 +319,8 @@ class AttributeValueManager(models.Manager):
 
         return results
 
-    def _add_new_records(self, objects_data, objects_not_in_db, results):
-        for obj in objects_data:
+    def _add_new_records(self, objects_enumerated, objects_not_in_db, results):
+        for index, obj in objects_enumerated:
             # updating object data with defaults as they contain new values
             defaults = obj.pop("defaults")
             obj.update(defaults)
@@ -319,7 +328,7 @@ class AttributeValueManager(models.Manager):
             # add new record to the list of new records, so it can be bulk created later
             record = self.model(**obj)
             objects_not_in_db.append(record)
-            results.append(record)
+            results.append((index, record))
 
 
 class AttributeValue(ModelWithExternalReference):

--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -243,9 +243,7 @@ class AttributeValueManager(models.Manager):
         objects_not_in_db: List[AttributeValue] = []
 
         # prepare a list that will save order index of attribute values
-        objects_enumerated = [
-            (index, obj_data) for index, obj_data in enumerate(objects_data)
-        ]
+        objects_enumerated = list(enumerate(objects_data))
         query = self._prepare_query_for_bulk_operation(objects_data)
 
         # iterate over all records in db and check if they match any of objects data
@@ -257,6 +255,8 @@ class AttributeValueManager(models.Manager):
                     results.append((index, record))
                     # remove it from objects list, so it won't be added to new records
                     objects_enumerated.remove((index, obj))
+
+                    break
 
         # add what is left to the list of new records
         self._add_new_records(objects_enumerated, objects_not_in_db, results)
@@ -276,9 +276,7 @@ class AttributeValueManager(models.Manager):
         objects_not_in_db: List[AttributeValue] = []
         objects_to_be_updated = []
         update_fields = set()
-        objects_enumerated = [
-            (index, obj_data) for index, obj_data in enumerate(objects_data)
-        ]
+        objects_enumerated = list(enumerate(objects_data))
         query = self._prepare_query_for_bulk_operation(objects_data)
 
         # iterate over all records in db and check if they match any of objects data

--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -260,7 +260,7 @@ class AttributeValueManager(models.Manager):
 
         # add what is left to the list of new records
         self._add_new_records(objects_enumerated, objects_not_in_db, results)
-        # sort results to keep order of attribute values
+        # sort results by index as db record order might be different from sort_order
         results.sort()
         results = [obj for index, obj in results]
 
@@ -305,7 +305,7 @@ class AttributeValueManager(models.Manager):
         # add what is left to the list of new records
         self._add_new_records(objects_enumerated, objects_not_in_db, results)
 
-        # sort results by index
+        # sort results by index as db record order might be different from sort_order
         results.sort()
         results = [obj for index, obj in results]
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -2007,14 +2007,14 @@ def test_update_product_variant_change_attribute_values_ordering(
     assert len(values) == 3
     assert [value["id"] for value in values] == [
         graphene.Node.to_global_id("AttributeValue", val.pk)
-        for val in [attr_value_1, attr_value_2, attr_value_3]
+        for val in [attr_value_2, attr_value_1, attr_value_3]
     ]
     variant.refresh_from_db()
     assert list(
         variant.attributes.first().variantvalueassignment.values_list(
             "value_id", flat=True
         )
-    ) == [attr_value_1.pk, attr_value_2.pk, attr_value_3.pk]
+    ) == [attr_value_2.pk, attr_value_1.pk, attr_value_3.pk]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I want to merge this change because it fixes bug introduced in #14985 with attribute values not been saved in correct order on update.  and fixes test that was modified by it but shouldn't have been. 
The mentioned PR was already merged but not ported to higher versions so this fix should be implemented within the ports.

To reproduce problem: 

1. Use Saleor 3.14 
2. create product type with reference values 
3. create product
4. assign 3 or more references 
5. save product
6. rearrange reference order and save 
7. refresh

Result: Products references will be in initial order instead of a new one
Expected result: Products references will be in a new order

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
