### PR TITLE
Fix external shipping method calls on checkout lines add

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -943,9 +943,11 @@ def get_external_shipping_id(container: Union["Checkout", "Order"]):
     )
 
 
-def delete_external_shipping_id(checkout: Checkout):
+def delete_external_shipping_id(checkout: Checkout, save: bool = False):
     metadata = get_or_create_checkout_metadata(checkout)
     metadata.delete_value_from_private_metadata(PRIVATE_META_APP_SHIPPING_ID)
+    if save:
+        metadata.save(update_fields=["private_metadata"])
 
 
 def get_or_create_checkout_metadata(checkout: "Checkout") -> CheckoutMetadata:

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -29,6 +29,7 @@ from .utils import (
     get_checkout,
     get_variants_and_total_quantities,
     group_lines_input_on_add,
+    update_checkout_external_shipping_method_if_invalid,
     update_checkout_shipping_method_if_invalid,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
@@ -213,6 +214,7 @@ class CheckoutLinesAdd(BaseMutation):
             manager,
             replace,
         )
+        update_checkout_external_shipping_method_if_invalid(checkout_info, lines)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         invalidate_checkout_prices(checkout_info, lines, manager, save=True)
         cls.call_event(manager.checkout_updated, checkout)

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -56,15 +56,6 @@ class CheckoutLineData:
     metadata_list: Optional[list] = None
 
 
