### PR TITLE
Improve the perfomance of update products search vector task

### DIFF
--- a/saleor/core/utils/editorjs.py
+++ b/saleor/core/utils/editorjs.py
@@ -69,10 +69,10 @@ def clean_list_item(blocks, block, plain_text_list, to_string, index):
     for item_index, item in enumerate(block["data"]["items"]):
         if not item:
             return
-        new_text = clean_text_data(item)
         if to_string:
-            plain_text_list.append(strip_tags(new_text))
+            plain_text_list.append(strip_tags(item))
         else:
+            new_text = clean_text_data_block(item)
             blocks[index]["data"]["items"][item_index] = new_text
 
 
@@ -80,16 +80,16 @@ def clean_image_item(blocks, block, plain_text_list, to_string, index):
     file_url = block["data"].get("file", {}).get("url")
     caption = block["data"].get("caption")
     if file_url:
-        file_url = clean_text_data(file_url)
         if to_string:
             plain_text_list.append(strip_tags(file_url))
         else:
+            file_url = clean_text_data_block(file_url)
             blocks[index]["data"]["file"]["ulr"] = file_url
     if caption:
-        caption = clean_text_data(caption)
         if to_string:
             plain_text_list.append(strip_tags(caption))
         else:
+            caption = clean_text_data_block(caption)
             blocks[index]["data"]["caption"] = caption
 
 
@@ -98,25 +98,31 @@ def clean_embed_item(blocks, block, plain_text_list, to_string, index):
         data = block["data"].get(field)
         if not data:
             return
-        data = clean_text_data(data)
         if to_string:
             plain_text_list.append(strip_tags(data))
         else:
+            data = clean_text_data_block(data)
             blocks[index]["data"][field] = data
 
 
-def clean_other_items(blocks, block, plain_text_list, to_string, index):
+def clean_other_items(
+    blocks,
+    block,
+    plain_text_list,
+    to_string,
+    index,
+):
     text = block["data"].get("text")
     if not text:
         return
-    new_text = clean_text_data(text)
     if to_string:
-        plain_text_list.append(strip_tags(new_text))
+        plain_text_list.append(strip_tags(text))
     else:
+        new_text = clean_text_data_block(text)
         blocks[index]["data"]["text"] = new_text
 
 
-def clean_text_data(text: str) -> str:
+def clean_text_data_block(text: str) -> str:
     """Look for url in text, check if URL is allowed and return the cleaned URL.
 
     By default, only the protocol ``javascript`` is denied.

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -452,7 +452,7 @@ def create_products_by_schema(placeholder_dir, create_images):
     assign_products_to_collections(associations=types["product.collectionproduct"])
 
     all_products_qs = Product.objects.all()
-    update_products_search_vector(all_products_qs)
+    update_products_search_vector(all_products_qs.values_list("id", flat=True))
 
 
 class SaleorProvider(BaseProvider):

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -176,7 +176,7 @@ def _get_preorder_variants_to_clean():
     expires=settings.BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC,
 )
 def update_products_search_vector_task():
-    products = Product.objects.filter(search_index_dirty=True).order_by()[
+    products = Product.objects.filter(search_index_dirty=True).order_by("updated_at")[
         :PRODUCTS_BATCH_SIZE
     ]
     update_products_search_vector(products, use_batches=False)

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -20,7 +20,7 @@ from ..warehouse.management import deactivate_preorder_for_variant
 from ..webhook.event_types import WebhookEventAsyncType
 from ..webhook.utils import get_webhooks_for_event
 from .models import Product, ProductType, ProductVariant
-from .search import PRODUCTS_BATCH_SIZE, update_products_search_vector
+from .search import update_products_search_vector
 from .utils.variant_prices import update_discounted_prices_for_promotion
 from .utils.variants import (
     fetch_variants_for_promotion_rules,
@@ -29,6 +29,8 @@ from .utils.variants import (
 
 logger = logging.getLogger(__name__)
 task_logger = get_task_logger(__name__)
+
+PRODUCTS_BATCH_SIZE = 300
 
 VARIANTS_UPDATE_BATCH = 500
 # Results in update time ~0.2s
@@ -176,10 +178,12 @@ def _get_preorder_variants_to_clean():
     expires=settings.BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC,
 )
 def update_products_search_vector_task():
-    products = Product.objects.filter(search_index_dirty=True).order_by("updated_at")[
-        :PRODUCTS_BATCH_SIZE
-    ]
-    update_products_search_vector(products, use_batches=False)
+    products = (
+        Product.objects.filter(search_index_dirty=True)
+        .order_by("updated_at")[:PRODUCTS_BATCH_SIZE]
+        .values_list("id", flat=True)
+    )
+    update_products_search_vector(products)
 
 
 @app.task(queue=settings.COLLECTION_PRODUCT_UPDATED_QUEUE_NAME)

--- a/saleor/product/tests/test_product_search.py
+++ b/saleor/product/tests/test_product_search.py
@@ -9,7 +9,7 @@ def test_update_products_search_vector(product_list):
     Product.objects.bulk_update(product_list, ["search_vector"])
 
     # when
-    update_products_search_vector(Product.objects.all())
+    update_products_search_vector(Product.objects.all().values_list("id", flat=True))
 
     # then
     for product in product_list:

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -287,7 +287,7 @@ def test_update_products_search_vector_task_with_static_number_of_queries(
         product_list[i].save(update_fields=["search_index_dirty"])
 
     # when & # then
-    with django_assert_num_queries(12):
+    with django_assert_num_queries(15):
         update_products_search_vector_task()
 
 

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -275,6 +275,22 @@ def test_update_products_search_vector_task(product):
     assert product.search_index_dirty is False
 
 
+@pytest.mark.parametrize("dirty_products_number", [0, 1, 2, 3])
+def test_update_products_search_vector_task_with_static_number_of_queries(
+    product, product_list, dirty_products_number, django_assert_num_queries
+):
+    # given
+    product.search_index_dirty = True
+    product.save()
+    for i in range(dirty_products_number):
+        product_list[i].search_index_dirty = True
+        product_list[i].save(update_fields=["search_index_dirty"])
+
+    # when & # then
+    with django_assert_num_queries(12):
+        update_products_search_vector_task()
+
+
 @pytest.mark.slow
 @pytest.mark.limit_memory("50 MB")
 def test_mem_usage_update_products_discounted_prices(lots_of_products_with_variants):


### PR DESCRIPTION
I want to merge this change because it should cover: https://github.com/saleor/saleor/issues/15180

Internal link: https://linear.app/saleor/issue/MERX-67/optimize-update-products-search-vector-task

The results:
Tested on main, and on this branch

|   | Main |  This branch | 
| ------------- | ------------- | -- |
| Exectuion time  | 206.42s  | 27.04s | 
| DB queries called  | 9000+  |  43 |
| *Maximum memory usage: |  1658.36MB |  766.98MB | 

`*` memory usage tested by `memory_profiler` connected to celery worker 👇 
```python
from memory_profiler import memory_usage
mem_usage = memory_usage(7989, interval=.2, timeout=220)
max(mem_usage)
1658.359375
```

> [!NOTE]  
> 27 sec is still a big amount, but I had a really big dataset of attributes with rich_test and plain_text. The bulk_update took more than 20second on my setup.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
