### PR TITLE
Fix setting invalid identifier

### DIFF
--- a/saleor/app/management/commands/create_app.py
+++ b/saleor/app/management/commands/create_app.py
@@ -25,7 +25,10 @@ class Command(BaseCommand):
             "--identifier",
             dest="identifier",
             default="",
-            help="Canonical app ID.",
+            help=(
+                "Canonical app ID. If not provided, "
+                "the identifier will be generated based on app.id."
+            ),
         )
         parser.add_argument(
             "--permission",

--- a/saleor/app/management/commands/create_app.py
+++ b/saleor/app/management/commands/create_app.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Dict, Optional
 
+import graphene
 import requests
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -20,6 +21,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("name", type=str)
+        parser.add_argument(
+            "--identifier",
+            dest="identifier",
+            default="",
+            help="Canonical app ID.",
+        )
         parser.add_argument(
             "--permission",
             action="append",
@@ -66,9 +73,13 @@ class Command(BaseCommand):
         name = options["name"]
         is_active = options["activate"]
         target_url = options["target_url"]
+        identifier = options["identifier"]
         permissions = list(set(options["permissions"]))
         permissions = clean_permissions(permissions)
-        app = App.objects.create(name=name, is_active=is_active)
+        app = App.objects.create(name=name, is_active=is_active, identifier=identifier)
+        if not identifier:
+            app.identifier = graphene.Node.to_global_id("App", app.pk)
+            app.save()
         app.permissions.set(permissions)
         _, auth_token = app.tokens.create()  # type: ignore[call-arg] # method of a related manager # noqa: E501
         data = {

--- a/saleor/app/migrations/0028_set_identifier.py
+++ b/saleor/app/migrations/0028_set_identifier.py
@@ -1,0 +1,33 @@
+from django.apps import apps as registry
+from django.db import migrations
+from django.db.models.signals import post_migrate
+
+from .tasks.saleor3_14 import (
+    set_identifier_for_local_apps_task,
+    set_identifier_for_local_apps_task_with_none_global_id,
+)
+
+
+# Fixes the issue from previous identifier changes, where `app_create` was setting
+# identifier based on NULL PK
+# Need to rerun migration task from migration 0027 cause of missing
+# setting up `identifier` on create_app command
+
+
+def set_identifier_for_local_apps(apps, _schema_editor):
+    def on_migrations_complete(sender=None, **kwargs):
+        set_identifier_for_local_apps_task.delay()
+        set_identifier_for_local_apps_task_with_none_global_id.delay()
+
+    sender = registry.get_app_config("app")
+    post_migrate.connect(on_migrations_complete, weak=False, sender=sender)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0027_set_identifier_when_missing"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_identifier_for_local_apps, migrations.RunPython.noop),
+    ]

--- a/saleor/app/tests/test_app_commands.py
+++ b/saleor/app/tests/test_app_commands.py
@@ -1,5 +1,6 @@
 from unittest.mock import ANY, Mock
 
+import graphene
 import pytest
 import requests
 from django.core.management import call_command
@@ -95,6 +96,7 @@ def test_creates_app_object():
     tokens = app.tokens.all()
     assert len(tokens) == 1
     assert app.uuid is not None
+    assert app.identifier == graphene.Node.to_global_id("App", app.id)
 
 
 def test_app_has_all_required_permissions():
@@ -135,3 +137,22 @@ def test_sends_data_to_target_url(monkeypatch):
         timeout=ANY,
         allow_redirects=False,
     )
+
+
+def test_creates_app_with_identifier():
+    # given
+    name = "Single App"
+    permissions = ["MANAGE_USERS", "MANAGE_ORDERS"]
+
+    # when
+    call_command("create_app", name, permission=permissions, identifier="test.test")
+
+    # then
+    apps = App.objects.filter(name=name)
+    assert len(apps) == 1
+
+    app = apps[0]
+    tokens = app.tokens.all()
+    assert len(tokens) == 1
+    assert app.uuid is not None
+    assert app.identifier == "test.test"

--- a/saleor/graphql/app/mutations/app_create.py
+++ b/saleor/graphql/app/mutations/app_create.py
@@ -76,7 +76,9 @@ class AppCreate(ModelMutation):
 
     @classmethod
     def save(cls, info, instance, cleaned_input):
-        instance.identifier = graphene.Node.to_global_id("App", instance.pk)
         instance.save()
+        if not instance.identifier:
+            instance.identifier = graphene.Node.to_global_id("App", instance.pk)
+            instance.save()
         _, auth_token = instance.tokens.create(name="Default")
         return auth_token

--- a/saleor/graphql/app/mutations/app_create.py
+++ b/saleor/graphql/app/mutations/app_create.py
@@ -77,8 +77,7 @@ class AppCreate(ModelMutation):
     @classmethod
     def save(cls, info, instance, cleaned_input):
         instance.save()
-        if not instance.identifier:
-            instance.identifier = graphene.Node.to_global_id("App", instance.pk)
-            instance.save()
+        instance.identifier = graphene.Node.to_global_id("App", instance.pk)
+        instance.save()
         _, auth_token = instance.tokens.create(name="Default")
         return auth_token

--- a/saleor/graphql/app/tests/mutations/test_app_create.py
+++ b/saleor/graphql/app/tests/mutations/test_app_create.py
@@ -70,6 +70,7 @@ def test_app_create_mutation(
     assert default_token
     assert default_token[-4:] == app.tokens.get().token_last_4
     assert app.uuid is not None
+    assert app.identifier == graphene.Node.to_global_id("App", app.pk)
 
 
 @freeze_time("2022-05-12 12:00:00")


### PR DESCRIPTION
Fix to the invalid set `App.identifier` in `AppCreate` mutation + missing setting `App.identifier` in `create_app` command. 
Command also contains optional new argument, I decided it should not be a problem to port this logic, please raise concerns if any.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
