### PR TITLE
Fix creating promotion rule with metadata

### DIFF
--- a/saleor/graphql/core/filters.py
+++ b/saleor/graphql/core/filters.py
@@ -92,10 +92,12 @@ def filter_status(qs, _, value):
 
 def filter_metadata(qs, _, value):
     for metadata_item in value:
-        if metadata_item.value:
-            qs = qs.filter(metadata__contains={metadata_item.key: metadata_item.value})
+        metadata_value = metadata_item.get("value")
+        metadata_key = metadata_item.get("key")
+        if metadata_value:
+            qs = qs.filter(metadata__contains={metadata_key: metadata_value})
         else:
-            qs = qs.filter(metadata__has_key=metadata_item.key)
+            qs = qs.filter(metadata__has_key=metadata_key)
     return qs
 
 


### PR DESCRIPTION
I want to merge this change because it fixes creating promotion rule with metadata in predicate.

resolves #15245

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
