### PR TITLE
Remove prefetched_for_webhook to legacy payload generators.

### DIFF
--- a/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
@@ -33,7 +33,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
             collection_id__in=collections_ids
         )
         products = list(
-            models.Product.objects.prefetched_for_webhook(single_object=False).filter(
+            models.Product.objects.filter(
                 Exists(collection_products.filter(product_id=OuterRef("id")))
             )
         )

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -551,7 +551,7 @@ class ProductVariantChannelListingUpdate(BaseMutation):
     ):
         validate_one_of_args_is_in_mutation("sku", sku, "id", id)
 
-        qs = ProductVariantModel.objects.prefetched_for_webhook()
+        qs = ProductVariantModel.objects.all()
         if id:
             variant = cls.get_node_or_error(
                 info, id, only_type=ProductVariant, field="id", qs=qs

--- a/saleor/graphql/product/mutations/collection/collection_add_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_add_products.py
@@ -47,7 +47,7 @@ class CollectionAddProducts(BaseMutation):
             products,
             "products",
             Product,
-            qs=models.Product.objects.prefetched_for_webhook(single_object=False),
+            qs=models.Product.objects.all(),
         )
         cls.clean_products(products)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/product/mutations/collection/collection_remove_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_remove_products.py
@@ -43,7 +43,7 @@ class CollectionRemoveProducts(BaseMutation):
             products,
             "products",
             only_type=Product,
-            qs=models.Product.objects.prefetched_for_webhook(single_object=False),
+            qs=models.Product.objects.all(),
         )
         collection.products.remove(*products)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/product/mutations/product/product_media_create.py
+++ b/saleor/graphql/product/mutations/product/product_media_create.py
@@ -102,7 +102,7 @@ class ProductMediaCreate(BaseMutation):
             input["product"],
             field="product",
             only_type=Product,
-            qs=models.Product.objects.prefetched_for_webhook(),
+            qs=models.Product.objects.all(),
         )
 
         alt = input.get("alt", "")

--- a/saleor/graphql/product/mutations/product/product_media_delete.py
+++ b/saleor/graphql/product/mutations/product/product_media_delete.py
@@ -30,12 +30,10 @@ class ProductMediaDelete(BaseMutation):
         cls, _root, info: ResolveInfo, /, *, id: str
     ):
         media_obj = cls.get_node_or_error(info, id, only_type=ProductMedia)
+        product = models.Product.objects.get(pk=media_obj.product_id)  # type: ignore
         media_id = media_obj.id
         media_obj.delete()
         media_obj.id = media_id
-        product = models.Product.objects.prefetched_for_webhook().get(
-            pk=media_obj.product_id
-        )
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.product_updated, product)
         cls.call_event(manager.product_media_deleted, media_obj)

--- a/saleor/graphql/product/mutations/product/product_media_reorder.py
+++ b/saleor/graphql/product/mutations/product/product_media_reorder.py
@@ -45,7 +45,7 @@ class ProductMediaReorder(BaseMutation):
             product_id,
             field="product_id",
             only_type=Product,
-            qs=models.Product.objects.prefetched_for_webhook(),
+            qs=models.Product.objects.all(),
         )
 
         if len(media_ids) != product.media.count():

--- a/saleor/graphql/product/mutations/product/product_media_update.py
+++ b/saleor/graphql/product/mutations/product/product_media_update.py
@@ -43,9 +43,7 @@ class ProductMediaUpdate(BaseMutation):
         cls, _root, info: ResolveInfo, /, *, id, input
     ):
         media = cls.get_node_or_error(info, id, only_type=ProductMedia)
-        product = models.Product.objects.prefetched_for_webhook().get(
-            pk=media.product_id
-        )
+        product = models.Product.objects.get(pk=media.product_id)
         alt = input.get("alt")
         if alt is not None:
             if len(alt) > ALT_CHAR_LIMIT:

--- a/saleor/graphql/product/mutations/product_variant/product_variant_preorder_deactivate.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_preorder_deactivate.py
@@ -41,7 +41,7 @@ class ProductVariantPreorderDeactivate(BaseMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id
     ):
-        qs = models.ProductVariant.objects.prefetched_for_webhook()
+        qs = models.ProductVariant.objects.all()
         variant = cls.get_node_or_error(
             info, id, field="id", only_type=ProductVariant, qs=qs
         )

--- a/saleor/graphql/product/mutations/product_variant/product_variant_reorder.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_reorder.py
@@ -48,7 +48,7 @@ class ProductVariantReorder(BaseMutation):
         pk = cls.get_global_id_or_error(product_id, only_type=Product)
 
         try:
-            product = models.Product.objects.prefetched_for_webhook().get(pk=pk)
+            product = models.Product.objects.get(pk=pk)
         except ObjectDoesNotExist:
             raise ValidationError(
                 {
@@ -59,7 +59,7 @@ class ProductVariantReorder(BaseMutation):
                 }
             )
 
-        variants_m2m = product.variants
+        variants_m2m = product.variants.all()
         operations = {}
 
         for move_info in moves:
