### PR TITLE
Add token field as optional argument to transaction mutations and query

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_process.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_process.py
@@ -17,14 +17,20 @@ from .....payment.utils import (
     get_final_session_statuses,
     handle_transaction_process_session,
 )
-from ....core.descriptions import ADDED_IN_313, ADDED_IN_316, PREVIEW_FEATURE
+from ....core.descriptions import (
+    ADDED_IN_313,
+    ADDED_IN_314,
+    ADDED_IN_316,
+    PREVIEW_FEATURE,
+)
 from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.mutations import BaseMutation
-from ....core.scalars import JSON
+from ....core.scalars import JSON, UUID
 from ....core.types import common as common_types
+from ....core.validators import validate_one_of_args_is_in_mutation
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import TransactionEvent, TransactionItem
-from .utils import clean_customer_ip_address
+from .utils import clean_customer_ip_address, get_transaction_item
 
 if TYPE_CHECKING:
     pass
@@ -44,8 +50,19 @@ class TransactionProcess(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The ID of the transaction to process.",
-            required=True,
+            description=(
+                "The ID of the transaction to process. "
+                "One of field id or token is required."
+            ),
+            required=False,
+        )
+        token = UUID(
+            description=(
+                "The token of the transaction to process. "
+                "One of field id or token is required."
+            )
+            + ADDED_IN_314,
+            required=False,
         )
         data = graphene.Argument(
             JSON, description="The data that will be passed to the payment gateway."
@@ -165,11 +182,11 @@ class TransactionProcess(BaseMutation):
         return app
 
     @classmethod
-    def perform_mutation(cls, root, info, *, id, data=None, customer_ip_address=None):
-        transaction_item = cls.get_node_or_error(
-            info, id, only_type="TransactionItem", field="token"
-        )
-        transaction_item = cast(payment_models.TransactionItem, transaction_item)
+    def perform_mutation(
+        cls, root, info, *, token=None, id=None, data=None, customer_ip_address=None
+    ):
+        validate_one_of_args_is_in_mutation("id", id, "token", token)
+        transaction_item = get_transaction_item(id, token)
         events = transaction_item.events.all()
         if processed_event := cls.get_already_processed_event(events):
             return cls(

--- a/saleor/graphql/payment/mutations/transaction/utils.py
+++ b/saleor/graphql/payment/mutations/transaction/utils.py
@@ -16,16 +16,19 @@ if TYPE_CHECKING:
     pass
 
 
-def get_transaction_item(id: str) -> payment_models.TransactionItem:
-    """Get transaction based on global ID.
+def get_transaction_item(id, token) -> payment_models.TransactionItem:
+    """Get transaction based on token or global ID.
 
     The transactions created before 3.13 were using the `id` field as a graphql ID.
     From 3.13, the `token` is used as a graphql ID. All transactionItems created
     before 3.13 will use an `int` id as an identification.
     """
-    _, db_id = from_global_id_or_error(
-        global_id=id, only_type=TransactionItem, raise_error=True
-    )
+    if token:
+        db_id = str(token)
+    else:
+        _, db_id = from_global_id_or_error(
+            global_id=id, only_type=TransactionItem, raise_error=True
+        )
     if db_id.isdigit():
         query_params = {"id": db_id, "use_old_id": True}
     else:

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -6,6 +6,7 @@ from ..core.connection import create_connection_slice, filter_connection_queryse
 from ..core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import FilterConnectionField, PermissionsField
+from ..core.scalars import UUID
 from ..core.utils import from_global_id_or_error
 from .filters import PaymentFilterInput
 from .mutations import (
@@ -56,7 +57,20 @@ class PaymentQueries(graphene.ObjectType):
         TransactionItem,
         description="Look up a transaction by ID." + ADDED_IN_36 + PREVIEW_FEATURE,
         id=graphene.Argument(
-            graphene.ID, description="ID of a transaction.", required=True
+            graphene.ID,
+            description=(
+                "ID of a transaction. Either it or token is required "
+                "to fetch the transaction data."
+            ),
+            required=False,
+        ),
+        token=graphene.Argument(
+            UUID,
+            description=(
+                "Token of a transaction. Either it or ID is required "
+                "to fetch the transaction data."
+            ),
+            required=False,
         ),
         permissions=[
             PaymentPermissions.HANDLE_PAYMENTS,
@@ -77,9 +91,14 @@ class PaymentQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_transaction(_root, info: ResolveInfo, **kwargs):
-        _, id = from_global_id_or_error(kwargs["id"], TransactionItem)
-        if not id:
+        id = kwargs.get("id")
+        token = kwargs.get("token")
+        if id is None and token is None:
             return None
+        # If token is provided we ignore the id input.
+        if token:
+            return resolve_transaction(info, str(token))
+        _, id = from_global_id_or_error(id, TransactionItem)  # type: ignore[arg-type]
         return resolve_transaction(info, id)
 
 

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -99,7 +99,7 @@ def test_transaction_event_report_by_app(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -110,6 +110,84 @@ def test_transaction_event_report_by_app(
     ) {
         transactionEventReport(
             id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            time: $time
+            externalUrl: $externalUrl
+            message: $message
+            availableActions: $availableActions
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    event = TransactionEvent.objects.filter(
+        type=TransactionEventType.CHARGE_SUCCESS
+    ).first()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == TransactionEventTypeEnum.CHARGE_SUCCESS.value
+    assert event.amount_value == amount
+    assert event.currency == transaction.currency
+    assert event.created_at == event_time
+    assert event.external_url == external_url
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+
+
+def test_transaction_event_report_by_app_via_token(
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    event_time = timezone.now()
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+    message = "Sucesfull charge"
+    psp_reference = "111-abc"
+    amount = Decimal("11.00")
+    variables = {
+        "token": transaction.token,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+        "time": event_time.isoformat(),
+        "externalUrl": external_url,
+        "message": message,
+        "availableActions": [TransactionActionEnum.REFUND.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $token: UUID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $time: DateTime
+        $externalUrl: String
+        $message: String
+        $availableActions: [TransactionActionEnum!]!
+    ) {
+        transactionEventReport(
+            token: $token
             type: $type
             amount: $amount
             pspReference: $pspReference
@@ -177,7 +255,7 @@ def test_transaction_event_report_by_user(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -250,7 +328,7 @@ def test_transaction_event_report_by_another_user(
         MUTATION_DATA_FRAGMENT
         + """
        mutation TransactionEventReport(
-           $id: ID!
+           $id: ID
            $type: TransactionEventTypeEnum!
            $amount: PositiveDecimal!
            $pspReference: String!
@@ -316,7 +394,7 @@ def test_transaction_event_report_no_permission(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -368,7 +446,7 @@ def test_transaction_event_report_called_by_non_app_owner(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -410,7 +488,7 @@ def test_transaction_event_report_called_by_non_user_owner(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -469,7 +547,7 @@ def test_transaction_event_report_event_already_exists(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -704,7 +782,7 @@ def test_transaction_event_report_incorrect_amount_for_already_existing(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -784,7 +862,7 @@ def test_transaction_event_report_calls_amount_recalculations(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -847,7 +925,7 @@ def test_transaction_event_updates_order_total_charged(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -903,7 +981,7 @@ def test_transaction_event_updates_order_total_authorized(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -959,7 +1037,7 @@ def test_transaction_event_updates_search_vector(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1020,7 +1098,7 @@ def test_transaction_event_report_authorize_event_already_exists(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1097,7 +1175,7 @@ def test_transaction_event_updates_checkout_payment_statuses(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1159,7 +1237,7 @@ def test_transaction_event_updates_checkout_last_transaction_modified_at(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1223,7 +1301,7 @@ def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1287,7 +1365,7 @@ def test_transaction_event_updates_checkout_full_paid_with_pending_charge_amount
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1345,7 +1423,7 @@ def test_transaction_event_report_with_info_event(
         MUTATION_DATA_FRAGMENT
         + """
      mutation TransactionEventReport(
-         $id: ID!
+         $id: ID
          $type: TransactionEventTypeEnum!
          $amount: PositiveDecimal!
          $pspReference: String!
@@ -1419,7 +1497,7 @@ def test_transaction_event_report_accepts_old_id_for_old_transaction(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1500,7 +1578,7 @@ def test_transaction_event_report_doesnt_accept_old_id_for_new_transaction(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1567,7 +1645,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_fully_paid(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1623,7 +1701,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_partially_pai
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1678,7 +1756,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_partially_aut
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1733,7 +1811,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_fully_authori
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1790,7 +1868,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_fully_refunde
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1847,7 +1925,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_partially_ref
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1904,7 +1982,7 @@ def test_transaction_event_report_by_app_assign_app_owner(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
@@ -1977,7 +2055,7 @@ def test_transaction_event_report_assign_transaction_psp_reference_if_missing(
         MUTATION_DATA_FRAGMENT
         + """
     mutation TransactionEventReport(
-        $id: ID!
+        $id: ID
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -21,12 +21,93 @@ TEST_SERVER_DOMAIN = "testserver.com"
 
 MUTATION_TRANSACTION_UPDATE = """
 mutation TransactionUpdate(
-    $id: ID!,
-    $transaction_event: TransactionEventInput,
+    $id: ID
+    $transaction_event: TransactionEventInput
     $transaction: TransactionUpdateInput
     ){
     transactionUpdate(
             id: $id,
+            transactionEvent: $transaction_event,
+            transaction: $transaction
+        ){
+        transaction{
+                id
+                actions
+                pspReference
+                name
+                message
+                modifiedAt
+                createdAt
+                externalUrl
+                authorizedAmount{
+                    amount
+                    currency
+                }
+                canceledAmount{
+                    currency
+                    amount
+                }
+                chargedAmount{
+                    currency
+                    amount
+                }
+                refundedAmount{
+                    currency
+                    amount
+                }
+                privateMetadata{
+                    key
+                    value
+                }
+                metadata{
+                    key
+                    value
+                }
+                createdBy{
+                    ... on User {
+                        id
+                    }
+                    ... on App {
+                        id
+                    }
+                }
+                events{
+                    pspReference
+                    message
+                    createdAt
+                    externalUrl
+                    amount{
+                        amount
+                        currency
+                    }
+                    type
+                    createdBy{
+                        ... on User {
+                            id
+                        }
+                        ... on App {
+                            id
+                        }
+                    }
+                }
+        }
+        errors{
+            field
+            message
+            code
+        }
+    }
+}
+"""
+
+MUTATION_TRANSACTION_UPDATE_BY_TOKEN = """
+mutation TransactionUpdate(
+    $token: UUID
+    $transaction_event: TransactionEventInput
+    $transaction: TransactionUpdateInput
+    ){
+    transactionUpdate(
+            token: $token,
             transactionEvent: $transaction_event,
             transaction: $transaction
         ){
@@ -265,6 +346,35 @@ def test_transaction_update_name_by_app(
     # when
     response = app_api_client.post_graphql(
         MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    transaction.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionUpdate"]["transaction"]
+    assert data["name"] == name
+    assert transaction.name == name
+
+
+def test_transaction_update_name_by_app_via_token(
+    transaction_item_created_by_app, permission_manage_payments, app_api_client
+):
+    # given
+    transaction = transaction_item_created_by_app
+    name = "New credit card"
+
+    variables = {
+        "token": transaction.token,
+        "transaction": {
+            "name": name,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE_BY_TOKEN,
+        variables,
+        permissions=[permission_manage_payments],
     )
 
     # then

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -26,6 +26,7 @@ from ..core.descriptions import (
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import JSONString, PermissionsField
 from ..core.scalars import JSON
+from ..core.scalars import UUID as UUIDScalar
 from ..core.tracing import traced_resolver
 from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList
 from ..meta.permissions import public_payment_permissions
@@ -408,6 +409,9 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
 
 
 class TransactionItem(ModelObjectType[models.TransactionItem]):
+    token = graphene.Field(
+        UUIDScalar, description="The transaction token." + ADDED_IN_314, required=True
+    )
     created_at = graphene.DateTime(
         required=True,
         description="Date and time at which payment transaction was created.",

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -683,8 +683,15 @@ type Query {
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transaction(
-    """ID of a transaction."""
-    id: ID!
+    """
+    ID of a transaction. Either it or token is required to fetch the transaction data.
+    """
+    id: ID
+
+    """
+    Token of a transaction. Either it or ID is required to fetch the transaction data.
+    """
+    token: UUID
   ): TransactionItem @doc(category: "Payments")
 
   """Look up a page by ID or slug."""
@@ -11260,6 +11267,13 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   """
   metafields(keys: [String!]): Metadata
 
+  """
+  The transaction token.
+  
+  Added in Saleor 3.14.
+  """
+  token: UUID!
+
   """Date and time at which payment transaction was created."""
   createdAt: DateTime!
 
@@ -16542,8 +16556,15 @@ type Mutation {
   Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionUpdate(
-    """The ID of the transaction."""
-    id: ID!
+    """The ID of the transaction. One of field id or token is required."""
+    id: ID
+
+    """
+    The token of the transaction. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
+    token: UUID
 
     """Input data required to create a new transaction object."""
     transaction: TransactionUpdateInput
@@ -16570,8 +16591,15 @@ type Mutation {
     """
     amount: PositiveDecimal
 
-    """The ID of the transaction."""
-    id: ID!
+    """The ID of the transaction. One of field id or token is required."""
+    id: ID
+
+    """
+    The token of the transaction. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
+    token: UUID
   ): TransactionRequestAction @doc(category: "Payments")
 
   """
@@ -16587,8 +16615,15 @@ type Mutation {
     """The ID of the granted refund."""
     grantedRefundId: ID!
 
-    """The ID of the transaction."""
-    id: ID!
+    """The ID of the transaction. One of field id or token is required."""
+    id: ID
+
+    """
+    The token of the transaction. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
+    token: UUID
   ): TransactionRequestRefundForGrantedRefund @doc(category: "Payments")
 
   """
@@ -16612,8 +16647,8 @@ type Mutation {
     """
     externalUrl: String
 
-    """The ID of the transaction."""
-    id: ID!
+    """The ID of the transaction. One of field id or token is required."""
+    id: ID
 
     """The message related to the event."""
     message: String
@@ -16625,6 +16660,13 @@ type Mutation {
     The time of the event to report. If not provide, the current time will be used.
     """
     time: DateTime
+
+    """
+    The token of the transaction. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
+    token: UUID
 
     """Current status of the event to report."""
     type: TransactionEventTypeEnum!
@@ -16707,8 +16749,17 @@ type Mutation {
     """The data that will be passed to the payment gateway."""
     data: JSON
 
-    """The ID of the transaction to process."""
-    id: ID!
+    """
+    The ID of the transaction to process. One of field id or token is required.
+    """
+    id: ID
+
+    """
+    The token of the transaction to process. One of field id or token is required.
+    
+    Added in Saleor 3.14.
+    """
+    token: UUID
   ): TransactionProcess @doc(category: "Payments")
 
   """


### PR DESCRIPTION
I want to merge this change because it's a port of https://github.com/saleor/saleor/pull/15351

It adds the token argument on
- TransactionUpdate mutation
- TransactionRequestAction mutation
- TransactionProcess mutation
- TransactionEventReport mutation
- Transaction query

And since 3.15 also on
- transactionRequestRefundForGrantedRefund mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
