### PR TITLE
Add crit header to jwt/jws

### DIFF
--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -147,7 +147,7 @@ class JWTManager(JWTManagerBase):
             payload,
             cls.get_private_key(),  # type: ignore[arg-type] # key is typed as str for all algos # noqa: E501
             algorithm="RS256",
-            headers={"kid": KID},
+            headers={"kid": KID, "crit": ["b64"]},
         )
 
     @classmethod
@@ -156,7 +156,7 @@ class JWTManager(JWTManagerBase):
             payload,
             key=cls.get_private_key(),  # type: ignore[arg-type] # key is typed as str for all algos # noqa: E501
             algorithm="RS256",
-            headers={"kid": KID},
+            headers={"kid": KID, "crit": ["b64"]},
             is_payload_detached=is_payload_detached,
         )
 


### PR DESCRIPTION
I want to merge this change because it adds crit header to jwt/jws
more context: https://linear.app/saleor/issue/SHOPX-270/add-header-to-jws

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
