### PR TITLE
Fix migrations with no reverse sql

### DIFF
--- a/saleor/account/migrations/0078_add_group_channels_conf.py
+++ b/saleor/account/migrations/0078_add_group_channels_conf.py
@@ -25,6 +25,7 @@ class Migration(migrations.Migration):
                 ALTER TABLE account_group
                 ALTER COLUMN restricted_access_to_channels
                 SET DEFAULT false;
-            """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
     ]

--- a/saleor/attribute/migrations/0035_assignedproductattributevalue_product_add_index.py
+++ b/saleor/attribute/migrations/0035_assignedproductattributevalue_product_add_index.py
@@ -21,7 +21,8 @@ class Migration(migrations.Migration):
             """
                 DROP INDEX CONCURRENTLY IF EXISTS
                 attribute_assignedproductattributevalue_product_id_805656f1;
-            """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
         AddIndexConcurrently(
             model_name="assignedproductattributevalue",

--- a/saleor/discount/migrations/0055_drop_sales_from_db.py
+++ b/saleor/discount/migrations/0055_drop_sales_from_db.py
@@ -21,6 +21,7 @@ class Migration(migrations.Migration):
                     DROP TABLE discount_saletranslation;
                     DROP TABLE discount_sale;
                     """,
+                    reverse_sql=migrations.RunSQL.noop,
                 ),
             ]
         )

--- a/saleor/order/migrations/0129_alter_order_number.py
+++ b/saleor/order/migrations/0129_alter_order_number.py
@@ -23,7 +23,8 @@ class Migration(migrations.Migration):
 
             SELECT setval('order_order_number_seq', coalesce(max(number), 0) + 1, false)
             FROM order_order;
-        """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.AlterField(
             model_name="order",

--- a/saleor/product/migrations/0130_create_product_description_search_vector.py
+++ b/saleor/product/migrations/0130_create_product_description_search_vector.py
@@ -60,9 +60,8 @@ class Migration(migrations.Migration):
             tsvector_update_trigger(
                 'search_vector', 'pg_catalog.english', 'description_plaintext', 'name'
             )
-
-
-        """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.RunSQL(
             """
@@ -83,7 +82,8 @@ class Migration(migrations.Migration):
 
             CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
                 ON product_product FOR EACH ROW EXECUTE FUNCTION messages_trigger();
-            """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.RunPython(
             parse_description_json_field,

--- a/saleor/product/migrations/0131_update_ts_vector_existing_product_name.py
+++ b/saleor/product/migrations/0131_update_ts_vector_existing_product_name.py
@@ -17,6 +17,7 @@ class Migration(migrations.Migration):
             setweight(
             to_tsvector('pg_catalog.english', coalesce(description_plaintext, '')), 'B'
             );
-            """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
     ]

--- a/saleor/product/migrations/0156_product_search_document.py
+++ b/saleor/product/migrations/0156_product_search_document.py
@@ -35,12 +35,14 @@ class Migration(migrations.Migration):
             """
             DROP TRIGGER IF EXISTS title_vector_update
             ON product_product
-        """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.RunSQL(
             """
             DROP TRIGGER IF EXISTS tsvectorupdate
             ON product_product
-        """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
     ]


### PR DESCRIPTION
I want to merge this change because, I've run into migration with missing reverse_sql.
Pr should update all missing ones.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
