### PR TITLE
fix `_get_the_cheapest_line` when there is no lines

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -410,8 +410,10 @@ def apply_voucher_to_checkout_line(
 
 
 def _get_the_cheapest_line(
-    lines_info: Iterable[CheckoutLineInfo],
-):
+    lines_info: Optional[Iterable[CheckoutLineInfo]],
+) -> Optional[CheckoutLineInfo]:
+    if not lines_info:
+        return None
     return min(
         lines_info, key=lambda line_info: line_info.channel_listing.discounted_price
     )


### PR DESCRIPTION
I want to merge this change because it fixes the case when there is no CheckoutLineInfo provided to find which line is the cheapest.

Fixes SHOPX-313

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
