### PR TITLE
Fix incorrect assigment of the shipping address

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -255,8 +255,8 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             and collection_point.click_and_collect_option
             == WarehouseClickAndCollectOption.LOCAL_STOCK
         ):
-            checkout.shipping_address = collection_point.address
-            checkout_info.shipping_address = collection_point.address
+            checkout.shipping_address = collection_point.address.get_copy()
+            checkout_info.shipping_address = checkout.shipping_address
             checkout_fields_to_update += ["shipping_address"]
         invalidate_prices_updated_fields = invalidate_checkout_prices(
             checkout_info, lines, manager, save=False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -553,6 +553,7 @@ def test_checkout_delivery_method_update_valid_method_not_all_shipping_data_for_
     )
     errors = data["errors"]
     assert checkout.shipping_address == delivery_method.address
+    assert checkout.shipping_address_id != delivery_method.address.id
     assert not errors
     assert getattr(checkout, attribute_name) == delivery_method
 


### PR DESCRIPTION
I want to merge this change because it creates a copy of the address assigned to checkout.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
