### PR TITLE
Add plugin to tax configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - Added new field `taxAppId` in `TaxConfiguration` and `TaxConfigurationPerCountry`.
   - Added new input `AppInput.identifier`.
   - Added new parameter `identifier` for `create_app` command.
-  - When `taxAppId` is provided for `TaxConfiguration` do not allow to finalize `checkoutComplete` or `draftOrderComplete` mutations if Tax App doesn't respond.
+  - When `taxAppId` is provided for `TaxConfiguration` do not allow to finalize `checkoutComplete` or `draftOrderComplete` mutations if Tax App or Avatax plugin didn't respond.
 
 # 3.18.0
 

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -367,13 +367,21 @@ def _call_plugin_or_tax_app(
     address: Optional["Address"] = None,
 ):
     if tax_app_identifier.startswith(PLUGIN_IDENTIFIER_PREFIX):
+        plugin_ids = [tax_app_identifier.replace(PLUGIN_IDENTIFIER_PREFIX, "")]
+        plugins = manager.get_plugins(
+            checkout_info.channel.slug,
+            active_only=True,
+            plugin_ids=plugin_ids,
+        )
+        if not plugins:
+            raise TaxEmptyData("Empty tax data.")
         _apply_tax_data_from_plugins(
             checkout,
             manager,
             checkout_info,
             lines,
             address,
-            plugin_ids=[tax_app_identifier.replace(PLUGIN_IDENTIFIER_PREFIX, "")],
+            plugin_ids=plugin_ids,
         )
         if checkout.tax_error:
             raise TaxEmptyData("Empty tax data.")

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -8,7 +8,7 @@ from prices import Money, TaxedMoney
 
 from ..checkout import base_calculations
 from ..core.prices import quantize_price
-from ..core.taxes import EmptyTaxData, TaxData, zero_money, zero_taxed_money
+from ..core.taxes import TaxData, TaxEmptyData, zero_money, zero_taxed_money
 from ..discount.utils import (
     create_or_update_discount_objects_from_promotion_for_checkout,
 )
@@ -253,7 +253,7 @@ def _fetch_checkout_prices_if_expired(
                 prices_entered_with_tax,
                 address,
             )
-        except EmptyTaxData as e:
+        except TaxEmptyData as e:
             checkout.tax_error = str(e)
 
         if not should_charge_tax:
@@ -277,7 +277,7 @@ def _fetch_checkout_prices_if_expired(
                     prices_entered_with_tax,
                     address,
                 )
-            except EmptyTaxData as e:
+            except TaxEmptyData as e:
                 checkout.tax_error = str(e)
         else:
             # Calculate net prices without taxes.
@@ -376,13 +376,13 @@ def _call_plugin_or_tax_app(
             plugin_ids=[tax_app_identifier.split(":")[1]],
         )
         if checkout.tax_error:
-            raise EmptyTaxData("Empty tax data.")
+            raise TaxEmptyData("Empty tax data.")
     else:
         tax_data = manager.get_taxes_for_checkout(
             checkout_info, lines, tax_app_identifier
         )
         if tax_data is None:
-            raise EmptyTaxData("Empty tax data.")
+            raise TaxEmptyData("Empty tax data.")
         _apply_tax_data(checkout, lines, tax_data)
 
 

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -373,7 +373,7 @@ def _call_plugin_or_tax_app(
             checkout_info,
             lines,
             address,
-            plugin_ids=[tax_app_identifier.split(":")[1]],
+            plugin_ids=[tax_app_identifier.replace(PLUGIN_IDENTIFIER_PREFIX, "")],
         )
         if checkout.tax_error:
             raise TaxEmptyData("Empty tax data.")

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -328,7 +328,9 @@ def _calculate_and_add_tax(
     address: Optional["Address"] = None,
 ):
     if tax_calculation_strategy == TaxCalculationStrategy.TAX_APP:
