### PR TITLE
async webhooks: add extra data in failure logs

### DIFF
--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -306,6 +306,16 @@ def handle_webhook_retry(
     When MaxRetriesExceededError is raised the function will end without exception.
     """
     is_success = True
+    log_extra_details = {
+        "webhook": {
+            "id": webhook.id,
+            "target_url": webhook.target_url,
+            "event": delivery.event_type,
+            "execution_mode": "async",
+            "duration": response.duration,
+            "http_status_code": response.response_status_code,
+        },
+    }
     task_logger.info(
         "[Webhook ID: %r] Failed request to %r: %r for event: %r."
         " Delivery attempt id: %r",
@@ -314,6 +324,7 @@ def handle_webhook_retry(
         response.content,
         delivery.event_type,
         delivery_attempt.id,
+        extra=log_extra_details,
     )
     if response.response_status_code and 300 <= response.response_status_code < 500:
         # do not retry for 30x and 40x status codes
@@ -323,6 +334,7 @@ def handle_webhook_retry(
             webhook.target_url,
             response.response_status_code,
             delivery.id,
+            extra=log_extra_details,
         )
         return False
     try:
@@ -339,6 +351,7 @@ def handle_webhook_retry(
             webhook.id,
             webhook.target_url,
             delivery.id,
+            extra=log_extra_details,
         )
     return is_success
 


### PR DESCRIPTION
This adds additional data to async webhooks failures to improve filtering and analysis of JSON logs.

Added:
- `webhook.id`: the ID of the table row `webhook_webhook`
- `webhook.target_url`: the URL where the webhook was attempted to be sent to
- `webhook.event`: the event name (e.g., `product_variant_updated`), see https://github.com/saleor/saleor/blob/ddb8921a67441288b2489135a2490f6062d7a7c4/saleor/webhook/event_types.py#L23-L201 for all possible values
- `webhook.duration`: the amount of time it took until the failure happened
- `webhook.http_status_code`: the HTTP status code (e.g., `500`, `404`)


Closes: https://github.com/saleor/saleor/issues/14292

Example:
<div align=center><img width="400" alt="Screen Shot 2024-01-25 at 11 04 04 PM" src="https://github.com/saleor/saleor/assets/6186720/0881fc98-2bf2-4ec3-bb50-94f4040c20b4"></div>


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
