### PR TITLE
Always apply discount from single promotion rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 - Drop `OrderBulkCreateInput.voucher` field. Use `OrderBulkCreateInput.voucherCode` instead. - #14553 by @zedzior
+- Do not stack promotion rules within the promotion. Only the best promotion rule will be applied within the promotion. Previously discounts from all promotion rules were applied to the variant's price - #15309 by @korycins
 
 ### GraphQL API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 - Drop `OrderBulkCreateInput.voucher` field. Use `OrderBulkCreateInput.voucherCode` instead. - #14553 by @zedzior
-- Do not stack promotion rules within the promotion. Only the best promotion rule will be applied within the promotion. Previously discounts from all promotion rules were applied to the variant's price - #15309 by @korycins
+- Do not stack promotion rules within the promotion. Only the best promotion rule will be applied within the promotion. Previously discounts from all rules within the promotion that gives the best discount were applied to the variant's price - #15309 by @korycins
 
 ### GraphQL API
 

--- a/saleor/discount/tests/test_utils/test_calculate_discounted_price_for_promotions.py
+++ b/saleor/discount/tests/test_utils/test_calculate_discounted_price_for_promotions.py
@@ -52,20 +52,16 @@ def test_variant_discounts_multiple_promotions(product, channel_USD):
     rule_high.channels.add(channel_USD)
 
     rules_info_per_promotion_id = {
-        variant.id: {
-            promotion_low_discount.id: [
-                PromotionRuleInfo(
-                    rule=rule_low,
-                    channel_ids=[channel_USD.id],
-                )
-            ],
-            promotion_high_discount.id: [
-                PromotionRuleInfo(
-                    rule=rule_high,
-                    channel_ids=[channel_USD.id],
-                )
-            ],
-        }
+        variant.id: [
+            PromotionRuleInfo(
+                rule=rule_low,
+                channel_ids=[channel_USD.id],
+            ),
+            PromotionRuleInfo(
+                rule=rule_high,
+                channel_ids=[channel_USD.id],
+            ),
+        ],
     }
 
     variant_channel_listing = variant.channel_listings.get(channel=channel_USD)
@@ -74,7 +70,7 @@ def test_variant_discounts_multiple_promotions(product, channel_USD):
     # when
     applied_rule_id, applied_discount = calculate_discounted_price_for_promotions(
         price=price,
-        rules_info_per_variant_and_promotion_id=rules_info_per_promotion_id,
+        rules_info_per_variant=rules_info_per_promotion_id,
         channel=channel_USD,
         variant_id=variant.id,
     )
@@ -140,24 +136,20 @@ def test_variant_discounts_multiple_promotions_and_rules(product, channel_USD):
     channel_USD.promotionrule_set.add(rule_low_1, rule_low_2, rule_high_1)
 
     rules_info_per_promotion_id = {
-        variant.id: {
-            promotion_low_discount.id: [
-                PromotionRuleInfo(
-                    rule=rule_low_1,
-                    channel_ids=[channel_USD.id],
-                ),
-                PromotionRuleInfo(
-                    rule=rule_low_2,
-                    channel_ids=[channel_USD.id],
-                ),
-            ],
-            promotion_high_discount.id: [
-                PromotionRuleInfo(
-                    rule=rule_high_1,
-                    channel_ids=[channel_USD.id],
-                ),
-            ],
-        }
+        variant.id: [
+            PromotionRuleInfo(
+                rule=rule_low_1,
+                channel_ids=[channel_USD.id],
+            ),
+            PromotionRuleInfo(
+                rule=rule_low_2,
+                channel_ids=[channel_USD.id],
+            ),
+            PromotionRuleInfo(
+                rule=rule_high_1,
+                channel_ids=[channel_USD.id],
+            ),
+        ],
     }
 
     variant_channel_listing = variant.channel_listings.get(channel=channel_USD)
@@ -166,7 +158,7 @@ def test_variant_discounts_multiple_promotions_and_rules(product, channel_USD):
     # when
     applied_rule_id, applied_discount = calculate_discounted_price_for_promotions(
         price=price,
-        rules_info_per_variant_and_promotion_id=rules_info_per_promotion_id,
+        rules_info_per_variant=rules_info_per_promotion_id,
         channel=channel_USD,
         variant_id=variant.id,
     )

