### PR TITLE
add `taxConfiguration` to `Channel` for Avalara tax calculation

### DIFF
--- a/saleor/graphql/channel/tests/queries/test_channel.py
+++ b/saleor/graphql/channel/tests/queries/test_channel.py
@@ -20,6 +20,10 @@ QUERY_CHANNEL = """
             stockSettings{
                 allocationStrategy
             }
+            taxConfiguration {
+              id
+              pricesEnteredWithTax
+            }
         }
     }
 """
@@ -29,6 +33,9 @@ def test_query_channel_as_staff_user(staff_api_client, channel_USD):
     # given
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     variables = {"id": channel_id}
+    tax_configuration_id = graphene.Node.to_global_id(
+        "TaxConfiguration", channel_USD.tax_configuration.id
+    )
 
     # when
     response = staff_api_client.post_graphql(QUERY_CHANNEL, variables=variables)
@@ -45,12 +52,17 @@ def test_query_channel_as_staff_user(staff_api_client, channel_USD):
         AllocationStrategyEnum[allocation_strategy].value
         == channel_USD.allocation_strategy
     )
+    assert channel_data["taxConfiguration"]["id"] == tax_configuration_id
+    assert channel_data["taxConfiguration"]["pricesEnteredWithTax"] is True
 
 
 def test_query_channel_as_app(app_api_client, channel_USD):
     # given
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     variables = {"id": channel_id}
+    tax_configuration_id = graphene.Node.to_global_id(
+        "TaxConfiguration", channel_USD.tax_configuration.id
+    )
 
     # when
     response = app_api_client.post_graphql(QUERY_CHANNEL, variables=variables)
@@ -67,6 +79,8 @@ def test_query_channel_as_app(app_api_client, channel_USD):
         AllocationStrategyEnum[allocation_strategy].value
         == channel_USD.allocation_strategy
     )
+    assert channel_data["taxConfiguration"]["id"] == tax_configuration_id
+    assert channel_data["taxConfiguration"]["pricesEnteredWithTax"] is True
 
 
 def test_query_channel_as_customer(user_api_client, channel_USD):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5168,6 +5168,13 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   Requires one of the following permissions: MANAGE_CHANNELS, HANDLE_PAYMENTS.
   """
   paymentSettings: PaymentSettings!
+
+  """
+  Channel specific tax configuration.
+  
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  """
+  taxConfiguration: TaxConfiguration!
 }
 
 """
@@ -5683,6 +5690,116 @@ Determine the transaction flow strategy.
 enum TransactionFlowStrategyEnum @doc(category: "Payments") {
   AUTHORIZATION
   CHARGE
+}
+
+"""
+Channel-specific tax configuration.
+
+Added in Saleor 3.9.
+"""
+type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes") {
+  """The ID of the object."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """A channel to which the tax configuration applies to."""
+  channel: Channel!
+
+  """Determines whether taxes are charged in the given channel."""
+  chargeTaxes: Boolean!
+
+  """
+  The default strategy to use for tax calculation in the given channel. Taxes can be calculated either using user-defined flat rates or with a tax app. Empty value means that no method is selected and taxes are not calculated.
+  """
+  taxCalculationStrategy: TaxCalculationStrategy
+
+  """Determines whether displayed prices should include taxes."""
+  displayGrossPrices: Boolean!
+
+  """Determines whether prices are entered with the tax included."""
+  pricesEnteredWithTax: Boolean!
+
+  """List of country-specific exceptions in tax configuration."""
+  countries: [TaxConfigurationPerCountry!]!
+
+  """
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
+  
+  Added in Saleor 3.19.
+  """
+  taxAppId: String
+}
+
+enum TaxCalculationStrategy @doc(category: "Taxes") {
+  FLAT_RATES
+  TAX_APP
+}
+
+"""
+Country-specific exceptions of a channel's tax configuration.
+
+Added in Saleor 3.9.
+"""
+type TaxConfigurationPerCountry @doc(category: "Taxes") {
+  """Country in which this configuration applies."""
+  country: CountryDisplay!
+
+  """Determines whether taxes are charged in this country."""
+  chargeTaxes: Boolean!
+
+  """
+  A country-specific strategy to use for tax calculation. Taxes can be calculated either using user-defined flat rates or with a tax app. If not provided, use the value from the channel's tax configuration.
+  """
+  taxCalculationStrategy: TaxCalculationStrategy
+
+  """
+  Determines whether displayed prices should include taxes for this country.
+  """
+  displayGrossPrices: Boolean!
+
+  """
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
+  
+  Added in Saleor 3.19.
+  """
+  taxAppId: String
 }
 
 """Represents shipping method postal code rule."""
@@ -9753,116 +9870,6 @@ enum TranslatableKinds {
   SHIPPING_METHOD
   VARIANT
   VOUCHER
-}
-
-"""
-Channel-specific tax configuration.
-
-Added in Saleor 3.9.
-"""
-type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes") {
-  """The ID of the object."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """A channel to which the tax configuration applies to."""
-  channel: Channel!
-
-  """Determines whether taxes are charged in the given channel."""
-  chargeTaxes: Boolean!
-
-  """
-  The default strategy to use for tax calculation in the given channel. Taxes can be calculated either using user-defined flat rates or with a tax app. Empty value means that no method is selected and taxes are not calculated.
-  """
-  taxCalculationStrategy: TaxCalculationStrategy
-
-  """Determines whether displayed prices should include taxes."""
-  displayGrossPrices: Boolean!
-
-  """Determines whether prices are entered with the tax included."""
-  pricesEnteredWithTax: Boolean!
-
-  """List of country-specific exceptions in tax configuration."""
-  countries: [TaxConfigurationPerCountry!]!
-
-  """
-  The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
-  
-  Added in Saleor 3.19.
-  """
-  taxAppId: String
-}
-
-enum TaxCalculationStrategy @doc(category: "Taxes") {
-  FLAT_RATES
-  TAX_APP
-}
-
-"""
-Country-specific exceptions of a channel's tax configuration.
-
-Added in Saleor 3.9.
-"""
-type TaxConfigurationPerCountry @doc(category: "Taxes") {
-  """Country in which this configuration applies."""
-  country: CountryDisplay!
-
-  """Determines whether taxes are charged in this country."""
-  chargeTaxes: Boolean!
-
-  """
-  A country-specific strategy to use for tax calculation. Taxes can be calculated either using user-defined flat rates or with a tax app. If not provided, use the value from the channel's tax configuration.
-  """
-  taxCalculationStrategy: TaxCalculationStrategy
-
-  """
-  Determines whether displayed prices should include taxes for this country.
-  """
-  displayGrossPrices: Boolean!
-
-  """
-  The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
-  
-  Added in Saleor 3.19.
-  """
-  taxAppId: String
 }
 
 type TaxConfigurationCountableConnection @doc(category: "Taxes") {


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/15610

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
