### PR TITLE
Clean naive datetime warnings

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -1,8 +1,9 @@
-import datetime
 from decimal import Decimal
 from unittest import mock
 
 import pytest
+import pytz
+from django.utils import timezone
 from freezegun import freeze_time
 
 from .....channel import TransactionFlowStrategy
@@ -1899,7 +1900,7 @@ def test_customer_ip_address_ipv6(
 @freeze_time("2023-03-18 12:00:00")
 @pytest.mark.parametrize(
     "previous_last_transaction_modified_at",
-    [None, datetime.datetime(2020, 1, 1)],
+    [None, timezone.datetime(2020, 1, 1, tzinfo=pytz.UTC)],
 )
 @mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")

--- a/saleor/graphql/payment/tests/queries/test_transaction.py
+++ b/saleor/graphql/payment/tests/queries/test_transaction.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 from decimal import Decimal
 
 import graphene
 import pytest
+from django.utils import timezone
 from freezegun import freeze_time
 
 from .....payment import TransactionEventType
@@ -276,7 +276,7 @@ def test_transaction_created_by_app_marked_to_remove(
 ):
     # given
     app.is_active = False
-    app.removed_at = datetime.now()
+    app.removed_at = timezone.now()
     app.save()
 
     webhook_app.identifier = app.identifier
@@ -727,7 +727,7 @@ def test_transaction_event_by_app_marked_to_remove(
     identifier = "app.identifier"
     app.identifier = identifier
     app.is_active = False
-    app.removed_at = datetime.now()
+    app.removed_at = timezone.now()
     app.save()
     webhook_app.identifier = identifier
     webhook_app.save()

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
@@ -1,8 +1,8 @@
 import json
-from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
+from django.utils import timezone
 from freezegun import freeze_time
 
 from .....core.prices import quantize_price
@@ -111,7 +111,7 @@ def test_checkout_transaction_cancel_request(
     checkout_with_items, webhook_app, permission_manage_payments
 ):
     # given
-    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.price_expiration = timezone.now() - timezone.timedelta(hours=10)
     checkout_with_items.save()
     authorized_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
@@ -1,8 +1,8 @@
 import json
-from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
+from django.utils import timezone
 from freezegun import freeze_time
 
 from .....core.prices import quantize_price
@@ -117,7 +117,7 @@ def test_checkout_transaction_charge_request(
     checkout_with_items, webhook_app, permission_manage_payments
 ):
     # given
-    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.price_expiration = timezone.now() - timezone.timedelta(hours=10)
     checkout_with_items.save()
     authorized_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
@@ -1,8 +1,8 @@
 import json
-from datetime import datetime, timedelta
 from decimal import Decimal
 
 import graphene
+from django.utils import timezone
 from freezegun import freeze_time
 
 from .....core.prices import quantize_price
@@ -153,7 +153,7 @@ def test_checkout_transaction_refund_request(
     checkout_with_items, webhook_app, permission_manage_payments
 ):
     # given
-    checkout_with_items.price_expiration = datetime.now() - timedelta(hours=10)
+    checkout_with_items.price_expiration = timezone.now() - timezone.timedelta(hours=10)
     checkout_with_items.save()
     charged_value = Decimal("10")
     webhook_app.permissions.add(permission_manage_payments)


### PR DESCRIPTION
I want to merge this change to clean warnings from pytest results.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