--- a/saleor/discount/tests/test_utils/test_calculate_discounted_price_for_promotions.py
+++ b/saleor/discount/tests/test_utils/test_calculate_discounted_price_for_promotions.py
@@ -72,7 +72,7 @@ def test_variant_discounts_multiple_promotions(product, channel_USD):
     price = variant_channel_listing.price
 
     # when
-    applied_discounts = calculate_discounted_price_for_promotions(
+    applied_rule_id, applied_discount = calculate_discounted_price_for_promotions(
         price=price,
         rules_info_per_variant_and_promotion_id=rules_info_per_promotion_id,
         channel=channel_USD,
@@ -80,11 +80,8 @@ def test_variant_discounts_multiple_promotions(product, channel_USD):
     )
 
     # then
-    assert len(applied_discounts) == 1
-    assert applied_discounts[0] == (
-        rule_high.id,
-        price - rule_high.reward_value / 100 * price,
-    )
+    assert applied_rule_id == rule_high.id
+    assert applied_discount == (price - rule_high.reward_value / 100 * price)
 
 
 def test_variant_discounts_multiple_promotions_and_rules(product, channel_USD):
@@ -167,7 +164,7 @@ def test_variant_discounts_multiple_promotions_and_rules(product, channel_USD):
     price = variant_channel_listing.price
 
     # when
-    applied_discounts = calculate_discounted_price_for_promotions(
+    applied_rule_id, applied_discount = calculate_discounted_price_for_promotions(
         price=price,
         rules_info_per_variant_and_promotion_id=rules_info_per_promotion_id,
         channel=channel_USD,
@@ -175,8 +172,5 @@ def test_variant_discounts_multiple_promotions_and_rules(product, channel_USD):
     )
 
     # then
-    assert len(applied_discounts) == 1
-    assert applied_discounts[0] == (
-        rule_high_1.id,
-        price - rule_high_1.reward_value / 100 * price,
-    )
+    assert applied_rule_id == rule_high_1.id
+    assert applied_discount == (price - rule_high_1.reward_value / 100 * price)

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -2,13 +2,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from decimal import ROUND_HALF_UP, Decimal
 from functools import partial
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Optional,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Callable, Optional, Union, cast
 from uuid import UUID
 
 import graphene
@@ -179,52 +173,49 @@ def calculate_discounted_price_for_promotions(
     ],
     channel: "Channel",
     variant_id: int,
-) -> list[tuple[UUID, Money]]:
+) -> Optional[tuple[UUID, Money]]:
     """Return minimum product's price of all prices with promotions applied."""
-    applied_discounts = []
+    applied_discount = None
     rules_info_per_promotion_id = rules_info_per_variant_and_promotion_id.get(
         variant_id
     )
     if rules_info_per_promotion_id:
