### PR TITLE
Reuse prefetched channel in shipping filtering webhook

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -671,7 +671,7 @@ def update_delivery_method_lists_for_checkout_info(
         )
         # Filter shipping methods using sync webhooks
         excluded_methods = manager.excluded_shipping_methods_for_checkout(
-            checkout_info.checkout, all_methods
+            checkout_info.checkout, checkout_info.channel, all_methods
         )
         initialize_shipping_method_active_status(all_methods, excluded_methods)
         return all_methods

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -562,7 +562,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(72):
+    with django_assert_num_queries(71):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2164,6 +2164,7 @@ class PluginsManager(PaymentInterface):
     def excluded_shipping_methods_for_checkout(
         self,
         checkout: "Checkout",
+        channel: "Channel",
         available_shipping_methods: list["ShippingMethodData"],
     ) -> list[ExcludedShippingMethod]:
         return self.__run_method_on_plugins(
@@ -2171,7 +2172,7 @@ class PluginsManager(PaymentInterface):
             [],
             checkout,
             available_shipping_methods,
-            channel_slug=checkout.channel.slug,
+            channel_slug=channel.slug,
         )
 
     def perform_mutation(


### PR DESCRIPTION
The `excluded_shipping_methods_for_checkout` is fetching a channel object from checkout, while there is the channel object already available in `checkout_info`.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
