### PR TITLE
Change slug pattern for numeric attribute values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Other changes
 - Don't raise InsufficientStock for track_inventory=False variants #15475 by @carlosa54
 - DB performance improvements in attribute dataloaders - #15474 by @AjmalPonneth
+- Change numeric attribute value slug pattern - #15566 by @zedzior
 
 # 3.19.0
 

--- a/saleor/attribute/__init__.py
+++ b/saleor/attribute/__init__.py
@@ -42,7 +42,6 @@ class AttributeInputType:
         REFERENCE,
         RICH_TEXT,
         PLAIN_TEXT,
-        NUMERIC,
         DATE,
         DATE_TIME,
     ]

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -594,7 +594,7 @@ class AttributeAssignmentMixin:
     @classmethod
     def _pre_save_numeric_values(
         cls,
-        instance: T_INSTANCE,
+        _,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
     ):
@@ -605,10 +605,13 @@ class AttributeAssignmentMixin:
         else:
             return tuple()
 
+        slug = slugify(unidecode(f"{value}_{attribute.id}"))
         defaults = {
-            "name": value,
+            "attribute": attribute,
+            "slug": slug,
+            "defaults": {"name": value},
         }
-        return cls._update_or_create_value(instance, attribute, defaults)
+        return ((AttributeValueBulkActionEnum.UPDATE_OR_CREATE, defaults),)
 
     @classmethod
     def _pre_save_values(

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -2255,7 +2255,6 @@ def test_create_product_with_numeric_attribute_new_attribute_value(
     content = get_graphql_content(response)
     data = content["data"]["productCreate"]
     assert data["errors"] == []
-    product_pk = graphene.Node.from_global_id(data["product"]["id"])[1]
     assert data["product"]["name"] == product_name
     assert data["product"]["slug"] == product_slug
     assert data["product"]["productType"]["name"] == product_type.name
@@ -2267,7 +2266,7 @@ def test_create_product_with_numeric_attribute_new_attribute_value(
     values = data["product"]["attributes"][0]["values"]
     assert len(values) == 1
     assert values[0]["name"] == expected_name
-    assert values[0]["slug"] == f"{product_pk}_{numeric_attribute.id}"
+    assert values[0]["slug"] == slugify(f"{value}_{numeric_attribute.id}")
 
     numeric_attribute.refresh_from_db()
     assert numeric_attribute.values.count() == values_count + 1
@@ -2311,7 +2310,6 @@ def test_create_product_with_numeric_attribute_existing_value(
     content = get_graphql_content(response)
     data = content["data"]["productCreate"]
     assert data["errors"] == []
-    product_pk = graphene.Node.from_global_id(data["product"]["id"])[1]
     assert data["product"]["name"] == product_name
     assert data["product"]["slug"] == product_slug
     assert data["product"]["productType"]["name"] == product_type.name
@@ -2323,7 +2321,7 @@ def test_create_product_with_numeric_attribute_existing_value(
     values = data["product"]["attributes"][0]["values"]
     assert len(values) == 1
     assert values[0]["name"] == existing_value.name
-    assert values[0]["slug"] == f"{product_pk}_{numeric_attribute.id}"
+    assert values[0]["slug"] == slugify(f"{existing_value}_{numeric_attribute.id}")
 
     numeric_attribute.refresh_from_db()
     assert numeric_attribute.values.count() == values_count + 1

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -658,7 +658,7 @@ def test_update_product_with_numeric_attribute_value(
                 "id": ANY,
                 "name": new_value,
                 "slug": slugify(
-                    f"{product.id}_{numeric_attribute.id}", allow_unicode=True
+                    f"{new_value}_{numeric_attribute.id}", allow_unicode=True
                 ),
                 "reference": None,
                 "file": None,
@@ -685,18 +685,16 @@ def test_update_product_with_numeric_attribute_value_new_value_is_not_created(
     query = MUTATION_UPDATE_PRODUCT
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
-
+    new_value = "45.2"
     attribute_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
     product_type.product_attributes.add(numeric_attribute)
-    slug_value = slugify(f"{product.id}_{numeric_attribute.id}", allow_unicode=True)
+    slug_value = slugify(f"{new_value}_{numeric_attribute.id}", allow_unicode=True)
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0"
     )
     associate_attribute_values_to_instance(product, {numeric_attribute.pk: [value]})
 
     value_count = AttributeValue.objects.count()
-
-    new_value = "45.2"
 
     variables = {
         "productId": product_id,
@@ -2159,9 +2157,7 @@ def test_update_product_with_numeric_attribute_value_by_numeric_field(
             {
                 "id": ANY,
                 "name": new_value,
-                "slug": slugify(
-                    f"{product.id}_{numeric_attribute.id}", allow_unicode=True
-                ),
+                "slug": slugify(f"{new_value}_{numeric_attribute.id}"),
                 "reference": None,
                 "file": None,
                 "boolean": None,
@@ -2188,9 +2184,10 @@ def test_update_product_with_numeric_attribute_by_numeric_field_null_value(
 
     attribute_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
     product_type.product_attributes.add(numeric_attribute)
-    slug_value = slugify(f"{product.id}_{numeric_attribute.id}", allow_unicode=True)
+    new_value = "20.0"
+    slug_value = slugify(f"{new_value}_{numeric_attribute.id}")
     value = AttributeValue.objects.create(
-        attribute=numeric_attribute, slug=slug_value, name="20.0"
+        attribute=numeric_attribute, slug=slug_value, name=new_value
     )
     associate_attribute_values_to_instance(product, {numeric_attribute.pk: [value]})
 
@@ -2225,15 +2222,13 @@ def test_update_product_with_numeric_attribute_by_numeric_field_new_value_not_cr
 
     attribute_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
     product_type.product_attributes.add(numeric_attribute)
-    slug_value = slugify(f"{product.id}_{numeric_attribute.id}", allow_unicode=True)
+    new_value = "45.2"
+    slug_value = slugify(f"{new_value}_{numeric_attribute.id}", allow_unicode=True)
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0"
     )
     associate_attribute_values_to_instance(product, {numeric_attribute.pk: [value]})
-
     value_count = AttributeValue.objects.count()
-
-    new_value = "45.2"
 
     variables = {
         "productId": product_id,

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -1175,13 +1175,11 @@ def test_create_variant_with_numeric_attribute(
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     assert not content["errors"]
     data = content["productVariant"]
-    variant_pk = graphene.Node.from_global_id(data["id"])[1]
     assert data["name"] == sku
     assert data["sku"] == sku
     assert data["attributes"][0]["attribute"]["slug"] == variant_slug
-    assert (
-        data["attributes"][0]["values"][0]["slug"]
-        == f"{variant_pk}_{numeric_attribute.pk}"
+    assert data["attributes"][0]["values"][0]["slug"] == slugify(
+        f"{variant_value}_{numeric_attribute.pk}"
     )
     assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
     assert data["weight"]["value"] == weight


### PR DESCRIPTION
Issue: https://github.com/saleor/saleor/issues/15190

I want to merge this change, because it changes the slug of numeric attribute values from `{instance.id}_{attribute.id}` to `{actual_numeric_value}_{attribute.id}`. This will make numeric values reusable. Previous solution was resulting in redundant, duplicated attribute values created. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
