### PR TITLE
Remove outdated EventDelivery, EventDeliveryAttempt and EventPayload in batches

### DIFF
--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -1,11 +1,21 @@
+import logging
+
 from botocore.exceptions import ClientError
+from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.files.storage import default_storage
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef
 from django.utils import timezone
 
 from ..celeryconf import app
-from .models import EventDelivery, EventDeliveryAttempt, EventPayload
+from .models import EventDelivery, EventPayload
+
+task_logger: logging.Logger = get_task_logger(__name__)
+
+# Batch size was tested on db with 1mln payloads and deliveries, each delivery
+# had multiple attempts. One task took less than 0,5 second, memory usage didn't raise
+# more than 100 MB.
+BATCH_SIZE = 1000
 
 
 @app.task
@@ -14,20 +24,24 @@ def delete_from_storage_task(path):
 
 
 @app.task
-def delete_event_payloads_task():
+def delete_event_payloads_task(expiration_date=None):
+    expiration_date = (
+        expiration_date
+        or timezone.now() + settings.EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT
+    )
     delete_period = timezone.now() - settings.EVENT_PAYLOAD_DELETE_PERIOD
-    deliveries = EventDelivery.objects.filter(created_at__lte=delete_period)
-    attempts = EventDeliveryAttempt.objects.filter(
-        Q(Exists(deliveries.filter(id=OuterRef("delivery_id"))))
-        | Q(delivery__isnull=True, created_at__lte=delete_period)
-    )
-    payloads = EventPayload.objects.filter(
-        deliveries__isnull=True, created_at__lte=delete_period
-    )
-
-    attempts._raw_delete(attempts.db)  # type: ignore[attr-defined] # raw access # noqa: E501
-    deliveries._raw_delete(deliveries.db)  # type: ignore[attr-defined] # raw access # noqa: E501
-    payloads._raw_delete(payloads.db)  # type: ignore[attr-defined] # raw access # noqa: E501
+    valid_deliveries = EventDelivery.objects.filter(created_at__gt=delete_period)
+    payloads_to_delete = EventPayload.objects.filter(
+        ~Exists(valid_deliveries.filter(payload_id=OuterRef("id")))
+    ).order_by("-pk")
+    ids = payloads_to_delete.values_list("pk", flat=True)[:BATCH_SIZE]
+    qs = EventPayload.objects.filter(pk__in=ids)
+    if ids:
+        if expiration_date > timezone.now():
+            qs.delete()
+            delete_event_payloads_task.delay(expiration_date)
+        else:
+            task_logger.error("Task invocation time limit reached, aborting task")
 
 
 @app.task(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -627,6 +627,9 @@ CELERY_BEAT_MAX_LOOP_INTERVAL = 300  # 5 minutes
 EVENT_PAYLOAD_DELETE_PERIOD = timedelta(
     seconds=parse(os.environ.get("EVENT_PAYLOAD_DELETE_PERIOD", "14 days"))
 )
+EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT = timedelta(
+    seconds=parse(os.environ.get("EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT", "1 hour"))
+)
 # Time needed for the App to send `APP_DELETED` webhook after removing for Saleor.
 # App is not visible for the user after removing, but it still exists in the database.
 # Saleor needs time to process sending `APP_DELETED` webhook and possible retrying,


### PR DESCRIPTION
Backport of logic that got introduced to this task in `3.15`.