### PR TITLE
add crit header to `JWTManager.jws_encode`

### DIFF
--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
 from django.urls import reverse
 from django.utils.module_loading import import_string
-from jwt import api_jws
+from jwt import api_jws, api_jwt
 from jwt.algorithms import RSAAlgorithm
 
 from .utils import build_absolute_uri, get_domain
@@ -160,7 +160,7 @@ class JWTManager(JWTManagerBase):
 
     @classmethod
     def encode(cls, payload):
-        return jwt.encode(
+        return api_jwt.encode(
             payload,
             cls.get_private_key(),  # type: ignore[arg-type] # key is typed as str for all algos # noqa: E501
             algorithm="RS256",
@@ -173,7 +173,7 @@ class JWTManager(JWTManagerBase):
             payload,
             key=cls.get_private_key(),  # type: ignore[arg-type] # key is typed as str for all algos # noqa: E501
             algorithm="RS256",
-            headers={"kid": cls.get_key_id()},
+            headers={"kid": cls.get_key_id(), "crit": ["b64"]},
             is_payload_detached=is_payload_detached,
         )
 


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
