### PR TITLE
Fix setting `search_document` for new users created via OpenID 

### DIFF
--- a/saleor/plugins/openid_connect/tests/test_plugin.py
+++ b/saleor/plugins/openid_connect/tests/test_plugin.py
@@ -8,7 +8,7 @@ from django.core import signing
 from django.core.exceptions import ValidationError
 from freezegun import freeze_time
 
-from ....account.models import Group
+from ....account.models import Group, User
 from ....core.jwt import (
     JWT_ACCESS_TYPE,
     JWT_REFRESH_TOKEN_COOKIE_NAME,
@@ -657,6 +657,81 @@ def test_external_obtain_access_tokens_user_which_is_no_more_staff(
     decoded_access_token = jwt_decode(tokens.token)
     assert decoded_access_token["permissions"] == []
     assert decoded_access_token["is_staff"] is False
+
+
+@freeze_time("2019-03-18 12:00:00")
+@patch("saleor.plugins.openid_connect.utils.cache.set")
+@patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_external_obtain_access_tokens_user_created(
+    mocked_cache_get,
+    mocked_cache_set,
+    openid_plugin,
+    monkeypatch,
+    rf,
+    id_token,
+    id_payload,
+):
+    # given
+    mocked_jwt_validator = MagicMock()
+    mocked_jwt_validator.__getitem__.side_effect = id_payload.__getitem__
+    mocked_jwt_validator.get.side_effect = id_payload.get
+
+    mocked_cache_get.side_effect = lambda cache_key: None
+
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.utils.get_decoded_token",
+        Mock(return_value=mocked_jwt_validator),
+    )
+    plugin = openid_plugin(use_oauth_scope_permissions=True)
+    oauth_payload = {
+        "access_token": "FeHkE_QbuU3cYy1a1eQUrCE5jRcUnBK3",
+        "refresh_token": "refresh",
+        "id_token": id_token,
+        "scope": "openid profile email offline_access",
+        "expires_in": 86400,
+        "token_type": "Bearer",
+        "expires_at": 1600851112,
+    }
+    mocked_fetch_token = Mock(return_value=oauth_payload)
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.client.OAuth2Client.fetch_token",
+        mocked_fetch_token,
+    )
+    redirect_uri = "http://localhost:3000/used-logged-in"
+    state = signing.dumps({"redirectUri": redirect_uri})
+    code = "oauth-code"
+    user_count = User.objects.count()
+
+    # when
+    tokens = plugin.external_obtain_access_tokens(
+        {"state": state, "code": code}, rf.request(), previous_value=None
+    )
+
+    # then
+    assert User.objects.count() == user_count + 1
+    user = tokens.user
+    assert user.search_document
+    mocked_fetch_token.assert_called_once_with(
+        "https://saleor.io/oauth/token",
+        code=code,
+        redirect_uri=redirect_uri,
+    )
+
+    claims = get_parsed_id_token(
+        oauth_payload,
+        plugin.config.json_web_key_set_url,
+    )
+    expected_tokens = create_tokens_from_oauth_payload(
+        oauth_payload, user, claims, permissions=[], owner=plugin.PLUGIN_ID
+    )
+
+    decoded_access_token = jwt_decode(tokens.token)
+    assert decoded_access_token["permissions"] == []
+    assert decoded_access_token["is_staff"] is False
+    assert tokens.token == expected_tokens["token"]
+    decoded_refresh_token = jwt_decode(tokens.refresh_token)
+    assert tokens.csrf_token == decoded_refresh_token["csrf_token"]
+    assert decoded_refresh_token["oauth_refresh_token"] == "refresh"
 
 
 @freeze_time("2019-03-18 12:00:00")