-def _is_external_shipping_valid(checkout_info: "CheckoutInfo"):
-    if external_shipping_id := get_external_shipping_id(checkout_info.checkout):
-        for method in checkout_info.valid_delivery_methods:
-            if method.id == external_shipping_id:
-                return True
-        return False
-    return True
-
-
 def clean_delivery_method(
     checkout_info: "CheckoutInfo",
     lines: Iterable[CheckoutLineInfo],
@@ -96,6 +87,15 @@ def clean_delivery_method(
 
     valid_methods = checkout_info.valid_delivery_methods
     return method in valid_methods
+
+
+def _is_external_shipping_valid(checkout_info: "CheckoutInfo"):
+    if external_shipping_id := get_external_shipping_id(checkout_info.checkout):
+        for method in checkout_info.valid_delivery_methods:
+            if method.id == external_shipping_id:
+                return True
+        return False
+    return True
 
 
 def update_checkout_external_shipping_method_if_invalid(

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -23,6 +23,8 @@ from ....checkout.fetch import CheckoutInfo, CheckoutLineInfo
 from ....checkout.utils import (
     calculate_checkout_quantity,
     clear_delivery_method,
+    delete_external_shipping_id,
+    get_external_shipping_id,
     is_shipping_required,
 )
 from ....core.exceptions import InsufficientStock, PermissionDenied
@@ -52,6 +54,15 @@ class CheckoutLineData:
     custom_price: Optional[Decimal] = None
     custom_price_to_update: bool = False
     metadata_list: Optional[list] = None
+
+
+def _is_external_shipping_valid(checkout_info: "CheckoutInfo"):
+    if external_shipping_id := get_external_shipping_id(checkout_info.checkout):
+        for method in checkout_info.valid_delivery_methods:
+            if method.id == external_shipping_id:
+                return True
+        return False
+    return True
 
 
 def clean_delivery_method(
@@ -87,8 +98,16 @@ def clean_delivery_method(
     return method in valid_methods
 
 
-def update_checkout_shipping_method_if_invalid(
+def update_checkout_external_shipping_method_if_invalid(
     checkout_info: "CheckoutInfo", lines: Iterable[CheckoutLineInfo]
+):
+    if not _is_external_shipping_valid(checkout_info):
+        delete_external_shipping_id(checkout_info.checkout, save=True)
+
+
+def update_checkout_shipping_method_if_invalid(
+    checkout_info: "CheckoutInfo",
+    lines: Iterable[CheckoutLineInfo],
 ):
     quantity = calculate_checkout_quantity(lines)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -731,6 +731,7 @@ def test_checkout_lines_add_existing_variant_override_previous_custom_price(
 def test_checkout_lines_add_deletes_external_shipping_method_if_invalid(
     mocked_webhook, app_api_client, checkout_with_item, permission_handle_checkouts
 ):
+    # given
     mocked_webhook.return_value = []
     checkout = checkout_with_item
     line = checkout.lines.first()
@@ -746,11 +747,15 @@ def test_checkout_lines_add_deletes_external_shipping_method_if_invalid(
         "lines": [{"variantId": variant_id, "quantity": 7, "price": price}],
         "channelSlug": checkout.channel.slug,
     }
+
+    # when
     response = app_api_client.post_graphql(
         MUTATION_CHECKOUT_LINES_ADD,
         variables,
         permissions=[permission_handle_checkouts],
     )
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]
@@ -766,6 +771,7 @@ def test_checkout_lines_add_doesnt_delete_external_shipping_method_if_valid(
     permission_handle_checkouts,
     address,
 ):
+    # given
     external_method_data = ShippingMethodData(
         id=graphene.Node.to_global_id("App", app_api_client.app.id),
         price=Money(Decimal(10), checkout_with_item.currency),
@@ -788,11 +794,15 @@ def test_checkout_lines_add_doesnt_delete_external_shipping_method_if_valid(
         "lines": [{"variantId": variant_id, "quantity": 7, "price": price}],
         "channelSlug": checkout.channel.slug,
     }
+
+    # when
     response = app_api_client.post_graphql(
         MUTATION_CHECKOUT_LINES_ADD,
         variables,
         permissions=[permission_handle_checkouts],
     )
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -6,11 +6,13 @@ import graphene
 import pytest
 import pytz
 from django.utils import timezone
+from prices import Money
 
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
 from .....checkout.utils import (
+    PRIVATE_META_APP_SHIPPING_ID,
     calculate_checkout_quantity,
     invalidate_checkout_prices,
     recalculate_checkout_discount,
@@ -18,6 +20,7 @@ from .....checkout.utils import (
 from .....discount import RewardValueType
 from .....plugins.manager import get_plugins_manager
 from .....product.models import ProductChannelListing
+from .....shipping.interface import ShippingMethodData
 from .....warehouse import WarehouseClickAndCollectOption
 from .....warehouse.models import Reservation, Stock
 from .....warehouse.tests.utils import get_available_quantity_for_stock
@@ -722,6 +725,80 @@ def test_checkout_lines_add_existing_variant_override_previous_custom_price(
     line = checkout.lines.last()
     assert line.quantity == 10
     assert line.price_override == price
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_shipping_methods_for_checkout")
+def test_checkout_lines_add_deletes_external_shipping_method_if_invalid(
+    mocked_webhook, app_api_client, checkout_with_item, permission_handle_checkouts
+):
+    mocked_webhook.return_value = []
+    checkout = checkout_with_item
+    line = checkout.lines.first()
+    metadata = checkout.metadata_storage
+    metadata.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: "QXBwOjEzMzc="}
+    metadata.save(update_fields=["private_metadata"])
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
+    price = Decimal("13.11")
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "quantity": 7, "price": price}],
+        "channelSlug": checkout.channel.slug,
+    }
+    response = app_api_client.post_graphql(
+        MUTATION_CHECKOUT_LINES_ADD,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesAdd"]
+    assert not data["errors"]
+    metadata.refresh_from_db()
+    assert metadata.private_metadata == {}
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_shipping_methods_for_checkout")
+def test_checkout_lines_add_doesnt_delete_external_shipping_method_if_valid(
+    mocked_webhook,
+    app_api_client,
+    checkout_with_item,
+    permission_handle_checkouts,
+    address,
+):
+    external_method_data = ShippingMethodData(
+        id=graphene.Node.to_global_id("App", app_api_client.app.id),
+        price=Money(Decimal(10), checkout_with_item.currency),
+        active=True,
+    )
+    mocked_webhook.return_value = [external_method_data]
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.save()
+    line = checkout.lines.first()
+    metadata = checkout.metadata_storage
+    metadata.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: external_method_data.id}
+    metadata.save(update_fields=["private_metadata"])
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
+    price = Decimal("13.11")
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "quantity": 7, "price": price}],
+        "channelSlug": checkout.channel.slug,
+    }
+    response = app_api_client.post_graphql(
+        MUTATION_CHECKOUT_LINES_ADD,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesAdd"]
+    assert not data["errors"]
+    assert metadata.private_metadata == {
+        PRIVATE_META_APP_SHIPPING_ID: external_method_data.id
+    }
 
 
 def test_checkout_lines_add_custom_price_app_no_perm(app_api_client, checkout, stock):


### PR DESCRIPTION
I want to merge this change because it fixes a bug that called external shipping methods on `checkoutLinesAdd` even when assigned one was no longer valid.
Steps to reproduce:
1. Add shippable item to the cart, go to checkout, fill in the address and select external shipping method.
2. Invalidate shipping method on app side (so app no longer returns assigned method).
3. Go back to product page and add another item to the cart.
4. `list_shipping_methods_for_checkout` webhook is called, this is expected
5. as the method was no longer valid (response from app didn't include it) it should be removed from checkout metadata - this is the issue, it was not happening.
6. Add another item to the cart
7. `list_shipping_methods_for_checkout` should no longer be called as Saleor deattatched the external method from checkout metadata.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
