### PR TITLE
Add more usages of replica

### DIFF
--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -213,13 +213,17 @@ class AccountQueries(graphene.ObjectType):
     @staticmethod
     def resolve_customers(_root, info: ResolveInfo, **kwargs):
         qs = resolve_customers(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, UserCountableConnection)
 
     @staticmethod
     def resolve_permission_groups(_root, info: ResolveInfo, **kwargs):
         qs = resolve_permission_groups(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, GroupCountableConnection)
 
     @staticmethod
@@ -235,7 +239,9 @@ class AccountQueries(graphene.ObjectType):
     @staticmethod
     def resolve_staff_users(_root, info: ResolveInfo, **kwargs):
         qs = resolve_staff_users(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, UserCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -125,7 +125,9 @@ class AppQueries(graphene.ObjectType):
     @staticmethod
     def resolve_apps(_root, info: ResolveInfo, **kwargs):
         qs = resolve_apps(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, AppCountableConnection)
 
     @staticmethod
@@ -144,7 +146,9 @@ class AppQueries(graphene.ObjectType):
     @staticmethod
     def resolve_app_extensions(_root, info: ResolveInfo, **kwargs):
         qs = resolve_app_extensions(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(
             qs, info, kwargs, AppExtensionCountableConnection
         )

--- a/saleor/graphql/attribute/schema.py
+++ b/saleor/graphql/attribute/schema.py
@@ -61,7 +61,9 @@ class AttributeQueries(graphene.ObjectType):
 
     def resolve_attributes(self, info: ResolveInfo, *, search=None, **kwargs):
         qs = resolve_attributes(info)
-        qs = filter_connection_queryset(qs, kwargs, info.context)
+        qs = filter_connection_queryset(
+            qs, kwargs, info.context, allow_replica=info.context.allow_replica
+        )
         if search:
             qs = filter_attribute_search(qs, None, search)
         return create_connection_slice(qs, info, kwargs, AttributeCountableConnection)

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -282,7 +282,9 @@ class Attribute(ModelObjectType[models.Attribute]):
                 QuerySet[models.AttributeValue], models.AttributeValue.objects.none()
             )
 
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(
             qs, info, kwargs, AttributeValueCountableConnection
         )

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -95,7 +95,9 @@ class CheckoutQueries(graphene.ObjectType):
     @staticmethod
     def resolve_checkouts(_root, info: ResolveInfo, *, channel=None, **kwargs):
         qs = resolve_checkouts(info, channel)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, CheckoutCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/csv/schema.py
+++ b/saleor/graphql/csv/schema.py
@@ -35,7 +35,9 @@ class CsvQueries(graphene.ObjectType):
 
     def resolve_export_files(self, info: ResolveInfo, **kwargs):
         qs = resolve_export_files(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, ExportFileCountableConnection)
 
 

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -174,7 +174,9 @@ class DiscountQueries(graphene.ObjectType):
     def resolve_sales(_root, info: ResolveInfo, *, channel=None, **kwargs):
         qs = resolve_sales(info, channel_slug=channel, **kwargs)
         kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, SaleCountableConnection)
 
     @staticmethod
@@ -186,7 +188,9 @@ class DiscountQueries(graphene.ObjectType):
     def resolve_vouchers(_root, info: ResolveInfo, *, channel=None, **kwargs):
         qs = resolve_vouchers(info, channel_slug=channel, **kwargs)
         kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, VoucherCountableConnection)
 
     @staticmethod
@@ -197,7 +201,9 @@ class DiscountQueries(graphene.ObjectType):
     @staticmethod
     def resolve_promotions(_root, info: ResolveInfo, **kwargs):
         qs = resolve_promotions(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, PromotionCountableConnection)
 
 

--- a/saleor/graphql/giftcard/schema.py
+++ b/saleor/graphql/giftcard/schema.py
@@ -103,7 +103,9 @@ class GiftCardQueries(graphene.ObjectType):
         if search:
             qs = search_gift_cards(qs, search)
         qs = filter_connection_queryset(
-            qs, {"sort_by": sort_by, "filter": filter, **kwargs}
+            qs,
+            {"sort_by": sort_by, "filter": filter, **kwargs},
+            allow_replica=info.context.allow_replica,
         )
         return create_connection_slice(
             qs,
@@ -123,7 +125,9 @@ class GiftCardQueries(graphene.ObjectType):
     @staticmethod
     def resolve_gift_card_tags(_root, info: ResolveInfo, **data):
         qs = resolve_gift_card_tags(info)
-        qs = filter_connection_queryset(qs, data)
+        qs = filter_connection_queryset(
+            qs, data, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, data, GiftCardTagCountableConnection)
 
 

--- a/saleor/graphql/menu/schema.py
+++ b/saleor/graphql/menu/schema.py
@@ -88,7 +88,9 @@ class MenuQueries(graphene.ObjectType):
         if channel is None:
             channel = get_default_channel_slug_or_graphql_error()
         qs = resolve_menus(info, channel)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, MenuCountableConnection)
 
     @staticmethod
