### PR TITLE
Fix setting `search_document` for new users created via OpenID

### DIFF
--- a/saleor/plugins/openid_connect/tests/test_plugin.py
+++ b/saleor/plugins/openid_connect/tests/test_plugin.py
@@ -8,7 +8,7 @@ from django.core import signing
 from django.core.exceptions import ValidationError
 from freezegun import freeze_time
 
-from ....account.models import Group
+from ....account.models import Group, User
 from ....core.jwt import (
     JWT_ACCESS_TYPE,
     JWT_REFRESH_TOKEN_COOKIE_NAME,
@@ -657,6 +657,81 @@ def test_external_obtain_access_tokens_user_which_is_no_more_staff(
     decoded_access_token = jwt_decode(tokens.token)
     assert decoded_access_token["permissions"] == []
     assert decoded_access_token["is_staff"] is False
+
+
+@freeze_time("2019-03-18 12:00:00")
+@patch("saleor.plugins.openid_connect.utils.cache.set")
+@patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_external_obtain_access_tokens_user_created(
+    mocked_cache_get,
+    mocked_cache_set,
+    openid_plugin,
+    monkeypatch,
+    rf,
+    id_token,
+    id_payload,
+):
+    # given
+    mocked_jwt_validator = MagicMock()
+    mocked_jwt_validator.__getitem__.side_effect = id_payload.__getitem__
+    mocked_jwt_validator.get.side_effect = id_payload.get
+
+    mocked_cache_get.side_effect = lambda cache_key: None
+
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.utils.get_decoded_token",
+        Mock(return_value=mocked_jwt_validator),
+    )
+    plugin = openid_plugin(use_oauth_scope_permissions=True)
+    oauth_payload = {
+        "access_token": "FeHkE_QbuU3cYy1a1eQUrCE5jRcUnBK3",
+        "refresh_token": "refresh",
+        "id_token": id_token,
+        "scope": "openid profile email offline_access",
+        "expires_in": 86400,
+        "token_type": "Bearer",
+        "expires_at": 1600851112,
+    }
+    mocked_fetch_token = Mock(return_value=oauth_payload)
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.client.OAuth2Client.fetch_token",
+        mocked_fetch_token,
+    )
+    redirect_uri = "http://localhost:3000/used-logged-in"
+    state = signing.dumps({"redirectUri": redirect_uri})
+    code = "oauth-code"
+    user_count = User.objects.count()
+
+    # when
+    tokens = plugin.external_obtain_access_tokens(
+        {"state": state, "code": code}, rf.request(), previous_value=None
+    )
+
+    # then
+    assert User.objects.count() == user_count + 1
+    user = tokens.user
+    assert user.search_document
+    mocked_fetch_token.assert_called_once_with(
+        "https://saleor.io/oauth/token",
+        code=code,
+        redirect_uri=redirect_uri,
+    )
+
+    claims = get_parsed_id_token(
+        oauth_payload,
+        plugin.config.json_web_key_set_url,
+    )
+    expected_tokens = create_tokens_from_oauth_payload(
+        oauth_payload, user, claims, permissions=[], owner=plugin.PLUGIN_ID
+    )
+
+    decoded_access_token = jwt_decode(tokens.token)
+    assert decoded_access_token["permissions"] == []
+    assert decoded_access_token["is_staff"] is False
+    assert tokens.token == expected_tokens["token"]
+    decoded_refresh_token = jwt_decode(tokens.refresh_token)
+    assert tokens.csrf_token == decoded_refresh_token["csrf_token"]
+    assert decoded_refresh_token["oauth_refresh_token"] == "refresh"
 
 
 @freeze_time("2019-03-18 12:00:00")

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -493,10 +493,11 @@ def _update_user_details(
         user.last_name = user_last_name
         fields_to_save.update({"last_name", "search_document"})
 
-    if "search_document" in fields_to_save:
+    if not user.search_document or "search_document" in fields_to_save:
         user.search_document = prepare_user_search_document_value(
             user, attach_addresses_data=False
         )
+        fields_to_save.add("search_document")
 
     if fields_to_save:
         user.save(update_fields=fields_to_save)


### PR DESCRIPTION
Fix not setting `search_document` value for new customers created via openID plugin.

As the `search_document` was not updated, the user cannot be find be `customers` query with `search` filter like:
```
customers(filter: {search: "test@example.com"}, first:10) {
  edges{
        node{
          id
  
        }
      }
  }
```

Port of https://github.com/saleor/saleor/pull/15432

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