-        # If taxAppId is not configured remain previous behaviour to call plugin and apps
+        # If taxAppId is not configured run all active plugins and tax apps.
+        # If taxAppId is provided run Avatax plugin or Tax App. taxAppId can be
+        # configured with Avatax plugin identifier.
         if not tax_app_identifier:
             # Call the tax plugins.
             _apply_tax_data_from_plugins(
@@ -340,7 +342,7 @@ def _calculate_and_add_tax(
             )
             _apply_tax_data(checkout, lines, tax_data)
         else:
-            _call_plugin_or_app_tax(
+            _call_plugin_or_tax_app(
                 tax_app_identifier,
                 checkout,
                 manager,
@@ -355,7 +357,7 @@ def _calculate_and_add_tax(
         )
 
 
-def _call_plugin_or_app_tax(
+def _call_plugin_or_tax_app(
     tax_app_identifier: Optional[str],
     checkout: "Checkout",
     manager: "PluginsManager",

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -330,7 +330,7 @@ def _calculate_and_add_tax(
 ):
     if tax_calculation_strategy == TaxCalculationStrategy.TAX_APP:
         # If taxAppId is not configured run all active plugins and tax apps.
-        # If taxAppId is provided run Avatax plugin or Tax App. taxAppId can be
+        # If taxAppId is provided run tax plugin or Tax App. taxAppId can be
         # configured with Avatax plugin identifier.
         if not tax_app_identifier:
             # Call the tax plugins.

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -1765,11 +1765,15 @@ def test_create_order_store_shipping_prices(
     assert order.base_shipping_price == expected_base_shipping_price
     assert order.shipping_price == expected_shipping_price
     manager.calculate_checkout_shipping.assert_called_once_with(
-        checkout_info, lines, checkout.shipping_address
+        checkout_info, lines, checkout.shipping_address, plugin_ids=None
     )
     assert order.shipping_tax_rate == expected_shipping_tax_rate
     manager.get_checkout_shipping_tax_rate.assert_called_once_with(
-        checkout_info, lines, checkout.shipping_address, expected_shipping_price
+        checkout_info,
+        lines,
+        checkout.shipping_address,
+        expected_shipping_price,
+        plugin_ids=None,
     )
 
 
@@ -1815,11 +1819,15 @@ def test_create_order_store_shipping_prices_with_free_shipping_voucher(
     assert order.base_shipping_price == expected_base_shipping_price
     assert order.shipping_price == expected_shipping_price
     manager.calculate_checkout_shipping.assert_called_once_with(
-        checkout_info, lines, checkout.shipping_address
+        checkout_info, lines, checkout.shipping_address, plugin_ids=None
     )
     assert order.shipping_tax_rate == expected_shipping_tax_rate
     manager.get_checkout_shipping_tax_rate.assert_called_once_with(
-        checkout_info, lines, checkout.shipping_address, expected_shipping_price
+        checkout_info,
+        lines,
+        checkout.shipping_address,
+        expected_shipping_price,
+        plugin_ids=None,
     )
 
 

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -673,11 +673,15 @@ def test_create_order_from_checkout_store_shipping_prices(
     assert order.base_shipping_price == expected_base_shipping_price
     assert order.shipping_price == expected_shipping_price
     manager.calculate_checkout_shipping.assert_called_once_with(
-        mock.ANY, lines, checkout.shipping_address
+        mock.ANY, lines, checkout.shipping_address, plugin_ids=None
     )
     assert order.shipping_tax_rate == expected_shipping_tax_rate
     manager.get_checkout_shipping_tax_rate.assert_called_once_with(
-        mock.ANY, lines, checkout.shipping_address, expected_shipping_price
+        mock.ANY,
+        lines,
+        checkout.shipping_address,
+        expected_shipping_price,
+        plugin_ids=None,
     )
 
 
@@ -772,11 +776,15 @@ def test_create_order_from_store_shipping_prices_with_free_shipping_voucher(
     assert order.base_shipping_price == expected_base_shipping_price
     assert order.shipping_price == expected_shipping_price
     manager.calculate_checkout_shipping.assert_called_once_with(
-        mock.ANY, lines, checkout.shipping_address
+        mock.ANY, lines, checkout.shipping_address, plugin_ids=None
     )
     assert order.shipping_tax_rate == expected_shipping_tax_rate
     manager.get_checkout_shipping_tax_rate.assert_called_once_with(
-        mock.ANY, lines, checkout.shipping_address, expected_shipping_price
+        mock.ANY,
+        lines,
+        checkout.shipping_address,
+        expected_shipping_price,
+        plugin_ids=None,
     )
 
 

--- a/saleor/core/taxes.py
+++ b/saleor/core/taxes.py
@@ -8,7 +8,7 @@ class TaxError(Exception):
     """Default tax error."""
 
 
-class EmptyTaxData(Exception):
+class TaxEmptyData(Exception):
     """Empty tax data received from Tax App error."""
 
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -398,6 +398,7 @@ def test_checkout_complete_fails_with_invalid_tax_app(
     address,
     tax_app,
     tax_data_response,  # noqa: F811
+    settings,
 ):
     # given
     mock_request.return_value = tax_data_response
@@ -433,6 +434,7 @@ def test_checkout_complete_fails_with_invalid_tax_app(
     assert not EventDelivery.objects.exists()
 
     checkout.refresh_from_db()
+    assert checkout.price_expiration == timezone.now() + settings.CHECKOUT_PRICES_TTL
     assert checkout.tax_error == "Empty tax data."
 
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -5,7 +5,7 @@ import pytest
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
-from prices import Money
+from prices import Money, TaxedMoney
 
 from .....checkout import calculations
 from .....checkout.error_codes import CheckoutErrorCode
@@ -16,9 +16,9 @@ from .....core.models import EventDelivery
 from .....order import OrderStatus
 from .....order.models import Order
 from .....payment.model_helpers import get_subtotal
-from .....plugins.avatax.plugin import AvataxPlugin
-from .....plugins.avatax.tests.conftest import plugin_configuration  # noqa: F401
+from .....plugins import PLUGIN_IDENTIFIER_PREFIX
 from .....plugins.manager import get_plugins_manager
+from .....plugins.tests.sample_plugins import PluginSample
 from .....plugins.webhook.conftest import (  # noqa: F401
     tax_data_response,
     tax_line_data_response,
@@ -492,20 +492,25 @@ def test_checkout_complete_calls_correct_tax_app(
 
 
 @freeze_time()
-@mock.patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@mock.patch(
+    "saleor.plugins.tests.sample_plugins.PluginSample.calculate_checkout_line_total"
+)
+@override_settings(PLUGINS=["saleor.plugins.tests.sample_plugins.PluginSample"])
 def test_checkout_complete_calls_failing_plugin(
-    mock_get_checkout_tax_data,
+    mock_calculate_checkout_line_total,
     user_api_client,
     checkout_without_shipping_required,
     channel_USD,
-    plugin_configuration,  # noqa: F811
     address,
     settings,
 ):
     # given
-    mock_get_checkout_tax_data.return_value = None
-    plugin_configuration()
+    def side_effect(checkout_info, *args, **kwargs):
+        price = Money("10.0", checkout_info.checkout.currency)
+        checkout_info.checkout.tax_error = "Test error"
+        return TaxedMoney(price, price)
+
+    mock_calculate_checkout_line_total.side_effect = side_effect
 
     checkout = checkout_without_shipping_required
     checkout.billing_address = address
@@ -517,7 +522,9 @@ def test_checkout_complete_calls_failing_plugin(
     checkout.metadata_storage.save()
     checkout.save()
 
-    channel_USD.tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    channel_USD.tax_configuration.tax_app_id = (
+        PLUGIN_IDENTIFIER_PREFIX + PluginSample.PLUGIN_ID
+    )
     channel_USD.tax_configuration.save()
 
     variables = {

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -101,8 +101,13 @@ class DraftOrderComplete(BaseMutation):
         cls.check_channel_permissions(info, [order.channel_id])
         force_update = order.tax_error is not None
         order, _ = fetch_order_prices_if_expired(
-            order, manager, force_update=force_update, need_tax_calculation=True
+            order, manager, force_update=force_update
         )
+        if order.tax_error is not None:
+            raise ValidationError(
+                "Configured Tax App didn't responded.",
+                code=OrderErrorCode.TAX_ERROR.value,
+            )
         cls.validate_order(order)
 
         country = get_order_country(order)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -6,6 +6,7 @@ import pytz
 from django.db.models import Sum
 from django.test import override_settings
 from freezegun import freeze_time
+from prices import Money, TaxedMoney
 
 from .....core import EventDeliveryStatus
 from .....core.models import EventDelivery
@@ -14,11 +15,12 @@ from .....discount.models import VoucherCustomer
 from .....order import OrderOrigin, OrderStatus
 from .....order import events as order_events
 from .....order.error_codes import OrderErrorCode
+from .....order.interface import OrderTaxedPricesData
 from .....order.models import OrderEvent
 from .....payment.model_helpers import get_subtotal
-from .....plugins.avatax.plugin import AvataxPlugin
-from .....plugins.avatax.tests.conftest import plugin_configuration  # noqa: F401
+from .....plugins import PLUGIN_IDENTIFIER_PREFIX
 from .....plugins.base_plugin import ExcludedShippingMethod
+from .....plugins.tests.sample_plugins import PluginSample
 from .....plugins.webhook.conftest import (  # noqa: F401
     tax_data_response,
     tax_line_data_response,
@@ -1144,26 +1146,35 @@ def test_draft_order_complete_calls_correct_tax_app(
 
 
 @freeze_time()
-@patch("saleor.plugins.avatax.plugin.get_order_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.tests.sample_plugins.PluginSample.calculate_order_line_total")
+@override_settings(PLUGINS=["saleor.plugins.tests.sample_plugins.PluginSample"])
 def test_draft_order_complete_calls_failing_plugin(
-    mock_get_order_tax_data,
+    mock_calculate_order_line_total,
     staff_api_client,
     permission_group_manage_orders,
     draft_order,
-    plugin_configuration,  # noqa: F811
     channel_USD,
 ):
     # given
-    mock_get_order_tax_data.return_value = None
-    plugin_configuration()
+    def side_effect(order, *args, **kwargs):
+        price = Money("10.0", order.currency)
+        order.tax_error = "Test error"
+        return OrderTaxedPricesData(
+            price_with_discounts=TaxedMoney(price, price),
+            undiscounted_price=TaxedMoney(price, price),
+        )
+
+    mock_calculate_order_line_total.side_effect = side_effect
+
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     order = draft_order
     order.should_refresh_prices = True
     order.save()
 
-    channel_USD.tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    channel_USD.tax_configuration.tax_app_id = (
+        PLUGIN_IDENTIFIER_PREFIX + PluginSample.PLUGIN_ID
+    )
     channel_USD.tax_configuration.save()
 
     order_id = graphene.Node.to_global_id("Order", order.id)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1048,7 +1048,7 @@ def test_draft_order_complete_fails_with_invalid_tax_app(
     assert not EventDelivery.objects.exists()
 
     order.refresh_from_db()
-    assert order.should_refresh_prices
+    assert not order.should_refresh_prices
     assert order.tax_error == "Empty tax data."
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20881,7 +20881,7 @@ input TaxConfigurationUpdateInput @doc(category: "Taxes") {
   removeCountriesConfiguration: [CountryCode!]
 
   """
-  The tax app id that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
+  The tax app id that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. It's possible to set plugin by using prefix `plugin:` with `PLUGIN_ID` e.g. with Avalara `plugin:mirumee.taxes.avalara`.Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
   
   Added in Saleor 3.19.
   """

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -93,7 +93,9 @@ class TaxConfigurationUpdateInput(BaseInputObjectType):
             "The tax app id that will be used to calculate the taxes for the given channel. "
             "Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will "
             "iterate over all installed tax apps. If multiple tax apps exist with provided "
-            "tax app id use the `App` with newest `created` date. "
+            "tax app id use the `App` with newest `created` date. It's possible to set plugin "
+            "by using prefix `plugin:` with `PLUGIN_ID` "
+            "e.g. with Avalara `plugin:mirumee.taxes.avalara`."
             "Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`."
             + ADDED_IN_319
         ),

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from ....app.utils import get_active_tax_apps
 from ....permission.enums import CheckoutPermissions
+from ....plugins import PLUGIN_IDENTIFIER_PREFIX
 from ....tax import error_codes, models
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
@@ -168,18 +169,17 @@ class TaxConfigurationUpdate(ModelMutation):
         active_tax_app_identifiers = [app.identifier for app in active_tax_apps]
 
         # include plugin in list of possible tax apps
-        plugin_identifier_prefix = "plugin:"
         manager = get_plugin_manager_promise(info.context).get()
         plugin_ids = [
             identifier.split(":")[1]
             for identifier in identifiers
-            if identifier.startswith(plugin_identifier_prefix)
+            if identifier.startswith(PLUGIN_IDENTIFIER_PREFIX)
         ]
         valid_plugins = manager.get_plugins(
             instance.channel.slug, active_only=True, plugin_ids=plugin_ids
         )
         valid_plugin_identifiers = [
-            plugin_identifier_prefix + plugin.PLUGIN_ID for plugin in valid_plugins
+            PLUGIN_IDENTIFIER_PREFIX + plugin.PLUGIN_ID for plugin in valid_plugins
         ]
         active_tax_app_identifiers.extend(valid_plugin_identifiers)
 

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -171,7 +171,7 @@ class TaxConfigurationUpdate(ModelMutation):
         # include plugin in list of possible tax apps
         manager = get_plugin_manager_promise(info.context).get()
         plugin_ids = [
-            identifier.split(":")[1]
+            identifier.replace(PLUGIN_IDENTIFIER_PREFIX, "")
             for identifier in identifiers
             if identifier.startswith(PLUGIN_IDENTIFIER_PREFIX)
         ]

--- a/saleor/graphql/tax/tests/mutations/test_tax_configuration_update.py
+++ b/saleor/graphql/tax/tests/mutations/test_tax_configuration_update.py
@@ -3,6 +3,7 @@ import pytest
 from django.test import override_settings
 
 from .....core.tests.test_taxes import app_factory, tax_app_factory  # noqa: F401
+from .....plugins import PLUGIN_IDENTIFIER_PREFIX
 from .....plugins.tests.sample_plugins import PluginSample
 from .....tax.error_codes import TaxConfigurationUpdateErrorCode
 from .....tax.models import TaxConfiguration
@@ -398,7 +399,7 @@ def test_tax_configuration_update_tax_app_id_with_plugin(
     """Make sure that we are able to still use legacy plugin."""
     # given
     id = graphene.Node.to_global_id("TaxConfiguration", example_tax_configuration.pk)
-    plugin_id = "plugin:" + PluginSample.PLUGIN_ID
+    plugin_id = PLUGIN_IDENTIFIER_PREFIX + PluginSample.PLUGIN_ID
     variables = {
         "id": id,
         "input": {

--- a/saleor/graphql/tax/tests/mutations/test_tax_configuration_update.py
+++ b/saleor/graphql/tax/tests/mutations/test_tax_configuration_update.py
@@ -1,7 +1,9 @@
 import graphene
 import pytest
+from django.test import override_settings
 
 from .....core.tests.test_taxes import app_factory, tax_app_factory  # noqa: F401
+from .....plugins.tests.sample_plugins import PluginSample
 from .....tax.error_codes import TaxConfigurationUpdateErrorCode
 from .....tax.models import TaxConfiguration
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -389,13 +391,14 @@ def test_tax_configuration_update_tax_app_id_with_non_existent_app(
     assert errors[0]["code"] == TaxConfigurationUpdateErrorCode.NOT_FOUND.name
 
 
+@override_settings(PLUGINS=["saleor.plugins.tests.sample_plugins.PluginSample"])
 def test_tax_configuration_update_tax_app_id_with_plugin(
     example_tax_configuration, staff_api_client, permission_manage_taxes
 ):
     """Make sure that we are able to still use legacy plugin."""
     # given
     id = graphene.Node.to_global_id("TaxConfiguration", example_tax_configuration.pk)
-    plugin_id = "plugin:mirumee.taxes.avalara"
+    plugin_id = "plugin:" + PluginSample.PLUGIN_ID
     variables = {
         "id": id,
         "input": {

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -225,7 +225,7 @@ def _call_plugin_or_tax_app(
             order,
             lines,
             prices_entered_with_tax,
-            plugin_ids=[tax_app_identifier.split(":")[1]],
+            plugin_ids=[tax_app_identifier.replace(PLUGIN_IDENTIFIER_PREFIX, "")],
         )
         if order.tax_error:
             raise TaxEmptyData("Empty tax data.")

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -191,7 +191,7 @@ def _calculate_and_add_tax(
 ):
     if tax_calculation_strategy == TaxCalculationStrategy.TAX_APP:
         # If taxAppId is not configured run all active plugins and tax apps.
-        # If taxAppId is provided run Avatax plugin or Tax App. taxAppId can be
+        # If taxAppId is provided run tax plugin or Tax App. taxAppId can be
         # configured with Avatax plugin identifier.
         if not tax_app_identifier:
             # Get the taxes calculated with plugins.

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -220,12 +220,18 @@ def _call_plugin_or_tax_app(
     prices_entered_with_tax: bool,
 ):
     if tax_app_identifier.startswith(PLUGIN_IDENTIFIER_PREFIX):
+        plugin_ids = [tax_app_identifier.replace(PLUGIN_IDENTIFIER_PREFIX, "")]
+        plugins = manager.get_plugins(
+            order.channel.slug, active_only=True, plugin_ids=plugin_ids
+        )
+        if not plugins:
+            raise TaxEmptyData("Empty tax data.")
         _recalculate_with_plugins(
             manager,
             order,
             lines,
             prices_entered_with_tax,
-            plugin_ids=[tax_app_identifier.replace(PLUGIN_IDENTIFIER_PREFIX, "")],
+            plugin_ids=plugin_ids,
         )
         if order.tax_error:
             raise TaxEmptyData("Empty tax data.")

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -189,7 +189,9 @@ def _calculate_and_add_tax(
     prices_entered_with_tax: bool,
 ):
     if tax_calculation_strategy == TaxCalculationStrategy.TAX_APP:
-        # If taxAppId is not configured remain previous behaviour to call plugin and apps
+        # If taxAppId is not configured run all active plugins and tax apps.
+        # If taxAppId is provided run Avatax plugin or Tax App. taxAppId can be
+        # configured with Avatax plugin identifier.
         if not tax_app_identifier:
             # Get the taxes calculated with plugins.
             _recalculate_with_plugins(manager, order, lines, prices_entered_with_tax)
@@ -197,7 +199,7 @@ def _calculate_and_add_tax(
             tax_data = manager.get_taxes_for_order(order, tax_app_identifier)
             _apply_tax_data(order, lines, tax_data)
         else:
-            _call_plugin_or_app_tax(
+            _call_plugin_or_tax_app(
                 tax_app_identifier,
                 order,
                 lines,
@@ -209,7 +211,7 @@ def _calculate_and_add_tax(
         update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
 
 
-def _call_plugin_or_app_tax(
+def _call_plugin_or_tax_app(
     tax_app_identifier: Optional[str],
     order: "Order",
     lines: Iterable["OrderLine"],

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -7,7 +7,7 @@ from django.db.models import prefetch_related_objects
 from prices import Money, TaxedMoney
 
 from ..core.prices import quantize_price
-from ..core.taxes import EmptyTaxData, TaxData, TaxError, zero_taxed_money
+from ..core.taxes import TaxData, TaxEmptyData, TaxError, zero_taxed_money
 from ..discount import DiscountType
 from ..payment.model_helpers import get_subtotal
 from ..plugins import PLUGIN_IDENTIFIER_PREFIX
@@ -153,7 +153,7 @@ def _recalculate_prices(
                 manager,
                 prices_entered_with_tax,
             )
-        except EmptyTaxData as e:
+        except TaxEmptyData as e:
             order.tax_error = str(e)
 
         if not should_charge_tax:
@@ -175,7 +175,7 @@ def _recalculate_prices(
                     manager,
                     prices_entered_with_tax,
                 )
-            except EmptyTaxData as e:
+            except TaxEmptyData as e:
                 order.tax_error = str(e)
         else:
             _remove_tax(order, lines)
@@ -228,11 +228,11 @@ def _call_plugin_or_tax_app(
             plugin_ids=[tax_app_identifier.split(":")[1]],
         )
         if order.tax_error:
-            raise EmptyTaxData("Empty tax data.")
+            raise TaxEmptyData("Empty tax data.")
     else:
         tax_data = manager.get_taxes_for_order(order, tax_app_identifier)
         if tax_data is None:
-            raise EmptyTaxData("Empty tax data.")
+            raise TaxEmptyData("Empty tax data.")
         _apply_tax_data(order, lines, tax_data)
 
 

--- a/saleor/plugins/__init__.py
+++ b/saleor/plugins/__init__.py
@@ -1,6 +1,7 @@
 import importlib
 
 default_app_config = "saleor.plugins.apps.PluginConfig"
+PLUGIN_IDENTIFIER_PREFIX = "plugin:"
 
 
 def discover_plugins_modules(plugins: list[str]):

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -6280,3 +6280,83 @@ def test_order_confirmed_skip_with_country_exception_tax_app_id_plugin(
 
     # then
     api_post_request_task_mock.assert_not_called()
+
+
+@patch("saleor.plugins.avatax.plugin.get_order_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_get_order_tax_data_set_tax_error(
+    mock_get_order_tax_data, order, order_line, plugin_configuration
+):
+    # given
+    mock_get_order_tax_data.return_value = None
+
+    channel = order.channel
+    tax_configuration = channel.tax_configuration
+    tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    tax_configuration.save()
+    tax_configuration.country_exceptions.all().delete()
+
+    plugin_configuration(
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_postal_code="53-603",
+        from_country="PL",
+        shipping_tax_code="FR00001",
+    )
+
+    manager = get_plugins_manager(allow_replica=True)
+
+    # when
+    manager.calculate_order_total(order, order.lines.all())
+
+    # then
+    assert order.tax_error == "Empty tax data."
+
+
+@patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_get_checkout_tax_data_set_tax_error(
+    mock_get_checkout_tax_data,
+    checkout_with_item,
+    address,
+    ship_to_pl_address,
+    site_settings,
+    shipping_zone,
+    plugin_configuration,
+):
+    # given
+    mock_get_checkout_tax_data.return_value = None
+
+    channel = checkout_with_item.channel
+    tax_configuration = channel.tax_configuration
+    tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    tax_configuration.save()
+    tax_configuration.country_exceptions.all().delete()
+
+    plugin_configuration(
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_postal_code="53-603",
+        from_country="PL",
+        shipping_tax_code="FR00001",
+    )
+
+    manager = get_plugins_manager(allow_replica=True)
+    site_settings.company_address = address
+    site_settings.save()
+
+    checkout_with_item.shipping_address = ship_to_pl_address
+    checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
+    checkout_with_item.save()
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
+
+    # when
+    manager.calculate_checkout_total(
+        checkout_info=checkout_info,
+        lines=lines,
+        address=address,
+    )
+
+    # then
+    assert checkout_with_item.tax_error == "Empty tax data."

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1778,7 +1778,10 @@ class PluginsManager(PaymentInterface):
         )
 
     def get_plugins(
-        self, channel_slug: Optional[str] = None, active_only=False
+        self,
+        channel_slug: Optional[str] = None,
+        active_only=False,
+        plugin_ids: Optional[list[str]] = None,
     ) -> list["BasePlugin"]:
         """Return list of plugins for a given channel."""
         if channel_slug:
@@ -1788,6 +1791,10 @@ class PluginsManager(PaymentInterface):
 
         if active_only:
             plugins = [plugin for plugin in plugins if plugin.active]
+
+        if plugin_ids:
+            plugins = [plugin for plugin in plugins if plugin.PLUGIN_ID in plugin_ids]
+
         return plugins
 
     def list_payment_gateways(


### PR DESCRIPTION
I want to merge this change because it adds possibility to set `plugin` directly on `taxConfiguration.taxAppId`.
Also contains:
- do not call Avalara using plugin if taxAppId set as Tax App
- reduce number of calls to Tax App if Tax App is not responding (in previous implementation, after failing checkoutComple/draftOrderComplete we will do potential call to Tax App when e.g. querying related object)

Changes will be ported to main branch.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1097

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
