### PR TITLE
Save discounted_price for ProduvtVariantBulkUpdate

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -691,7 +691,12 @@ class ProductVariantBulkUpdate(BaseMutation):
         models.ProductVariantChannelListing.objects.bulk_create(listings_to_create)
         models.ProductVariantChannelListing.objects.bulk_update(
             listings_to_update,
-            fields=["price_amount", "cost_price_amount", "preorder_quantity_threshold"],
+            fields=[
+                "price_amount",
+                "discounted_price_amount",
+                "cost_price_amount",
+                "preorder_quantity_threshold",
+            ],
         )
         warehouse_models.Stock.objects.filter(id__in=stocks_to_remove).delete()
         models.ProductVariantChannelListing.objects.filter(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -410,9 +410,7 @@ def test_product_variant_bulk_update_channel_listings_input(
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
     ProductChannelListing.objects.create(product=product, channel=channel_PLN)
-    existing_variant_listing = variant.channel_listings.exclude(
-        channel=channel_PLN
-    ).last()
+    existing_variant_listing = variant.channel_listings.get()
 
     assert variant.channel_listings.count() == 1
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -452,8 +450,21 @@ def test_product_variant_bulk_update_channel_listings_input(
     )
     get_graphql_content(response, ignore_errors=True)
 
-    existing_variant_listing.refresh_from_db()
     # then
+    existing_variant_listing.refresh_from_db()
+    assert (
+        existing_variant_listing.price_amount == new_price_for_existing_variant_listing
+    )
+    assert (
+        existing_variant_listing.discounted_price_amount
+        == new_price_for_existing_variant_listing
+    )
+    new_variant_listing = variant.channel_listings.get(channel=channel_PLN)
+    assert new_variant_listing.price_amount == not_existing_variant_listing_price
+    assert (
+        new_variant_listing.discounted_price_amount
+        == not_existing_variant_listing_price
+    )
 
     # only promotions with created channel will be marked as dirty
     second_promotion_rule.refresh_from_db()


### PR DESCRIPTION
I want to merge this change because it is port of changes from: https://github.com/saleor/saleor/pull/15662
it covers ([internal link](https://linear.app/saleor/issue/MERX-249/variant-has-incorrect-price-displayed-after-modifing-the-price)) the issue when discounted_price was not updating via ProductVariantBulkUpdate.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
