### PR TITLE
Add voucher type to TaxableObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `translatableContent` to all translation types; add translated object id to all translatable content types - #15617 by @zedzior
 - Add a `taxConfiguration` to a `Channel` - #15610 by @Air-t
 - Deprecate the `taxTypes` query - #15802 by @maarcingebala
+- Add voucher type to `TaxableObject` - #15810 by @tomaszszymanski129
 
 ### Saleor Apps
 

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -277,6 +277,7 @@ class TaxableObjectDiscount(BaseObjectType):
     amount = graphene.Field(
         Money, description="The amount of the discount.", required=True
     )
+    type = graphene.String(required=True, description="Type of the discount.")
 
     class Meta:
         doc_category = DOC_CATEGORY_TAXES
@@ -383,7 +384,13 @@ class TaxableObject(BaseObjectType):
                 checkout = checkout_info.checkout
                 discount_name = checkout.discount_name
                 return (
-                    [{"name": discount_name, "amount": checkout.discount}]
+                    [
+                        {
+                            "name": discount_name,
+                            "amount": checkout.discount,
+                            "type": checkout_info.voucher.type,
+                        }
+                    ]
                     if checkout.discount and not is_shipping_voucher
                     else []
                 )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -36039,6 +36039,9 @@ type TaxableObjectDiscount @doc(category: "Taxes") {
 
   """The amount of the discount."""
   amount: Money!
+
+  """Type of the discount."""
+  type: String!
 }
 
 type TaxableObjectLine @doc(category: "Taxes") {

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -40,6 +40,7 @@ subscription {
           amount {
             amount
           }
+          type
         }
 
         lines {
@@ -219,7 +220,9 @@ def test_checkout_calculate_taxes_with_voucher(
         "taxBase": {
             "address": None,
             "currency": "USD",
-            "discounts": [{"amount": {"amount": 20.0}}],
+            "discounts": [
+                {"amount": {"amount": 20.0}, "type": VoucherType.ENTIRE_ORDER}
+            ],
             "channel": {"id": to_global_id_or_none(checkout_with_voucher.channel)},
             "lines": [
                 {


### PR DESCRIPTION
I want to merge this change because it adds voucher type to TaxableObject
More context: https://linear.app/saleor/issue/SHOPX-325/bug-discounts-field-behaviour-on-calculatetaxes-event-is-inconsistent

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