@@ -104,7 +106,9 @@ class MenuQueries(graphene.ObjectType):
             channel = get_default_channel_slug_or_graphql_error()
         menu_items = resolve_menu_items(info)
         qs = ChannelQsContext(qs=menu_items, channel_slug=channel)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, MenuItemCountableConnection)
 
 

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -188,7 +188,9 @@ class OrderQueries(graphene.ObjectType):
                 {"direction": "-", "field": ["search_rank", "id"]}
             )
         qs = resolve_orders(info, channel)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, OrderCountableConnection)
 
     @staticmethod
@@ -207,7 +209,9 @@ class OrderQueries(graphene.ObjectType):
                 {"direction": "-", "field": ["search_rank", "id"]}
             )
         qs = resolve_draft_orders(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, OrderCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -12,16 +12,16 @@ def resolve_page(info, global_page_id=None, slug=None):
 
     if slug is not None:
         page = (
-            models.Page.objects.visible_to_user(requestor)
-            .using(get_database_connection_name(info.context))
+            models.Page.objects.using(get_database_connection_name(info.context))
+            .visible_to_user(requestor)
             .filter(slug=slug)
             .first()
         )
     else:
         _type, page_pk = from_global_id_or_error(global_page_id, Page)
         page = (
-            models.Page.objects.visible_to_user(requestor)
-            .using(get_database_connection_name(info.context))
+            models.Page.objects.using(get_database_connection_name(info.context))
+            .visible_to_user(requestor)
             .filter(pk=page_pk)
             .first()
         )
@@ -30,9 +30,9 @@ def resolve_page(info, global_page_id=None, slug=None):
 
 def resolve_pages(info):
     requestor = get_user_or_app_from_context(info.context)
-    return models.Page.objects.visible_to_user(requestor).using(
+    return models.Page.objects.using(
         get_database_connection_name(info.context)
-    )
+    ).visible_to_user(requestor)
 
 
 def resolve_page_type(info, id):

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -68,7 +68,9 @@ class PageQueries(graphene.ObjectType):
     @staticmethod
     def resolve_pages(_root, info: ResolveInfo, **kwargs):
         qs = resolve_pages(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, PageCountableConnection)
 
     @staticmethod
@@ -79,7 +81,9 @@ class PageQueries(graphene.ObjectType):
     @staticmethod
     def resolve_page_types(_root, info: ResolveInfo, **kwargs):
         qs = resolve_page_types(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, PageTypeCountableConnection)
 
 

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -92,7 +92,9 @@ class PageType(ModelObjectType[models.PageType]):
         qs = attribute_models.Attribute.objects.get_unassigned_page_type_attributes(
             root.pk
         ).using(get_database_connection_name(info.context))
-        qs = filter_connection_queryset(qs, kwargs, info.context)
+        qs = filter_connection_queryset(
+            qs, kwargs, info.context, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, AttributeCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -86,7 +86,9 @@ class PaymentQueries(graphene.ObjectType):
     @staticmethod
     def resolve_payments(_root, info: ResolveInfo, **kwargs):
         qs = resolve_payments(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, PaymentCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -342,7 +342,9 @@ class ProductQueries(graphene.ObjectType):
     @staticmethod
     def resolve_categories(_root, info: ResolveInfo, *, level=None, **kwargs):
         qs = resolve_categories(info, level=level)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, CategoryCountableConnection)
 
     @staticmethod
@@ -393,7 +395,9 @@ class ProductQueries(graphene.ObjectType):
             channel = get_default_channel_slug_or_graphql_error()
         qs = resolve_collections(info, channel)
         kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, CollectionCountableConnection)
 
     @staticmethod
@@ -460,7 +464,9 @@ class ProductQueries(graphene.ObjectType):
                 qs=search_products(qs.qs, search), channel_slug=channel
             )
         kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
 
     @staticmethod
