### PR TITLE
Provide default Sale.type when missing in PromotionRule

### DIFF
--- a/saleor/graphql/discount/types/sales.py
+++ b/saleor/graphql/discount/types/sales.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene import relay
 
-from ....discount import models
+from ....discount import DiscountValueType, models
 from ....permission.enums import DiscountPermissions
 from ....product.models import Category, Collection, Product, ProductVariant
 from ...channel import ChannelQsContext
@@ -141,7 +141,7 @@ class Sale(ChannelContextTypeWithMetadata, ModelObjectType[models.Promotion]):
     def resolve_type(root: ChannelContext[models.Promotion], info: ResolveInfo):
         def _get_type(rules):
             # We ensure, that old sales have at least one rule associated.
-            return rules[0].reward_value_type
+            return rules[0].reward_value_type or DiscountValueType.FIXED
 
         return (
             PromotionRulesByPromotionIdLoader(info.context)


### PR DESCRIPTION
I want to merge this change because it is port of changes from: https://github.com/saleor/saleor/pull/15268

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