--- a/saleor/plugins/openid_connect/tests/test_utils.py
+++ b/saleor/plugins/openid_connect/tests/test_utils.py
@@ -3,7 +3,7 @@ import time
 import warnings
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 import pytz
@@ -29,6 +29,7 @@ from ..utils import (
     JWKS_CACHE_TIME,
     JWKS_KEY,
     OIDC_DEFAULT_CACHE_TIME,
+    _update_user_details,
     assign_staff_to_default_group_and_update_permissions,
     create_jwt_refresh_token,
     create_jwt_token,
@@ -904,3 +905,112 @@ def test_assign_staff_to_default_group_and_update_permissions_update_user_permis
         permission_manage_users.name,
         permission_manage_orders.name,
     }
+
+
+@patch("saleor.plugins.openid_connect.utils.match_orders_with_new_user")
+@patch("saleor.plugins.openid_connect.utils.logger")
+def test_update_user_details_no_user_with_new_email_in_db(
+    mock_logger,
+    mock_match_orders_with_new_user,
+    customer_user,
+):
+    # given
+    assert customer_user.email != "test_user_email@example.com"
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        "test_user_email@example.com",
+        customer_user.first_name,
+        customer_user.last_name,
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    assert customer_user.email == "test_user_email@example.com"
+    assert mock_logger.mock_calls == []
+    mock_match_orders_with_new_user.assert_called_once_with(customer_user)
+
+
+@patch("saleor.plugins.openid_connect.utils.match_orders_with_new_user")
+@patch("saleor.plugins.openid_connect.utils.logger")
+def test_update_user_details_user_with_new_email_in_db(
+    mock_logger, mock_match_orders_with_new_user, customer_user, customer_user2
+):
+    # given
+    assert customer_user.email != customer_user2.email
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        customer_user2.email,
+        customer_user.first_name,
+        customer_user.last_name,
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    assert customer_user.email != customer_user2.email
+    assert mock_logger.mock_calls == [
+        call.warning(
+            "Unable to update user email as the new one already exists in DB",
+            extra={"oidc_key": "test oidc_key"},
+        )
+    ]
+    mock_match_orders_with_new_user.assert_not_called()
+
+
+def test_update_user_details_update_user_first_name(
+    customer_user,
+):
+    # given
+    expected_search_document = "test@example.com\ntest user_first_name\nwade\n"
+    assert customer_user.first_name != "test user_first_name"
+    assert customer_user.search_document != expected_search_document
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        customer_user.email,
+        "test user_first_name",
+        customer_user.last_name,
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    assert customer_user.first_name == "test user_first_name"
+    assert customer_user.search_document == expected_search_document
+
+
+def test_update_user_details_update_user_last_name(
+    customer_user,
+):
+    # given
+    expected_search_document = "test@example.com\nleslie\ntest user_last_name\n"
+    assert customer_user.last_name != "test user_last_name"
+    assert customer_user.search_document != expected_search_document
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        customer_user.email,
+        customer_user.first_name,
+        "test user_last_name",
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    assert customer_user.last_name == "test user_last_name"
+    assert customer_user.search_document == expected_search_document

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from jwt import PyJWTError
 
 from ...account.models import Group, User
+from ...account.search import prepare_user_search_document_value
 from ...account.utils import get_user_groups_permissions
 from ...core.http_client import HTTPClient
 from ...core.jwt import (
@@ -478,6 +479,12 @@ def _update_user_details(
         ):
             user.last_login = timezone.now()
             fields_to_save.append("last_login")
+
+    if not user.search_document:
+        user.search_document = prepare_user_search_document_value(
+            user, attach_addresses_data=False
+        )
+        fields_to_save.append("search_document")
 
     if fields_to_save:
         user.save(update_fields=fields_to_save)


### PR DESCRIPTION
Fix not setting `search_document` value for new customers created via openID plugin.

As the `search_document` was not updated, the user cannot be find be `customers` query with `search` filter like:
```
customers(filter: {search: "test@example.com"}, first:10) {
  edges{
        node{
          id
  
        }
      }
  }
```

Port of https://github.com/saleor/saleor/pull/15432 and https://github.com/saleor/saleor/pull/13948 (as it was missing)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
