### PR TITLE
Raise a `ValidationError` for invalid `shippingMethod` in `DraftOrderInput`

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -193,7 +193,8 @@ class DraftOrderCreate(
         shipping_method_input = {}
         if "shipping_method" in data:
             shipping_method_input["shipping_method"] = get_shipping_model_by_object_id(
-                object_id=data.pop("shipping_method", None), raise_error=False
+                object_id=data.pop("shipping_method", None),
+                error_field="shipping_method",
             )
 
         if email := data.get("user_email", None):

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -2799,3 +2799,53 @@ def test_draft_order_create_gift_promotion_flat_rates(
     assert discount_db.amount_value == gift_price
     assert discount_db.reason == f"Promotion: {promotion_id}"
     assert discount_db.type == DiscountType.ORDER_PROMOTION
+
+
+def test_draft_order_create_with_cc_warehouse_as_shipping_method(
+    app_api_client,
+    permission_manage_orders,
+    customer_user,
+    product_available_in_many_channels,
+    channel_PLN,
+    graphql_address_data,
+    warehouse_for_cc,
+):
+    # given
+    variant = product_available_in_many_channels.variants.first()
+    query = DRAFT_ORDER_CREATE_MUTATION
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variant_list = [
+        {"variantId": variant_id, "quantity": 2},
+    ]
+    shipping_address = graphql_address_data
+    channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
+    redirect_url = "https://www.example.com"
+    cc_warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse_for_cc.id)
+
+    variables = {
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": cc_warehouse_id,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == OrderErrorCode.INVALID.name
+    assert errors[0]["field"] == "shippingMethod"

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -1546,3 +1546,32 @@ def test_draft_order_update_gift_promotion(
         order["undiscountedTotal"]["net"]["amount"]
         == draft_order.undiscounted_total_net_amount
     )
+
+
+def test_draft_order_update_with_cc_warehouse_as_shipping_method(
+    staff_api_client, permission_group_manage_orders, order_with_lines, warehouse_for_cc
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order.save()
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    cc_warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse_for_cc.id)
+
+    variables = {
+        "id": order_id,
+        "input": {"shippingMethod": cc_warehouse_id},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == OrderErrorCode.INVALID.name
+    assert errors[0]["field"] == "shippingMethod"

--- a/saleor/graphql/shipping/utils.py
+++ b/saleor/graphql/shipping/utils.py
@@ -3,30 +3,40 @@ from typing import Optional, overload
 
 from django.core.exceptions import ValidationError
 
-from ...shipping.models import ShippingMethod
+from ...shipping import models
 from ..core.utils import from_global_id_or_error
+from .types import ShippingMethod, ShippingMethodType
 
 
 @overload
 def get_shipping_model_by_object_id(
-    object_id: str, raise_error=True
-) -> ShippingMethod: ...
+    object_id: str, raise_error=True, error_field="id"
+) -> models.ShippingMethod: ...
 
 
 @overload
 def get_shipping_model_by_object_id(
-    object_id: Optional[str], raise_error=False
-) -> Optional[ShippingMethod]: ...
+    object_id: Optional[str], raise_error=False, error_field="id"
+) -> Optional[models.ShippingMethod]: ...
 
 
-def get_shipping_model_by_object_id(object_id, raise_error=True):
+def get_shipping_model_by_object_id(object_id, raise_error=True, error_field="id"):
     if object_id:
-        _, object_pk = from_global_id_or_error(object_id)
-        shipping_method = ShippingMethod.objects.filter(pk=object_pk).first()
+        type, object_pk = from_global_id_or_error(object_id)
+        if type not in [str(ShippingMethod), str(ShippingMethodType)]:
+            raise ValidationError(
+                {
+                    error_field: ValidationError(
+                        "Must receive a ShippingMethod or ShippingMethodType id.",
+                        code="invalid",
+                    )
+                }
+            )
+        shipping_method = models.ShippingMethod.objects.filter(pk=object_pk).first()
         if not shipping_method and raise_error:
             raise ValidationError(
                 {
-                    "id": ValidationError(
+                    error_field: ValidationError(
                         f"Couldn't resolve to a node: {object_id}", code="not_found"
                     )
                 }
@@ -35,9 +45,11 @@ def get_shipping_model_by_object_id(object_id, raise_error=True):
     return None
 
 
-def get_instances_by_object_ids(object_ids: list[str]) -> Iterable[ShippingMethod]:
+def get_instances_by_object_ids(
+    object_ids: list[str],
+) -> Iterable[models.ShippingMethod]:
     model_ids = []
     for object_id in object_ids:
         _, object_pk = from_global_id_or_error(object_id)
         model_ids.append(object_pk)
-    return ShippingMethod.objects.filter(pk__in=model_ids)
+    return models.ShippingMethod.objects.filter(pk__in=model_ids)


### PR DESCRIPTION
Raise a `ValidationError` when a `ShippingMethod` id of a different type than `ShippingMethod` is provided.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
