### PR TITLE
ProductsQueryset manager execute duplicated channel queries

### DIFF
--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 
 from ...attribute import AttributeInputType
 from ...attribute.models import Attribute, AttributeValue
+from ...channel.models import Channel
 from ...permission.utils import has_one_of_permissions
 from ...product import models
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
@@ -38,7 +39,12 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
     if not value:
         return qs
 
-    product_qs = models.Product.objects.visible_to_user(requestor, channel_slug)
+    channel = None
+    if channel_slug is not None:
+        channel = Channel.objects.filter(slug=str(channel_slug)).first()
+    product_qs = models.Product.objects.visible_to_user(
+        requestor, channel, False if channel_slug is None else True
+    )
 
     if field == "in_category":
         _type, category_id = from_global_id_or_error(value, "Category")

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -57,7 +57,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
         product_qs = product_qs.filter(category__in=tree)
 
         if not has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
-            product_qs = product_qs.annotate_visible_in_listings(channel_slug).exclude(
+            product_qs = product_qs.annotate_visible_in_listings(channel).exclude(
                 visible_in_listings=False
             )
 

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -42,8 +42,9 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
     channel = None
     if channel_slug is not None:
         channel = Channel.objects.filter(slug=str(channel_slug)).first()
+    limited_channel_access = False if channel_slug is None else True
     product_qs = models.Product.objects.visible_to_user(
-        requestor, channel, False if channel_slug is None else True
+        requestor, channel, limited_channel_access
     )
 
     if field == "in_category":

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -170,7 +170,7 @@ def validate_product_is_published(order: "Order", errors: T_ERRORS):
     variant_ids = [line.variant_id for line in order.lines.all()]
     unpublished_product = Product.objects.filter(
         variants__id__in=variant_ids
-    ).not_published(order.channel.slug)
+    ).not_published(order.channel)
     if unpublished_product.exists():
         errors["lines"].append(
             ValidationError(
@@ -194,7 +194,7 @@ def validate_product_is_published_in_channel(
         )
     variant_ids = [variant.id for variant in variants]
     unpublished_product = list(
-        Product.objects.filter(variants__id__in=variant_ids).not_published(channel.slug)
+        Product.objects.filter(variants__id__in=variant_ids).not_published(channel)
     )
     if unpublished_product:
         unpublished_variants = ProductVariant.objects.filter(
@@ -313,9 +313,9 @@ def prepare_insufficient_stock_order_validation_errors(exc):
                 "Insufficient product stock.",
                 code=OrderErrorCode.INSUFFICIENT_STOCK.value,
                 params={
-                    "order_lines": [order_line_global_id]
-                    if order_line_global_id
-                    else [],
+                    "order_lines": (
+                        [order_line_global_id] if order_line_global_id else []
+                    ),
                     "warehouse": warehouse_global_id,
                 },
             )

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -73,12 +73,12 @@ def resolve_product(
     slug,
     external_reference,
     channel: Optional[Channel],
-    channel_slug_passed: bool,
+    limited_channel_access: bool,
     requestor,
 ):
     database_connection_name = get_database_connection_name(info.context)
     qs = models.Product.objects.using(database_connection_name).visible_to_user(
-        requestor, channel, channel_slug_passed
+        requestor, channel, limited_channel_access
     )
     if id:
         _type, id = from_global_id_or_error(id, "Product")
@@ -94,11 +94,11 @@ def resolve_products(
     info: ResolveInfo,
     requestor,
     channel: Optional[Channel],
-    channel_slug_passed: bool,
+    limited_channel_access: bool,
 ) -> ChannelQsContext:
     connection_name = get_database_connection_name(info.context)
     qs = models.Product.objects.using(connection_name).visible_to_user(
-        requestor, channel, channel_slug_passed
+        requestor, channel, limited_channel_access
     )
     if not has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
         if channel:
@@ -138,13 +138,15 @@ def resolve_variant(
     external_reference,
     *,
     channel: Optional[Channel],
-    channel_slug_passed: bool,
+    limited_channel_access: bool,
     requestor,
     requestor_has_access_to_all
 ):
     connection_name = get_database_connection_name(info.context)
     visible_products = (
-        models.Product.objects.visible_to_user(requestor, channel, channel_slug_passed)
+        models.Product.objects.visible_to_user(
+            requestor, channel, limited_channel_access
+        )
         .using(connection_name)
         .values_list("pk", flat=True)
     )
@@ -169,11 +171,11 @@ def resolve_product_variants(
     requestor,
     ids=None,
     channel: Optional[Channel] = None,
-    channel_slug_passed: bool = False,
+    limited_channel_access: bool = False,
 ) -> ChannelQsContext:
     connection_name = get_database_connection_name(info.context)
     visible_products = models.Product.objects.visible_to_user(
-        requestor, channel, channel_slug_passed
+        requestor, channel, limited_channel_access
     ).using(connection_name)
     qs = models.ProductVariant.objects.using(connection_name).filter(
         product__id__in=visible_products

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -183,7 +183,7 @@ def resolve_product_variants(
     channel_slug = channel.slug if channel else None
     if not requestor_has_access_to_all:
         visible_products = visible_products.annotate_visible_in_listings(
-            channel_slug
+            channel
         ).exclude(visible_in_listings=False)
         qs = (
             qs.filter(product__in=visible_products)

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -152,8 +152,7 @@ def resolve_variant(
         product__id__in=visible_products
     )
     if not requestor_has_access_to_all:
-        channel_slug = channel.slug if channel else None
-        qs = qs.available_in_channel(channel_slug)
+        qs = qs.available_in_channel(channel)
     if id:
         _, id = from_global_id_or_error(id, "ProductVariant")
         return qs.filter(pk=id).first()
@@ -187,7 +186,7 @@ def resolve_product_variants(
         ).exclude(visible_in_listings=False)
         qs = (
             qs.filter(product__in=visible_products)
-            .available_in_channel(channel_slug)
+            .available_in_channel(channel)
             .using(connection_name)
         )
     if ids:

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.db.models import Exists, OuterRef, Sum
 
 from ...channel.models import Channel
@@ -66,11 +68,17 @@ def resolve_digital_contents(info: ResolveInfo):
 
 
 def resolve_product(
-    info: ResolveInfo, id, slug, external_reference, channel_slug, requestor
+    info: ResolveInfo,
+    id,
+    slug,
+    external_reference,
+    channel: Optional[Channel],
+    channel_slug_passed: bool,
+    requestor,
 ):
     database_connection_name = get_database_connection_name(info.context)
     qs = models.Product.objects.using(database_connection_name).visible_to_user(
-        requestor, channel_slug=channel_slug
+        requestor, channel, channel_slug_passed
     )
     if id:
         _type, id = from_global_id_or_error(id, "Product")
@@ -83,18 +91,17 @@ def resolve_product(
 
 @traced_resolver
 def resolve_products(
-    info: ResolveInfo, requestor, channel_slug=None
+    info: ResolveInfo,
+    requestor,
+    channel: Optional[Channel],
+    channel_slug_passed: bool,
 ) -> ChannelQsContext:
     connection_name = get_database_connection_name(info.context)
     qs = models.Product.objects.using(connection_name).visible_to_user(
-        requestor, channel_slug
+        requestor, channel, channel_slug_passed
     )
     if not has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
-        if channel := (
-            Channel.objects.using(connection_name)
-            .filter(slug=str(channel_slug))
-            .first()
-        ):
+        if channel:
             product_channel_listings = (
                 models.ProductChannelListing.objects.using(connection_name)
                 .filter(channel_id=channel.id, visible_in_listings=True)
@@ -105,6 +112,7 @@ def resolve_products(
             )
         else:
             qs = models.Product.objects.none()
+    channel_slug = channel.slug if channel else None
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
 
 
@@ -129,13 +137,14 @@ def resolve_variant(
     sku,
     external_reference,
     *,
-    channel_slug,
+    channel: Optional[Channel],
+    channel_slug_passed: bool,
     requestor,
     requestor_has_access_to_all
 ):
     connection_name = get_database_connection_name(info.context)
     visible_products = (
-        models.Product.objects.visible_to_user(requestor, channel_slug)
+        models.Product.objects.visible_to_user(requestor, channel, channel_slug_passed)
         .using(connection_name)
         .values_list("pk", flat=True)
     )
@@ -143,6 +152,7 @@ def resolve_variant(
         product__id__in=visible_products
     )
     if not requestor_has_access_to_all:
+        channel_slug = channel.slug if channel else None
         qs = qs.available_in_channel(channel_slug)
     if id:
         _, id = from_global_id_or_error(id, "ProductVariant")
@@ -159,16 +169,18 @@ def resolve_product_variants(
     requestor_has_access_to_all,
     requestor,
     ids=None,
-    channel_slug=None,
+    channel: Optional[Channel] = None,
+    channel_slug_passed: bool = False,
 ) -> ChannelQsContext:
     connection_name = get_database_connection_name(info.context)
     visible_products = models.Product.objects.visible_to_user(
-        requestor, channel_slug
+        requestor, channel, channel_slug_passed
     ).using(connection_name)
     qs = models.ProductVariant.objects.using(connection_name).filter(
         product__id__in=visible_products
     )
 
+    channel_slug = channel.slug if channel else None
     if not requestor_has_access_to_all:
         visible_products = visible_products.annotate_visible_in_listings(
             channel_slug

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -422,7 +422,7 @@ class ProductQueries(graphene.ObjectType):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
 
-        channel_slug_passed = False if channel is None else True
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
@@ -433,7 +433,7 @@ class ProductQueries(graphene.ObjectType):
                 slug=slug,
                 external_reference=external_reference,
                 channel=channel_obj,
-                channel_slug_passed=channel_slug_passed,
+                limited_channel_access=limited_channel_access,
                 requestor=requestor,
             )
 
@@ -475,12 +475,12 @@ class ProductQueries(graphene.ObjectType):
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
-        channel_slug_passed = False if channel is None else True
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
         def _resolve_products(channel_obj):
-            qs = resolve_products(info, requestor, channel_obj, channel_slug_passed)
+            qs = resolve_products(info, requestor, channel_obj, limited_channel_access)
             if search:
                 qs = ChannelQsContext(
                     qs=search_products(qs.qs, search), channel_slug=channel
@@ -528,7 +528,7 @@ class ProductQueries(graphene.ObjectType):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
 
-        channel_slug_passed = False if channel is None else True
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
@@ -539,7 +539,7 @@ class ProductQueries(graphene.ObjectType):
                 sku,
                 external_reference,
                 channel=channel_obj,
-                channel_slug_passed=channel_slug_passed,
+                limited_channel_access=limited_channel_access,
                 requestor=requestor,
                 requestor_has_access_to_all=has_required_permissions,
             )
@@ -564,7 +564,7 @@ class ProductQueries(graphene.ObjectType):
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
-        channel_slug_passed = False if channel is None else True
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
@@ -573,7 +573,7 @@ class ProductQueries(graphene.ObjectType):
                 info,
                 ids=ids,
                 channel=channel_obj,
-                channel_slug_passed=channel_slug_passed,
+                limited_channel_access=limited_channel_access,
                 requestor_has_access_to_all=has_required_permissions,
                 requestor=requestor,
             )

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -8,6 +8,7 @@ from ...permission.utils import has_one_of_permissions
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ...product.search import search_products
 from ..channel import ChannelContext, ChannelQsContext
+from ..channel.dataloaders import ChannelBySlugLoader
 from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
@@ -421,19 +422,33 @@ class ProductQueries(graphene.ObjectType):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
 
+        channel_slug_passed = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
-        product = resolve_product(
-            info,
-            id=id,
-            slug=slug,
-            external_reference=external_reference,
-            channel_slug=channel,
-            requestor=requestor,
-        )
+        def _resolve_product(channel_obj):
+            product = resolve_product(
+                info,
+                id=id,
+                slug=slug,
+                external_reference=external_reference,
+                channel=channel_obj,
+                channel_slug_passed=channel_slug_passed,
+                requestor=requestor,
+            )
 
-        return ChannelContext(node=product, channel_slug=channel) if product else None
+            return (
+                ChannelContext(node=product, channel_slug=channel) if product else None
+            )
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_product)
+            )
+        else:
+            return _resolve_product(None)
 
     @staticmethod
     @traced_resolver
@@ -460,16 +475,28 @@ class ProductQueries(graphene.ObjectType):
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
+        channel_slug_passed = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
-        qs = resolve_products(info, requestor, channel_slug=channel)
-        if search:
-            qs = ChannelQsContext(
-                qs=search_products(qs.qs, search), channel_slug=channel
+
+        def _resolve_products(channel_obj):
+            qs = resolve_products(info, requestor, channel_obj, channel_slug_passed)
+            if search:
+                qs = ChannelQsContext(
+                    qs=search_products(qs.qs, search), channel_slug=channel
+                )
+            kwargs["channel"] = channel
+            qs = filter_connection_queryset(qs, kwargs)
+            return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_products)
             )
-        kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
-        return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+        else:
+            return _resolve_products(None)
 
     @staticmethod
     def resolve_product_type(_root, info: ResolveInfo, *, id):
@@ -501,20 +528,33 @@ class ProductQueries(graphene.ObjectType):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
 
+        channel_slug_passed = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
-        variant = resolve_variant(
-            info,
-            id,
-            sku,
-            external_reference,
-            channel_slug=channel,
-            requestor=requestor,
-            requestor_has_access_to_all=has_required_permissions,
-        )
+        def _resolve_product_variant(channel_obj):
+            variant = resolve_variant(
+                info,
+                id,
+                sku,
+                external_reference,
+                channel=channel_obj,
+                channel_slug_passed=channel_slug_passed,
+                requestor=requestor,
+                requestor_has_access_to_all=has_required_permissions,
+            )
+            return (
+                ChannelContext(node=variant, channel_slug=channel) if variant else None
+            )
 
-        return ChannelContext(node=variant, channel_slug=channel) if variant else None
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_product_variant)
+            )
+        else:
+            return _resolve_product_variant(None)
 
     @staticmethod
     def resolve_product_variants(
@@ -524,20 +564,33 @@ class ProductQueries(graphene.ObjectType):
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
+        channel_slug_passed = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
-        qs = resolve_product_variants(
-            info,
-            ids=ids,
-            channel_slug=channel,
-            requestor_has_access_to_all=has_required_permissions,
-            requestor=requestor,
-        )
-        kwargs["channel"] = qs.channel_slug
-        qs = filter_connection_queryset(qs, kwargs)
-        return create_connection_slice(
-            qs, info, kwargs, ProductVariantCountableConnection
-        )
+
+        def _resolve_product_variants(channel_obj):
+            qs = resolve_product_variants(
+                info,
+                ids=ids,
+                channel=channel_obj,
+                channel_slug_passed=channel_slug_passed,
+                requestor_has_access_to_all=has_required_permissions,
+                requestor=requestor,
+            )
+            kwargs["channel"] = qs.channel_slug
+            qs = filter_connection_queryset(qs, kwargs)
+            return create_connection_slice(
+                qs, info, kwargs, ProductVariantCountableConnection
+            )
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_product_variants)
+            )
+        else:
+            return _resolve_product_variants(None)
 
     @staticmethod
     @traced_resolver

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -741,7 +741,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(5):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
@@ -763,7 +763,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(5):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 2

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -741,7 +741,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
@@ -763,7 +763,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 2

