### PR TITLE
Clarify that identifier is needed as taxAppId in field description

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9823,7 +9823,7 @@ type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes
   countries: [TaxConfigurationPerCountry!]!
 
   """
-  The tax app id that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
   
   Added in Saleor 3.19.
   """
@@ -9858,7 +9858,7 @@ type TaxConfigurationPerCountry @doc(category: "Taxes") {
   displayGrossPrices: Boolean!
 
   """
-  The tax app id that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
   
   Added in Saleor 3.19.
   """
@@ -20881,7 +20881,7 @@ input TaxConfigurationUpdateInput @doc(category: "Taxes") {
   removeCountriesConfiguration: [CountryCode!]
 
   """
-  The tax app id that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. It's possible to set plugin by using prefix `plugin:` with `PLUGIN_ID` e.g. with Avalara `plugin:mirumee.taxes.avalara`.Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. It's possible to set plugin by using prefix `plugin:` with `PLUGIN_ID` e.g. with Avalara `plugin:mirumee.taxes.avalara`.Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
   
   Added in Saleor 3.19.
   """
@@ -20906,7 +20906,7 @@ input TaxConfigurationPerCountryInput @doc(category: "Taxes") {
   displayGrossPrices: Boolean!
 
   """
-  The tax app identifier that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
   
   Added in Saleor 3.19.
   """

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -47,7 +47,7 @@ class TaxConfigurationPerCountryInput(BaseInputObjectType):
     )
     tax_app_id = graphene.String(
         description=(
-            "The tax app identifier that will be used to calculate the taxes for the "
+            "The tax app `App.identifier` that will be used to calculate the taxes for the "
             "given channel and country. If not provided, use the value from the channel's "
             "tax configuration." + ADDED_IN_319
         ),
@@ -90,7 +90,7 @@ class TaxConfigurationUpdateInput(BaseInputObjectType):
     )
     tax_app_id = graphene.String(
         description=(
-            "The tax app id that will be used to calculate the taxes for the given channel. "
+            "The tax app `App.identifier` that will be used to calculate the taxes for the given channel. "
             "Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will "
             "iterate over all installed tax apps. If multiple tax apps exist with provided "
             "tax app id use the `App` with newest `created` date. It's possible to set plugin "

--- a/saleor/graphql/tax/types.py
+++ b/saleor/graphql/tax/types.py
@@ -52,7 +52,7 @@ class TaxConfiguration(ModelObjectType[models.TaxConfiguration]):
     )
     tax_app_id = graphene.String(
         description=(
-            "The tax app id that will be used to calculate the taxes for the given channel. "
+            "The tax app `App.identifier` that will be used to calculate the taxes for the given channel. "
             "Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will "
             "iterate over all installed tax apps. If multiple tax apps exist with provided "
             "tax app id use the `App` with newest `created` date. "
@@ -111,7 +111,7 @@ class TaxConfigurationPerCountry(ModelObjectType[models.TaxConfigurationPerCount
     )
     tax_app_id = graphene.String(
         description=(
-            "The tax app id that will be used to calculate the taxes for the given channel "
+            "The tax app `App.identifier` that will be used to calculate the taxes for the given channel "
             "and country. If not provided, use the value from the channel's tax configuration."
             + ADDED_IN_319
         ),


### PR DESCRIPTION
Current description doesn't specify that `App.identifier` field is needed over `App.id`

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
