### PR TITLE
update existing lines discount types with zero downtime support

### DIFF
--- a/saleor/discount/__init__.py
+++ b/saleor/discount/__init__.py
@@ -18,6 +18,7 @@ class DiscountValueType:
 class DiscountType:
     SALE = "sale"
     PROMOTION = "promotion"
+    CATALOGUE_PROMOTION = "catalogue_promotion"
     VOUCHER = "voucher"
     MANUAL = "manual"
     CHOICES = [

--- a/saleor/discount/migrations/0074_update_discount_type.py
+++ b/saleor/discount/migrations/0074_update_discount_type.py
@@ -1,0 +1,25 @@
+from django.apps import apps as registry
+from django.db import migrations
+from django.db.models.signals import post_migrate
+
+from ..tasks import set_discount_type_to_promotion_catalogue_task
+
+
+def update_order_line_discount_type(_apps, _schema_editor):
+    def on_migrations_complete():
+        set_discount_type_to_promotion_catalogue_task.delay()
+
+    sender = registry.get_app_config("discount")
+    post_migrate.connect(on_migrations_complete, weak=False, sender=sender)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("discount", "0073_auto_20231213_1535"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_order_line_discount_type, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -340,3 +340,13 @@ def set_promotion_rule_variants_task(start_id=None):
         qs = PromotionRule.objects.filter(pk__in=ids)
         fetch_variants_for_promotion_rules(rules=qs)
         set_promotion_rule_variants_task.delay(ids[-1])
+
+
+@app.task
+def set_discount_type_to_promotion_catalogue_task():
+    BATCH_SIZE = 100
+    lines = OrderLineDiscount.objects.filter(type=DiscountType.PROMOTION)[:BATCH_SIZE]
+    if not lines:
+        return
+    lines.update(type=DiscountType.CATALOGUE_PROMOTION)
+    set_discount_type_to_promotion_catalogue_task.delay()


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