@@ -471,7 +477,9 @@ class ProductQueries(graphene.ObjectType):
     @staticmethod
     def resolve_product_types(_root, info: ResolveInfo, **kwargs):
         qs = resolve_product_types(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, ProductTypeCountableConnection)
 
     @staticmethod
@@ -526,7 +534,9 @@ class ProductQueries(graphene.ObjectType):
             requestor=requestor,
         )
         kwargs["channel"] = qs.channel_slug
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(
             qs, info, kwargs, ProductVariantCountableConnection
         )

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -189,12 +189,17 @@ class Category(ModelObjectType[models.Category]):
         qs = ChannelQsContext(qs=qs, channel_slug=channel)
 
         kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
 
     @staticmethod
-    def __resolve_references(roots: list["Category"], _info):
-        return resolve_federation_references(Category, roots, models.Category.objects)
+    def __resolve_references(roots: list["Category"], info):
+        database_connection_name = get_database_connection_name(info.context)
+        return resolve_federation_references(
+            Category, roots, models.Category.objects.using(database_connection_name)
+        )
 
 
 class CategoryCountableConnection(CountableConnection):

--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -142,9 +142,9 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
         search = kwargs.get("search")
 
         requestor = get_user_or_app_from_context(info.context)
-        qs = root.node.products.visible_to_user(requestor, root.channel_slug).using(
+        qs = root.node.products.using(
             get_database_connection_name(info.context)
-        )
+        ).visible_to_user(requestor, root.channel_slug)
 
         if search:
             qs = ChannelQsContext(
@@ -154,7 +154,9 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
             qs = ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
 
         kwargs["channel"] = root.channel_slug
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/shipping/schema.py
+++ b/saleor/graphql/shipping/schema.py
@@ -70,7 +70,9 @@ class ShippingQueries(graphene.ObjectType):
     @staticmethod
     def resolve_shipping_zones(_root, info: ResolveInfo, *, channel=None, **kwargs):
         qs = resolve_shipping_zones(info, channel)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(
             qs, info, kwargs, ShippingZoneCountableConnection
         )

--- a/saleor/graphql/tax/schema.py
+++ b/saleor/graphql/tax/schema.py
@@ -125,7 +125,8 @@ class TaxQueries(graphene.ObjectType):
         qs = models.TaxConfiguration.objects.using(
             get_database_connection_name(info.context)
         ).all()
-        qs = filter_connection_queryset(qs, kwargs)
+        allow_replica = getattr(info.context, "allow_replica", True)
+        qs = filter_connection_queryset(qs, kwargs, allow_replica=allow_replica)
         return create_connection_slice(
             qs, info, kwargs, TaxConfigurationCountableConnection
         )
@@ -144,7 +145,8 @@ class TaxQueries(graphene.ObjectType):
         qs = models.TaxClass.objects.using(
             get_database_connection_name(info.context)
         ).all()
-        qs = filter_connection_queryset(qs, kwargs)
+        allow_replica = getattr(info.context, "allow_replica", True)
+        qs = filter_connection_queryset(qs, kwargs, allow_replica=allow_replica)
         return create_connection_slice(qs, info, kwargs, TaxClassCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -563,8 +563,8 @@ class PageTranslatableContent(ModelObjectType[page_models.Page]):
     @staticmethod
     def resolve_page(root: page_models.Page, info):
         return (
-            page_models.Page.objects.visible_to_user(info.context.user)
-            .using(get_database_connection_name(info.context))
+            page_models.Page.objects.using(get_database_connection_name(info.context))
+            .visible_to_user(info.context.user)
             .filter(pk=root.id)
             .first()
         )

--- a/saleor/graphql/warehouse/schema.py
+++ b/saleor/graphql/warehouse/schema.py
@@ -71,7 +71,9 @@ class WarehouseQueries(graphene.ObjectType):
     @staticmethod
     def resolve_warehouses(_root, info: ResolveInfo, **kwargs):
         qs = resolve_warehouses(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, WarehouseCountableConnection)
 
 
@@ -107,7 +109,9 @@ class StockQueries(graphene.ObjectType):
     @staticmethod
     def resolve_stocks(_root, info: ResolveInfo, **kwargs):
         qs = resolve_stocks(info)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(qs, info, kwargs, StockCountableConnection)
 
 

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -133,7 +133,9 @@ class EventDelivery(ModelObjectType[core_models.EventDelivery]):
         qs = core_models.EventDeliveryAttempt.objects.using(
             get_database_connection_name(info.context)
         ).filter(delivery=root)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(
             qs, info, kwargs, EventDeliveryAttemptCountableConnection
         )
@@ -246,7 +248,9 @@ class Webhook(ModelObjectType[models.Webhook]):
         qs = core_models.EventDelivery.objects.using(
             get_database_connection_name(info.context)
         ).filter(webhook_id=root.pk)
-        qs = filter_connection_queryset(qs, kwargs)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
         return create_connection_slice(
             qs, info, kwargs, EventDeliveryCountableConnection
         )

--- a/saleor/product/tests/test_product.py
+++ b/saleor/product/tests/test_product.py
@@ -160,7 +160,7 @@ def test_filtering_by_attribute(
 
 
 def test_clean_product_attributes_date_time_range_filter_input(
-    date_attribute, date_time_attribute
+    date_attribute, date_time_attribute, settings
 ):
     # filter date attribute
     filter_value = [
@@ -169,7 +169,9 @@ def test_clean_product_attributes_date_time_range_filter_input(
             {"gte": datetime(2020, 10, 5, tzinfo=pytz.utc)},
         )
     ]
-    values_qs = _clean_product_attributes_date_time_range_filter_input(filter_value)
+    values_qs = _clean_product_attributes_date_time_range_filter_input(
+        filter_value, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
 
     assert set(date_attribute.values.all()) == set(values_qs.all())
 
@@ -179,7 +181,9 @@ def test_clean_product_attributes_date_time_range_filter_input(
             {"gte": datetime(2020, 10, 5).date(), "lte": datetime(2020, 11, 4).date()},
         )
     ]
-    values_qs = _clean_product_attributes_date_time_range_filter_input(filter_value)
+    values_qs = _clean_product_attributes_date_time_range_filter_input(
+        filter_value, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
 
     assert {date_attribute.values.first().pk} == set(
         values_qs.values_list("pk", flat=True)
@@ -192,7 +196,9 @@ def test_clean_product_attributes_date_time_range_filter_input(
             {"lte": datetime(2020, 11, 4, tzinfo=timezone.utc)},
         )
     ]
-    values_qs = _clean_product_attributes_date_time_range_filter_input(filter_value)
+    values_qs = _clean_product_attributes_date_time_range_filter_input(
+        filter_value, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
 
     assert {date_attribute.values.first().pk} == set(
         values_qs.values_list("pk", flat=True)
@@ -204,15 +210,19 @@ def test_clean_product_attributes_date_time_range_filter_input(
             {"lte": datetime(2020, 10, 4, tzinfo=timezone.utc)},
         )
     ]
-    values_qs = _clean_product_attributes_date_time_range_filter_input(filter_value)
+    values_qs = _clean_product_attributes_date_time_range_filter_input(
+        filter_value, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
 
     assert values_qs.exists() is False
 
 
-def test_clean_product_attributes_boolean_filter_input(boolean_attribute):
+def test_clean_product_attributes_boolean_filter_input(boolean_attribute, settings):
     filter_value = [(boolean_attribute.slug, True)]
     queries = defaultdict(list)
-    _clean_product_attributes_boolean_filter_input(filter_value, queries)
+    _clean_product_attributes_boolean_filter_input(
+        filter_value, queries, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
 
     assert dict(queries) == {
         boolean_attribute.pk: [boolean_attribute.values.first().pk]
@@ -220,13 +230,17 @@ def test_clean_product_attributes_boolean_filter_input(boolean_attribute):
 
     filter_value = [(boolean_attribute.slug, False)]
     queries = defaultdict(list)
-    _clean_product_attributes_boolean_filter_input(filter_value, queries)
+    _clean_product_attributes_boolean_filter_input(
+        filter_value, queries, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
 
     assert dict(queries) == {boolean_attribute.pk: [boolean_attribute.values.last().pk]}
 
     filter_value = [(boolean_attribute.slug, True), (boolean_attribute.slug, False)]
     queries = defaultdict(list)
-    _clean_product_attributes_boolean_filter_input(filter_value, queries)
+    _clean_product_attributes_boolean_filter_input(
+        filter_value, queries, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
 
     assert dict(queries) == {
         boolean_attribute.pk: list(


### PR DESCRIPTION
- Pass `allow_replica` to `filter_connection_queryset`, which is needed for using replicas in filtering.
- Fix product filters to use replicas.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
