### PR TITLE
Make task's expiration date (time limit) configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Highlights
 - Introduce `order` promotion rules that allow applying discounts during checkout calculations when the checkout meets certain conditions. - #14696 by @IKarbowiak, @zedzior
 - Introduce gift reward as `order` promotion rule reward - #15259 by @zedzior, @IKarbowiak
+- New environment variable `EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT` to control time limit of `delete_event_payloads_task` - #15396 by @wcislo-saleor
 
 ### Breaking changes
 - Drop `OrderBulkCreateInput.voucher` field. Use `OrderBulkCreateInput.voucherCode` instead. - #14553 by @zedzior

--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 from botocore.exceptions import ClientError

--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -26,7 +26,10 @@ def delete_from_storage_task(path):
 
 @app.task
 def delete_event_payloads_task(expiration_date=None):
-    expiration_date = expiration_date or timezone.now() + datetime.timedelta(minutes=60)
+    expiration_date = (
+        expiration_date
+        or timezone.now() + settings.EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT
+    )
     delete_period = timezone.now() - settings.EVENT_PAYLOAD_DELETE_PERIOD
     valid_deliveries = EventDelivery.objects.filter(created_at__gt=delete_period)
     payloads_to_delete = EventPayload.objects.filter(
@@ -39,7 +42,7 @@ def delete_event_payloads_task(expiration_date=None):
             qs.delete()
             delete_event_payloads_task.delay(expiration_date)
         else:
-            task_logger.warning("Task invocation time limit reached, aborting task")
+            task_logger.error("Task invocation time limit reached, aborting task")
 
 
 @app.task(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -637,6 +637,9 @@ CELERY_BEAT_MAX_LOOP_INTERVAL = 300  # 5 minutes
 EVENT_PAYLOAD_DELETE_PERIOD = timedelta(
     seconds=parse(os.environ.get("EVENT_PAYLOAD_DELETE_PERIOD", "14 days"))
 )
+EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT = timedelta(
+    seconds=parse(os.environ.get("EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT", "1 hour"))
+)
 # Time between marking app "to remove" and removing the app from the database.
 # App is not visible for the user after removing, but it still exists in the database.
 # Saleor needs time to process sending `APP_DELETED` webhook and possible retrying,


### PR DESCRIPTION
I want to merge this change because in some environments 1 hour every day is not enough for clearing outdated event tables rows (`core_eventpayload`, `core_eventdelivery`, `core_eventdeliveryattempt`). Should such situation occur, raise an error instead of warning for better visibility as this may lead up to accumulation of events in the database, effectively clogging the database's disk space.

This has to be backported to previous versions, back to 3.15.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
