### PR TITLE
fixed duplicate attributes in attribute filter caused by product types

### DIFF
--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -69,7 +69,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
     product_types = set(product_qs.values_list("product_type_id", flat=True))
     return qs.filter(
         Q(product_types__in=product_types) | Q(product_variant_types__in=product_types)
-    )
+    ).distinct()
 
 
 def filter_attribute_search(qs, _, value):


### PR DESCRIPTION
I want to merge this change because it generate duplicate attributes by using attribute filter. distinct value was missing.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined
