### PR TITLE
Remove unique constraint

### DIFF
--- a/saleor/attribute/migrations/0040_clear_assignedattributes.py
+++ b/saleor/attribute/migrations/0040_clear_assignedattributes.py
@@ -19,10 +19,6 @@ class Migration(migrations.Migration):
                     ALTER TABLE attribute_assignedproductattributevalue
                     ALTER COLUMN product_id SET NOT NULL;
 
-                    ALTER TABLE attribute_assignedproductattributevalue
-                    ADD CONSTRAINT attribute_assignedproduc_value_id_product_id_6f6deb31_uniq
-                    UNIQUE (value_id, product_id);
-
                     DROP TABLE attribute_assignedproductattribute;
                     """,
                     reverse_sql="""
@@ -31,9 +27,6 @@ class Migration(migrations.Migration):
 
                     ALTER TABLE attribute_assignedproductattributevalue
                     ALTER COLUMN product_id DROP NOT NULL;
-
-                    ALTER TABLE attribute_assignedproductattributevalue
-                    DROP CONSTRAINT IF EXISTS attribute_assignedproduc_value_id_product_id_6f6deb31_uniq;
 
                     CREATE TABLE attribute_assignedproductattribute (
                         id serial NOT NULL PRIMARY KEY,
@@ -50,10 +43,6 @@ class Migration(migrations.Migration):
                     ALTER TABLE attribute_assignedpageattributevalue
                     ALTER COLUMN page_id SET NOT NULL;
 
-                    ALTER TABLE attribute_assignedpageattributevalue
-                    ADD CONSTRAINT attribute_assignedpageat_value_id_page_id_851cd501_uniq
-                    UNIQUE (value_id, page_id);
-
                     DROP TABLE attribute_assignedpageattribute;
                     """,
                     reverse_sql="""
@@ -62,9 +51,6 @@ class Migration(migrations.Migration):
 
                     ALTER TABLE attribute_assignedpageattributevalue
                     ALTER COLUMN page_id DROP NOT NULL;
-
-                    ALTER TABLE attribute_assignedpageattributevalue
-                    DROP CONSTRAINT IF EXISTS attribute_assignedpageat_value_id_page_id_851cd501_uniq;
 
                     CREATE TABLE attribute_assignedpageattribute (
                         id serial NOT NULL PRIMARY KEY,


### PR DESCRIPTION
I want to merge this change to remove unique constraint that we not currently ensure uniqueness.
Until we fix the issue, we are going to remove adding constraint.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
