### PR TITLE
GHA: publish container images using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -12,6 +12,11 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-20.04
+
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,8 +53,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ secrets.CR_USERNAME }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push
         id: docker_build


### PR DESCRIPTION

GHCR packages can be published using the temporary GITHUB_TOKEN thus this commit removes the usage of manually created and maintained GitHub secrets.

Cherry-pick of 8fbd56dbc9d8fc199fc8c25170280c7da24d483a (`main`).
