### PR TITLE
Wrap celery tasks related to promotion in cls.call_event

### DIFF
--- a/saleor/graphql/discount/mutations/bulk_mutations.py
+++ b/saleor/graphql/discount/mutations/bulk_mutations.py
@@ -97,7 +97,7 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
             cls.call_event(
                 manager.sale_deleted, sale, catalogue_info, webhooks=webhooks
             )
-        update_discounted_prices_task.delay(list(product_ids))
+        cls.call_event(update_discounted_prices_task.delay, list(product_ids))
 
     @classmethod
     def get_sale_and_rules(cls, qs: QuerySet[models.Promotion]):

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -47,7 +47,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
         for promotion in promotions:
             cls.call_event(manager.promotion_deleted, promotion, webhooks=webhooks)
 
-        update_discounted_prices_task.delay(list(product_ids))
+        cls.call_event(update_discounted_prices_task.delay, list(product_ids))
 
     @classmethod
     def get_product_ids(cls, qs: QuerySet[models.Promotion]):

--- a/saleor/graphql/discount/mutations/promotion/promotion_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_delete.py
@@ -58,5 +58,5 @@ class PromotionDelete(ModelDeleteMutation):
             response = super().perform_mutation(root, info, id=id)
             instance.id = promotion_id
             cls.call_event(manager.promotion_deleted, instance)
-            update_discounted_prices_task.delay(product_ids)
+            cls.call_event(update_discounted_prices_task.delay, product_ids)
         return response

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
@@ -70,8 +70,9 @@ class PromotionRuleCreate(ModelMutation):
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         products = get_products_for_rule(instance, update_rule_variants=True)
         if products:
-            update_discounted_prices_task.delay(
-                list(products.values_list("id", flat=True))
+            cls.call_event(
+                update_discounted_prices_task.delay,
+                list(products.values_list("id", flat=True)),
             )
         clear_promotion_old_sale_id(instance.promotion, save=True)
         app = get_app_promise(info.context).get()

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
@@ -66,7 +66,7 @@ class PromotionRuleDelete(ModelDeleteMutation):
         instance.id = db_id
 
         if product_ids:
-            update_discounted_prices_task.delay(product_ids)
+            cls.call_event(update_discounted_prices_task.delay, product_ids)
 
         app = get_app_promise(info.context).get()
         events.rule_deleted_event(info.context.user, app, [instance])

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -200,7 +200,7 @@ class PromotionRuleUpdate(ModelMutation):
         products = get_products_for_rule(instance, update_rule_variants=True)
         product_ids = set(products.values_list("id", flat=True)) | previous_product_ids
         if product_ids:
-            update_discounted_prices_task.delay(list(product_ids))
+            cls.call_event(update_discounted_prices_task.delay, list(product_ids))
         clear_promotion_old_sale_id(instance.promotion, save=True)
         app = get_app_promise(info.context).get()
         events.rule_updated_event(info.context.user, app, [instance])

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -66,7 +66,7 @@ class SaleBaseCatalogueMutation(BaseMutation):
                 product_ids = new_product_ids - previous_product_ids
             else:
                 product_ids = previous_product_ids - new_product_ids
-            update_discounted_prices_task.delay(list(product_ids))
+            cls.call_event(update_discounted_prices_task.delay, list(product_ids))
 
     @classmethod
     def get_product_ids_for_predicate(cls, predicate: dict) -> set[int]:

--- a/saleor/graphql/discount/mutations/sale/sale_delete.py
+++ b/saleor/graphql/discount/mutations/sale/sale_delete.py
@@ -68,7 +68,7 @@ class SaleDelete(ModelDeleteMutation):
 
             manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.sale_deleted, promotion, previous_catalogue)
-            update_discounted_prices_task.delay(list(product_ids))
+            cls.call_event(update_discounted_prices_task.delay, list(product_ids))
 
         return response
 