-        applied_discounts = get_best_promotion_discount(
+        applied_discount = get_best_promotion_discount(
             price, rules_info_per_promotion_id, channel
         )
-    return applied_discounts
+    return applied_discount
 
 
 def get_best_promotion_discount(
     price: Money,
     rules_info_per_promotion_id: dict[UUID, list[PromotionRuleInfo]],
     channel: "Channel",
-) -> list[tuple[UUID, Money]]:
-    """Return the rules with the discount amounts for the best promotion.
+) -> Optional[tuple[UUID, Money]]:
+    """Return the rule with the discount amount for the best promotion.
 
     The data for the promotion that gives the best saving are returned in the following
     shape:
-    [
-        (rule_id_1, discount_amount_1),
-        (rule_id_2, discount_amount_2),
-    ]
+        (rule_id_1, discount_amount_1)
     """
-    available_discounts = [
-        [
-            (rule_id, discount)
-            for rule_id, discount in get_product_promotion_discounts(
-                rules_info=rules_info,
-                channel=channel,
-            )
-        ]
-        for _, rules_info in rules_info_per_promotion_id.items()
-    ]
-    applied_discounts = max(
-        [
-            [(rule_id, price - discount(price)) for rule_id, discount in discounts]
-            for discounts in available_discounts
-        ],
-        key=lambda x: sum(y[1].amount for y in x),  # sort over a max discount
-    )
+    available_discounts = []
+    for rules_info in rules_info_per_promotion_id.values():
+        for rule_id, discount in get_product_promotion_discounts(
+            rules_info=rules_info,
+            channel=channel,
+        ):
+            available_discounts.append((rule_id, discount))
 
-    return applied_discounts
+    applied_discount = None
+    if available_discounts:
+        applied_discount = max(
+            [
+                (rule_id, price - discount(price))
+                for rule_id, discount in available_discounts
+            ],
+            key=lambda x: x[1].amount,  # sort over a max discount
+        )
+
+    return applied_discount
 
 
 def get_product_promotion_discounts(

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -168,27 +168,23 @@ def calculate_discounted_price_for_rules(
 def calculate_discounted_price_for_promotions(
     *,
     price: Money,
-    rules_info_per_variant_and_promotion_id: dict[
-        int, dict[UUID, list[PromotionRuleInfo]]
-    ],
+    rules_info_per_variant: dict[int, list[PromotionRuleInfo]],
     channel: "Channel",
     variant_id: int,
 ) -> Optional[tuple[UUID, Money]]:
     """Return minimum product's price of all prices with promotions applied."""
     applied_discount = None
-    rules_info_per_promotion_id = rules_info_per_variant_and_promotion_id.get(
-        variant_id
-    )
-    if rules_info_per_promotion_id:
+    rules_info_for_variant = rules_info_per_variant.get(variant_id)
+    if rules_info_for_variant:
         applied_discount = get_best_promotion_discount(
-            price, rules_info_per_promotion_id, channel
+            price, rules_info_for_variant, channel
         )
     return applied_discount
 
 
 def get_best_promotion_discount(
     price: Money,
-    rules_info_per_promotion_id: dict[UUID, list[PromotionRuleInfo]],
+    rules_info_for_variant: list[PromotionRuleInfo],
     channel: "Channel",
 ) -> Optional[tuple[UUID, Money]]:
     """Return the rule with the discount amount for the best promotion.
@@ -198,12 +194,11 @@ def get_best_promotion_discount(
         (rule_id_1, discount_amount_1)
     """
     available_discounts = []
-    for rules_info in rules_info_per_promotion_id.values():
-        for rule_id, discount in get_product_promotion_discounts(
-            rules_info=rules_info,
-            channel=channel,
-        ):
-            available_discounts.append((rule_id, discount))
+    for rule_id, discount in get_product_promotion_discounts(
+        rules_info=rules_info_for_variant,
+        channel=channel,
+    ):
+        available_discounts.append((rule_id, discount))
 
     applied_discount = None
     if available_discounts:
@@ -496,25 +491,18 @@ def _update_line_discount(
         updated_fields.append("translated_name")
 
 
-def get_variants_to_promotions_map(
+def get_variants_to_promotion_rules_map(
     variant_qs: "ProductVariantQueryset",
-) -> dict[int, dict[UUID, list[PromotionRuleInfo]]]:
+) -> dict[int, list[PromotionRuleInfo]]:
     """Return map of variant ids to the list of promotion rules that can be applied.
 
     The data is returned in the following shape:
     {
-        variant_id_1: {
-            promotion_id_1: [PromotionRuleInfo_1, PromotionRuleInfo_2],
-            promotion_id_2: [PromotionRuleInfo_3],
-        }
-        variant_id_2: {
-            promotion_id_1: [PromotionRuleInfo_1]
-        }
+        variant_id_1: [PromotionRuleInfo_1, PromotionRuleInfo_2, PromotionRuleInfo_3],
+        variant_id_2: [PromotionRuleInfo_1]
     }
     """
-    rules_info_per_variant_and_promotion_id: dict[
-        int, dict[UUID, list[PromotionRuleInfo]]
-    ] = defaultdict(lambda: defaultdict(list))
+    rules_info_per_variant: dict[int, list[PromotionRuleInfo]] = defaultdict(list)
 
     promotions = Promotion.objects.active()
     PromotionRuleVariant = PromotionRule.variants.through
@@ -537,14 +525,14 @@ def get_variants_to_promotions_map(
         if not rule:
             continue
         variant_id = promotion_rule_variant.productvariant_id
-        rules_info_per_variant_and_promotion_id[variant_id][rule.promotion_id].append(
+        rules_info_per_variant[variant_id].append(
             PromotionRuleInfo(
                 rule=rule,
                 channel_ids=rule_to_channel_ids_map.get(rule_id, []),
             )
         )
 
-    return rules_info_per_variant_and_promotion_id
+    return rules_info_per_variant
 
 
 def _get_rule_to_channel_ids_map(rules: QuerySet):

--- a/saleor/product/tests/test_product_minimal_variant_price.py
+++ b/saleor/product/tests/test_product_minimal_variant_price.py
@@ -1,4 +1,4 @@
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from unittest.mock import patch
 
 import before_after
@@ -179,25 +179,12 @@ def test_update_discounted_price_for_promotion_discount_multiple_applicable_rule
     update_discounted_prices_for_promotion(Product.objects.filter(id__in=[product.id]))
 
     # then
-    percentage_reward_value = (
-        (variant_price * (percentage_reward_value / 100))
-        .quantize(rounding=ROUND_HALF_UP)
-        .amount
-    )
-    expected_price_amount = round(
-        variant_price.amount - reward_value - percentage_reward_value, 2
-    )
+    expected_price_amount = round(variant_price.amount - reward_value, 2)
     product_channel_listing.refresh_from_db()
     variant_channel_listing.refresh_from_db()
     assert product_channel_listing.discounted_price_amount == expected_price_amount
     assert variant_channel_listing.discounted_price_amount == expected_price_amount
-    assert variant_channel_listing.promotion_rules.count() == 2
-    assert (
-        variant_channel_listing.variantlistingpromotionrule.get(
-            promotion_rule_id=rule_1.id
-        ).discount_amount
-        == percentage_reward_value
-    )
+    assert variant_channel_listing.promotion_rules.count() == 1
     assert (
         variant_channel_listing.variantlistingpromotionrule.get(
             promotion_rule_id=rule_2.id

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -12,7 +12,7 @@ from ...discount import PromotionRuleInfo
 from ...discount.models import PromotionRule
 from ...discount.utils import (
     calculate_discounted_price_for_promotions,
-    get_variants_to_promotions_map,
+    get_variants_to_promotion_rules_map,
 )
 from ..managers import ProductsQueryset, ProductVariantQueryset
 from ..models import (
@@ -35,7 +35,7 @@ def update_discounted_prices_for_promotion(products: ProductsQueryset):
     variant_qs = ProductVariant.objects.filter(
         Exists(products.filter(id=OuterRef("product_id")))
     )
-    rules_info_per_variant_and_promotion_id = get_variants_to_promotions_map(variant_qs)
+    rules_info_per_variant = get_variants_to_promotion_rules_map(variant_qs)
     product_to_variant_listings_per_channel_map = (
         _get_product_to_variant_channel_listings_per_channel_map(variant_qs)
     )
@@ -67,7 +67,7 @@ def update_discounted_prices_for_promotion(products: ProductsQueryset):
             variant_listing_promotion_rule_to_update,
         ) = _get_discounted_variants_prices_for_promotions(
             variant_listings,
-            rules_info_per_variant_and_promotion_id,
+            rules_info_per_variant,
             product_channel_listing.channel,
             variant_listing_to_listing_rule_per_rule_map,
         )
@@ -218,9 +218,7 @@ def _get_variant_listings_to_listing_rule_per_rule_id_map(
 
 def _get_discounted_variants_prices_for_promotions(
     variant_listings: list[ProductVariantChannelListing],
-    rules_info_per_variant_and_promotion_id: dict[
-        int, dict[UUID, list[PromotionRuleInfo]]
-    ],
+    rules_info_per_variant: dict[int, list[PromotionRuleInfo]],
     channel: Channel,
     variant_listing_to_listing_rule_per_rule_map: dict,
 ) -> tuple[
@@ -240,9 +238,7 @@ def _get_discounted_variants_prices_for_promotions(
     for variant_listing in variant_listings:
         applied_discount = calculate_discounted_price_for_promotions(
             price=variant_listing.price,
-            rules_info_per_variant_and_promotion_id=(
-                rules_info_per_variant_and_promotion_id
-            ),
+            rules_info_per_variant=rules_info_per_variant,
             channel=channel,
             variant_id=variant_listing.variant_id,
         )


### PR DESCRIPTION
I want to merge this change because covers the flow explained here: https://github.com/saleor/saleor/issues/14920

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1077

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
