### PR TITLE
Fix filtering by order predicate

### DIFF
--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1387,9 +1387,11 @@ def test_recalculate_checkout_discount_with_checkout_discount_voucher_not_applic
     rule = catalogue_promotion_without_rules.rules.create(
         name="Fixed promotion rule",
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 20,
+            "discountedObjectPredicate": {
+                "baseTotalPrice": {
+                    "range": {
+                        "gte": 20,
+                    }
                 }
             }
         },

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -1248,9 +1248,11 @@ def test_create_or_update_discount_objects_from_promotion(
                 name="Order promotion rule 1",
                 promotion=promotion,
                 order_predicate={
-                    "base_total_price": {
-                        "range": {
-                            "gte": 10,
+                    "discountedObjectPredicate": {
+                        "baseTotalPrice": {
+                            "range": {
+                                "gte": 10,
+                            }
                         }
                     }
                 },
@@ -1262,9 +1264,11 @@ def test_create_or_update_discount_objects_from_promotion(
                 name="Order promotion rule 2",
                 promotion=promotion,
                 order_predicate={
-                    "base_total_price": {
-                        "range": {
-                            "gte": 20,
+                    "discountedObjectPredicate": {
+                        "baseTotalPrice": {
+                            "range": {
+                                "gte": 20,
+                            }
                         }
                     }
                 },
@@ -1323,9 +1327,11 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
                 name="Order promotion rule 1",
                 promotion=promotion,
                 order_predicate={
-                    "base_total_price": {
-                        "range": {
-                            "gte": 10,
+                    "discountedObjectPredicate": {
+                        "baseTotalPrice": {
+                            "range": {
+                                "gte": 10,
+                            }
                         }
                     }
                 },
@@ -1337,9 +1343,11 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
                 name="Order promotion rule 2",
                 promotion=promotion,
                 order_predicate={
-                    "base_subtotal_price": {
-                        "range": {
-                            "gte": 20,
+                    "discountedObjectPredicate": {
+                        "baseTotalPrice": {
+                            "range": {
+                                "gte": 20,
+                            }
                         }
                     }
                 },
@@ -1351,9 +1359,11 @@ def test_create_or_update_discount_objects_from_promotion_best_rule_applies(
                 name="Order promotion rule 1",
                 promotion=promotion,
                 order_predicate={
-                    "base_total_price": {
-                        "range": {
-                            "gte": 100,
+                    "discountedObjectPredicate": {
+                        "baseTotalPrice": {
+                            "range": {
+                                "gte": 100,
+                            }
                         }
                     }
                 },
@@ -1419,9 +1429,11 @@ def test_create_or_update_discount_objects_from_promotion_subtotal_price_discoun
                 name="Order promotion rule 2",
                 promotion=promotion,
                 order_predicate={
-                    "base_total_price": {
-                        "range": {
-                            "gte": 20,
+                    "discountedObjectPredicate": {
+                        "baseTotalPrice": {
+                            "range": {
+                                "gte": 20,
+                            }
                         }
                     }
                 },
@@ -1475,9 +1487,11 @@ def test_create_or_update_discount_from_promotion_voucher_code_set_checkout_disc
         name="Order promotion rule 1",
         promotion=promotion,
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 10,
+            "discountedObjectPredicate": {
+                "baseTotalPrice": {
+                    "range": {
+                        "gte": 10,
+                    }
                 }
             }
         },
@@ -1531,9 +1545,11 @@ def test_create_or_update_discount_from_promotion_checkout_discount_updated(
         name="Order promotion rule 1",
         promotion=promotion,
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 10,
+            "discountedObjectPredicate": {
+                "baseTotalPrice": {
+                    "range": {
+                        "gte": 10,
+                    }
                 }
             }
         },
@@ -1594,9 +1610,11 @@ def test_create_or_update_discount_from_promotion_rule_not_applies_anymore(
         name="Order promotion rule 1",
         promotion=promotion,
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 200,
+            "discountedObjectPredicate": {
+                "baseTotalPrice": {
+                    "range": {
+                        "gte": 200,
+                    }
                 }
             }
         },

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -287,9 +287,11 @@ def test_add_to_existing_line_catalogue_and_order_discount_applies(
     # create order promotion discount
     rule = catalogue_promotion_without_rules.rules.create(
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 20,
+            "discountedObjectPredicate": {
+                "baseTotalPrice": {
+                    "range": {
+                        "gte": 20,
+                    }
                 }
             }
         },
@@ -394,9 +396,11 @@ def test_add_to_existing_line_on_promotion_with_voucher_checkout_promotion_not_a
     # create order promotion discount
     rule = catalogue_promotion_without_rules.rules.create(
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 20,
+            "discountedObjectPredicate": {
+                "baseTotalPrice": {
+                    "range": {
+                        "gte": 20,
+                    }
                 }
             }
         },

--- a/saleor/graphql/discount/tests/test_utils.py
+++ b/saleor/graphql/discount/tests/test_utils.py
@@ -5,6 +5,7 @@ import graphene
 from ....discount import RewardValueType
 from ....discount.models import Promotion, PromotionRule
 from ..utils import (
+    _camel_to_snake_case,
     convert_migrated_sale_predicate_to_catalogue_info,
     get_variants_for_catalogue_predicate,
     get_variants_for_promotion,
@@ -344,3 +345,46 @@ def test_convert_migrated_sale_predicate_to_catalogue_info(
 
     # then
     assert catalogue_info == expected_result
+
+
+def test_camel_to_snake_case():
+    order_predicate = {
+        "AND": [
+            {
+                "discountedObjectPredicate": {
+                    "OR": [
+                        {"userPredicate": {"isStaff": True}},
+                        {"subtotalPrice": {"range": {"gte": 100}}},
+                    ]
+                }
+            },
+            {
+                "discountedLineObjectPredicate": {
+                    "quantity": {"range": {"gte": 3}},
+                    "cataloguePredicate": {
+                        "categoryPredicate": {"name": {"eq": "Shirt"}}
+                    },
+                }
+            },
+        ]
+    }
+    assert _camel_to_snake_case(order_predicate) == {
+        "AND": [
+            {
+                "discounted_object_predicate": {
+                    "OR": [
+                        {"user_predicate": {"is_staff": True}},
+                        {"subtotal_price": {"range": {"gte": 100}}},
+                    ]
+                }
+            },
+            {
+                "discounted_line_object_predicate": {
+                    "quantity": {"range": {"gte": 3}},
+                    "catalogue_predicate": {
+                        "category_predicate": {"name": {"eq": "Shirt"}}
+                    },
+                }
+            },
+        ]
+    }

--- a/saleor/graphql/discount/tests/test_utils.py
+++ b/saleor/graphql/discount/tests/test_utils.py
@@ -5,7 +5,7 @@ import graphene
 from ....discount import RewardValueType
 from ....discount.models import Promotion, PromotionRule
 from ..utils import (
-    _camel_to_snake_case,
+    _predicate_to_snake_case,
     convert_migrated_sale_predicate_to_catalogue_info,
     get_variants_for_catalogue_predicate,
     get_variants_for_promotion,
@@ -347,43 +347,77 @@ def test_convert_migrated_sale_predicate_to_catalogue_info(
     assert catalogue_info == expected_result
 
 
-def test_camel_to_snake_case():
+def test_predicate_to_snake_case():
     order_predicate = {
         "AND": [
             {
                 "discountedObjectPredicate": {
                     "OR": [
-                        {"userPredicate": {"isStaff": True}},
-                        {"subtotalPrice": {"range": {"gte": 100}}},
+                        {
+                            "discountedObjectPredicate": {
+                                "userPredicate": {"isStaff": True}
+                            }
+                        },
+                        {
+                            "discountedObjectPredicate": {
+                                "subtotalPrice": {"range": {"gte": 100}}
+                            }
+                        },
                     ]
                 }
             },
             {
                 "discountedLineObjectPredicate": {
-                    "quantity": {"range": {"gte": 3}},
-                    "cataloguePredicate": {
-                        "categoryPredicate": {"name": {"eq": "Shirt"}}
-                    },
+                    "OR": [
+                        {
+                            "discountedLineObjectPredicate": {
+                                "quantityAvailable": {"range": {"gte": 3}}
+                            }
+                        },
+                        {"discountedLineObjectPredicate": {"name": {"eq": "Shirt"}}},
+                        {
+                            "discountedLineObjectPredicate": {
+                                "mainTitle": {"oneOf": [1, "ABC", "Yo"]}
+                            }
+                        },
+                    ]
                 }
             },
         ]
     }
-    assert _camel_to_snake_case(order_predicate) == {
+    assert _predicate_to_snake_case(order_predicate) == {
         "AND": [
             {
                 "discounted_object_predicate": {
                     "OR": [
-                        {"user_predicate": {"is_staff": True}},
-                        {"subtotal_price": {"range": {"gte": 100}}},
+                        {
+                            "discounted_object_predicate": {
+                                "user_predicate": {"is_staff": True}
+                            }
+                        },
+                        {
+                            "discounted_object_predicate": {
+                                "subtotal_price": {"range": {"gte": 100}}
+                            }
+                        },
                     ]
                 }
             },
             {
                 "discounted_line_object_predicate": {
-                    "quantity": {"range": {"gte": 3}},
-                    "catalogue_predicate": {
-                        "category_predicate": {"name": {"eq": "Shirt"}}
-                    },
+                    "OR": [
+                        {
+                            "discounted_line_object_predicate": {
+                                "quantity_available": {"range": {"gte": 3}}
+                            }
+                        },
+                        {"discounted_line_object_predicate": {"name": {"eq": "Shirt"}}},
+                        {
+                            "discounted_line_object_predicate": {
+                                "main_title": {"oneOf": [1, "ABC", "Yo"]}
+                            }
+                        },
+                    ]
                 }
             },
         ]

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -307,7 +307,7 @@ def _handle_checkout_predicate(
     operator,
     currency: Optional[str] = None,
 ):
-    predicate_data = _camel_to_snake_case(predicate_data)
+    predicate_data = _predicate_to_snake_case(predicate_data)
     if predicate := predicate_data.get("discounted_object_predicate"):
         if currency:
             predicate["currency"] = currency
@@ -326,19 +326,19 @@ def _handle_checkout_predicate(
     return result_qs
 
 
-def _camel_to_snake_case(obj: Any) -> Any:
+def _predicate_to_snake_case(obj: Any) -> Any:
     if isinstance(obj, dict):
         data = {}
         for k, v in obj.items():
             if k in ["AND", "OR"]:
-                data[k] = _camel_to_snake_case(v)
-            elif k == "eq":
+                data[k] = _predicate_to_snake_case(v)
+            elif k in ["eq", "oneOf"]:
                 data[k] = v
             else:
-                data[_camel_to_snake_case(k)] = _camel_to_snake_case(v)
+                data[_predicate_to_snake_case(k)] = _predicate_to_snake_case(v)
         return data
     if isinstance(obj, list):
-        return [_camel_to_snake_case(item) for item in obj]
+        return [_predicate_to_snake_case(item) for item in obj]
     if isinstance(obj, str):
         return to_snake_case(obj)
     return obj

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -329,13 +329,13 @@ def _handle_checkout_predicate(
 def _predicate_to_snake_case(obj: Any) -> Any:
     if isinstance(obj, dict):
         data = {}
-        for k, v in obj.items():
-            if k in ["AND", "OR"]:
-                data[k] = _predicate_to_snake_case(v)
-            elif k in ["eq", "oneOf"]:
-                data[k] = v
+        for key, value in obj.items():
+            if key in ["AND", "OR"]:
+                data[key] = _predicate_to_snake_case(value)
+            elif key in ["eq", "oneOf"]:
+                data[key] = value
             else:
-                data[_predicate_to_snake_case(k)] = _predicate_to_snake_case(v)
+                data[_predicate_to_snake_case(key)] = _predicate_to_snake_case(value)
         return data
     if isinstance(obj, list):
         return [_predicate_to_snake_case(item) for item in obj]

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
 from copy import deepcopy
 from enum import Enum
-from typing import Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 import graphene
 from django.db.models import Exists, OuterRef, QuerySet
+from graphene.utils.str_converters import to_snake_case
 
 from ...checkout.models import Checkout
 from ...discount.models import Promotion, PromotionRule
@@ -306,21 +307,41 @@ def _handle_checkout_predicate(
     operator,
     currency: Optional[str] = None,
 ):
-    if currency:
-        predicate_data["currency"] = currency
+    predicate_data = _camel_to_snake_case(predicate_data)
+    if predicate := predicate_data.get("discounted_object_predicate"):
+        if currency:
+            predicate["currency"] = currency
 
-    checkouts = where_filter_qs(
-        Checkout.objects.filter(pk__in=base_qs.values("pk")),
-        {},
-        CheckoutDiscountedObjectWhere,
-        predicate_data,
-        None,
-    )
-    if operator == Operators.AND:
-        result_qs &= checkouts
-    else:
-        result_qs |= checkouts
+        checkouts = where_filter_qs(
+            Checkout.objects.filter(pk__in=base_qs.values("pk")),
+            {},
+            CheckoutDiscountedObjectWhere,
+            predicate,
+            None,
+        )
+        if operator == Operators.AND:
+            result_qs &= checkouts
+        else:
+            result_qs |= checkouts
     return result_qs
+
+
+def _camel_to_snake_case(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        data = {}
+        for k, v in obj.items():
+            if k in ["AND", "OR"]:
+                data[k] = _camel_to_snake_case(v)
+            elif k == "eq":
+                data[k] = v
+            else:
+                data[_camel_to_snake_case(k)] = _camel_to_snake_case(v)
+        return data
+    if isinstance(obj, list):
+        return [_camel_to_snake_case(item) for item in obj]
+    if isinstance(obj, str):
+        return to_snake_case(obj)
+    return obj
 
 
 def convert_migrated_sale_predicate_to_model_ids(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1134,9 +1134,11 @@ def test_checkout_payload_includes_order_promotion_discount(
     rule = catalogue_promotion_without_rules.rules.create(
         name="Fixed promotion rule",
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 20,
+            "discountedObjectPredicate": {
+                "baseTotalPrice": {
+                    "range": {
+                        "gte": 20,
+                    }
                 }
             }
         },

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -417,11 +417,7 @@ def checkout_with_item_and_order_discount(
 
     rule = catalogue_promotion_without_rules.rules.create(
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 20,
-                }
-            }
+            "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 20}}}
         },
         reward_value_type=RewardValueType.FIXED,
         reward_value=reward_value,
@@ -5791,11 +5787,7 @@ def order_promotion_rule(channel_USD, order_promotion_without_rules):
         name="Order promotion rule",
         promotion=order_promotion_without_rules,
         order_predicate={
-            "base_total_price": {
-                "range": {
-                    "gte": 20,
-                }
-            }
+            "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 20}}}
         },
         reward_value_type=RewardValueType.PERCENTAGE,
         reward_value=Decimal("25"),


### PR DESCRIPTION
I want to merge this change because it fixes filtering by order predicate.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
