### PR TITLE
Refactor line weight calculation to reuse DB queries

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -82,6 +82,7 @@ from .fetch import (
 )
 from .models import Checkout
 from .utils import (
+    calculate_checkout_weight,
     get_checkout_metadata,
     get_or_create_checkout_metadata,
     get_voucher_for_checkout_info,
@@ -152,7 +153,7 @@ def _process_shipping_data_for_order(
         "shipping_address": shipping_address,
         "base_shipping_price": base_shipping_price,
         "shipping_price": shipping_price,
-        "weight": checkout_info.checkout.get_total_weight(lines),
+        "weight": calculate_checkout_weight(lines),
         **get_shipping_tax_class_kwargs_for_order(tax_class),
     }
     result.update(delivery_method_info.delivery_method_order_field)

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -671,7 +671,7 @@ def update_delivery_method_lists_for_checkout_info(
         )
         # Filter shipping methods using sync webhooks
         excluded_methods = manager.excluded_shipping_methods_for_checkout(
-            checkout_info.checkout, all_methods
+            checkout_info.checkout, checkout_info.channel, all_methods
         )
         initialize_shipping_method_active_status(all_methods, excluded_methods)
         return all_methods

--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -1,10 +1,9 @@
 """Checkout-related ORM models."""
 
-from collections.abc import Iterable
 from datetime import date
 from decimal import Decimal
 from operator import attrgetter
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional
 from uuid import uuid4
 
 from django.conf import settings
@@ -19,19 +18,14 @@ from prices import Money
 from ..channel.models import Channel
 from ..core.models import ModelWithMetadata
 from ..core.taxes import zero_money
-from ..core.weight import zero_weight
 from ..giftcard.models import GiftCard
 from ..permission.enums import CheckoutPermissions
 from ..shipping.models import ShippingMethod
 from . import CheckoutAuthorizeStatus, CheckoutChargeStatus
 
 if TYPE_CHECKING:
-    from django_measurement import Weight
-
-    from ..order.fetch import OrderLineInfo
     from ..payment.models import Payment
     from ..product.models import ProductVariant
-    from .fetch import CheckoutLineInfo
 
 
 def get_default_country():
@@ -233,19 +227,6 @@ class Checkout(models.Model):
         if balance is None:
             return zero_money(currency=self.currency)
         return Money(balance, self.currency)
-
-    def get_total_weight(
-        self, lines: Union[Iterable["CheckoutLineInfo"], Iterable["OrderLineInfo"]]
-    ) -> "Weight":
-        # FIXME: it does not make sense for this method to live in the Checkout model
-        # since it's used in the Order model as well. We should move it to a separate
-        # helper.
-        weights = zero_weight()
-        for checkout_line_info in lines:
-            line = checkout_line_info.line
-            if line.variant:
-                weights += line.variant.get_weight() * line.quantity
-        return weights
 
     def get_line(self, variant: "ProductVariant") -> Optional["CheckoutLine"]:
         """Return a line matching the given variant and data if any."""

--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -10,7 +10,11 @@ from ...plugins.manager import get_plugins_manager
 from ...product.models import Category
 from .. import calculations, utils
 from ..models import Checkout
-from ..utils import add_variant_to_checkout, calculate_checkout_quantity
+from ..utils import (
+    add_variant_to_checkout,
+    calculate_checkout_quantity,
+    calculate_checkout_weight,
+)
 
 
 @pytest.fixture
@@ -283,4 +287,4 @@ def test_get_total_weight(checkout_with_item):
     line.quantity = 6
     line.save()
     lines, _ = fetch_checkout_lines(checkout_with_item)
-    assert checkout_with_item.get_total_weight(lines) == Weight(kg=60)
+    assert calculate_checkout_weight(lines) == Weight(kg=60)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -22,6 +22,7 @@ from ..core.utils.promo_code import (
     promo_code_is_voucher,
 )
 from ..core.utils.translations import get_translation
+from ..core.weight import zero_weight
 from ..discount import DiscountType, VoucherType
 from ..discount.interface import VoucherInfo, fetch_voucher_info
 from ..discount.models import (
@@ -59,6 +60,8 @@ from .fetch import (
 from .models import Checkout, CheckoutLine, CheckoutMetadata
 
 if TYPE_CHECKING:
+    from measurement.measures import Weight
+
     from ..account.models import Address
     from ..order.models import Order
     from .fetch import CheckoutInfo, CheckoutLineInfo
@@ -865,6 +868,7 @@ def get_valid_internal_shipping_methods_for_checkout(
         checkout_info.checkout,
         channel_id=checkout_info.checkout.channel_id,
         price=subtotal,
+        shipping_address=checkout_info.shipping_address,
         country_code=country_code,
         lines=lines,
     )
@@ -1024,3 +1028,21 @@ def get_checkout_metadata(checkout: "Checkout"):
         return checkout.metadata_storage
     else:
         return CheckoutMetadata(checkout=checkout)
+
+
+def calculate_checkout_weight(lines: Iterable["CheckoutLineInfo"]) -> "Weight":
+    weights = zero_weight()
+    for checkout_line_info in lines:
+        variant = checkout_line_info.variant
+        if variant:
+            line_weight = get_checkout_line_weight(checkout_line_info)
+            weights += line_weight * checkout_line_info.line.quantity
+    return weights
+
+
+def get_checkout_line_weight(line_info: "CheckoutLineInfo"):
+    return (
+        line_info.variant.weight
+        or line_info.product.weight
+        or line_info.product_type.weight
+    )

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -562,7 +562,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(88):
+    with django_assert_num_queries(72):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -562,7 +562,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(72):
+    with django_assert_num_queries(71):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -349,7 +349,7 @@ def test_order_query(
 
     expected_methods = ShippingMethod.objects.applicable_shipping_methods(
         price=order.subtotal.gross,
-        weight=order.get_total_weight(),
+        weight=order.weight,
         country_code=order.shipping_address.country.code,
         channel_id=order.channel_id,
     )
@@ -997,7 +997,7 @@ def test_order_query_in_pln_channel(
 
     expected_methods = ShippingMethod.objects.applicable_shipping_methods(
         price=order.subtotal.gross,
-        weight=order.get_total_weight(),
+        weight=order.weight,
         country_code=order.shipping_address.country.code,
         channel_id=order.channel_id,
     )

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -498,9 +498,6 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
     def total_balance(self):
         return self.total_charged - self.total.gross
 
-    def get_total_weight(self, _lines=None):
-        return self.weight
-
 
 class OrderLineQueryset(models.QuerySet["OrderLine"]):
     def digital(self):

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -658,12 +658,12 @@ def test_get_order_weight_non_existing_product(
         app=None,
         manager=anonymous_plugins,
     )
-    old_weight = order.get_total_weight()
+    old_weight = order.weight
 
     product.delete()
 
     order.refresh_from_db()
-    new_weight = order.get_total_weight()
+    new_weight = order.weight
 
     assert old_weight == new_weight
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -611,7 +611,8 @@ def get_all_shipping_methods_for_order(
     if not order.is_shipping_required():
         return []
 
-    if not order.shipping_address:
+    shipping_address = order.shipping_address
+    if not shipping_address:
         return []
 
     all_methods = []
@@ -622,7 +623,8 @@ def get_all_shipping_methods_for_order(
             order,
             channel_id=order.channel_id,
             price=order.subtotal.gross,
-            country_code=order.shipping_address.country.code,
+            shipping_address=shipping_address,
+            country_code=shipping_address.country.code,
         )
         .prefetch_related("channel_listings")
     )

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2164,6 +2164,7 @@ class PluginsManager(PaymentInterface):
     def excluded_shipping_methods_for_checkout(
         self,
         checkout: "Checkout",
+        channel: "Channel",
         available_shipping_methods: list["ShippingMethodData"],
     ) -> list[ExcludedShippingMethod]:
         return self.__run_method_on_plugins(
@@ -2171,7 +2172,7 @@ class PluginsManager(PaymentInterface):
             [],
             checkout,
             available_shipping_methods,
-            channel_slug=checkout.channel.slug,
+            channel_slug=channel.slug,
         )
 
     def perform_mutation(


### PR DESCRIPTION
Refactor weight calculation in `applicable_shipping_methods_for_instance` to use already prefetched data, instead of making separate DB queries. In benchmark it results in queries count going down from 88 to 72 for creating a checkout.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