--- a/saleor/graphql/product/tests/benchmark/test_variant.py
+++ b/saleor/graphql/product/tests/benchmark/test_variant.py
@@ -384,7 +384,7 @@ def test_products_variants_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
@@ -400,7 +400,7 @@ def test_products_variants_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 4

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -1961,7 +1961,7 @@ def test_query_product_media_by_id_zero_size_value_original_image_returned(
     )
 
 
-def test_query_product_for_federation(api_client, product, channel_USD):
+def test_query_product_for_federation_as_customer(api_client, product, channel_USD):
     product_id = graphene.Node.to_global_id("Product", product.pk)
     variables = {
         "representations": [
@@ -1993,6 +1993,231 @@ def test_query_product_for_federation(api_client, product, channel_USD):
             "name": product.name,
         }
     ]
+
+
+def test_query_product_for_federation_as_customer_not_existing_channel(
+    api_client, product, channel_USD
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": "not-existing-channel",
+            },
+        ],
+    }
+    query = """
+      query GetProductInFederation($representations: [_Any]) {
+        _entities(representations: $representations) {
+          __typename
+          ... on Product {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_customer_channel_not_active(
+    api_client, product, channel_USD
+):
+    channel_USD.is_active = False
+    channel_USD.save()
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": channel_USD.slug,
+            },
+        ],
+    }
+    query = """
+      query GetProductInFederation($representations: [_Any]) {
+        _entities(representations: $representations) {
+          __typename
+          ... on Product {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_customer_without_channel(
+    api_client, product, channel_USD
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+            },
+        ],
+    }
+    query = """
+      query GetProductInFederation($representations: [_Any]) {
+        _entities(representations: $representations) {
+          __typename
+          ... on Product {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_staff_user(
+    staff_api_client, staff_user, product, channel_USD, permission_manage_products
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": channel_USD.slug,
+            },
+        ],
+    }
+    query = """
+      query GetProductInFederation($representations: [_Any]) {
+        _entities(representations: $representations) {
+          __typename
+          ... on Product {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [
+        {
+            "__typename": "Product",
+            "id": product_id,
+            "name": product.name,
+        }
+    ]
+
+
+def test_query_product_for_federation_as_staff_user_without_chanel(
+    staff_api_client, staff_user, product, channel_USD, permission_manage_products
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {"__typename": "Product", "id": product_id},
+        ],
+    }
+    query = """
+      query GetProductInFederation($representations: [_Any]) {
+        _entities(representations: $representations) {
+          __typename
+          ... on Product {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [
+        {
+            "__typename": "Product",
+            "id": product_id,
+            "name": product.name,
+        }
+    ]
+
+
+def test_query_product_for_federation_as_staff_user_not_existing_channel(
+    staff_api_client, staff_user, product, channel_USD, permission_manage_products
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": "not-existing-channel",
+            },
+        ],
+    }
+    query = """
+      query GetProductInFederation($representations: [_Any]) {
+        _entities(representations: $representations) {
+          __typename
+          ... on Product {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_staff_user_channel_not_active(
+    staff_api_client, staff_user, product, channel_USD, permission_manage_products
+):
+    channel_USD.is_active = False
+    channel_USD.save()
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": "not-existing-channel",
+            },
+        ],
+    }
+    query = """
+      query GetProductInFederation($representations: [_Any]) {
+        _entities(representations: $representations) {
+          __typename
+          ... on Product {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
 
 
 def test_query_product_media_for_federation(

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -166,7 +166,7 @@ class Category(ModelObjectType[models.Category]):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
         tree = root.get_descendants(include_self=True)
-        channel_slug_passed = False if channel is None else True
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
         connection_name = get_database_connection_name(info.context)
@@ -175,7 +175,7 @@ class Category(ModelObjectType[models.Category]):
             qs = models.Product.objects.using(connection_name).all()
             if not has_required_permissions:
                 qs = (
-                    qs.visible_to_user(requestor, channel_obj, channel_slug_passed)
+                    qs.visible_to_user(requestor, channel_obj, limited_channel_access)
                     .annotate_visible_in_listings(channel_obj)
                     .exclude(
                         visible_in_listings=False,

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -176,13 +176,13 @@ class Category(ModelObjectType[models.Category]):
             if not has_required_permissions:
                 qs = (
                     qs.visible_to_user(requestor, channel_obj, channel_slug_passed)
-                    .annotate_visible_in_listings(channel)
+                    .annotate_visible_in_listings(channel_obj)
                     .exclude(
                         visible_in_listings=False,
                     )
                 )
-            if channel and has_required_permissions:
-                qs = qs.filter(channel_listings__channel__slug=channel)
+            if channel_obj and has_required_permissions:
+                qs = qs.filter(channel_listings__channel_id=channel_obj.id)
             qs = qs.filter(category__in=tree)
             qs = ChannelQsContext(qs=qs, channel_slug=channel)
 

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -12,6 +12,7 @@ from ....thumbnail.utils import (
     get_thumbnail_size,
 )
 from ...channel import ChannelQsContext
+from ...channel.dataloaders import ChannelBySlugLoader
 from ...channel.utils import get_default_channel_slug_or_graphql_error
 from ...core.connection import (
     CountableConnection,
@@ -165,26 +166,38 @@ class Category(ModelObjectType[models.Category]):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
         tree = root.get_descendants(include_self=True)
+        channel_slug_passed = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
         connection_name = get_database_connection_name(info.context)
-        qs = models.Product.objects.using(connection_name).all()
-        if not has_required_permissions:
-            qs = (
-                qs.visible_to_user(requestor, channel)
-                .annotate_visible_in_listings(channel)
-                .exclude(
-                    visible_in_listings=False,
-                )
-            )
-        if channel and has_required_permissions:
-            qs = qs.filter(channel_listings__channel__slug=channel)
-        qs = qs.filter(category__in=tree)
-        qs = ChannelQsContext(qs=qs, channel_slug=channel)
 
-        kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
-        return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+        def _resolve_products(channel_obj):
+            qs = models.Product.objects.using(connection_name).all()
+            if not has_required_permissions:
+                qs = (
+                    qs.visible_to_user(requestor, channel_obj, channel_slug_passed)
+                    .annotate_visible_in_listings(channel)
+                    .exclude(
+                        visible_in_listings=False,
+                    )
+                )
+            if channel and has_required_permissions:
+                qs = qs.filter(channel_listings__channel__slug=channel)
+            qs = qs.filter(category__in=tree)
+            qs = ChannelQsContext(qs=qs, channel_slug=channel)
+
+            kwargs["channel"] = channel
+            qs = filter_connection_queryset(qs, kwargs)
+            return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_products)
+            )
+        else:
+            return _resolve_products(None)
 
     @staticmethod
     def __resolve_references(roots: List["Category"], _info):

--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -138,11 +138,11 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
         root: ChannelContext[models.Collection], info: ResolveInfo, **kwargs
     ):
         requestor = get_user_or_app_from_context(info.context)
-        channel_slug_passed = False if root.channel_slug is None else True
+        limited_channel_access = False if root.channel_slug is None else True
 
         def _resolve_products(channel):
             qs = root.node.products.visible_to_user(  # type: ignore[attr-defined] # mypy does not properly resolve the related manager # noqa: E501
-                requestor, channel, channel_slug_passed
+                requestor, channel, limited_channel_access
             ).using(
                 get_database_connection_name(info.context)
             )

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -9,6 +9,7 @@ from graphene import relay
 from promise import Promise
 
 from ....attribute import models as attribute_models
+from ....channel.models import Channel
 from ....core.utils import build_absolute_uri, get_currency_for_country
 from ....core.weight import convert_weight_to_default_weight_unit
 from ....permission.auth_filters import AuthorizationFilters
@@ -773,18 +774,21 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
             channels[root.channel].add(root.id)
 
         variants = {}
-        for channel, ids in channels.items():
+        channels_map = Channel.objects.in_bulk(set(channels.keys()), field_name="slug")
+        for channel_slug, ids in channels.items():
+            channel_slug_passed = False if channel_slug is None else True
             qs = resolve_product_variants(
                 info,
                 requestor_has_access_to_all,
                 requestor,
                 ids=ids,
-                channel_slug=channel,
+                channel=channels_map.get(channel_slug),
+                channel_slug_passed=channel_slug_passed,
             ).qs
             for variant in qs:
                 global_id = graphene.Node.to_global_id("ProductVariant", variant.id)
-                variants[f"{channel}_{global_id}"] = ChannelContext(
-                    channel_slug=channel, node=variant
+                variants[f"{channel_slug}_{global_id}"] = ChannelContext(
+                    channel_slug=channel_slug, node=variant
                 )
 
         return [variants.get(root_id) for root_id in roots_ids]
@@ -1526,14 +1530,17 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
                 channels[root.channel].add(root_id)
 
         products = {}
-        for channel, ids in channels.items():
+
+        channels_map = Channel.objects.in_bulk(set(channels.keys()), field_name="slug")
+        for channel_slug, ids in channels.items():
+            channel_slug_passed = False if channel_slug is None else True
             queryset = resolve_products(
-                info, requestor, channel_slug=channel
+                info, requestor, channels_map.get(channel_slug), channel_slug_passed
             ).qs.filter(id__in=ids)
 
             for product in queryset:
-                products[f"{channel}_{product.id}"] = ChannelContext(
-                    channel_slug=channel, node=product
+                products[f"{channel_slug}_{product.id}"] = ChannelContext(
+                    channel_slug=channel_slug, node=product
                 )
 
         return [products.get(root_id) for root_id in roots_ids]
@@ -1708,12 +1715,26 @@ class ProductType(ModelObjectType[models.ProductType]):
     @staticmethod
     def resolve_products(root: models.ProductType, info, *, channel=None, **kwargs):
         requestor = get_user_or_app_from_context(info.context)
+        channel_slug_passed = False if channel is None else True
         if channel is None:
             channel = get_default_channel_slug_or_graphql_error()
-        qs = root.products.visible_to_user(requestor, channel)
-        qs = ChannelQsContext(qs=qs, channel_slug=channel)
-        kwargs["channel"] = channel
-        return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+
+        def _resolve_products(channel_obj):
+            qs = root.products.visible_to_user(
+                requestor, channel_obj, channel_slug_passed
+            )
+            qs = ChannelQsContext(qs=qs, channel_slug=channel)
+            kwargs["channel"] = channel
+            return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_products)
+            )
+        else:
+            return _resolve_products(None)
 
     @staticmethod
     def resolve_available_attributes(root: models.ProductType, info, **kwargs):

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -267,7 +267,7 @@ class ProductsQueryset(models.QuerySet["Product"]):
         return self.published_with_variants(channel)
 
     def annotate_publication_info(self, channel: Channel):
-        return self.annotate_is_published(channel).annotate_published_at(channel.slug)
+        return self.annotate_is_published(channel).annotate_published_at(channel)
 
     def annotate_is_published(self, channel: Channel):
         query = Subquery(
@@ -279,10 +279,10 @@ class ProductsQueryset(models.QuerySet["Product"]):
             is_published=ExpressionWrapper(query, output_field=BooleanField())
         )
 
-    def annotate_published_at(self, channel_slug: str):
+    def annotate_published_at(self, channel: Channel):
         query = Subquery(
             ProductChannelListing.objects.filter(
-                product_id=OuterRef("pk"), channel__slug=str(channel_slug)
+                product_id=OuterRef("pk"), channel_id=channel.id
             ).values_list("published_at")[:1]
         )
         return self.annotate(

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -267,14 +267,12 @@ class ProductsQueryset(models.QuerySet["Product"]):
         return self.published_with_variants(channel)
 
     def annotate_publication_info(self, channel: Channel):
-        return self.annotate_is_published(channel.slug).annotate_published_at(
-            channel.slug
-        )
+        return self.annotate_is_published(channel).annotate_published_at(channel.slug)
 
-    def annotate_is_published(self, channel_slug: str):
+    def annotate_is_published(self, channel: Channel):
         query = Subquery(
             ProductChannelListing.objects.filter(
-                product_id=OuterRef("pk"), channel__slug=str(channel_slug)
+                product_id=OuterRef("pk"), channel_id=channel.id
             ).values_list("is_published")[:1]
         )
         return self.annotate(

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -213,7 +213,7 @@ class ProductsQueryset(models.QuerySet["Product"]):
 
     def not_published(self, channel: Channel):
         today = datetime.datetime.now(pytz.UTC)
-        return self.annotate_publication_info(channel.slug).filter(
+        return self.annotate_publication_info(channel).filter(
             Q(published_at__gt=today) & Q(is_published=True)
             | Q(is_published=False)
             | Q(is_published__isnull=True)
@@ -266,9 +266,9 @@ class ProductsQueryset(models.QuerySet["Product"]):
             return self.none()
         return self.published_with_variants(channel)
 
-    def annotate_publication_info(self, channel_slug: str):
-        return self.annotate_is_published(channel_slug).annotate_published_at(
-            channel_slug
+    def annotate_publication_info(self, channel: Channel):
+        return self.annotate_is_published(channel.slug).annotate_published_at(
+            channel.slug
         )
 
     def annotate_is_published(self, channel_slug: str):

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -209,9 +209,9 @@ class ProductsQueryset(models.QuerySet["Product"]):
         ).values("id")
         return self.filter(Exists(channel_listings.filter(product_id=OuterRef("pk"))))
 
-    def not_published(self, channel_slug: str):
+    def not_published(self, channel: Channel):
         today = datetime.datetime.now(pytz.UTC)
-        return self.annotate_publication_info(channel_slug).filter(
+        return self.annotate_publication_info(channel.slug).filter(
             Q(published_at__gt=today) & Q(is_published=True)
             | Q(is_published=False)
             | Q(is_published__isnull=True)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -237,7 +237,7 @@ class ProductsQueryset(models.QuerySet["Product"]):
         self,
         requestor: Union["User", "App", None],
         channel: Optional[Channel],
-        channel_slug_passed: bool,
+        limited_channel_access: bool,
     ):
         """Determine which products should be visible to user.
 
@@ -245,14 +245,14 @@ class ProductsQueryset(models.QuerySet["Product"]):
         products are visible to user.
         For user with permission we can return:
         - all products if channel is not passed to query.
-            (channel=None, channel_slug_passed=False)
+            (channel=None, limited_channel_access=False)
         - no products if channel is passed but it does not exist.
-            (channel=None, channel_slug_passed=True)
+            (channel=None, limited_channel_access=True)
         - all products assigned to channel if channel is passed and exists.
-            (channel=Channel, channel_slug_passed=True)
+            (channel=Channel, limited_channel_access=True)
         """
         if has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
-            if channel_slug_passed:
+            if limited_channel_access:
                 if channel:
                     channel_listings = ProductChannelListing.objects.filter(
                         channel_id=channel.id

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -289,10 +289,14 @@ class ProductsQueryset(models.QuerySet["Product"]):
             published_at=ExpressionWrapper(query, output_field=DateTimeField())
         )
 
-    def annotate_visible_in_listings(self, channel_slug):
+    def annotate_visible_in_listings(self, channel: Optional[Channel]):
+        if not channel:
+            return self.annotate(
+                visible_in_listings=Value(False, output_field=BooleanField())
+            )
         query = Subquery(
             ProductChannelListing.objects.filter(
-                product_id=OuterRef("pk"), channel__slug=str(channel_slug)
+                product_id=OuterRef("pk"), channel_id=channel.id
             ).values_list("visible_in_listings")[:1]
         )
         return self.annotate(

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -367,7 +367,7 @@ def test_filter_not_published_product_is_unpublished(product, channel_USD):
     channel_listing.is_published = False
     channel_listing.save(update_fields=["is_published"])
 
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 1
 
 
@@ -378,7 +378,7 @@ def test_filter_not_published_product_published_tomorrow(product, channel_USD):
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["is_published", "published_at"])
 
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 1
 
 
@@ -389,12 +389,12 @@ def test_filter_not_published_product_not_published_tomorrow(product, channel_US
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["is_published", "published_at"])
 
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 1
 
 
 def test_filter_not_published_product_is_published(product, channel_USD):
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 0
 
 
@@ -405,18 +405,18 @@ def test_filter_not_published_product_is_unpublished_other_channel(
         product=product, channel=channel_PLN, is_published=False
     )
 
-    available_products_usd = models.Product.objects.not_published(channel_USD.slug)
+    available_products_usd = models.Product.objects.not_published(channel_USD)
     assert available_products_usd.count() == 0
 
-    available_products_pln = models.Product.objects.not_published(channel_PLN.slug)
+    available_products_pln = models.Product.objects.not_published(channel_PLN)
     assert available_products_pln.count() == 1
 
 
 def test_filter_not_published_product_without_assigned_channel(
     product, channel_USD, channel_PLN
 ):
-    not_available_products_usd = models.Product.objects.not_published(channel_USD.slug)
+    not_available_products_usd = models.Product.objects.not_published(channel_USD)
     assert not_available_products_usd.count() == 0
 
-    not_available_products_pln = models.Product.objects.not_published(channel_PLN.slug)
+    not_available_products_pln = models.Product.objects.not_published(channel_PLN)
     assert not_available_products_pln.count() == 1

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -291,32 +291,14 @@ def test_visible_to_customer_user(customer_user, product_list, channel_USD):
 
     # when
     available_products = models.Product.objects.visible_to_user(
-        customer_user, channel_USD.slug
+        customer_user, channel_USD, True
     )
 
     # then
     assert available_products.count() == len(product_list) - 1
 
 
-def test_visible_to_customer_user_without_channel_slug(
-    customer_user,
-    product_list,
-    channel_USD,
-    django_assert_num_queries,
-):
-    # given
-    product = product_list[0]
-    product.channel_listings.all().delete()
-
-    # when
-    available_products = models.Product.objects.visible_to_user(customer_user, None)
-
-    # then
-    with django_assert_num_queries(0):
-        assert available_products.count() == 0
-
-
-def test_visible_to_customer_user_with_not_existing_channel_slug(
+def test_visible_to_customer_user_without_channel(
     customer_user,
     product_list,
     channel_USD,
@@ -328,7 +310,27 @@ def test_visible_to_customer_user_with_not_existing_channel_slug(
 
     # when
     available_products = models.Product.objects.visible_to_user(
-        customer_user, "not-existing"
+        customer_user, None, False
+    )
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_products.count() == 0
+
+
+def test_visible_to_customer_user_with_not_existing_channel_slug_passed(
+    customer_user,
+    product_list,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    # when
+    available_products = models.Product.objects.visible_to_user(
+        customer_user, None, True
     )
 
     # then
@@ -349,7 +351,7 @@ def test_visible_to_staff_user(
     staff_user.user_permissions.add(permission_manage_products)
 
     # when
-    available_products = models.Product.objects.visible_to_user(staff_user, None)
+    available_products = models.Product.objects.visible_to_user(staff_user, None, False)
 
     # then
     assert available_products.count() == len(product_list)
@@ -369,14 +371,14 @@ def test_visible_to_staff_user_with_channel(
 
     # when
     available_products = models.Product.objects.visible_to_user(
-        staff_user, channel_USD.slug
+        staff_user, channel_USD, True
     )
 
     # then
     assert available_products.count() == len(product_list) - 1
 
 
-def test_visible_to_staff_user_with_not_existing_channel_slug(
+def test_visible_to_staff_user_with_not_existing_channel_slug_passed(
     staff_user,
     product_list,
     permission_manage_products,
@@ -389,9 +391,7 @@ def test_visible_to_staff_user_with_not_existing_channel_slug(
     staff_user.user_permissions.add(permission_manage_products)
 
     # when
-    available_products = models.Product.objects.visible_to_user(
-        staff_user, "not-existing"
-    )
+    available_products = models.Product.objects.visible_to_user(staff_user, None, True)
 
     # then
     assert available_products.count() == 0

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -192,11 +192,11 @@ def test_available_products_only_published(product_list, channel_USD):
     channel_listing.is_published = False
     channel_listing.save(update_fields=["is_published"])
 
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 2
     assert all(
         [
-            product.channel_listings.get(channel__slug=channel_USD.slug).is_published
+            product.channel_listings.get(channel__slug=channel_USD).is_published
             for product in available_products
         ]
     )
@@ -208,11 +208,11 @@ def test_available_products_only_available(product_list, channel_USD):
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["published_at"])
 
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 2
     assert all(
         [
-            product.channel_listings.get(channel__slug=channel_USD.slug).is_published
+            product.channel_listings.get(channel__slug=channel_USD).is_published
             for product in available_products
         ]
     )
@@ -224,11 +224,11 @@ def test_available_products_available_from_yesterday(product_list, channel_USD):
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["published_at"])
 
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 3
     assert all(
         [
-            product.channel_listings.get(channel__slug=channel_USD.slug).is_published
+            product.channel_listings.get(channel__slug=channel_USD).is_published
             for product in available_products
         ]
     )
@@ -237,7 +237,7 @@ def test_available_products_available_from_yesterday(product_list, channel_USD):
 def test_available_products_available_without_channel_listings(
     product_list, channel_PLN
 ):
-    available_products = models.Product.objects.published(channel_PLN.slug)
+    available_products = models.Product.objects.published(channel_PLN)
     assert available_products.count() == 0
 
 
@@ -248,9 +248,9 @@ def test_available_products_available_with_many_channels(
         product__in=product_list_with_many_channels, channel=channel_PLN
     ).update(is_published=False)
 
-    available_products = models.Product.objects.published(channel_PLN.slug)
+    available_products = models.Product.objects.published(channel_PLN)
     assert available_products.count() == 0
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 3
 
 

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -266,27 +266,21 @@ def test_available_products_with_variants(product_list, channel_USD):
     product = product_list[0]
     product.variants.all().delete()
 
-    available_products = models.Product.objects.published_with_variants(
-        channel_USD.slug
-    )
+    available_products = models.Product.objects.published_with_variants(channel_USD)
     assert available_products.count() == 2
 
 
 def test_available_products_with_variants_in_many_channels_usd(
     product_list_with_variants_many_channel, channel_USD
 ):
-    available_products = models.Product.objects.published_with_variants(
-        channel_USD.slug
-    )
+    available_products = models.Product.objects.published_with_variants(channel_USD)
     assert available_products.count() == 1
 
 
 def test_available_products_with_variants_in_many_channels_pln(
     product_list_with_variants_many_channel, channel_PLN
 ):
-    available_products = models.Product.objects.published_with_variants(
-        channel_PLN.slug
-    )
+    available_products = models.Product.objects.published_with_variants(channel_PLN)
     assert available_products.count() == 2
 
 

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -316,6 +316,26 @@ def test_visible_to_customer_user_without_channel_slug(
         assert available_products.count() == 0
 
 
+def test_visible_to_customer_user_with_not_existing_channel_slug(
+    customer_user,
+    product_list,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    # when
+    available_products = models.Product.objects.visible_to_user(
+        customer_user, "not-existing"
+    )
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_products.count() == 0
+
+
 def test_visible_to_staff_user(
     staff_user,
     product_list,
@@ -354,6 +374,27 @@ def test_visible_to_staff_user_with_channel(
 
     # then
     assert available_products.count() == len(product_list) - 1
+
+
+def test_visible_to_staff_user_with_not_existing_channel_slug(
+    staff_user,
+    product_list,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_products = models.Product.objects.visible_to_user(
+        staff_user, "not-existing"
+    )
+
+    # then
+    assert available_products.count() == 0
 
 
 def test_filter_not_published_product_is_unpublished(product, channel_USD):


### PR DESCRIPTION
I want to merge this change because:
- Optimize ProductsQueryset.published function
- Optimize ProductsQueryset.not_published function
- Optimize ProductsQueryset.published_with_variants function
- Optimize ProductsQueryset.visible_to_user function
- Optimize ProductsQueryset.annotate_publication_info function
- Optimize ProductsQueryset.annotate_is_published function
- Optimize ProductsQueryset.annotate_published_at function
- Optimize ProductsQueryset.annotate_visible_in_listings function
- Optimize ProductVariantQueryset.available_in_channel function

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
