### PR TITLE
Optimize validate_draft_order function to run less queries

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -54,7 +54,7 @@ from .models import (
 if TYPE_CHECKING:
     from ..account.models import User
     from ..checkout.fetch import CheckoutInfo
-    from ..order.models import Order
+    from ..order.models import Order, OrderLine
     from ..plugins.manager import PluginsManager
     from ..product.managers import ProductVariantQueryset
     from ..product.models import VariantChannelListingPromotionRule
@@ -283,19 +283,23 @@ def validate_voucher_for_checkout(
     )
 
 
-def validate_voucher_in_order(order: "Order"):
+def validate_voucher_in_order(
+    order: "Order", lines: Iterable["OrderLine"], channel: "Channel"
+):
     if not order.voucher:
         return
 
+    from ..order.utils import get_total_quantity
+
     subtotal = order.subtotal
-    quantity = order.get_total_quantity()
+    quantity = get_total_quantity(lines)
     customer_email = order.get_customer_email()
-    tax_configuration = order.channel.tax_configuration
+    tax_configuration = channel.tax_configuration
     prices_entered_with_tax = tax_configuration.prices_entered_with_tax
     value = subtotal.gross if prices_entered_with_tax else subtotal.net
 
     validate_voucher(
-        order.voucher, value, quantity, customer_email, order.channel, order.user
+        order.voucher, value, quantity, customer_email, channel, order.user
     )
 
 

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -111,7 +111,7 @@ class DraftOrderComplete(BaseMutation):
         cls.validate_order(order)
 
         country = get_order_country(order)
-        validate_draft_order(order, country, manager)
+        validate_draft_order(order, order.lines.all(), country, manager)
         with traced_atomic_transaction():
             cls.update_user_fields(order)
             order.status = OrderStatus.UNFULFILLED

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1930,21 +1930,26 @@ class Order(ModelObjectType[models.Order]):
     def resolve_can_finalize(root: models.Order, info):
         if root.status == OrderStatus.DRAFT:
 
-            def _validate_draft_order(manager):
+            @allow_writer_in_context(info.context)
+            def _validate_draft_order(data):
+                lines, manager = data
                 country = get_order_country(root)
                 database_connection_name = get_database_connection_name(info.context)
                 try:
                     validate_draft_order(
-                        root,
-                        country,
-                        manager,
+                        order=root,
+                        lines=lines,
+                        country=country,
+                        manager=manager,
                         database_connection_name=database_connection_name,
                     )
                 except ValidationError:
                     return False
                 return True
 
-            return get_plugin_manager_promise(info.context).then(_validate_draft_order)
+            lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
+            manager = get_plugin_manager_promise(info.context)
+            return Promise.all([lines, manager]).then(_validate_draft_order)
         return True
 
     @staticmethod
@@ -2158,21 +2163,26 @@ class Order(ModelObjectType[models.Order]):
     def resolve_errors(root: models.Order, info):
         if root.status == OrderStatus.DRAFT:
 
-            def _validate_order(manager):
+            @allow_writer_in_context(info.context)
+            def _validate_order(data):
+                lines, manager = data
                 country = get_order_country(root)
                 database_connection_name = get_database_connection_name(info.context)
                 try:
                     validate_draft_order(
-                        root,
-                        country,
-                        manager,
+                        order=root,
+                        lines=lines,
+                        country=country,
+                        manager=manager,
                         database_connection_name=database_connection_name,
                     )
                 except ValidationError as e:
                     return validation_error_to_error_type(e, OrderError)
                 return []
 
-            return get_plugin_manager_promise(info.context).then(_validate_order)
+            lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
+            manager = get_plugin_manager_promise(info.context)
+            return Promise.all([lines, manager]).then(_validate_order)
 
         return []
 

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -678,7 +678,9 @@ def test_get_voucher_discount_for_order_voucher_validation(
     quantity = order_with_lines.get_total_quantity()
     customer_email = order_with_lines.get_customer_email()
 
-    validate_voucher_in_order(order_with_lines)
+    validate_voucher_in_order(
+        order_with_lines, order_with_lines.lines.all(), order_with_lines.channel
+    )
 
     mock_validate_voucher.assert_called_once_with(
         voucher,
@@ -699,7 +701,9 @@ def test_validate_voucher_in_order_without_voucher(
 
     assert not order_with_lines.voucher
 
-    validate_voucher_in_order(order_with_lines)
+    validate_voucher_in_order(
+        order_with_lines, order_with_lines.lines.all(), order_with_lines.channel
+    )
     mock_validate_voucher.assert_not_called()
 
 
@@ -745,6 +749,7 @@ def test_value_voucher_order_discount(
         billing_address=address_usa,
         channel=channel_USD,
     )
+    order.lines = Mock(all=Mock(return_value=[]))
     discount = get_voucher_discount_for_order(order)
     assert discount == Money(expected_value, "USD")
 
@@ -784,6 +789,7 @@ def test_shipping_voucher_order_discount(
         voucher=voucher,
         channel=channel_USD,
     )
+    order.lines = Mock(all=Mock(return_value=[]))
     discount = get_voucher_discount_for_order(order)
     assert discount == Money(expected_value, "USD")
 
@@ -840,6 +846,7 @@ def test_shipping_voucher_checkout_discount_not_applicable_returns_zero(
         voucher=voucher,
         channel=channel_USD,
     )
+    order.lines = Mock(all=Mock(return_value=[]))
     with pytest.raises(NotApplicable):
         get_voucher_discount_for_order(order)
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -664,6 +664,10 @@ def is_shipping_required(lines: Iterable["OrderLine"]):
     return any(line.is_shipping_required for line in lines)
 
 
+def get_total_quantity(lines: Iterable["OrderLine"]):
+    return sum([line.quantity for line in lines])
+
+
 def get_valid_collection_points_for_order(
     lines: Iterable["OrderLine"],
     channel_id: int,
@@ -741,7 +745,7 @@ def get_voucher_discount_for_order(order: Order) -> Money:
     """
     if not order.voucher:
         return zero_money(order.currency)
-    validate_voucher_in_order(order)
+    validate_voucher_in_order(order, order.lines.all(), order.channel)
     subtotal = order.subtotal
     if order.voucher.type == VoucherType.ENTIRE_ORDER:
         return order.voucher.get_discount_amount_for(subtotal.gross, order.channel)


### PR DESCRIPTION
The `validate_draft_order` function is used in two queries and one mutation. In each case, it runs a lot of duplicated queries due to not properly using dataloaders and accessing not prefetched data via implicit DB queries. This PR partially improves it and loads order lines via dataloader, which are then passed around via arguments. 

There are still many queries to optimize here but it already improved a lot. Example: fetching 5 draft orders and `errors` field:
```
{
  draftOrders(first:5) {
    edges {
      node {
        id
        errors {
          field
          message
        }
      }
    }
  }
}
```

Before: 48 queries
After: 19 queries

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
