### PR TITLE
Fix typos

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -731,7 +731,7 @@ FORMAT_FILED_DESCRIPTION = (
     "\n\nMany fields in the JSON refer to address fields by one-letter "
     "abbreviations. These are defined as follows:\n\n"
     "- `N`: Name\n"
-    "- `O`: Organisation\n"
+    "- `O`: Organization\n"
     "- `A`: Street Address Line(s)\n"
     "- `D`: Dependent locality (may be an inner-city district or a suburb)\n"
     "- `C`: City or Locality\n"

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -545,7 +545,7 @@ class App(ModelObjectType[models.App]):
     )
     version = graphene.String(description="Version number of the app.")
     access_token = graphene.String(
-        description="JWT token used to authenticate by thridparty app."
+        description="JWT token used to authenticate by third-party app."
     )
     author = graphene.String(
         description=("The App's author name." + ADDED_IN_313 + PREVIEW_FEATURE)

--- a/saleor/graphql/attribute/descriptions.py
+++ b/saleor/graphql/attribute/descriptions.py
@@ -47,7 +47,7 @@ class AttributeValueDescriptions:
         + RICH_CONTENT
     )
     PLAIN_TEXT = (
-        "Represents the text of the attribute value, plain text without formating."
+        "Represents the text of the attribute value, plain text without formatting."
     )
     BOOLEAN = "Represents the boolean value of the attribute value."
     DATE = "Represents the date value of the attribute value."

--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -91,7 +91,7 @@ class OrderSettingsInput(BaseInputObjectType):
     automatically_fulfill_non_shippable_gift_card = graphene.Boolean(
         required=False,
         description="When enabled, all non-shippable gift card orders "
-        "will be fulfilled automatically. By defualt set to True.",
+        "will be fulfilled automatically. By default set to True.",
     )
     expire_orders_after = Minute(
         required=False,

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -256,7 +256,7 @@ class OrderSettings(ObjectType):
     allow_unpaid_orders = graphene.Boolean(
         required=True,
         description=(
-            "Determine if it is possible to place unpdaid order by calling "
+            "Determine if it is possible to place unpaid order by calling "
             "`checkoutComplete` mutation." + ADDED_IN_315 + PREVIEW_FEATURE
         ),
     )

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -259,7 +259,7 @@ class CheckoutError(Error):
     code = CheckoutErrorCode(description="The error code.", required=True)
     variants = NonNullList(
         graphene.ID,
-        description="List of varint IDs which causes the error.",
+        description="List of variant IDs which causes the error.",
         required=False,
     )
     lines = NonNullList(
@@ -408,7 +408,7 @@ class PermissionGroupError(Error):
     )
     channels = NonNullList(
         graphene.ID,
-        description="List of chnnels IDs which causes the error.",
+        description="List of channels IDs which causes the error.",
         required=False,
     )
 

--- a/saleor/graphql/notifications/mutations/external_notification_trigger.py
+++ b/saleor/graphql/notifications/mutations/external_notification_trigger.py
@@ -32,7 +32,7 @@ class ExternalNotificationTriggerInput(graphene.InputObjectType):
     extra_payload = JSONString(
         description=(
             "Additional payload that will be merged with "
-            "the one based on the bussines object ID."
+            "the one based on the business object ID."
         )
     )
     external_event_type = graphene.String(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3147,7 +3147,7 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
   """Version number of the app."""
   version: String
 
-  """JWT token used to authenticate by thridparty app."""
+  """JWT token used to authenticate by third-party app."""
   accessToken: String
 
   """
@@ -5606,7 +5606,7 @@ type OrderSettings {
   deleteExpiredOrdersAfter: Day!
 
   """
-  Determine if it is possible to place unpdaid order by calling `checkoutComplete` mutation.
+  Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.
   
   Added in Saleor 3.15.
   
@@ -6483,7 +6483,7 @@ type AttributeValue implements Node @doc(category: "Attributes") {
   richText: JSONString
 
   """
-  Represents the text of the attribute value, plain text without formating.
+  Represents the text of the attribute value, plain text without formatting.
   """
   plainText: String
 
@@ -10179,7 +10179,7 @@ type Shop implements ObjectWithMetadata {
   enableAccountConfirmationByEmail: Boolean
 
   """
-  Determines if user can login without confirmation when `enableAccountConfrimation` is enabled.
+  Determines if user can login without confirmation when `enableAccountConfirmation` is enabled.
   
   Added in Saleor 3.15.
   
@@ -15006,7 +15006,7 @@ type AddressValidationData @doc(category: "Users") {
   Many fields in the JSON refer to address fields by one-letter abbreviations. These are defined as follows:
   
   - `N`: Name
-  - `O`: Organisation
+  - `O`: Organization
   - `A`: Street Address Line(s)
   - `D`: Dependent locality (may be an inner-city district or a suburb)
   - `C`: City or Locality
@@ -15024,7 +15024,7 @@ type AddressValidationData @doc(category: "Users") {
   Many fields in the JSON refer to address fields by one-letter abbreviations. These are defined as follows:
   
   - `N`: Name
-  - `O`: Organisation
+  - `O`: Organization
   - `A`: Street Address Line(s)
   - `D`: Dependent locality (may be an inner-city district or a suburb)
   - `C`: City or Locality
@@ -27543,7 +27543,7 @@ input ExternalNotificationTriggerInput {
   ids: [ID!]!
 
   """
-  Additional payload that will be merged with the one based on the bussines object ID.
+  Additional payload that will be merged with the one based on the business object ID.
   """
   extraPayload: JSONString
 
@@ -28855,7 +28855,7 @@ type CheckoutError @doc(category: "Checkout") {
   """The error code."""
   code: CheckoutErrorCode!
 
-  """List of varint IDs which causes the error."""
+  """List of variant IDs which causes the error."""
   variants: [ID!]
 
   """List of line Ids which cause the error."""
@@ -29558,7 +29558,7 @@ input OrderSettingsInput @doc(category: "Orders") {
   automaticallyConfirmAllNewOrders: Boolean
 
   """
-  When enabled, all non-shippable gift card orders will be fulfilled automatically. By defualt set to True.
+  When enabled, all non-shippable gift card orders will be fulfilled automatically. By default set to True.
   """
   automaticallyFulfillNonShippableGiftCard: Boolean
 
@@ -29917,7 +29917,7 @@ input AttributeValueCreateInput @doc(category: "Attributes") {
   richText: JSONString
 
   """
-  Represents the text of the attribute value, plain text without formating.
+  Represents the text of the attribute value, plain text without formatting.
   
   DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
@@ -30046,7 +30046,7 @@ input AttributeValueUpdateInput @doc(category: "Attributes") {
   richText: JSONString
 
   """
-  Represents the text of the attribute value, plain text without formating.
+  Represents the text of the attribute value, plain text without formatting.
   
   DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
@@ -31880,7 +31880,7 @@ type PermissionGroupError @doc(category: "Users") {
   """List of user IDs which causes the error."""
   users: [ID!]
 
-  """List of chnnels IDs which causes the error."""
+  """List of channels IDs which causes the error."""
   channels: [ID!]
 }
 

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -324,7 +324,7 @@ class Shop(graphene.ObjectType):
         graphene.Boolean,
         description=(
             "Determines if user can login without confirmation when "
-            "`enableAccountConfrimation` is enabled." + ADDED_IN_315
+            "`enableAccountConfirmation` is enabled." + ADDED_IN_315
         ),
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )


### PR DESCRIPTION
I want to merge this change because...

It fixes typos found in the `graphql.schema`

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

NA, docs will be auto updated during next release

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
