### PR TITLE
Raise 404 when the image for thumbnail creation cannot be open

### DIFF
--- a/saleor/thumbnail/tests/test_views.py
+++ b/saleor/thumbnail/tests/test_views.py
@@ -279,6 +279,27 @@ def test_handle_thumbnail_view_invalid_image_mime_type(
     assert Thumbnail.objects.count() == thumbnail_count
 
 
+def test_handle_thumbnail_view_image_does_not_exist(
+    client, staff_user, product_with_image, settings
+):
+    # given
+    product_media = product_with_image.media.first()
+    product_media.image.name = "invalid_image.jpg"
+    product_media.save(update_fields=["image"])
+
+    size = 500
+    product_media_id = graphene.Node.to_global_id("ProductMedia", product_media.id)
+    thumbnail_count = Thumbnail.objects.count()
+
+    # when
+    response = client.get(f"/thumbnail/{product_media_id}/{size}/")
+
+    # then
+    assert response.status_code == 404
+    assert response.content.decode("utf-8") == "Cannot found image file."
+    assert Thumbnail.objects.count() == thumbnail_count
+
+
 def test_handle_icon_thumbnail_view_with_format(
     client, app, icon_image, media_root, settings
 ):

--- a/saleor/thumbnail/views.py
+++ b/saleor/thumbnail/views.py
@@ -108,6 +108,9 @@ def handle_thumbnail(
         processed_image = ProcessedImage(image.name, size_px, format)
     try:
         thumbnail_file, _ = processed_image.create_thumbnail()
+    except FileNotFoundError as error:
+        logger.info(str(error))
+        return HttpResponseNotFound("Cannot found image file.")
     except ValueError as error:
         logger.info(str(error))
         return HttpResponseBadRequest("Invalid image.")


### PR DESCRIPTION
Port https://github.com/saleor/saleor/pull/15634

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
