### PR TITLE
Fix failing exif data validation for images

### DIFF
--- a/saleor/thumbnail/utils.py
+++ b/saleor/thumbnail/utils.py
@@ -173,7 +173,16 @@ class ProcessedImage:
 
         # Ensuring image is properly rotated
         if hasattr(image, "_getexif"):
-            exif_datadict = image._getexif()  # returns None if no EXIF data
+            try:
+                # validation of the exif data was added in separate PR:
+                # https://github.com/saleor/saleor/pull/11224, it means that there is a
+                # possibility that we could have the file with corrupted exif data.
+                # exif data is only used to apply some optional action on the image,
+                # but without it, we are still able to create a thumbnail.
+                exif_datadict = image._getexif()  # returns None if no EXIF data
+            except SyntaxError:
+                exif_datadict = None
+
             if exif_datadict is not None:
                 exif = dict(exif_datadict.items())
                 orientation = exif.get(self.EXIF_ORIENTATION_KEY, None)


### PR DESCRIPTION
I want to merge this change because there is a possibility of having the images with incorrect exif data. It is not mandatory to generate the thumbnail image, so in case of having incorrect data we will catch it, and process the image.
This will solve the issue (internal link):https://linear.app/saleor/issue/MERX-207/syntaxerror-not-a-tiff-file

Port of changes from: https://github.com/saleor/saleor/pull/15684

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
