### PR TITLE
Fix attribute value assotiation for multiple attributes

### DIFF
--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
+from functools import reduce
 from typing import Union
 
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
 
 from ..page.models import Page
 from ..product.models import Product, ProductVariant
@@ -51,14 +52,22 @@ def associate_attribute_values_to_instance(
 
 
 def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
+    if not attr_val_map:
+        return
     values_map = defaultdict(set)
     slug_value_to_value_map = {}
-    values = AttributeValue.objects.filter(
-        attribute_id__in=attr_val_map.keys(),
-        # slug is used as newly created values have no id yet because of
-        # using `ignore_conflicts=True` flag in `bulk_create
-        slug__in=[v.slug for values in attr_val_map.values() for v in values],
+
+    # we need to fetch the proper values which attribute ids and value slug matches
+    lookup = reduce(
+        lambda acc, val_map_item: acc
+        | Q(
+            attribute_id=val_map_item[0], slug__in=[val.slug for val in val_map_item[1]]
+        ),
+        attr_val_map.items(),
+        Q(),
     )
+    values = AttributeValue.objects.filter(lookup)
+
     for value in values:
         values_map[value.attribute_id].add(value.slug)
         slug_value_to_value_map[value.slug] = value

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1824,6 +1824,7 @@ def attribute_generator():
         slug="attr",
         name="Attr",
         type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.DROPDOWN,
         filterable_in_storefront=True,
         filterable_in_dashboard=True,
         available_in_grid=True,
@@ -1833,6 +1834,7 @@ def attribute_generator():
             slug=slug,
             name=name,
             type=type,
+            input_type=input_type,
             filterable_in_storefront=filterable_in_storefront,
             filterable_in_dashboard=filterable_in_dashboard,
             available_in_grid=available_in_grid,
@@ -1971,6 +1973,28 @@ def attribute_without_values():
         visible_in_storefront=True,
         entity_type=None,
     )
+
+
+@pytest.fixture
+def multiselect_attribute(db, attribute_generator, attribute_values_generator):
+    attribute = attribute_generator(
+        slug="multi",
+        name="Multi",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.MULTISELECT,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+    )
+    slugs = ["choice-1", "choice-1"]
+    names = ["Choice 1", "Choice 2"]
+    attribute_values_generator(
+        attribute=attribute,
+        names=names,
+        slugs=slugs,
+    )
+
+    return attribute
 
 
 @pytest.fixture


### PR DESCRIPTION
When the attribute value map contains values with the slug that exists also in another attribute which id was provided in the map as well the `"Some values are not from the provided attribute."` error was raised.

Example:
- Atrribute 1, current values: ["Blue", "Red"]
- Attribute 2, current values: []

Attribute assignment with following values:
```
{
  "attribute-1": ["New value"],
  "attribute-2": ["Red"]
 }
```

Such scenario was raising an error

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
