### PR TITLE
Raise an error when product is empty in `ProductVariantCreate` mutation

### DIFF
--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -214,6 +214,16 @@ class ProductVariantCreate(ModelMutation):
         else:
             # If the variant is getting created, no product type is associated yet,
             # retrieve it from the required "product" input field
+            product = cleaned_input["product"]
+            if not product:
+                raise ValidationError(
+                    {
+                        "product": ValidationError(
+                            "Product cannot be set empty.",
+                            code=ProductErrorCode.INVALID.value,
+                        )
+                    }
+                )
             product_type = cleaned_input["product"].product_type
             used_attribute_values = get_used_variants_attribute_values(
                 cleaned_input["product"]


### PR DESCRIPTION
Raise an error when providing `product: ''` to `ProductVariantCreate` mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
