### PR TITLE
Handle errors in `authenticate_user` for `OpenIDConnectPlugin`

### DIFF
--- a/saleor/plugins/openid_connect/plugin.py
+++ b/saleor/plugins/openid_connect/plugin.py
@@ -5,7 +5,7 @@ from authlib.common.errors import AuthlibBaseError
 from django.core import signing
 from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
-from jwt import ExpiredSignatureError, InvalidTokenError
+from jwt import DecodeError, ExpiredSignatureError, InvalidTokenError
 from requests import HTTPError, PreparedRequest
 
 from ...account.models import User
@@ -498,8 +498,11 @@ class OpenIDConnectPlugin(BasePlugin):
             token, owner=self.PLUGIN_ID
         ):
             # Check if the token is created by this plugin
-            payload = jwt_decode(token)
-            user = get_user_from_access_payload(payload, request)
+            try:
+                payload = jwt_decode(token)
+                user = get_user_from_access_payload(payload, request)
+            except (InvalidTokenError, DecodeError):
+                return previous_value
             if user.is_staff:
                 assign_staff_to_default_group_and_update_permissions(
                     user, self.config.default_group_name
@@ -509,13 +512,16 @@ class OpenIDConnectPlugin(BasePlugin):
         staff_user_domains = get_staff_user_domains(self.config)
 
         if self.use_oauth_access_token:
-            user = get_user_from_oauth_access_token(
-                token,
-                self.config.json_web_key_set_url,
-                self.config.user_info_url,
-                self.config.use_scope_permissions,
-                self.config.audience,
-                staff_user_domains,
-                self.config.default_group_name,
-            )
+            try:
+                user = get_user_from_oauth_access_token(
+                    token,
+                    self.config.json_web_key_set_url,
+                    self.config.user_info_url,
+                    self.config.use_scope_permissions,
+                    self.config.audience,
+                    staff_user_domains,
+                    self.config.default_group_name,
+                )
+            except AuthenticationError:
+                return previous_value
         return user or previous_value

--- a/saleor/plugins/openid_connect/tests/test_plugin.py
+++ b/saleor/plugins/openid_connect/tests/test_plugin.py
@@ -7,6 +7,7 @@ from authlib.jose.errors import JoseError
 from django.core import signing
 from django.core.exceptions import ValidationError
 from freezegun import freeze_time
+from jwt import InvalidTokenError
 
 from ....account.models import Group, User
 from ....core.jwt import (
@@ -20,6 +21,7 @@ from ....core.jwt import (
 from ....graphql.account.mutations.authentication.utils import _get_new_csrf_token
 from ...base_plugin import ExternalAccessTokens
 from ...models import PluginConfiguration
+from ..exceptions import AuthenticationError
 from ..utils import (
     create_jwt_refresh_token,
     create_jwt_token,
@@ -1178,6 +1180,118 @@ def test_authenticate_user_with_jwt_access_token_which_is_no_more_staff(
     assert user.is_staff is False
     assert list(user.effective_permissions) == []
     mock_send_user_event.assert_called_once_with(user, False, True)
+
+
+def test_authenticate_user_get_user_from_oauth_access_token_raises_authentication_error(
+    openid_plugin,
+    customer_user,
+    monkeypatch,
+    rf,
+):
+    # given
+    plugin = openid_plugin(
+        oauth_authorization_url=None,
+        oauth_token_url=None,
+        json_web_key_set_url="https://saleor.io/.well-known/jwks.json",
+        user_info_url="https://saleor.io/userinfo",
+        use_oauth_scope_permissions=True,
+    )
+
+    # mock get token from request
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.get_token_from_request",
+        lambda _: "OAuth_access_token",
+    )
+    # mock request to api to fetch user info details
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.get_user_from_oauth_access_token",
+        Mock(side_effect=AuthenticationError()),
+    )
+
+    # when
+    user = plugin.authenticate_user(rf.request(), None)
+
+    # then
+    assert user is None
+
+
+def test_authenticate_user_get_user_from_access_payload_decode_error(
+    openid_plugin,
+    customer_user,
+    monkeypatch,
+    rf,
+):
+    # given
+    plugin = openid_plugin(
+        oauth_authorization_url="https://saleor.io/auth",
+        oauth_token_url="https://saleor.io/token",
+        json_web_key_set_url="https://saleor.io/.well-known/jwks.json",
+        user_info_url="https://saleor.io/userinfo",
+        use_oauth_scope_permissions=True,
+    )
+
+    # mock get token from request
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.get_token_from_request",
+        lambda _: "OAuth_access_token",
+    )
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.is_owner_of_token_valid",
+        Mock(return_value=True),
+    )
+    # mock request to api to fetch user info details
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.get_user_from_access_payload",
+        Mock(side_effect=InvalidTokenError()),
+    )
+
+    # when
+    user = plugin.authenticate_user(rf.request(), None)
+
+    # then
+    assert user is None
+
+
+def test_authenticate_user_get_user_from_access_payload_raises_invalid_token_error(
+    openid_plugin,
+    decoded_access_token,
+    customer_user,
+    monkeypatch,
+    rf,
+):
+    # given
+    plugin = openid_plugin(
+        oauth_authorization_url="https://saleor.io/auth",
+        oauth_token_url="https://saleor.io/token",
+        json_web_key_set_url="https://saleor.io/.well-known/jwks.json",
+        user_info_url="https://saleor.io/userinfo",
+        use_oauth_scope_permissions=True,
+    )
+
+    # mock get token from request
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.get_token_from_request",
+        lambda _: "OAuth_access_token",
+    )
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.jwt_decode",
+        lambda _: decoded_access_token,
+    )
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.is_owner_of_token_valid",
+        Mock(return_value=True),
+    )
+    # mock request to api to fetch user info details
+    monkeypatch.setattr(
+        "saleor.plugins.openid_connect.plugin.get_user_from_access_payload",
+        Mock(side_effect=InvalidTokenError()),
+    )
+
+    # when
+    user = plugin.authenticate_user(rf.request(), None)
+
+    # then
+    assert user is None
 
 
 @freeze_time("2021-03-08 12:00:00")


### PR DESCRIPTION
The `authenticate_user` should not raise any error, the `None` should be returned.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
