### PR TITLE
Allow to provide shipping flag for the same order granted refund

### DIFF
--- a/saleor/graphql/order/mutations/order_grant_refund_update.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_update.py
@@ -305,7 +305,9 @@ class OrderGrantRefundUpdate(BaseMutation):
                 params={"add_lines": add_errors},
             )
 
-        if grant_refund_for_shipping and shipping_costs_already_granted(order):
+        if grant_refund_for_shipping and shipping_costs_already_granted(
+            order, grant_refund_pk_to_exclude=granted_refund.pk
+        ):
             error_code = OrderGrantRefundUpdateErrorCode.SHIPPING_COSTS_ALREADY_GRANTED
             errors["grant_refund_for_shipping"] = ValidationError(
                 "Shipping costs have already been granted.",

--- a/saleor/graphql/order/mutations/order_grant_refund_utils.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_utils.py
@@ -9,8 +9,13 @@ from ....order import models
 from ...core.utils import from_global_id_or_error
 
 
-def shipping_costs_already_granted(order: models.Order):
-    if order.granted_refunds.filter(shipping_costs_included=True):
+def shipping_costs_already_granted(
+    order: models.Order, grant_refund_pk_to_exclude=None
+):
+    qs = order.granted_refunds.filter(shipping_costs_included=True)
+    if grant_refund_pk_to_exclude:
+        qs = qs.exclude(pk=grant_refund_pk_to_exclude)
+    if qs.exists():
         return True
     return False
 

--- a/saleor/graphql/order/tests/mutations/test_order_grant_refund_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_grant_refund_update.py
@@ -492,8 +492,13 @@ def test_grant_refund_update_by_app_missing_input(
     assert errors[0]["field"] == "input"
 
 
+@pytest.mark.parametrize("current_include_shipping", [True, False])
 def test_grant_refund_update_include_grant_refund_for_shipping(
-    app_api_client, staff_user, permission_manage_orders, order_with_lines
+    current_include_shipping,
+    app_api_client,
+    staff_user,
+    permission_manage_orders,
+    order_with_lines,
 ):
     # given
     current_reason = "Granted refund reason."
@@ -503,6 +508,7 @@ def test_grant_refund_update_include_grant_refund_for_shipping(
         currency=order_with_lines.currency,
         reason=current_reason,
         user=staff_user,
+        shipping_costs_included=current_include_shipping,
     )
     granted_refund_id = to_global_id_or_none(granted_refund)
     app_api_client.app.permissions.set([permission_manage_orders])


### PR DESCRIPTION
I want to merge this change because it excludes the current updating order-granted-refund from the validation of includeShippingCosts. Previously we were raising the error, when granted-refund from the input had `includeShippingCosts` set to True, and we were calling update with `includeShippingCosts` set to True once again.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
