### PR TITLE
Add allow_writer_in_context in resolvers

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -11,6 +11,7 @@ from ...checkout.base_calculations import (
 )
 from ...checkout.calculations import fetch_checkout_data
 from ...checkout.utils import get_valid_collection_points_for_checkout
+from ...core.db.connection import allow_writer_in_context
 from ...core.taxes import zero_money, zero_taxed_money
 from ...core.utils.lazyobjects import unwrap_lazy
 from ...graphql.core.context import get_database_connection_name
@@ -288,6 +289,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                 checkout.token
             )
 
+            @allow_writer_in_context(info.context)
             def calculate_line_unit_price(data):
                 checkout_info, lines = data
                 database_connection_name = get_database_connection_name(info.context)
@@ -365,6 +367,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                 checkout.token
             )
 
+            @allow_writer_in_context(info.context)
             def calculate_line_total_price(data):
                 (checkout_info, lines) = data
                 database_connection_name = get_database_connection_name(info.context)
@@ -854,20 +857,26 @@ class Checkout(ModelObjectType[models.Checkout]):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_shipping_methods(root: models.Checkout, info: ResolveInfo):
+        @allow_writer_in_context(info.context)
+        def with_checkout_info(checkout_info):
+            return unwrap_lazy(checkout_info.all_shipping_methods)
+
         return (
             CheckoutInfoByCheckoutTokenLoader(info.context)
             .load(root.token)
-            .then(lambda checkout_info: unwrap_lazy(checkout_info.all_shipping_methods))
+            .then(with_checkout_info)
         )
 
     @staticmethod
     def resolve_delivery_method(root: models.Checkout, info: ResolveInfo):
+        @allow_writer_in_context(info.context)
+        def with_checkout_info(checkout_info):
+            return checkout_info.delivery_method_info.delivery_method
+
         return (
             CheckoutInfoByCheckoutTokenLoader(info.context)
             .load(root.token)
-            .then(
-                lambda checkout_info: checkout_info.delivery_method_info.delivery_method
-            )
+            .then(with_checkout_info)
         )
 
     @staticmethod
@@ -885,6 +894,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_total_price(root: models.Checkout, info: ResolveInfo):
+        @allow_writer_in_context(info.context)
         def calculate_total_price(data):
             address, lines, checkout_info, manager = data
             database_connection_name = get_database_connection_name(info.context)
@@ -904,6 +914,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_subtotal_price(root: models.Checkout, info: ResolveInfo):
+        @allow_writer_in_context(info.context)
         def calculate_subtotal_price(data):
             address, lines, checkout_info, manager = data
             database_connection_name = get_database_connection_name(info.context)
@@ -922,6 +933,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_shipping_price(root: models.Checkout, info: ResolveInfo):
+        @allow_writer_in_context(info.context)
         def calculate_shipping_price(data):
             address, lines, checkout_info, manager = data
             database_connection_name = get_database_connection_name(info.context)
@@ -944,22 +956,28 @@ class Checkout(ModelObjectType[models.Checkout]):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_available_shipping_methods(root: models.Checkout, info: ResolveInfo):
+        @allow_writer_in_context(info.context)
+        def with_checkout_info(checkout_info):
+            return checkout_info.valid_shipping_methods
+
         return (
             CheckoutInfoByCheckoutTokenLoader(info.context)
             .load(root.token)
-            .then(lambda checkout_info: checkout_info.valid_shipping_methods)
+            .then(with_checkout_info)
         )
 
     @staticmethod
     @traced_resolver
     def resolve_available_collection_points(root: models.Checkout, info: ResolveInfo):
+        @allow_writer_in_context(info.context)
         def get_available_collection_points(lines):
             database_connection_name = get_database_connection_name(info.context)
