### PR TITLE
Add PositiveInteger scaler field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added caching of GraphQL documents for common queries to improve performance - #14843 by @patrys
 - Added `VOUCHER_CODES_CREATED` and `VOUCHER_CODES_DELETED` webhooks events. - #14652 by @SzymJ
 - Fixed validation for streetAddress1 or streetAddress2 are too long - #13973 by sonbui00
+- Added `PositiveInteger` in Scalars types - #15342 by @emZubair
 
 
 # 3.18.0

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -163,3 +163,17 @@ class Minute(graphene.Int):
 
 class Day(graphene.Int):
     """The `Day` scalar type represents number of days by integer value."""
+
+
+class PositiveInteger(graphene.Int):
+    """Positive Int custom field.
+
+    Should use in places where int value must be nonnegative (0 or greater).
+    """
+
+    @staticmethod
+    def parse_literal(ast):
+        value = super(PositiveInteger, PositiveInteger).parse_literal(ast)
+        if value and value < 0:
+            return None
+        return value


### PR DESCRIPTION
I want to merge this change because it adds scaler type `PositiveInteger` similar to `PositiveDecimal`. This can help remove the validations for input fields like `models.PositiveIntegerField`. 
Example:  i.e `ShippingMethod`'s `maximum_delivery_days` & `minimum_delivery_days` have validations in `clean_` methods to ensure we have +ve value, validations like this can be avoided with this. 

Suggestion: [There should be PositiveInteger similar to PositiveDecimal](https://github.com/saleor/saleor/discussions/15341)


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
