### PR TITLE
Fix creating promotion rule without catalogue predicate

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/validators.py
+++ b/saleor/graphql/discount/mutations/promotion/validators.py
@@ -117,6 +117,9 @@ def clean_predicate(predicate, error_class, index=None):
     Operators cannot be mixed with other filter inputs. There could be only
     one operator on each level.
     """
+    if not predicate:
+        return {}
+
     if isinstance(predicate, list):
         return [
             clean_predicate(item, error_class, index)

--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -1408,3 +1408,53 @@ def test_promotion_create_events_by_app(
     rule_ids = [event["ruleId"] for event in events if event.get("ruleId")]
     rules = data["promotion"]["rules"]
     assert all([rule["id"] in rule_ids for rule in rules])
+
+
+def test_promotion_create_without_catalogue_predicate(
+    staff_api_client,
+    permission_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    variant,
+    product,
+):
+    # given
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    promotion_name = "test promotion"
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": "test promotion rule",
+                    "description": description_json,
+                    "channels": channel_ids,
+                    "rewardValueType": RewardValueTypeEnum.PERCENTAGE.name,
+                    "rewardValue": Decimal("50"),
+                    "cataloguePredicate": None,
+                }
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PROMOTION_CREATE_MUTATION, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    assert not data["errors"]
+    assert data["promotion"]
+    assert len(data["promotion"]["rules"]) == 1
+    assert data["promotion"]["rules"][0]["cataloguePredicate"] == {}


### PR DESCRIPTION
port #15276
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
