### PR TITLE
Fix relation between order and click and collect address

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -152,6 +152,9 @@ def _process_shipping_data_for_order(
         if checkout_info.user.addresses.filter(pk=shipping_address.pk).exists():
             shipping_address = shipping_address.get_copy()
 
+    if shipping_address and delivery_method_info.warehouse_pk:
+        shipping_address = shipping_address.get_copy()
+
     shipping_method = delivery_method_info.delivery_method
     tax_class = getattr(shipping_method, "tax_class", None)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -2580,7 +2580,7 @@ def test_complete_checkout_for_local_click_and_collect(
     order_count = Order.objects.count()
     checkout = checkout_with_item_for_cc
     checkout.collection_point = warehouse_for_cc
-    checkout.shipping_address = None
+    checkout.shipping_address = warehouse_for_cc.address
     checkout.save(update_fields=["collection_point", "shipping_address"])
 
     variables = {
@@ -2622,7 +2622,8 @@ def test_complete_checkout_for_local_click_and_collect(
 
     assert order.collection_point == warehouse_for_cc
     assert order.shipping_method is None
-    assert order.shipping_address == warehouse_for_cc.address
+    assert order.shipping_address
+    assert order.shipping_address.id != warehouse_for_cc.address.id
     assert order.shipping_price == zero_taxed_money(payment.currency)
     assert order.lines.count() == 1
 
@@ -2691,7 +2692,8 @@ def test_complete_checkout_for_global_click_and_collect(
 
     assert order.collection_point == warehouse_for_cc
     assert order.shipping_method is None
-    assert order.shipping_address == warehouse_for_cc.address
+    assert order.shipping_address
+    assert order.shipping_address.id != warehouse_for_cc.address.id
     assert order.shipping_price == zero_taxed_money(payment.currency)
     assert order.lines.count() == 1
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -2346,7 +2346,8 @@ def test_complete_checkout_for_local_click_and_collect(
 
     assert order.collection_point == warehouse_for_cc
     assert order.shipping_method is None
-    assert order.shipping_address == warehouse_for_cc.address
+    assert order.shipping_address
+    assert order.shipping_address.id != warehouse_for_cc.address.id
     assert order.shipping_price == zero_taxed_money(order.channel.currency_code)
     assert order.lines.count() == 1
 
@@ -2408,7 +2409,8 @@ def test_complete_checkout_for_global_click_and_collect(
 
     assert order.collection_point == warehouse_for_cc
     assert order.shipping_method is None
-    assert order.shipping_address == warehouse_for_cc.address
+    assert order.shipping_address
+    assert order.shipping_address.id != warehouse_for_cc.address.id
     assert order.shipping_price == zero_taxed_money(order.channel.currency_code)
     assert order.lines.count() == 1
 

--- a/saleor/order/migrations/0172_update_order_cc_addresses.py
+++ b/saleor/order/migrations/0172_update_order_cc_addresses.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+from django.apps import apps as registry
+from django.db.models.signals import post_migrate
+from .tasks.saleor3_14 import update_order_addresses_task
+
+
+def update_order_addresses(apps, schema_editor):
+    def on_migrations_complete(sender=None, **kwargs):
+        update_order_addresses_task.delay()
+
+    sender = registry.get_app_config("order")
+    post_migrate.connect(on_migrations_complete, weak=False, sender=sender)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("order", "0171_order_order_user_email_user_id_idx"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_order_addresses, migrations.RunPython.noop),
+    ]

--- a/saleor/order/migrations/tasks/saleor3_14.py
+++ b/saleor/order/migrations/tasks/saleor3_14.py
@@ -1,17 +1,43 @@
 from django.utils import timezone
+from django.db.models import OuterRef, Exists
+from django.forms.models import model_to_dict
 
 from ....celeryconf import app
 from ... import OrderStatus
 from ...models import Order
+from ....account.models import Address
+from ....warehouse.models import Warehouse
 
 # Batch size of size 5000 is about 5MB memory usage in task
-BATCH_SIZE = 5000
+PROPAGATE_EXPIRED_AT_BATCH_SIZE = 5000
+
+# The batch of size 250 takes ~0.5 second and consumes ~20MB memory at peak
+ADDRESS_UPDATE_BATCH_SIZE = 250
 
 
 @app.task
 def order_propagate_expired_at_task():
     qs = Order.objects.filter(status=OrderStatus.EXPIRED, expired_at__isnull=True)
-    order_ids = qs.values_list("pk", flat=True)[:BATCH_SIZE]
+    order_ids = qs.values_list("pk", flat=True)[:PROPAGATE_EXPIRED_AT_BATCH_SIZE]
     if order_ids:
         Order.objects.filter(id__in=order_ids).update(expired_at=timezone.now())
         order_propagate_expired_at_task.delay()
+
+
+@app.task
+def update_order_addresses_task():
+    qs = Order.objects.filter(
+        Exists(Warehouse.objects.filter(address_id=OuterRef("shipping_address_id"))),
+    )
+    order_ids = qs.values_list("pk", flat=True)[:ADDRESS_UPDATE_BATCH_SIZE]
+    addresses = []
+    if order_ids:
+        orders = Order.objects.filter(id__in=order_ids)
+        for order in orders:
+            if cc_address := order.shipping_address:
+                order_address = Address(**model_to_dict(cc_address, exclude=["id"]))
+                order.shipping_address = order_address
+                addresses.append(order_address)
+        Address.objects.bulk_create(addresses, ignore_conflicts=True)
+        Order.objects.bulk_update(orders, ["shipping_address"])
+        update_order_addresses_task.delay()


### PR DESCRIPTION
Prevent warehouse addresses from being overwritten when changing shipping addresses for click and collect orders.

When completing checkout, the order should create own address instance it shouldn't be share with the cc warehouse.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
