### PR TITLE
Add token field as optional argument to transaction mutations and query

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -103,6 +103,7 @@ from ..core.scalars import JSON, UUID, PositiveDecimal
 from ..core.types import BaseInputObjectType, BaseObjectType
 from ..core.types import common as common_types
 from ..core.utils import from_global_id_or_error
+from ..core.validators import validate_one_of_args_is_in_mutation
 from ..meta.mutations import MetadataInput
 from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import get_user_or_app_from_context
@@ -1157,7 +1158,11 @@ class TransactionUpdate(TransactionCreate):
     class Arguments:
         id = graphene.ID(
             description="The ID of the transaction.",
-            required=True,
+            required=False,
+        )
+        token = UUID(
+            description="The token of the transaction to process.",
+            required=False,
         )
         transaction = TransactionUpdateInput(
             description="Input data required to create a new transaction object.",
@@ -1290,19 +1295,35 @@ class TransactionUpdate(TransactionCreate):
             transaction_data["app_identifier"] = app.identifier
 
     @classmethod
-    def perform_mutation(  # type: ignore[override]
+    def perform_mutation(
         cls,
         _root,
         info: ResolveInfo,
         /,
         *,
-        id: str,
+        token=None,
+        id=None,
         transaction=None,
         transaction_event=None,
     ):
-        app = get_app_promise(info.context).get()
+        validate_one_of_args_is_in_mutation("id", id, "token", token)
+        if id:
+            instance = get_transaction_item(id)
+        elif token:
+            instance = payment_models.TransactionItem.objects.filter(
+                token=token
+            ).first()  # type: ignore
+            if not instance:
+                raise ValidationError(
+                    {
+                        "token": ValidationError(
+                            "Couldn't find a transaction with provided token.",
+                            code="not_found",
+                        )
+                    }
+                )
         user = info.context.user
-        instance = get_transaction_item(id)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
 
         cls.check_can_update(
@@ -1370,7 +1391,11 @@ class TransactionRequestAction(BaseMutation):
     class Arguments:
         id = graphene.ID(
             description="The ID of the transaction.",
-            required=True,
+            required=False,
+        )
+        token = UUID(
+            description="The token of the transaction.",
+            required=False,
         )
         action_type = graphene.Argument(
             TransactionActionEnum,
@@ -1475,10 +1500,26 @@ class TransactionRequestAction(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info: ResolveInfo, /, **data):
-        id = data["id"]
+        id = data.get("id")
+        token = data.get("token")
         action_type = data["action_type"]
         action_value = data.get("amount")
-        transaction = get_transaction_item(id)
+        validate_one_of_args_is_in_mutation("id", id, "token", token)
+        if id:
+            transaction = get_transaction_item(id)
+        elif token:
+            transaction = payment_models.TransactionItem.objects.filter(
+                token=token
+            ).first()  # type: ignore
+            if not transaction:
+                raise ValidationError(
+                    {
+                        "token": ValidationError(
+                            "Couldn't find a transaction with provided token.",
+                            code="not_found",
+                        )
+                    }
+                )
         if transaction.order_id:
             order = cast(Order, transaction.order)
             channel = order.channel
@@ -2174,7 +2215,11 @@ class TransactionProcess(BaseMutation):
     class Arguments:
         id = graphene.ID(
             description="The ID of the transaction to process.",
-            required=True,
+            required=False,
+        )
+        token = UUID(
+            description="The token of the transaction to process.",
+            required=False,
         )
         data = graphene.Argument(
             JSON, description="The data that will be passed to the payment gateway."
@@ -2284,11 +2329,26 @@ class TransactionProcess(BaseMutation):
         return app
 
     @classmethod
-    def perform_mutation(cls, root, info, *, id, data=None):
-        transaction_item = cls.get_node_or_error(
-            info, id, only_type="TransactionItem", field="token"
-        )
-        transaction_item = cast(payment_models.TransactionItem, transaction_item)
+    def perform_mutation(cls, root, info, *, token=None, id=None, data=None):
+        validate_one_of_args_is_in_mutation("id", id, "token", token)
+        if id:
+            transaction_item = cls.get_node_or_error(
+                info, id, only_type="TransactionItem", field="token"
+            )
+            transaction_item = cast(payment_models.TransactionItem, transaction_item)
+        elif token:
+            transaction_item = payment_models.TransactionItem.objects.filter(
+                token=token
+            ).first()  # type: ignore
+            if not transaction_item:
+                raise ValidationError(
+                    {
+                        "token": ValidationError(
+                            "Couldn't find a transaction with provided token.",
+                            code="not_found",
+                        )
+                    }
+                )
         events = transaction_item.events.all()
         if processed_event := cls.get_already_processed_event(events):
             return cls(

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1125,16 +1125,19 @@ class TransactionCreate(BaseMutation):
         return TransactionCreate(transaction=new_transaction)
 
 
-def get_transaction_item(id: str) -> payment_models.TransactionItem:
-    """Get transaction based on global ID.
+def get_transaction_item(id, token) -> payment_models.TransactionItem:
+    """Get transaction based on token or global ID.
 
     The transactions created before 3.13 were using the `id` field as a graphql ID.
     From 3.13, the `token` is used as a graphql ID. All transactionItems created
     before 3.13 will use an `int` id as an identification.
     """
-    _, db_id = from_global_id_or_error(
-        global_id=id, only_type=TransactionItem, raise_error=True
-    )
+    if token:
+        db_id = str(token)
+    else:
+        _, db_id = from_global_id_or_error(
+            global_id=id, only_type=TransactionItem, raise_error=True
+        )
     if db_id.isdigit():
         query_params = {"id": db_id, "use_old_id": True}
     else:
@@ -1312,21 +1315,7 @@ class TransactionUpdate(TransactionCreate):
         transaction_event=None,
     ):
         validate_one_of_args_is_in_mutation("id", id, "token", token)
-        if id:
-            instance = get_transaction_item(id)
-        elif token:
-            instance = payment_models.TransactionItem.objects.filter(
-                token=token
-            ).first()  # type: ignore
-            if not instance:
-                raise ValidationError(
-                    {
-                        "token": ValidationError(
-                            "Couldn't find a transaction with provided token.",
-                            code="not_found",
-                        )
-                    }
-                )
+        instance = get_transaction_item(id, token)
         user = info.context.user
         app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
@@ -1515,21 +1504,7 @@ class TransactionRequestAction(BaseMutation):
         action_type = data["action_type"]
         action_value = data.get("amount")
         validate_one_of_args_is_in_mutation("id", id, "token", token)
-        if id:
-            transaction = get_transaction_item(id)
-        elif token:
-            transaction = payment_models.TransactionItem.objects.filter(
-                token=token
-            ).first()  # type: ignore
-            if not transaction:
-                raise ValidationError(
-                    {
-                        "token": ValidationError(
-                            "Couldn't find a transaction with provided token.",
-                            code="not_found",
-                        )
-                    }
-                )
+        transaction = get_transaction_item(id, token)
         if transaction.order_id:
             order = cast(Order, transaction.order)
             channel = order.channel
@@ -1708,22 +1683,7 @@ class TransactionEventReport(ModelMutation):
         available_actions=None,
     ):
         validate_one_of_args_is_in_mutation("id", id, "token", token)
-        if id:
-            transaction = get_transaction_item(id)
-        elif token:
-            transaction = payment_models.TransactionItem.objects.filter(
-                token=token
-            ).first()  # type: ignore
-            if not transaction:
-                raise ValidationError(
-                    {
-                        "token": ValidationError(
-                            "Couldn't find a transaction with provided token.",
-                            code="not_found",
-                        )
-                    }
-                )
-
+        transaction = get_transaction_item(id, token)
         user = info.context.user
         app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
@@ -2373,24 +2333,7 @@ class TransactionProcess(BaseMutation):
     @classmethod
     def perform_mutation(cls, root, info, *, token=None, id=None, data=None):
         validate_one_of_args_is_in_mutation("id", id, "token", token)
-        if id:
-            transaction_item = cls.get_node_or_error(
-                info, id, only_type="TransactionItem", field="token"
-            )
-            transaction_item = cast(payment_models.TransactionItem, transaction_item)
-        elif token:
-            transaction_item = payment_models.TransactionItem.objects.filter(
-                token=token
-            ).first()  # type: ignore
-            if not transaction_item:
-                raise ValidationError(
-                    {
-                        "token": ValidationError(
-                            "Couldn't find a transaction with provided token.",
-                            code="not_found",
-                        )
-                    }
-                )
+        transaction_item = get_transaction_item(id, token)
         events = transaction_item.events.all()
         if processed_event := cls.get_already_processed_event(events):
             return cls(

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1157,11 +1157,16 @@ class TransactionUpdate(TransactionCreate):
 
     class Arguments:
         id = graphene.ID(
-            description="The ID of the transaction.",
+            description=(
+                "The ID of the transaction. One of field id or token is required."
+            ),
             required=False,
         )
         token = UUID(
-            description="The token of the transaction to process.",
+            description=(
+                "The token of the transaction. One of field id or token is required."
+            )
+            + ADDED_IN_314,
             required=False,
         )
         transaction = TransactionUpdateInput(
@@ -1390,11 +1395,16 @@ class TransactionRequestAction(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The ID of the transaction.",
+            description=(
+                "The ID of the transaction. One of field id or token is required."
+            ),
             required=False,
         )
         token = UUID(
-            description="The token of the transaction.",
+            description=(
+                "The token of the transaction. One of field id or token is required."
+            )
+            + ADDED_IN_314,
             required=False,
         )
         action_type = graphene.Argument(
@@ -1567,11 +1577,16 @@ class TransactionEventReport(ModelMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The ID of the transaction.",
+            description=(
+                "The ID of the transaction. One of field id or token is required."
+            ),
             required=False,
         )
         token = UUID(
-            description="The token of the transaction.",
+            description=(
+                "The token of the transaction. One of field id or token is required."
+            )
+            + ADDED_IN_314,
             required=False,
         )
         psp_reference = graphene.String(
@@ -2234,11 +2249,18 @@ class TransactionProcess(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The ID of the transaction to process.",
+            description=(
+                "The ID of the transaction to process. "
+                "One of field id or token is required."
+            ),
             required=False,
         )
         token = UUID(
-            description="The token of the transaction to process.",
+            description=(
+                "The token of the transaction to process. "
+                "One of field id or token is required."
+            )
+            + ADDED_IN_314,
             required=False,
         )
         data = graphene.Argument(

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -28,11 +28,14 @@ def resolve_payments(info):
     return payments.filter(order_id__in=orders.values("id"))
 
 
-def resolve_transaction(info, id):
-    if id.isdigit():
-        query_params = {"id": id, "use_old_id": True}
-    else:
-        query_params = {"token": id}
+def resolve_transaction(info, id, token):
+    if id:
+        if id.isdigit():
+            query_params = {"id": id, "use_old_id": True}
+        else:
+            query_params = {"token": id}
+    elif token:
+        query_params = {"token": token}
     return (
         models.TransactionItem.objects.using(get_database_connection_name(info.context))
         .filter(**query_params)

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -28,14 +28,11 @@ def resolve_payments(info):
     return payments.filter(order_id__in=orders.values("id"))
 
 
-def resolve_transaction(info, id, token):
-    if id:
-        if id.isdigit():
-            query_params = {"id": id, "use_old_id": True}
-        else:
-            query_params = {"token": id}
-    elif token:
-        query_params = {"token": token}
+def resolve_transaction(info, id):
+    if id.isdigit():
+        query_params = {"id": id, "use_old_id": True}
+    else:
+        query_params = {"token": id}
     return (
         models.TransactionItem.objects.using(get_database_connection_name(info.context))
         .filter(**query_params)

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -52,10 +52,20 @@ class PaymentQueries(graphene.ObjectType):
         TransactionItem,
         description="Look up a transaction by ID." + ADDED_IN_36 + PREVIEW_FEATURE,
         id=graphene.Argument(
-            graphene.ID, description="ID of a transaction.", required=False
+            graphene.ID,
+            description=(
+                "ID of a transaction. Either it or token is required "
+                "to fetch the transaction data."
+            ),
+            required=False,
         ),
         token=graphene.Argument(
-            UUID, description="Token of a transaction.", required=False
+            UUID,
+            description=(
+                "Token of a transaction. Either it or ID is required "
+                "to fetch the transaction data."
+            ),
+            required=False,
         ),
         permissions=[
             PaymentPermissions.HANDLE_PAYMENTS,

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -82,7 +82,7 @@ class PaymentQueries(graphene.ObjectType):
             return None
         # If token is provided we ignore the id input.
         if token:
-            return resolve_transaction(info, token)
+            return resolve_transaction(info, str(token))
         _, id = from_global_id_or_error(id, TransactionItem)  # type: ignore[arg-type]
         return resolve_transaction(info, id)
 

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -76,13 +76,15 @@ class PaymentQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_transaction(_root, info: ResolveInfo, **kwargs):
-        if "id" in kwargs:
-            _, id = from_global_id_or_error(kwargs["id"], TransactionItem)
-            if not id:
-                return None
-            return resolve_transaction(info, id, None)
-        elif "token" in kwargs:
-            return resolve_transaction(info, None, kwargs["token"])
+        id = kwargs.get("id")
+        token = kwargs.get("token")
+        if id is None and token is None:
+            return None
+        # If token is provided we ignore the id input.
+        if token:
+            return resolve_transaction(info, token)
+        _, id = from_global_id_or_error(id, TransactionItem)  # type: ignore[arg-type]
+        return resolve_transaction(info, id)
 
 
 class PaymentMutations(graphene.ObjectType):

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -25,11 +25,65 @@ from ....tests.utils import get_graphql_content
 
 TRANSACTION_PROCESS = """
 mutation TransactionProcess(
-  $id: ID!,
+  $id: ID,
   $data: JSON
 ) {
   transactionProcess(
     id: $id
+    data: $data
+  ) {
+    data
+    transaction {
+      id
+      authorizedAmount {
+        currency
+        amount
+      }
+      chargedAmount {
+        currency
+        amount
+      }
+      chargePendingAmount {
+        amount
+        currency
+      }
+      authorizePendingAmount {
+        amount
+        currency
+      }
+    }
+    transactionEvent {
+      id
+      amount {
+        currency
+        amount
+      }
+      type
+      createdBy {
+        ... on App {
+          id
+        }
+      }
+      pspReference
+      message
+      externalUrl
+    }
+    errors{
+      field
+      message
+      code
+    }
+  }
+}
+"""
+
+TRANSACTION_PROCESS_BY_TOKEN = """
+mutation TransactionProcess(
+  $token: UUID,
+  $data: JSON
+) {
+  transactionProcess(
+    token: $token
     data: $data
   ) {
     data
@@ -339,6 +393,69 @@ def test_for_checkout_with_data(
 
     # when
     response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    checkout.refresh_from_db()
+    _assert_fields(
+        content=content,
+        source_object=checkout,
+        expected_amount=expected_amount,
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_process=mocked_process,
+        charged_value=expected_amount,
+        data=expected_data,
+        returned_data=expected_response["data"],
+    )
+    assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_for_checkout_with_data_via_token(
+    mocked_process,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    transaction_item_generator,
+):
+    # given
+    expected_amount = Decimal("10.00")
+
+    checkout = checkout_with_prices
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout_with_prices.pk, app=webhook_app
+    )
+    TransactionEvent.objects.create(
+        transaction=transaction_item,
+        amount_value=expected_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = expected_amount
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = PaymentGatewayData(
+        app_identifier=expected_app_identifier, data=expected_response
+    )
+    expected_data = {"some": "json-data"}
+    variables = {
+        "token": transaction_item.token,
+        "data": expected_data,
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS_BY_TOKEN, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -89,6 +89,7 @@ mutation TransactionProcess(
     data
     transaction {
       id
+      token
       authorizedAmount {
         currency
         amount
@@ -471,6 +472,9 @@ def test_for_checkout_with_data_via_token(
         charged_value=expected_amount,
         data=expected_data,
         returned_data=expected_response["data"],
+    )
+    assert content["data"]["transactionProcess"]["transaction"]["token"] == str(
+        transaction_item.token
     )
     assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL

--- a/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
@@ -16,12 +16,58 @@ from ...enums import TransactionActionEnum
 
 MUTATION_TRANSACTION_REQUEST_ACTION = """
 mutation TransactionRequestAction(
-    $id: ID!,
+    $id: ID,
     $action_type: TransactionActionEnum!,
     $amount: PositiveDecimal
     ){
     transactionRequestAction(
             id: $id,
+            actionType: $action_type,
+            amount: $amount
+        ){
+        transaction{
+                id
+                actions
+                reference
+                pspReference
+                type
+                status
+                modifiedAt
+                createdAt
+                authorizedAmount{
+                    amount
+                    currency
+                }
+                voidedAmount{
+                    currency
+                    amount
+                }
+                chargedAmount{
+                    currency
+                    amount
+                }
+                refundedAmount{
+                    currency
+                    amount
+                }
+        }
+        errors{
+            field
+            message
+            code
+        }
+    }
+}
+"""
+
+MUTATION_TRANSACTION_REQUEST_ACTION_BY_TOKEN = """
+mutation TransactionRequestAction(
+    $token: UUID,
+    $action_type: TransactionActionEnum!,
+    $amount: PositiveDecimal
+    ){
+    transactionRequestAction(
+            token: $token,
             actionType: $action_type,
             amount: $amount
         ){
@@ -102,6 +148,83 @@ def test_transaction_request_charge_action_for_order(
     # when
     response = app_api_client.post_graphql(
         MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    request_event = TransactionEvent.objects.filter(
+        type=TransactionEventType.CHARGE_REQUEST
+    ).first()
+
+    assert mocked_is_active.called
+    assert request_event
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.CHARGE,
+            action_value=expected_called_charge_amount,
+            event=request_event,
+            transaction_app_owner=None,
+        ),
+        channel_slug=order_with_lines.channel.slug,
+    )
+
+    event = order_with_lines.events.first()
+    assert event.type == OrderEvents.TRANSACTION_CHARGE_REQUESTED
+    assert Decimal(event.parameters["amount"]) == expected_called_charge_amount
+    assert event.parameters["reference"] == transaction.psp_reference
+
+    assert TransactionEvent.objects.get(
+        transaction=transaction,
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=expected_called_charge_amount,
+    )
+
+
+@pytest.mark.parametrize(
+    "charge_amount, expected_called_charge_amount",
+    [
+        (Decimal("8.00"), Decimal("8.00")),
+        (None, Decimal("10.00")),
+        (Decimal("100"), Decimal("10.00")),
+    ],
+)
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_charge_action_for_order_via_token(
+    mocked_payment_action_request,
+    mocked_is_active,
+    charge_amount,
+    expected_called_charge_amount,
+    order_with_lines,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.side_effect = [True, False]
+
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["charge", "void"],
+        currency="USD",
+        order_id=order_with_lines.pk,
+        authorized_value=Decimal("10"),
+    )
+
+    variables = {
+        "token": transaction.token,
+        "action_type": TransactionActionEnum.CHARGE.name,
+        "amount": charge_amount,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION_BY_TOKEN,
         variables,
         permissions=[permission_manage_payments],
     )

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -402,7 +402,7 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
 
 class TransactionItem(ModelObjectType[models.TransactionItem]):
     token = graphene.Field(
-        UUIDScalar, description="The transaction token.", required=False
+        UUIDScalar, description="The transaction token.", required=True
     )
     created_at = graphene.DateTime(required=True)
     modified_at = graphene.DateTime(required=True)

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -402,7 +402,7 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
 
 class TransactionItem(ModelObjectType[models.TransactionItem]):
     token = graphene.Field(
-        UUIDScalar, description="The transaction token.", required=True
+        UUIDScalar, description="The transaction token." + ADDED_IN_314, required=True
     )
     created_at = graphene.DateTime(required=True)
     modified_at = graphene.DateTime(required=True)
@@ -535,10 +535,6 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
 
     @staticmethod
     def resolve_id(root: models.TransactionItem, _info: ResolveInfo):
-        return root.token
-
-    @staticmethod
-    def resolve_token(root: models.TransactionItem, _info):
         return root.token
 
     @staticmethod

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -24,6 +24,7 @@ from ..core.descriptions import (
 )
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import JSONString, PermissionsField
+from ..core.scalars import UUID as UUIDScalar
 from ..core.tracing import traced_resolver
 from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList
 from ..meta.permissions import public_payment_permissions
@@ -400,6 +401,9 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
 
 
 class TransactionItem(ModelObjectType[models.TransactionItem]):
+    token = graphene.Field(
+        UUIDScalar, description="The transaction token.", required=False
+    )
     created_at = graphene.DateTime(required=True)
     modified_at = graphene.DateTime(required=True)
     actions = NonNullList(
@@ -531,6 +535,10 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
 
     @staticmethod
     def resolve_id(root: models.TransactionItem, _info: ResolveInfo):
+        return root.token
+
+    @staticmethod
+    def resolve_token(root: models.TransactionItem, _info):
         return root.token
 
     @staticmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -648,7 +648,10 @@ type Query {
   """
   transaction(
     """ID of a transaction."""
-    id: ID!
+    id: ID
+
+    """Token of a transaction."""
+    token: UUID
   ): TransactionItem @doc(category: "Payments")
 
   """Look up a page by ID or slug."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10104,6 +10104,9 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   metafields(keys: [String!]): Metadata
+
+  """The transaction token."""
+  token: UUID
   createdAt: DateTime!
   modifiedAt: DateTime!
 
@@ -14563,10 +14566,14 @@ type Mutation {
   Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionUpdate(
-    """The ID of the transaction."""
+    """The ID of the transaction. One of field id or token is required."""
     id: ID
 
-    """The token of the transaction to process."""
+    """
+    The token of the transaction. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
     token: UUID
 
     """Input data required to create a new transaction object."""
@@ -14594,10 +14601,14 @@ type Mutation {
     """
     amount: PositiveDecimal
 
-    """The ID of the transaction."""
+    """The ID of the transaction. One of field id or token is required."""
     id: ID
 
-    """The token of the transaction."""
+    """
+    The token of the transaction. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
     token: UUID
   ): TransactionRequestAction @doc(category: "Payments")
 
@@ -14622,7 +14633,7 @@ type Mutation {
     """
     externalUrl: String
 
-    """The ID of the transaction."""
+    """The ID of the transaction. One of field id or token is required."""
     id: ID
 
     """The message related to the event."""
@@ -14636,7 +14647,11 @@ type Mutation {
     """
     time: DateTime
 
-    """The token of the transaction."""
+    """
+    The token of the transaction. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
     token: UUID
 
     """Current status of the event to report."""
@@ -14706,10 +14721,16 @@ type Mutation {
     """The data that will be passed to the payment gateway."""
     data: JSON
 
-    """The ID of the transaction to process."""
+    """
+    The ID of the transaction to process. One of field id or token is required.
+    """
     id: ID
 
-    """The token of the transaction to process."""
+    """
+    The token of the transaction to process. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
     token: UUID
   ): TransactionProcess @doc(category: "Payments")
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14561,7 +14561,10 @@ type Mutation {
   """
   transactionUpdate(
     """The ID of the transaction."""
-    id: ID!
+    id: ID
+
+    """The token of the transaction to process."""
+    token: UUID
 
     """Input data required to create a new transaction object."""
     transaction: TransactionUpdateInput
@@ -14589,7 +14592,10 @@ type Mutation {
     amount: PositiveDecimal
 
     """The ID of the transaction."""
-    id: ID!
+    id: ID
+
+    """The token of the transaction."""
+    token: UUID
   ): TransactionRequestAction @doc(category: "Payments")
 
   """
@@ -14695,7 +14701,10 @@ type Mutation {
     data: JSON
 
     """The ID of the transaction to process."""
-    id: ID!
+    id: ID
+
+    """The token of the transaction to process."""
+    token: UUID
   ): TransactionProcess @doc(category: "Payments")
 
   """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10106,7 +10106,7 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   metafields(keys: [String!]): Metadata
 
   """The transaction token."""
-  token: UUID
+  token: UUID!
   createdAt: DateTime!
   modifiedAt: DateTime!
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14623,7 +14623,7 @@ type Mutation {
     externalUrl: String
 
     """The ID of the transaction."""
-    id: ID!
+    id: ID
 
     """The message related to the event."""
     message: String
@@ -14635,6 +14635,9 @@ type Mutation {
     The time of the event to report. If not provide, the current time will be used.
     """
     time: DateTime
+
+    """The token of the transaction."""
+    token: UUID
 
     """Current status of the event to report."""
     type: TransactionEventTypeEnum!

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -647,10 +647,14 @@ type Query {
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transaction(
-    """ID of a transaction."""
+    """
+    ID of a transaction. Either it or token is required to fetch the transaction data.
+    """
     id: ID
 
-    """Token of a transaction."""
+    """
+    Token of a transaction. Either it or ID is required to fetch the transaction data.
+    """
     token: UUID
   ): TransactionItem @doc(category: "Payments")
 
@@ -10105,7 +10109,11 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   """
   metafields(keys: [String!]): Metadata
 
-  """The transaction token."""
+  """
+  The transaction token.
+  
+  Added in Saleor 3.14.
+  """
   token: UUID!
   createdAt: DateTime!
   modifiedAt: DateTime!


### PR DESCRIPTION
I want to merge this change because it adds the token argument on
- TransactionUpdate mutation
- TransactionRequestAction mutation
- TransactionProcess mutation
- TransactionEventReport mutation
- Transaction query

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [X] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [X] Link to documentation:
- https://github.com/saleor/saleor-docs/pull/1082

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
