### PR TITLE
Fix checkout base prices when tax app is broken

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -254,7 +254,7 @@ def _fetch_checkout_prices_if_expired(
                 address,
             )
         except TaxEmptyData as e:
-            _get_checkout_base_prices(checkout, checkout_info, lines)
+            _set_checkout_base_prices(checkout, checkout_info, lines)
             checkout.tax_error = str(e)
 
         if not should_charge_tax:
@@ -279,11 +279,11 @@ def _fetch_checkout_prices_if_expired(
                     address,
                 )
             except TaxEmptyData as e:
-                _get_checkout_base_prices(checkout, checkout_info, lines)
+                _set_checkout_base_prices(checkout, checkout_info, lines)
                 checkout.tax_error = str(e)
         else:
             # Calculate net prices without taxes.
-            _get_checkout_base_prices(checkout, checkout_info, lines)
+            _set_checkout_base_prices(checkout, checkout_info, lines)
 
     checkout_update_fields = [
         "voucher_code",
@@ -504,7 +504,7 @@ def _apply_tax_data_from_plugins(
     )
 
 
-def _get_checkout_base_prices(
+def _set_checkout_base_prices(
     checkout: "Checkout",
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -254,6 +254,7 @@ def _fetch_checkout_prices_if_expired(
                 address,
             )
         except TaxEmptyData as e:
+            _get_checkout_base_prices(checkout, checkout_info, lines)
             checkout.tax_error = str(e)
 
         if not should_charge_tax:
@@ -278,6 +279,7 @@ def _fetch_checkout_prices_if_expired(
                     address,
                 )
             except TaxEmptyData as e:
+                _get_checkout_base_prices(checkout, checkout_info, lines)
                 checkout.tax_error = str(e)
         else:
             # Calculate net prices without taxes.

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -634,6 +634,7 @@ def test_fetch_checkout_data_calls_inactive_plugin(
     fetch_checkout_data(**fetch_kwargs)
 
     # then
+    assert checkout.total.gross.amount > 0
     assert checkout_with_items.tax_error == "Empty tax data."
 
 

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -24,7 +24,7 @@ from ..base_calculations import (
 from ..calculations import (
     _apply_tax_data,
     _calculate_and_add_tax,
-    _get_checkout_base_prices,
+    _set_checkout_base_prices,
     fetch_checkout_data,
 )
 from ..fetch import CheckoutLineInfo, fetch_checkout_info, fetch_checkout_lines
@@ -269,7 +269,7 @@ def test_fetch_checkout_data_flat_rates_and_no_tax_calc_strategy(
     assert checkout.shipping_tax_rate == Decimal("0.2300")
 
 
-def test_get_checkout_base_prices_no_charge_taxes_with_voucher(
+def test_set_checkout_base_prices_no_charge_taxes_with_voucher(
     checkout_with_item, voucher_percentage
 ):
     # given
@@ -312,7 +312,7 @@ def test_get_checkout_base_prices_no_charge_taxes_with_voucher(
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when
-    _get_checkout_base_prices(checkout, checkout_info, lines)
+    _set_checkout_base_prices(checkout, checkout_info, lines)
     checkout.save()
     checkout.lines.bulk_update(
         [line_info.line for line_info in lines],
@@ -339,7 +339,7 @@ def test_get_checkout_base_prices_no_charge_taxes_with_voucher(
     assert line.total_price == checkout.total
 
 
-def test_get_checkout_base_prices_no_charge_taxes_with_order_promotion(
+def test_set_checkout_base_prices_no_charge_taxes_with_order_promotion(
     checkout_with_item_and_order_discount,
 ):
     # given
@@ -359,7 +359,7 @@ def test_get_checkout_base_prices_no_charge_taxes_with_order_promotion(
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when
-    _get_checkout_base_prices(checkout, checkout_info, lines)
+    _set_checkout_base_prices(checkout, checkout_info, lines)
     checkout.save()
     checkout.lines.bulk_update(
         [line_info.line for line_info in lines],


### PR DESCRIPTION
Solves a case when one uses a tax app and that app fails with an error (network or response) and the checkout ended up in broken state.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