--- a/saleor/graphql/discount/mutations/sale/sale_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_update.py
@@ -198,7 +198,7 @@ class SaleUpdate(ModelMutation):
             )
             update_variants_for_promotion(variants, promotion)
             if product_ids | previous_product_ids:
-                update_discounted_prices_task.delay(list(product_ids))
+                cls.call_event(update_discounted_prices_task.delay, list(product_ids))
 
     @classmethod
     def send_sale_notifications(

--- a/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
@@ -47,6 +47,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
         for product in products:
             cls.call_event(manager.product_updated, product, webhooks=webhooks)
 
-        update_products_discounted_prices_for_promotion_task.delay(
-            [product.id for product in products]
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay,
+            [product.id for product in products],
         )

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -356,7 +356,7 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
             cls.update_channels(product, cleaned_input.get("update_channels", []))
             cls.remove_channels(product, cleaned_input.get("remove_channels", []))
             product = ProductModel.objects.prefetched_for_webhook().get(pk=product.pk)
-            update_discounted_prices_task.delay([product.id])
+            cls.call_event(update_discounted_prices_task.delay, [product.id])
             manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.product_updated, product)
 
@@ -541,7 +541,7 @@ class ProductVariantChannelListingUpdate(BaseMutation):
                     channel=channel,
                     defaults=defaults,
                 )
-            update_discounted_prices_task.delay([variant.product_id])
+            cls.call_event(update_discounted_prices_task.delay, [variant.product_id])
             manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.product_variant_updated, variant)
 

--- a/saleor/graphql/product/mutations/collection/collection_delete.py
+++ b/saleor/graphql/product/mutations/collection/collection_delete.py
@@ -48,7 +48,9 @@ class CollectionDelete(ModelDeleteMutation):
 
         for ids_batch in cls.batch_product_ids(product_ids):
             collection_product_updated_task.delay(ids_batch)
-        update_products_discounted_prices_for_promotion_task.delay(product_ids)
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay, product_ids
+        )
 
         return CollectionDelete(
             collection=ChannelContext(node=result.collection, channel_slug=None)

--- a/saleor/graphql/product/mutations/collection/collection_remove_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_remove_products.py
@@ -50,8 +50,9 @@ class CollectionRemoveProducts(BaseMutation):
         for product in products:
             cls.call_event(manager.product_updated, product)
         # Updated the db entries, recalculating discounts of affected products
-        update_products_discounted_prices_for_promotion_task.delay(
-            [p.pk for p in products]
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay,
+            [p.pk for p in products],
         )
         return CollectionRemoveProducts(
             collection=ChannelContext(node=collection, channel_slug=None)

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -220,7 +220,9 @@ class ProductCreate(ModelMutation):
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, _cleaned_input):
         product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
-        update_products_discounted_prices_for_promotion_task.delay([instance.id])
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay, [instance.id]
+        )
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.product_created, product)
 

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -51,7 +51,10 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
         if "category" in cleaned_input or "collections" in cleaned_input:
-            update_products_discounted_prices_for_promotion_task.delay([instance.id])
+            cls.call_event(
+                update_products_discounted_prices_for_promotion_task.delay,
+                [instance.id],
+            )
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.product_updated, product)
 

--- a/saleor/graphql/product/mutations/product_variant/product_variant_delete.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_delete.py
@@ -51,8 +51,9 @@ class ProductVariantDelete(ModelDeleteMutation, ModelWithExtRefMutation):
     @classmethod
     def success_response(cls, instance):
         # Update the "discounted_prices" of the parent product
-        update_products_discounted_prices_for_promotion_task.delay(
-            [instance.product_id]
+        cls.call_event(
+            update_products_discounted_prices_for_promotion_task.delay,
+            [instance.product_id],
         )
         product = models.Product.objects.get(id=instance.product_id)
         product.search_index_dirty = True


### PR DESCRIPTION
I want to merge this change because it is port of changes:#15443

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
