### PR TITLE
Don't raise InsufficientStock for track_inventory=False variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Saleor Apps
 
 ### Other changes
+- Don't raise InsufficientStock for track_inventory=False variants #15475 by @carlosa54
 
 # 3.19.0
 

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -291,13 +291,16 @@ def check_stock_quantity_bulk(
         if quantity > 0:
             _check_quantity_limits(variant, quantity, global_quantity_limit)
 
+            if not variant.track_inventory:
+                continue
+
             if not stocks:
                 insufficient_stocks.append(
                     InsufficientStockData(
                         variant=variant, available_quantity=available_quantity
                     )
                 )
-            elif variant.track_inventory and quantity > available_quantity:
+            elif quantity > available_quantity:
                 insufficient_stocks.append(
                     InsufficientStockData(
                         variant=variant,

--- a/saleor/warehouse/tests/test_stock_availability.py
+++ b/saleor/warehouse/tests/test_stock_availability.py
@@ -233,6 +233,17 @@ def test_check_stock_quantity_bulk(variant_with_many_stocks, channel_USD):
             global_quantity_limit,
         )
 
+    # test that it doesn't raise an error if variant.track_inventory is False
+    variant.track_inventory = False
+    variant.save(update_fields=["track_inventory"])
+    check_stock_quantity_bulk(
+        [variant],
+        country_code,
+        [available_quantity],
+        channel_USD.slug,
+        global_quantity_limit,
+    )
+
 
 def test_check_stock_quantity_bulk_no_channel_shipping_zones(
     variant_with_many_stocks, channel_USD


### PR DESCRIPTION
I want to merge this change because it fixes an issue when a variant has `track_inventory=False` but Saleor is still checking for stocks.

Fixes https://github.com/saleor/saleor/issues/7531

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
