### PR TITLE
Fix cache for shipping methods

### DIFF
--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -151,7 +151,10 @@ if TYPE_CHECKING:
     from ...webhook.models import Webhook
 
 
-CACHE_TIME_SHIPPING_LIST_METHODS_FOR_CHECKOUT: Final[int] = 5 * 60  # 5 minutes
+# Set the timeout for the shipping methods cache to 12 hours as it was the lowest
+# time labels were valid for when checking documentation for the carriers
+# (FedEx, UPS, TNT, DHL).
+CACHE_TIME_SHIPPING_LIST_METHODS_FOR_CHECKOUT: Final[int] = 3600 * 12
 
 
 logger = logging.getLogger(__name__)

--- a/saleor/webhook/transport/shipping.py
+++ b/saleor/webhook/transport/shipping.py
@@ -222,5 +222,5 @@ def get_cache_data_for_shipping_list_methods_for_checkout(payload: str) -> dict:
 
     # drop fields that change between requests but are not relevant for cache key
     key_data[0].pop("last_change")
-    key_data[0]["meta"].pop("issued_at")
+    key_data[0].pop("meta")
     return key_data


### PR DESCRIPTION
I want to merge this change because it fixes issue when method for listing shipping methods for checkout was called twice due to external shipping method.
Also increase cache time for listing shipping methods for checkout to 12h as it was lowest time where label was valid.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
