### PR TITLE
Add url and metadata for two product entities #15567

### DIFF
--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -315,6 +315,8 @@ class ProductChannelListing(PublishableModel):
         amount_field="discounted_price_amount", currency_field="currency"
     )
     discounted_price_dirty = models.BooleanField(default=False)
+    url = models.URLField(blank=True, null=True, help_text="Direct links to sales channels")
+    metadata = JSONField(default=dict, blank=True, help_text="Metadata for storing additional information")
 
     class Meta:
         unique_together = [["product", "channel"]]
@@ -508,6 +510,8 @@ class ProductVariantChannelListing(models.Model):
     )
 
     preorder_quantity_threshold = models.IntegerField(blank=True, null=True)
+    url = models.URLField(blank=True, null=True, help_text="Direct links to sales channels")
+    metadata = JSONField(default=dict, blank=True, help_text="Metadata for storing additional information")
 
     objects = managers.ProductVariantChannelListingManager()
 


### PR DESCRIPTION
Related to issue #15567 for adding metadata to channel listings.
This commit introduces two new fields, url and metadata, to the ProductChannelListing and ProductVariantChannelListing entities. These changes address the following needs:

The url field provides a link to the sales channel listing, allowing users to navigate straight to the product on different marketplaces.
The metadata field is a JSON field that enables the storage of additional information.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [x] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined
