### PR TITLE
Add lock on `PreorderAllocation` on deactivation preorders on variant

### DIFF
--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -808,9 +808,13 @@ def deactivate_preorder_for_variant(product_variant: ProductVariant):
         variant_id=product_variant.pk
     )
     channel_listings_pk = (channel_listing.id for channel_listing in channel_listings)
-    preorder_allocations = PreorderAllocation.objects.filter(
-        product_variant_channel_listing_id__in=channel_listings_pk
-    ).select_related("order_line", "order_line__order")
+    preorder_allocations = (
+        PreorderAllocation.objects.filter(
+            product_variant_channel_listing_id__in=channel_listings_pk
+        )
+        .select_for_update(of=("self",))
+        .select_related("order_line", "order_line__order")
+    )
 
     allocations_to_create = []
     stocks_to_create = []
@@ -875,6 +879,7 @@ def _get_stock_for_preorder_allocation(
     """
     order = preorder_allocation.order_line.order
     shipping_method_id = order.shipping_method_id
+
     if shipping_method_id is not None:
         warehouse = Warehouse.objects.filter(
             shipping_zones__id=order.shipping_method.shipping_zone_id  # type: ignore


### PR DESCRIPTION
Prevent `IntegrityError` - duplicate key value violates unique constraint when deactivating preorders for variant 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
