### PR TITLE
Deprecate `taxTypes` query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### GraphQL API
 - Add `translatableContent` to all translation types; add translated object id to all translatable content types - #15617 by @zedzior
-
 - Add a `taxConfiguration` to a `Channel` - #15610 by @Air-t
+- Deprecate the `taxTypes` query - #15802 by @maarcingebala
 
 ### Saleor Apps
 

--- a/saleor/graphql/core/schema.py
+++ b/saleor/graphql/core/schema.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.fields import BaseField
 from ..plugins.dataloaders import get_plugin_manager_promise
@@ -13,6 +14,7 @@ class CoreQueries(graphene.ObjectType):
         NonNullList(TaxType),
         description="List of all tax rates available from tax gateway.",
         doc_category=DOC_CATEGORY_TAXES,
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `taxClasses` field instead.",
     )
 
     def resolve_tax_types(self, info: ResolveInfo):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1282,7 +1282,7 @@ type Query {
   ): ExportFileCountableConnection
 
   """List of all tax rates available from tax gateway."""
-  taxTypes: [TaxType!] @doc(category: "Taxes")
+  taxTypes: [TaxType!] @doc(category: "Taxes") @deprecated(reason: "This field will be removed in Saleor 4.0. Use `taxClasses` field instead.")
 
   """
   Look up a checkout by id.


### PR DESCRIPTION
This query should have been deprecated when Flat Rates when introduced.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
