### PR TITLE
Fix setting `search_document` for new users created via OpenID 

### DIFF
--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -494,10 +494,11 @@ def _update_user_details(
         user.last_name = user_last_name
         fields_to_save.update({"last_name", "search_document"})
 
-    if "search_document" in fields_to_save:
+    if not user.search_document or "search_document" in fields_to_save:
         user.search_document = prepare_user_search_document_value(
             user, attach_addresses_data=False
         )
+        fields_to_save.add("search_document")
 
     if fields_to_save:
         user.save(update_fields=fields_to_save)


### PR DESCRIPTION
Fix not setting `search_document` value for new customers created via openID plugin.

As the `search_document` was not updated, the user cannot be find be `customers` query with `search` filter like:
```
customers(filter: {search: "test@example.com"}, first:10) {
  edges{
        node{
          id
  
        }
      }
  }
```

Port of https://github.com/saleor/saleor/pull/15432

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
