### PR TITLE
Fix save checkout shipping_address for Click and Collect option.

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -248,11 +248,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             checkout_info, lines, manager, save=False
         )
         checkout.save(
-            update_fields=[
-                "shipping_method",
-                "collection_point",
-            ]
-            + invalidate_prices_updated_fields
+            update_fields=checkout_fields_to_update + invalidate_prices_updated_fields
         )
         get_or_create_checkout_metadata(checkout).save()
         cls.call_event(manager.checkout_updated, checkout)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -523,9 +523,9 @@ def test_checkout_delivery_method_update_valid_method_not_all_shipping_data_for_
 ):
     # given
     mock_clean_delivery.return_value = True
-
+    checkout_address = Address.objects.create(country="US")
     checkout = checkout_with_item_for_cc
-    checkout.shipping_address = Address.objects.create(country="US")
+    checkout.shipping_address = checkout_address
     checkout.save()
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
@@ -551,7 +551,7 @@ def test_checkout_delivery_method_update_valid_method_not_all_shipping_data_for_
         checkout_info=checkout_info, lines=lines, method=shipping_method_data
     )
     errors = data["errors"]
-
+    assert checkout.shipping_address == delivery_method.address
     assert not errors
     assert getattr(checkout, attribute_name) == delivery_method
 


### PR DESCRIPTION
This is the missing test check for task, also missing `checkout.shipping_address` field update.
issue: https://linear.app/saleor/issue/SHOPX-175/bug-billing-address-is-used-for-tax-calculation-for-clickandcollect
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
