### PR TITLE
Mark user as unconfirmed by default in CustomerCreate

### DIFF
--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -23,7 +23,12 @@ from ...account.types import Address, AddressInput, User
 from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel, validate_channel
 from ...core import ResolveInfo, SaleorContext
-from ...core.descriptions import ADDED_IN_310, ADDED_IN_314, ADDED_IN_315
+from ...core.descriptions import (
+    ADDED_IN_310,
+    ADDED_IN_314,
+    ADDED_IN_315,
+    DEPRECATED_IN_3X_INPUT,
+)
 from ...core.doc_category import DOC_CATEGORY_USERS
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelDeleteMutation, ModelMutation
@@ -232,6 +237,16 @@ class UserCreateInput(CustomerInput):
             "only one channel exists."
         )
     )
+    is_confirmed = graphene.Boolean(
+        required=False,
+        description=(
+            "User account is confirmed."
+            + ADDED_IN_315
+            + DEPRECATED_IN_3X_INPUT
+            + "\n\nThe user will be always set as unconfirmed. "
+            "The confirmation will take place when the user sets the password."
+        ),
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_USERS
@@ -287,6 +302,11 @@ class BaseCustomerCreate(ModelMutation, I18nMixin):
         email = cleaned_input.get("email")
         if email:
             cleaned_input["email"] = email.lower()
+
+        # Always set the user as unconfirmed during account creation.
+        # The confirmation will take place when the user sets the password.
+        if not instance.id:
+            cleaned_input["is_confirmed"] = False
 
         return cleaned_input
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -31466,6 +31466,10 @@ input UserCreateInput @doc(category: "Users") {
   User account is confirmed.
   
   Added in Saleor 3.15.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0.
+  
+  The user will be always set as unconfirmed. The confirmation will take place when the user sets the password.
   """
   isConfirmed: Boolean
 


### PR DESCRIPTION
Mark the user as unconfirmed by default in `CustomerCreate` mutation.
- The mutation is sending an email for setting the password. 
- The user will confirm an account by setting the password.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
