### PR TITLE
Charge transaction items on orderConfirm

### DIFF
--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1336,6 +1336,13 @@ def order_unconfirmed(order):
 
 
 @pytest.fixture
+def order_unconfirmed_with_lines(order_with_lines):
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    order_with_lines.save(update_fields=["status"])
+    return order_with_lines
+
+
+@pytest.fixture
 def product_type_generator(
     attribute_generator, attribute_value_generator, default_tax_class
 ):


### PR DESCRIPTION
I want to merge this change because it implements charging transaction items at the point of order confirmation.
I'm merging this to the feature branch because it relies on a couple more tickets (like the one in which there is a flag to control this behavior).

Ticket: https://linear.app/saleor/issue/SHOPX-193/orderconfirm-should-capture-transactionitems-that-have-action-charge

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