@@ -84,5 +84,5 @@ class ProductVariantReorder(BaseMutation):
             perform_reordering(variants_m2m, operations)
             product.save(update_fields=["updated_at"])
             cls.call_event(manager.product_updated, product)
-            product = ChannelContext(node=product, channel_slug=None)
-        return ProductVariantReorder(product=product)
+            context = ChannelContext(node=product, channel_slug=None)
+        return ProductVariantReorder(product=context)

--- a/saleor/graphql/product/mutations/product_variant/product_variant_set_default.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_set_default.py
@@ -40,7 +40,7 @@ class ProductVariantSetDefault(BaseMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, product_id, variant_id
     ):
-        qs = models.Product.objects.prefetched_for_webhook()
+        qs = models.Product.objects.all()
         product = cls.get_node_or_error(
             info, product_id, field="product_id", only_type=Product, qs=qs
         )

--- a/saleor/graphql/product/mutations/product_variant/variant_media_assign.py
+++ b/saleor/graphql/product/mutations/product_variant/variant_media_assign.py
@@ -38,7 +38,7 @@ class VariantMediaAssign(BaseMutation):
         media = cls.get_node_or_error(
             info, media_id, field="media_id", only_type=ProductMedia
         )
-        qs = models.ProductVariant.objects.prefetched_for_webhook()
+        qs = models.ProductVariant.objects.all()
         variant = cls.get_node_or_error(
             info, variant_id, field="variant_id", only_type=ProductVariant, qs=qs
         )

--- a/saleor/graphql/product/mutations/product_variant/variant_media_unassign.py
+++ b/saleor/graphql/product/mutations/product_variant/variant_media_unassign.py
@@ -38,7 +38,7 @@ class VariantMediaUnassign(BaseMutation):
         media = cls.get_node_or_error(
             info, media_id, field="image_id", only_type=ProductMedia
         )
-        qs = models.ProductVariant.objects.prefetched_for_webhook()
+        qs = models.ProductVariant.objects.all()
         variant = cls.get_node_or_error(
             info, variant_id, field="variant_id", only_type=ProductVariant, qs=qs
         )

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -225,7 +225,6 @@ class ProductsQueryset(models.QuerySet):
             "variants__stocks__allocations",
             "variants__channel_listings__channel",
             "channel_listings__channel",
-            "product_type__product_attributes__values",
             "product_type__attributeproduct",
         )
         if single_object:

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -37,8 +37,9 @@ from ..order.models import Fulfillment, FulfillmentLine, Order, OrderLine
 from ..order.utils import get_order_country
 from ..page.models import Page
 from ..payment import ChargeStatus
+from ..payment.models import Payment, TransactionItem
 from ..product import ProductMediaTypes
-from ..product.models import Collection, Product, ProductMedia
+from ..product.models import Collection, Product, ProductMedia, ProductVariant
 from ..shipping.interface import ShippingMethodData
 from ..tax.models import TaxClassCountryRate
 from ..tax.utils import get_charge_taxes_for_order
@@ -53,12 +54,6 @@ from .serializers import (
     serialize_product_attributes,
     serialize_variant_attributes,
 )
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from ..product.models import ProductVariant
-
-from ..payment.models import Payment, TransactionItem
 
 if TYPE_CHECKING:
     from ..discount.models import Promotion
@@ -713,6 +708,7 @@ def _get_charge_taxes_for_product(product: "Product") -> bool:
 def generate_product_payload(
     product: "Product", requestor: Optional["RequestorOrLazyObject"] = None
 ):
+    product = Product.objects.prefetched_for_webhook().get(pk=product.pk)
     serializer = PayloadSerializer(
         extra_model_fields={"ProductVariant": ("quantity", "quantity_allocated")}
     )
@@ -839,6 +835,14 @@ def generate_product_variant_payload(
     requestor: Optional["RequestorOrLazyObject"] = None,
     with_meta: bool = True,
 ):
+    if (
+        product_variants_with_prefetch
+        := ProductVariant.objects.prefetched_for_webhook().filter(
+            pk__in=[variant.pk for variant in product_variants]
+        )
+    ):
+        product_variants = product_variants_with_prefetch
+
     extra_dict_data = {
         "id": lambda v: v.get_global_id(),
         "attributes": lambda v: serialize_variant_attributes(v),
@@ -1130,15 +1134,7 @@ def generate_sample_payload(event_name: str) -> Optional[dict]:
         user = generate_fake_user()
         payload = generate_customer_payload(user)
     elif event_name == WebhookEventAsyncType.PRODUCT_CREATED:
-        product = _get_sample_object(
-            Product.objects.prefetch_related(
-                "category",
-                "collections",
-                "variants",
-                "attributevalues__value",
-                "product_type__attributeproduct__attribute",
-            )
-        )
+        product = _get_sample_object(Product.objects.all())
         payload = generate_product_payload(product) if product else None
     elif event_name in checkout_events:
         checkout = _get_sample_object(


### PR DESCRIPTION
Port to https://github.com/saleor/saleor/pull/15369

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
