### PR TITLE
Add references to the items they translate for translations

### DIFF
--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1990,44 +1990,83 @@ subscription {
       translation {
         ... on ProductTranslation {
           id
+          product {
+            id
+          }
         }
         ... on CollectionTranslation {
           id
+          collection {
+            id
+          }
         }
         ... on CategoryTranslation {
           id
+          category {
+            id
+          }
         }
         ... on AttributeTranslation {
           id
+          attribute {
+            id
+          }
         }
         ... on ProductVariantTranslation {
           id
+          productvariant {
+            id
+          }
         }
         ... on PageTranslation {
           id
+          page {
+            id
+          }
         }
         ... on ShippingMethodTranslation {
           id
+          shippingmethod {
+            id
+          }
         }
         ... on SaleTranslation {
           id
           __typename
+          sale {
+            id
+          }
         }
         ... on VoucherTranslation {
           id
+          voucher {
+            id
+          }
         }
         ... on MenuItemTranslation {
           id
+          menuitem {
+            id
+          }
         }
         ... on AttributeValueTranslation {
           id
+          attributevalue {
+            id
+          }
         }
         ... on PromotionTranslation {
           id
           __typename
+          promotion {
+            id
+          }
         }
         ... on PromotionRuleTranslation {
           id
+          promotionrule {
+            id
+          }
         }
       }
     }
@@ -2042,44 +2081,83 @@ subscription {
       translation {
         ... on ProductTranslation {
           id
+          product {
+            id
+          }
         }
         ... on CollectionTranslation {
           id
+          collection {
+            id
+          }
         }
         ... on CategoryTranslation {
           id
+          category {
+            id
+          }
         }
         ... on AttributeTranslation {
           id
+          attribute {
+            id
+          }
         }
         ... on ProductVariantTranslation {
           id
+          productvariant {
+            id
+          }
         }
         ... on PageTranslation {
           id
+          page {
+            id
+          }
         }
         ... on ShippingMethodTranslation {
           id
+          shippingmethod {
+            id
+          }
         }
         ... on SaleTranslation {
           id
           __typename
+          sale {
+            id
+          }
         }
         ... on VoucherTranslation {
           id
+          voucher {
+            id
+          }
         }
         ... on MenuItemTranslation {
           id
+          menuitem {
+            id
+          }
         }
         ... on AttributeValueTranslation {
           id
+          attributevalue {
+            id
+          }
         }
         ... on PromotionTranslation {
           id
           __typename
+          promotion {
+            id
+          }
         }
         ... on PromotionRuleTranslation {
           id
+          promotionrule {
+            id
+          }
         }
       }
     }


### PR DESCRIPTION
As is stated in [issue 13969](https://github.com/saleor/saleor/issues/13969), when receiving the TRANSLATION_CREATED event from a webhook, it has no way of knowing what the translation is supposed to be translating. Translations should have references to the items they translate. So I add the id of translated item for TRANSLATION_CREATED event and TRANSLATION_UPDATED event.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