-            return get_valid_collection_points_for_checkout(
+            result = get_valid_collection_points_for_checkout(
                 lines,
                 root.channel_id,
                 database_connection_name=database_connection_name,
             )
+            return list(result)
 
         return (
             CheckoutLinesInfoByCheckoutTokenLoader(info.context)
@@ -979,12 +997,12 @@ class Checkout(ModelObjectType[models.Checkout]):
         )
 
         def get_available_payment_gateways(results):
-            (checkout, lines_info) = results
+            (checkout_info, lines_info) = results
             return manager.list_payment_gateways(
                 currency=root.currency,
-                checkout_info=checkout,
+                checkout_info=checkout_info,
                 checkout_lines=lines_info,
-                channel_slug=root.channel.slug,
+                channel_slug=checkout_info.channel.slug,
             )
 
         return Promise.all([checkout_info, checkout_lines_info]).then(
@@ -1025,20 +1043,21 @@ class Checkout(ModelObjectType[models.Checkout]):
     def resolve_stock_reservation_expires(
         root: models.Checkout, info: ResolveInfo, site
     ):
-        if not is_reservation_enabled(site.settings):
-            return None
-
-        def get_oldest_stock_reservation_expiration_date(reservations):
-            if not reservations:
+        with allow_writer_in_context(info.context):
+            if not is_reservation_enabled(site.settings):
                 return None
 
-            return min(reservation.reserved_until for reservation in reservations)
+            def get_oldest_stock_reservation_expiration_date(reservations):
+                if not reservations:
+                    return None
 
-        return (
-            StocksReservationsByCheckoutTokenLoader(info.context)
-            .load(root.token)
-            .then(get_oldest_stock_reservation_expiration_date)
-        )
+                return min(reservation.reserved_until for reservation in reservations)
+
+            return (
+                StocksReservationsByCheckoutTokenLoader(info.context)
+                .load(root.token)
+                .then(get_oldest_stock_reservation_expiration_date)
+            )
 
     @staticmethod
     @one_of_permissions_required(

--- a/saleor/permission/enums.py
+++ b/saleor/permission/enums.py
@@ -160,12 +160,16 @@ def get_permissions(
         codenames = get_permissions_codename()
     else:
         codenames = split_permission_codename(permissions)
-    return get_permissions_from_codenames(codenames)
+    return get_permissions_from_codenames(codenames, database_connection_name)
 
 
-def get_permissions_from_codenames(permission_codenames: list[str]) -> QuerySet:
+def get_permissions_from_codenames(
+    permission_codenames: list[str],
+    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+) -> QuerySet:
     return (
-        Permission.objects.filter(codename__in=permission_codenames)
+        Permission.objects.using(database_connection_name)
+        .filter(codename__in=permission_codenames)
         .prefetch_related("content_type")
         .order_by("codename")
     )

--- a/saleor/shipping/utils.py
+++ b/saleor/shipping/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from django_countries import countries
 
@@ -7,6 +7,7 @@ from ..plugins.base_plugin import ExcludedShippingMethod
 from .interface import ShippingMethodData
 
 if TYPE_CHECKING:
+    from ..tax.models import TaxClass
     from .models import ShippingMethod, ShippingMethodChannelListing
 
 
@@ -30,11 +31,17 @@ def get_countries_without_shipping_zone():
 
 
 def convert_to_shipping_method_data(
-    shipping_method: "ShippingMethod", listing: "ShippingMethodChannelListing"
+    shipping_method: "ShippingMethod",
+    listing: "ShippingMethodChannelListing",
+    tax_class: Optional["TaxClass"] = None,
 ) -> "ShippingMethodData":
     price = listing.price
     minimum_order_price = listing.minimum_order_price
     maximum_order_price = listing.maximum_order_price
+
+    if not tax_class:
+        # Tax class should be passed as argument, this is a fallback.
+        tax_class = shipping_method.tax_class
 
     return ShippingMethodData(
         id=str(shipping_method.id),
@@ -48,7 +55,7 @@ def convert_to_shipping_method_data(
         metadata=shipping_method.metadata,
         private_metadata=shipping_method.private_metadata,
         price=price,
-        tax_class=shipping_method.tax_class,
+        tax_class=tax_class,
         minimum_order_price=minimum_order_price,
         maximum_order_price=maximum_order_price,
     )

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -28,9 +28,11 @@ def update_order_prices_with_flat_rates(
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ):
     country_code = get_order_country(order)
-    default_country_rate_obj = TaxClassCountryRate.objects.filter(
-        country=country_code, tax_class=None
-    ).first()
+    default_country_rate_obj = (
+        TaxClassCountryRate.objects.using(database_connection_name)
+        .filter(country=country_code, tax_class=None)
+        .first()
+    )
     default_tax_rate = (
         default_country_rate_obj.rate if default_country_rate_obj else Decimal(0)
     )

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -127,7 +127,8 @@ class WarehouseQueryset(models.QuerySet["Warehouse"]):
         )
 
         stocks_qs = (
-            Stock.objects.annotate_available_quantity()
+            Stock.objects.using(self.db)
+            .annotate_available_quantity()
             .annotate(line_quantity=F("available_quantity") - Subquery(lines_quantity))
             .order_by("line_quantity")
             .filter(


### PR DESCRIPTION
Add more usages of `allow_writer_in_context` context manager:
- checkout resolvers
- order resolvers

Plus few other small changes where `using()` or proper DB alias was missing.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
