### PR TITLE
Fix query with available variants for gift promotion.

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -738,7 +738,7 @@ def _get_available_for_purchase_variant_ids(
         available_for_purchase_at__lte=today,
         channel_id=channel.id,
     )
-    available_variant_ids = ProductVariant.objects.filter(
+    available_variant_ids = variants.filter(
         Exists(product_listings.filter(product_id=OuterRef("product_id")))
     ).values_list("id", flat=True)
     return set(available_variant_ids)


### PR DESCRIPTION
The query was wrong and could return variants not associated with gift promotion.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
