### PR TITLE
async webhooks: add extra data in failure logs

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -588,6 +588,14 @@ def handle_webhook_retry(
     When MaxRetriesExceededError is raised the function will end without exception.
     """
     is_success = True
+    log_extra_details = {
+        "webhook": {
+            "id": webhook.id,
+            "target_url": webhook.target_url,
+            "event": delivery.event_type,
+            "execution_mode": "async",
+        },
+    }
     task_logger.info(
         "[Webhook ID: %r] Failed request to %r: %r for event: %r."
         " Delivery attempt id: %r",
@@ -596,6 +604,7 @@ def handle_webhook_retry(
         response_content,
         delivery.event_type,
         delivery_attempt.id,
+        extra=log_extra_details,
     )
     try:
         countdown = celery_task.retry_backoff * (2**celery_task.request.retries)
@@ -612,6 +621,7 @@ def handle_webhook_retry(
             webhook.id,
             webhook.target_url,
             delivery.id,
+            extra=log_extra_details,
         )
     return is_success
 


### PR DESCRIPTION
This adds additional data to async webhooks failures to improve filtering and analysis of JSON logs.

Added:
- `webhook.id`: the ID of the table row `webhook_webhook`
- `webhook.target_url`: the URL where the webhook was attempted to be sent to
- `webhook.event`: the event name (e.g., `product_variant_updated`), see https://github.com/saleor/saleor/blob/ddb8921a67441288b2489135a2490f6062d7a7c4/saleor/webhook/event_types.py#L23-L201 for all possible values

Backport of #15308

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
