### PR TITLE
Add allow_writer context manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ extend_exclude = ["conftest\\.py", ".*/conftest\\.py", ".*/tests/.*"]
   [tool.deptry.per_rule_ignores]
   DEP001 = ["pkg_resources"]
   DEP002 = ["azure-common", "azure-storage-blob", "azure-storage-common", "django-redis", "gunicorn", "psycopg2"]
-  DEP003 = ["sqlparse"]
   DEP004 = ["debug_toolbar", "graphiql_debug_toolbar"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ extend_exclude = ["conftest\\.py", ".*/conftest\\.py", ".*/tests/.*"]
   [tool.deptry.per_rule_ignores]
   DEP001 = ["pkg_resources"]
   DEP002 = ["azure-common", "azure-storage-blob", "azure-storage-common", "django-redis", "gunicorn", "psycopg2"]
+  DEP003 = ["sqlparse"]
   DEP004 = ["debug_toolbar", "graphiql_debug_toolbar"]
 
 [tool.ruff]

--- a/saleor/checkout/payment_utils.py
+++ b/saleor/checkout/payment_utils.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db.models import Exists, Q
 from prices import Money
 
+from ..core.db.connection import allow_writer
 from ..core.taxes import zero_money
 from ..payment.models import TransactionItem
 from . import CheckoutAuthorizeStatus, CheckoutChargeStatus
@@ -115,7 +116,8 @@ def update_checkout_payment_statuses(
             fields_to_update.append("charge_status")
         if fields_to_update:
             fields_to_update.append("last_change")
-            checkout.save(update_fields=fields_to_update)
+            with allow_writer():
+                checkout.save(update_fields=fields_to_update)
 
 
 def update_refundable_for_checkout(checkout_pk):

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from prices import Money
 
 from ..account.models import User
+from ..core.db.connection import allow_writer
 from ..core.exceptions import ProductNotPublished
 from ..core.taxes import zero_taxed_money
 from ..core.utils.promo_code import (
@@ -960,9 +961,7 @@ def cancel_active_payments(checkout: Checkout):
 
 def is_shipping_required(lines: Iterable["CheckoutLineInfo"]):
     """Check if shipping is required for given checkout lines."""
-    return any(
-        line_info.product.product_type.is_shipping_required for line_info in lines
-    )
+    return any(line_info.product_type.is_shipping_required for line_info in lines)
 
 
 def validate_variants_in_checkout_lines(lines: Iterable["CheckoutLineInfo"]):
@@ -1012,6 +1011,7 @@ def delete_external_shipping_id(checkout: Checkout, save: bool = False):
         metadata.save(update_fields=["private_metadata"])
 
 
+@allow_writer()
 def get_or_create_checkout_metadata(checkout: "Checkout") -> CheckoutMetadata:
     if hasattr(checkout, "metadata_storage"):
         return checkout.metadata_storage

--- a/saleor/core/db/connection.py
+++ b/saleor/core/db/connection.py
@@ -8,6 +8,8 @@ from django.core.management.color import color_style
 from django.db import connections
 from django.db.backends.base.base import BaseDatabaseWrapper
 
+from ...graphql.core.context import SaleorContext, get_database_connection_name
+
 logger = logging.getLogger(__name__)
 
 writer = settings.DATABASE_CONNECTION_DEFAULT_NAME
@@ -104,3 +106,13 @@ def _log_writer_usage(execute, sql, params, many, context):
         )
         logger.error(log_msg)
     return execute(sql, params, many, context)
+
+
+@contextmanager
+def allow_writer_in_context(context: SaleorContext):
+    conn_name = get_database_connection_name(context)
+    if conn_name == settings.DATABASE_CONNECTION_DEFAULT_NAME:
+        with allow_writer():
+            yield
+    else:
+        yield

--- a/saleor/core/db/connection.py
+++ b/saleor/core/db/connection.py
@@ -1,0 +1,106 @@
+import logging
+import traceback
+from contextlib import contextmanager
+
+import sqlparse
+from django.conf import settings
+from django.core.management.color import color_style
+from django.db import connections
+from django.db.backends.base.base import BaseDatabaseWrapper
+
+logger = logging.getLogger(__name__)
+
+writer = settings.DATABASE_CONNECTION_DEFAULT_NAME
+replica = settings.DATABASE_CONNECTION_REPLICA_NAME
+
+
+class UnsafeDBUsageError(Exception):
+    pass
+
+
+class UnsafeWriterAccessError(UnsafeDBUsageError):
+    pass
+
+
+class UnsafeReplicaUsageError(UnsafeDBUsageError):
+    pass
+
+
+@contextmanager
+def allow_writer():
+    from django.db import connections
+
+    default_connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+
+    # Check if we are already in an allow_writer block. If so we don't need to do
+    # anything and we don't have to close access to the writer at the end.
+    in_allow_writer_block = getattr(default_connection, "_allow_writer", False)
+    if not in_allow_writer_block:
+        setattr(default_connection, "_allow_writer", True)
+    try:
+        yield
+    finally:
+        if not in_allow_writer_block:
+            # Close writer access when exiting the outermost allow_writer block.
+            setattr(default_connection, "_allow_writer", False)
+
+
+def restrict_writer_middleware(get_response):
+    """Middleware that restricts write access to the default database connection.
+
+    This middleware will raise an error or log a warning if a write operation is
+    attempted on the default database connection. To allow writes, use the
+    `allow_writer` context manager or the `using` queryset method.
+    """
+
+    def middleware(request):
+        with connections[writer].execute_wrapper(_restrict_writer):
+            with connections[replica].execute_wrapper(_restrict_writer):
+                return get_response(request)
+
+    return middleware
+
+
+def _restrict_writer(execute, sql, params, many, context):
+    conn: BaseDatabaseWrapper = context["connection"]
+    allow_writer = getattr(conn, "_allow_writer", False)
+    if conn.alias == writer and not allow_writer:
+        raise UnsafeWriterAccessError(
+            f"Unsafe writer DB access, use `allow_writer` context manager. SQL: {sql}"
+        )
+    elif conn.alias == replica:
+        if not _is_read_only_query(sql):
+            raise UnsafeReplicaUsageError(f"Unsafe replica usage. SQL: {sql}")
+    return execute(sql, params, many, context)
+
+
+def _is_read_only_query(sql_query: str) -> bool:
+    for query in sqlparse.parse(sql_query):
+        query_type = query.get_type().upper()
+        if query_type != "SELECT":
+            return False
+    return True
+
+
+def log_writer_usage_middleware(get_response):
+    def middleware(request):
+        with connections[writer].execute_wrapper(_log_writer_usage):
+            return get_response(request)
+
+    return middleware
+
+
+def _log_writer_usage(execute, sql, params, many, context):
+    conn: BaseDatabaseWrapper = context["connection"]
+    allow_writer = getattr(conn, "_allow_writer", False)
+    if conn.alias == writer and not allow_writer:
+        stack_trace = traceback.extract_stack(limit=20)
+        error_msg = color_style().NOTICE(
+            "Unsafe writer DB access, use `allow_writer` context manager."
+        )
+        log_msg = (
+            f"{error_msg} SQL: {sql} \n"
+            f"Traceback: \n{''.join(traceback.format_list(stack_trace))}"
+        )
+        logger.error(log_msg)
+    return execute(sql, params, many, context)

--- a/saleor/core/db/tests/test_connection.py
+++ b/saleor/core/db/tests/test_connection.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch
+
+import pytest
+from django.db import connections
+
+from ....graphql.context import SaleorContext
+from ....tests.models import Book
+from ..connection import (
+    UnsafeWriterAccessError,
+    _log_writer_usage,
+    _restrict_writer,
+    allow_writer,
+    allow_writer_in_context,
+)
+
+
+def test_allow_writer(settings):
+    default_connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+    assert not getattr(default_connection, "_allow_writer", False)
+
+    with allow_writer():
+        assert hasattr(default_connection, "_allow_writer")
+        assert default_connection._allow_writer
+
+
+def test_allow_writer_yield_exception(settings):
+    default_connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+
+    def example_function():
+        raise Exception()
+
+    try:
+        with allow_writer():
+            example_function()
+    except Exception:
+        pass
+
+    assert hasattr(default_connection, "_allow_writer")
+    assert not default_connection._allow_writer
+
+
+def test_allow_writer_in_context_writer(settings):
+    context = SaleorContext()
+    context.allow_replica = False
+
+    with allow_writer_in_context(context):
+        connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+        assert hasattr(connection, "_allow_writer")
+        assert connection._allow_writer
+
+
+@patch("saleor.core.db.connection.get_database_connection_name")
+def test_allow_writer_in_context_replica(mocked_get_database_connection_name, settings):
+    mocked_get_database_connection_name.return_value = "replica"
+
+    context = SaleorContext()
+    context.allow_replica = True
+
+    with allow_writer_in_context(context):
+        connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+        assert not getattr(connection, "_allow_writer")
+
+
+def test_restrict_writer_raises_error(settings):
+    connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+
+    with pytest.raises(UnsafeWriterAccessError):
+        with connection.execute_wrapper(_restrict_writer):
+            Book.objects.first()
+
+
+def test_restrict_writer_in_allow_writer(settings):
+    connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+
+    with connection.execute_wrapper(_restrict_writer):
+        with allow_writer():
+            Book.objects.first()
+
+
+def test_log_writer_usage(settings, caplog):
+    connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
+
+    with connection.execute_wrapper(_log_writer_usage):
+        Book.objects.first()
+
+    assert caplog.records
+    msg = caplog.records[0].getMessage()
+    assert "Unsafe access to the writer DB detected" in msg

--- a/saleor/graphql/account/mutations/authentication/set_password.py
+++ b/saleor/graphql/account/mutations/authentication/set_password.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from .....account import events as account_events
 from .....account import models
 from .....account.error_codes import AccountErrorCode
+from .....core.db.connection import allow_writer
 from .....order.utils import match_orders_with_new_user
 from ....core import ResolveInfo
 from ....core.context import disallow_replica_in_context
@@ -35,6 +36,7 @@ class SetPassword(CreateToken):
         error_type_field = "account_errors"
 
     @classmethod
+    @allow_writer()
     def mutate(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, email, password, token
     ):

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -562,7 +562,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(89):
+    with django_assert_num_queries(88):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -345,13 +345,16 @@ def create_connection_slice(
     )
     args["sort_by"] = sort_by
 
-    slice = connection_from_queryset_slice(
-        queryset,
-        args,
-        connection_type,
-        edge_type or connection_type.Edge,
-        pageinfo_type or graphene.relay.PageInfo,
-    )
+    from ...core.db.connection import allow_writer_in_context
+
+    with allow_writer_in_context(info.context):
+        slice = connection_from_queryset_slice(
+            queryset,
+            args,
+            connection_type,
+            edge_type or connection_type.Edge,
+            pageinfo_type or graphene.relay.PageInfo,
+        )
 
     if isinstance(iterable, ChannelQsContext):
         edges_with_context = []

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -27,6 +27,7 @@ from graphene import ObjectType
 from graphene.types.mutation import MutationOptions
 from graphql.error import GraphQLError
 
+from ...core.db.connection import allow_writer
 from ...core.error_codes import MetadataErrorCode
 from ...core.exceptions import PermissionDenied
 from ...core.utils.events import call_event
@@ -511,6 +512,7 @@ class BaseMutation(graphene.Mutation):
         return one_of_permissions_or_auth_filter_required(context, all_permissions)
 
     @classmethod
+    @allow_writer()
     def mutate(cls, root, info: ResolveInfo, **data):
         disallow_replica_in_context(info.context)
         setup_context_user(info.context)
@@ -1043,6 +1045,7 @@ class BaseBulkMutation(BaseMutation):
         return count, errors
 
     @classmethod
+    @allow_writer()
     def mutate(cls, root, info: ResolveInfo, **data):
         disallow_replica_in_context(info.context)
         setup_context_user(info.context)

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -5,6 +5,7 @@ from graphql.error.base import GraphQLError
 from ....checkout import models as checkout_models
 from ....checkout.models import Checkout
 from ....core import models
+from ....core.db.connection import allow_writer
 from ....core.error_codes import MetadataErrorCode
 from ....core.exceptions import PermissionDenied
 from ....discount import models as discount_models
@@ -168,6 +169,7 @@ class BaseMetadataMutation(BaseMutation):
         return super().check_permissions(context, permissions)
 
     @classmethod
+    @allow_writer()
     def mutate(cls, root, info: ResolveInfo, **data):
         try:
             type_name, object_pk = cls.get_object_type_name_and_pk(data)

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from django.db.models import F
 
+from ....core.db.connection import allow_writer_in_context
 from ....product import ProductMediaTypes
 from ....product.models import (
     Category,
@@ -19,7 +20,10 @@ from ....product.models import (
     VariantChannelListingPromotionRule,
     VariantMedia,
 )
-from ...core.dataloaders import BaseThumbnailBySizeAndFormatLoader, DataLoader
+from ...core.dataloaders import (
+    BaseThumbnailBySizeAndFormatLoader,
+    DataLoader,
+)
 
 ProductIdAndChannelSlug = tuple[int, str]
 VariantIdAndChannelSlug = tuple[int, str]
@@ -556,6 +560,7 @@ class ProductTypeByProductIdLoader(DataLoader):
     context_key = "producttype_by_product_id"
 
     def batch_load(self, keys):
+        @allow_writer_in_context(self.context)
         def with_products(products):
             product_ids = {p.id for p in products}
             product_types_map = (

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -1,6 +1,7 @@
 import graphene
 from django.core.exceptions import ValidationError
 
+from ....core.db.connection import allow_writer
 from ....core.exceptions import PermissionDenied
 from ....permission.enums import ProductPermissions
 from ....product import models
@@ -172,6 +173,7 @@ class DigitalContentDelete(BaseMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
 
     @classmethod
+    @allow_writer()
     def mutate(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, variant_id: str
     ):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -112,6 +112,9 @@ DATABASES = {
         conn_max_age=DB_CONN_MAX_AGE,
     ),
 }
+DATABASES[DATABASE_CONNECTION_REPLICA_NAME]["TEST"] = {
+    "MIRROR": DATABASE_CONNECTION_DEFAULT_NAME
+}
 
 DATABASE_ROUTERS = ["saleor.core.db_routers.PrimaryReplicaRouter"]
 
@@ -230,6 +233,12 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "saleor.core.middleware.jwt_refresh_token_middleware",
 ]
+
+ENABLE_RESTRICT_WRITER_MIDDLEWARE = get_bool_from_env(
+    "ENABLE_RESTRICT_WRITER_MIDDLEWARE", False
+)
+if ENABLE_RESTRICT_WRITER_MIDDLEWARE:
+    MIDDLEWARE = ["saleor.core.db.connection.log_writer_usage_middleware"] + MIDDLEWARE
 
 INSTALLED_APPS = [
     # External apps that need to go before django's

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -112,9 +112,6 @@ DATABASES = {
         conn_max_age=DB_CONN_MAX_AGE,
     ),
 }
-DATABASES[DATABASE_CONNECTION_REPLICA_NAME]["TEST"] = {
-    "MIRROR": DATABASE_CONNECTION_DEFAULT_NAME
-}
 
 DATABASE_ROUTERS = ["saleor.core.db_routers.PrimaryReplicaRouter"]
 


### PR DESCRIPTION
Add middlewares to restrict writer database access:

- `restrict_writer_middleware` - raises an error when disallowed access to writer database is attempted
- `log_writer_usage_middleware` - prints a console warning for each disallowed writer database access

To allow writer database access with the above middlewares, code that does the DB query needs to wrapped with allow_writer context manager. There is also a helper context manager allow_writer_in_context which conditionally enables writer access based on current context. This is used to condtionally enable writer access in field resolvers executed by mutations, while those executed by queries should always use replicas.

This PR adds the middlewares, two context managers to allow writer access, and usages of those context managers in code:
- in mutations - we assume that mutation should always use a writer, so entire mutation logic is wrapped with `allow_writer` in base mutation classes
- places where a DB save is needed in queries (e.g. checkout prices recalculation which saves new prices when they expire)

Example log from log_writer_usage_middleware:

```
2024-03-22 10:42:42,857 ERROR saleor.core.db.connection Unsafe writer DB access, use `allow_writer` context manager. SQL: SELECT "channel_channel"."id", "channel_channel"."private_metadata", "channel_channel"."metadata", "channel_channel"."name", "channel_channel"."is_active", "channel_channel"."slug", "channel_channel"."currency_code", "channel_channel"."default_country", "channel_channel"."allocation_strategy", "channel_channel"."order_mark_as_paid_strategy", "channel_channel"."default_transaction_flow_strategy", "channel_channel"."automatically_confirm_all_new_orders", "channel_channel"."allow_unpaid_orders", "channel_channel"."automatically_fulfill_non_shippable_gift_card", "channel_channel"."expire_orders_after", "channel_channel"."delete_expired_orders_after", "channel_channel"."include_draft_order_in_voucher_usage", "channel_channel"."use_legacy_error_flow_for_checkout" FROM "channel_channel" WHERE "channel_channel"."id" = %s LIMIT 21
Traceback:
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/promise/promise.py", line 347, in _settle_promise_from_handler
    value, error_with_tb = try_catch(handler, value)  # , promise
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/promise/promise.py", line 87, in try_catch
    return (handler(*args, **kwargs), None)
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/checkout/types.py", line 950, in <lambda>
    .then(lambda checkout_info: checkout_info.valid_shipping_methods)
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/checkout/fetch.py", line 97, in valid_shipping_methods
    return [method for method in self.all_shipping_methods if method.active]
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/utils/functional.py", line 246, in inner
    self._setup()
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/utils/functional.py", line 382, in _setup
    self._wrapped = self._setupfunc()
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/core/utils/lazyobjects.py", line 27, in _wrapper
    return func()
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/checkout/fetch.py", line 673, in _resolve_all_shipping_methods
    excluded_methods = manager.excluded_shipping_methods_for_checkout(
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/plugins/manager.py", line 2174, in excluded_shipping_methods_for_checkout
    channel_slug=checkout.channel.slug,
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/fields/related_descriptors.py", line 187, in __get__
    rel_obj = self.get_object(instance)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/fields/related_descriptors.py", line 154, in get_object
    return qs.get(self.field.get_reverse_related_filter(instance))
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 431, in get
    num = len(clone)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 262, in __len__
    self._fetch_all()
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 1324, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 51, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 1175, in execute_sql
    cursor.execute(sql, params)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/backends/utils.py", line 98, in execute
    return super().execute(sql, params)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/core/db/connection.py", line 130, in _log_writer_usage
    stack_trace = traceback.extract_stack(limit=20)
 [PID:56513:ThreadPoolExecutor-0_0]
 ```

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
