### PR TITLE
Pe 161 misc add allow writer

### DIFF
--- a/saleor/graphql/executor.py
+++ b/saleor/graphql/executor.py
@@ -14,9 +14,10 @@ def _patched_complete_value_catching_error(*args, **kwargs):
 def patch_executor():
     """Patch `complete_value_catching_error` function to allow writer DB in mutations.
 
-    Patch the GraphQL executor's `complete_value_catching_error` function to wrap each
-    call with `allow_writer_in_context`. This allows to safely use writer DB in
-    mutations, while it will raise or log error when a resolver is run in a query.
+    The `complete_value_catching_error` function is called when resolving a field in
+    GraphQL. This patch wraps each call with `allow_writer_in_context` context manager.
+    This allows to use writer DB in resolvers, when they are called via mutation, while
+    they will still raise or log error when a resolver is run in a query.
     """
 
     executor.complete_value_catching_error = _patched_complete_value_catching_error

--- a/saleor/graphql/executor.py
+++ b/saleor/graphql/executor.py
@@ -1,0 +1,22 @@
+from graphql.execution import executor
+
+original_complete_value_catching_error = executor.complete_value_catching_error
+
+
+def _patched_complete_value_catching_error(*args, **kwargs):
+    info = args[3]
+    from saleor.core.db.connection import allow_writer_in_context
+
+    with allow_writer_in_context(info.context):
+        return original_complete_value_catching_error(*args, **kwargs)
+
+
+def patch_executor():
+    """Patch `complete_value_catching_error` function to allow writer DB in mutations.
+
+    Patch the GraphQL executor's `complete_value_catching_error` function to wrap each
+    call with `allow_writer_in_context`. This allows to safely use writer DB in
+    mutations, while it will raise or log error when a resolver is run in a query.
+    """
+
+    executor.complete_value_catching_error = _patched_complete_value_catching_error

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -14,6 +14,7 @@ from prices import TaxedMoney
 
 from ..channel.models import Channel
 from ..checkout import base_calculations
+from ..core.db.connection import allow_writer
 from ..core.models import EventDelivery
 from ..core.payments import PaymentInterface
 from ..core.prices import quantize_price
@@ -2219,4 +2220,8 @@ def get_plugins_manager(
     requestor_getter: Optional[Callable[[], "Requestor"]] = None,
 ) -> PluginsManager:
     with opentracing.global_tracer().start_active_span("get_plugins_manager"):
-        return PluginsManager(settings.PLUGINS, requestor_getter, allow_replica)
+        if allow_replica:
+            return PluginsManager(settings.PLUGINS, requestor_getter, allow_replica)
+        else:
+            with allow_writer():
+                return PluginsManager(settings.PLUGINS, requestor_getter, allow_replica)

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -412,9 +412,10 @@ def test_order_available_shipping_methods(
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    shipping_method = order_with_lines.shipping_method
 
     def respond(*args, **kwargs):
-        return webhook_response(order_with_lines.shipping_method)
+        return webhook_response(shipping_method)
 
     mocked_webhook.side_effect = respond
     permission_group_manage_orders.user_set.add(staff_api_client.user)

--- a/saleor/product/utils/digital_products.py
+++ b/saleor/product/utils/digital_products.py
@@ -4,6 +4,7 @@ from django.contrib.sites.models import Site
 from django.utils.timezone import now
 
 from ...account import events as account_events
+from ...core.db.connection import allow_writer
 from ..models import DigitalContentUrl
 
 
@@ -42,6 +43,7 @@ def digital_content_url_is_valid(content_url: DigitalContentUrl) -> bool:
     return True
 
 
+@allow_writer()
 def increment_download_count(content_url: DigitalContentUrl):
     content_url.download_num += 1
     content_url.save(update_fields=["download_num"])

--- a/saleor/product/views.py
+++ b/saleor/product/views.py
@@ -2,6 +2,7 @@ import mimetypes
 import os
 from typing import Union
 
+from django.conf import settings
 from django.http import FileResponse, HttpResponseNotFound
 from django.shortcuts import get_object_or_404
 
@@ -15,7 +16,9 @@ from .utils.digital_products import (
 def digital_product(request, token: str) -> Union[FileResponse, HttpResponseNotFound]:
     """Return the direct download link to content if given token is still valid."""
 
-    qs = DigitalContentUrl.objects.prefetch_related("line__order__user")
+    qs = DigitalContentUrl.objects.using(
+        settings.DATABASE_CONNECTION_REPLICA_NAME
+    ).prefetch_related("line__order__user")
     content_url = get_object_or_404(qs, token=token)  # type: DigitalContentUrl
     if not digital_content_url_is_valid(content_url):
         return HttpResponseNotFound("Url is not valid anymore")

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -29,6 +29,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 from . import PatchedSubscriberExecutionContext, __version__
 from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
+from .graphql.executor import patch_executor
 
 django_stubs_ext.monkeypatch()
 
@@ -877,6 +878,8 @@ PRODUCT_MAX_INDEXED_VARIANTS = 1000
 # to fix bug causing not returning errors for subscription queries.
 
 executor.SubscriberExecutionContext = PatchedSubscriberExecutionContext  # type: ignore
+
+patch_executor()
 
 # Optional queue names for Celery tasks.
 # Set None to route to the default queue, or a string value to use a separate one


### PR DESCRIPTION
- Patch `executor.complete_value_catching_error` functions which automatically wraps all resolvers with `allow_writer_in_context`. This allows to run writer DB queries in resolvers when inside a mutation, while in queries it will raise/log error (depending on the settings).
- Add misc allow_writer usages in places where it was missed before.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
