### PR TITLE
Add deepcoopy when updating CONFIG_STRUCTURE for AdminEmailPlugin

### DIFF
--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from dataclasses import asdict
 from typing import List, Union
 
@@ -143,7 +144,7 @@ class AdminEmailPlugin(BasePlugin):
             "label": "CSV export failed template",
         },
     }
-    CONFIG_STRUCTURE.update(DEFAULT_EMAIL_CONFIG_STRUCTURE)
+    CONFIG_STRUCTURE.update(deepcopy(DEFAULT_EMAIL_CONFIG_STRUCTURE))
     CONFIG_STRUCTURE["host"][
         "help_text"
     ] += " Leave it blank if you want to use system environment - EMAIL_HOST."

--- a/saleor/plugins/admin_email/tests/test_plugin.py
+++ b/saleor/plugins/admin_email/tests/test_plugin.py
@@ -8,7 +8,11 @@ from django.core.mail.backends.smtp import EmailBackend
 
 from ....core.notify_events import NotifyEventType
 from ....graphql.tests.utils import get_graphql_content
-from ...email_common import DEFAULT_EMAIL_VALUE, get_email_template
+from ...email_common import (
+    DEFAULT_EMAIL_CONFIG_STRUCTURE,
+    DEFAULT_EMAIL_VALUE,
+    get_email_template,
+)
 from ...manager import get_plugins_manager
 from ...models import PluginConfiguration
 from ..constants import (
@@ -24,7 +28,7 @@ from ..notify_events import (
     send_staff_order_confirmation,
     send_staff_reset_password,
 )
-from ..plugin import get_admin_event_map
+from ..plugin import AdminEmailPlugin, get_admin_event_map
 
 
 def test_event_map():
@@ -292,3 +296,30 @@ def test_plugin_manager_doesnt_load_email_templates_from_db(
     # email template from DB but returns default email value.
     assert email_config_item
     assert email_config_item["value"] == DEFAULT_EMAIL_VALUE
+
+
+def test_plugin_dont_change_default_help_text_config_value():
+    assert (
+        AdminEmailPlugin.CONFIG_STRUCTURE["host"]["help_text"]
+        != DEFAULT_EMAIL_CONFIG_STRUCTURE["host"]["help_text"]
+    )
+    assert (
+        AdminEmailPlugin.CONFIG_STRUCTURE["port"]["help_text"]
+        != DEFAULT_EMAIL_CONFIG_STRUCTURE["port"]["help_text"]
+    )
+    assert (
+        AdminEmailPlugin.CONFIG_STRUCTURE["username"]["help_text"]
+        != DEFAULT_EMAIL_CONFIG_STRUCTURE["username"]["help_text"]
+    )
+    assert (
+        AdminEmailPlugin.CONFIG_STRUCTURE["password"]["help_text"]
+        != DEFAULT_EMAIL_CONFIG_STRUCTURE["password"]["help_text"]
+    )
+    assert (
+        AdminEmailPlugin.CONFIG_STRUCTURE["use_tls"]["help_text"]
+        != DEFAULT_EMAIL_CONFIG_STRUCTURE["use_tls"]["help_text"]
+    )
+    assert (
+        AdminEmailPlugin.CONFIG_STRUCTURE["use_ssl"]["help_text"]
+        != DEFAULT_EMAIL_CONFIG_STRUCTURE["use_ssl"]["help_text"]
+    )


### PR DESCRIPTION
I want to merge this change because deepcopy will prevent override of default values for emails. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
