### PR TITLE
Handle replica/writer usages in thumbnails views

### DIFF
--- a/saleor/thumbnail/views.py
+++ b/saleor/thumbnail/views.py
@@ -2,6 +2,7 @@ import logging
 from collections import namedtuple
 from typing import Optional
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import (
     HttpResponseBadRequest,
@@ -12,6 +13,7 @@ from graphql.error import GraphQLError
 
 from ..account.models import User
 from ..app.models import App, AppInstallation
+from ..core.db.connection import allow_writer
 from ..core.utils.events import call_event
 from ..graphql.core.utils import from_global_id_or_error
 from ..plugins.manager import get_plugins_manager
@@ -82,16 +84,22 @@ def handle_thumbnail(
     else:
         instance_id_lookup = model_data.thumbnail_field + "_id"
 
-    if thumbnail := Thumbnail.objects.filter(
-        format=format, size=size_px, **{instance_id_lookup: pk}
-    ).first():
+    if (
+        thumbnail := Thumbnail.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+        .filter(format=format, size=size_px, **{instance_id_lookup: pk})
+        .first()
+    ):
         return HttpResponseRedirect(thumbnail.image.url)
 
     try:
         if object_type in UUID_IDENTIFIABLE_TYPES:
-            instance = model_data.model.objects.get(uuid=pk)
+            instance = model_data.model.objects.using(
+                settings.DATABASE_CONNECTION_REPLICA_NAME
+            ).get(uuid=pk)
         else:
-            instance = model_data.model.objects.get(id=pk)
+            instance = model_data.model.objects.using(
+                settings.DATABASE_CONNECTION_REPLICA_NAME
+            ).get(id=pk)
     except ObjectDoesNotExist:
         return HttpResponseNotFound("Instance with the given id cannot be found.")
 
@@ -118,16 +126,17 @@ def handle_thumbnail(
     thumbnail_file_name = prepare_thumbnail_file_name(image.name, size_px, format)
 
     # save image thumbnail
-    thumbnail = Thumbnail(
-        size=size_px, format=format, **{model_data.thumbnail_field: instance}
-    )
-    thumbnail.image.save(thumbnail_file_name, thumbnail_file)
-    thumbnail.save()
+    with allow_writer():
+        thumbnail = Thumbnail(
+            size=size_px, format=format, **{model_data.thumbnail_field: instance}
+        )
+        thumbnail.image.save(thumbnail_file_name, thumbnail_file)
+        thumbnail.save()
 
-    # set additional `instance` attribute, to easily get instance data
-    # for ThumbnailCreated subscription type
-    setattr(thumbnail, "instance", instance)
-    manager = get_plugins_manager(allow_replica=False)
-    call_event(manager.thumbnail_created, thumbnail)
+        # set additional `instance` attribute, to easily get instance data
+        # for ThumbnailCreated subscription type
+        setattr(thumbnail, "instance", instance)
+        manager = get_plugins_manager(allow_replica=False)
+        call_event(manager.thumbnail_created, thumbnail)
 
     return HttpResponseRedirect(thumbnail.image.url)


### PR DESCRIPTION
- Use replica DB to fetch thumbnail's parent objects.
- Add `allow_writer` to save logic that creates a new thumbnail.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
