### PR TITLE
Call product prices calculation tasks in on_commit

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -200,7 +200,9 @@ class PromotionCreate(ModelMutation):
         cls.call_event(manager.promotion_created, instance)
         if has_started:
             cls.send_promotion_started_webhook(manager, instance)
-        update_products_discounted_prices_of_promotion_task.delay(instance.pk)
+        cls.call_event(
+            update_products_discounted_prices_of_promotion_task.delay, instance.pk
+        )
 
     @classmethod
     def has_started(cls, instance: models.Promotion) -> bool:

--- a/saleor/graphql/discount/mutations/promotion/promotion_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_update.py
@@ -109,7 +109,9 @@ class PromotionUpdate(ModelMutation):
         # update the product undiscounted prices for promotion only when
         # start or end date has changed
         if "start_date" in cleaned_input or "end_date" in cleaned_input:
-            update_products_discounted_prices_of_promotion_task.delay(instance.pk)
+            cls.call_event(
+                update_products_discounted_prices_of_promotion_task.delay, instance.pk
+            )
 
     @classmethod
     def get_toggle_type(cls, instance, clean_input, previous_end_date) -> Optional[str]:

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -223,7 +223,9 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
         with traced_atomic_transaction():
             cls.add_channels(promotion, rule, cleaned_input.get("add_channels", []))
             cls.remove_channels(promotion, cleaned_input.get("remove_channels", []))
-            update_products_discounted_prices_of_promotion_task.delay(promotion.pk)
+            cls.call_event(
+                update_products_discounted_prices_of_promotion_task.delay, promotion.pk
+            )
 
     @classmethod
     def get_instance(cls, id):

--- a/saleor/graphql/discount/mutations/sale/sale_create.py
+++ b/saleor/graphql/discount/mutations/sale/sale_create.py
@@ -130,7 +130,9 @@ class SaleCreate(ModelMutation):
             )
             manager = get_plugin_manager_promise(info.context).get()
             cls.send_sale_notifications(manager, promotion, predicate)
-            update_products_discounted_prices_of_promotion_task.delay(promotion.pk)
+            cls.call_event(
+                update_products_discounted_prices_of_promotion_task.delay, promotion.pk
+            )
         return response
 
     @classmethod

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -883,7 +883,9 @@ class ProductBulkCreate(BaseMutation):
         for channel in channels:
             cls.call_event(manager.channel_updated, channel, webhooks=webhooks)
 
-        update_products_discounted_prices_for_promotion_task.delay(product_ids)
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay, product_ids
+        )
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -918,7 +918,9 @@ class ProductVariantBulkCreate(BaseMutation):
     @classmethod
     def post_save_actions(cls, info, instances, product):
         # Recalculate the "discounted price" for the parent product
-        update_products_discounted_prices_for_promotion_task.delay([product.pk])
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay, [product.pk]
+        )
         product.search_index_dirty = True
         product.save(update_fields=["search_index_dirty"])
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
@@ -126,7 +126,9 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             )
 
         # Recalculate the "discounted price" for the related products
-        update_products_discounted_prices_for_promotion_task.delay(product_pks)
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay, product_pks
+        )
 
         return response
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -700,7 +700,9 @@ class ProductVariantBulkUpdate(BaseMutation):
         manager = get_plugin_manager_promise(info.context).get()
 
         # Recalculate the "discounted price" for the parent product
-        update_products_discounted_prices_for_promotion_task.delay([product.pk])
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay, [product.pk]
+        )
         product.search_index_dirty = True
         product.save(update_fields=["search_index_dirty"])
 

--- a/saleor/graphql/product/mutations/collection/collection_add_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_add_products.py
@@ -54,8 +54,9 @@ class CollectionAddProducts(BaseMutation):
         with traced_atomic_transaction():
             collection.products.add(*products)
             # Updated the db entries, recalculating discounts of affected products
-            update_products_discounted_prices_for_promotion_task.delay(
-                [pq.pk for pq in products]
+            cls.call_event(
+                update_products_discounted_prices_for_promotion_task.delay,
+                [pq.pk for pq in products],
             )
             for product in products:
                 cls.call_event(manager.product_updated, product)

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -315,8 +315,9 @@ class ProductVariantCreate(ModelMutation):
                 instance.product.default_variant = instance
                 instance.product.save(update_fields=["default_variant", "updated_at"])
             # Recalculate the "discounted price" for the parent product
-            update_products_discounted_prices_for_promotion_task.delay(
-                [instance.product_id]
+            cls.call_event(
+                update_products_discounted_prices_for_promotion_task.delay,
+                [instance.product_id],
             )
             stocks = cleaned_input.get("stocks")
             if stocks:

--- a/saleor/product/tests/test_category.py
+++ b/saleor/product/tests/test_category.py
@@ -24,16 +24,20 @@ def test_delete_categories(
     mock_update_products_discounted_prices_for_promotion_task,
     categories_tree_with_published_products,
 ):
+    # given
     parent = categories_tree_with_published_products
     child = parent.children.first()
     product_list = [child.products.first(), parent.products.first()]
 
+    # when
     delete_categories([parent.pk], manager=get_plugins_manager(allow_replica=False))
 
     assert not Category.objects.filter(
         id__in=[category.id for category in [parent, child]]
     ).exists()
 
+    # then
+    flush_post_commit_hooks()
     calls = mock_update_products_discounted_prices_for_promotion_task.mock_calls
     assert len(calls) == 1
     call_kwargs = calls[0].kwargs

--- a/saleor/product/utils/__init__.py
+++ b/saleor/product/utils/__init__.py
@@ -65,8 +65,9 @@ def delete_categories(categories_ids: list[Union[str, int]], manager):
     for product in products:
         call_event(manager.product_updated, product, webhooks=webhooks)
 
-    update_products_discounted_prices_for_promotion_task.delay(
-        product_ids=[product.id for product in products]
+    call_event(
+        update_products_discounted_prices_for_promotion_task.delay,
+        product_ids=[product.id for product in products],
     )
 
 


### PR DESCRIPTION
I want to merge this change because it is port of changes from: https://github.com/saleor/saleor/pull/15271

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
