### PR TITLE
Fix gift reward creation during checkout creation

### DIFF
--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -535,14 +535,15 @@ def apply_gift_reward_if_applicable_on_checkout_creation(checkout: "Checkout") -
     if not gift_listing:
         return
 
+    amount_value = gift_listing.price_amount
     with transaction.atomic():
         line, _line_created = create_gift_line(checkout, gift_listing.variant_id)
         CheckoutLineDiscount.objects.create(
             type=DiscountType.ORDER_PROMOTION,
             line=line,
-            amount_value=best_discount_amount,
+            amount_value=amount_value,
             value_type=DiscountValueType.FIXED,
-            value=best_discount_amount,
+            value=amount_value,
             promotion_rule=best_rule,
             currency=checkout.currency,
         )

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -622,6 +622,11 @@ def test_checkout_create_with_gift_reward(
         line for line in checkout_data["lines"] if line["isGift"] is True
     ][0]
     assert gift_line_data["quantity"] == 1
+    gift_line = new_checkout.lines.get(is_gift=True)
+    assert gift_line.discounts.count() == 1
+    discount = gift_line.discounts.first()
+    gift_variant_listing = gift_line.variant.channel_listings.get(channel=channel_USD)
+    assert discount.amount_value == gift_variant_listing.price_amount
 
 
 def test_checkout_create_with_metadata_in_line(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create_from_order.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create_from_order.py
@@ -234,6 +234,12 @@ def test_checkout_create_from_order_with_gift_reward(
     _assert_checkout_lines(
         order_lines_map, checkout_lines, checkout_lines_from_response_map
     )
+    assert gift_line.discounts.count() == 1
+    discount = gift_line.discounts.first()
+    gift_variant_listing = gift_line.variant.channel_listings.get(
+        channel=checkout.channel
+    )
+    assert discount.amount_value == gift_variant_listing.price_amount
 
 
 def test_checkout_create_from_order_when_order_not_found(


### PR DESCRIPTION
Fix gift reward creation during checkout creation.
The `CheckoutLineDiscount` was created with invalid discount amount

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
