### PR TITLE
Handle `AuthenticationError` in `OpenIDConnectPlugin`

### DIFF
--- a/saleor/plugins/openid_connect/plugin.py
+++ b/saleor/plugins/openid_connect/plugin.py
@@ -292,14 +292,18 @@ class OpenIDConnectPlugin(BasePlugin):
                 }
             )
 
-        parsed_id_token = get_parsed_id_token(
-            token_data, self.config.json_web_key_set_url
-        )
-
-        user, user_created, user_updated = get_or_create_user_from_payload(
-            parsed_id_token,
-            self.config.authorization_url,
-        )
+        try:
+            parsed_id_token = get_parsed_id_token(
+                token_data, self.config.json_web_key_set_url
+            )
+            user, user_created, user_updated = get_or_create_user_from_payload(
+                parsed_id_token,
+                self.config.authorization_url,
+            )
+        except AuthenticationError as e:
+            raise ValidationError(
+                {"code": ValidationError(str(e), code=PluginErrorCode.INVALID.value)}
+            )
 
         user_permissions = []
         is_staff_user_email = self.is_staff_user_email(user)


### PR DESCRIPTION
Catch `AuthenticationError` and raise a `ValidationError` in `OpenIDConnectPlugin`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
