### PR TITLE
Recalculate prices with celery beat - improvements and compatibility between 3.18-3.19-main

### DIFF
--- a/saleor/discount/migrations/0072_promotionrule_variants_dirty.py
+++ b/saleor/discount/migrations/0072_promotionrule_variants_dirty.py
@@ -7,12 +7,26 @@ class Migration(migrations.Migration):
     dependencies = [
         ("discount", "0071_merge_20240307_1156"),
     ]
-
     operations = [
-        migrations.AddField(
-            model_name="promotionrule",
-            name="variants_dirty",
-            field=models.BooleanField(default=False),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    """
+                    ALTER TABLE discount_promotionrule
+                    ADD COLUMN IF NOT EXISTS variants_dirty boolean
+                    """,
+                    reverse_sql="""
+                    ALTER TABLE discount_promotionrule DROP COLUMN variants_dirty
+                    """,
+                )
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="promotionrule",
+                    name="variants_dirty",
+                    field=models.BooleanField(default=False),
+                )
+            ],
         ),
         migrations.RunSQL(
             """

--- a/saleor/discount/migrations/0072_promotionrule_variants_dirty.py
+++ b/saleor/discount/migrations/0072_promotionrule_variants_dirty.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
                     """
                     ALTER TABLE discount_promotionrule
                     ADD COLUMN IF NOT EXISTS variants_dirty boolean
+                    DEFAULT false;
                     """,
                     reverse_sql="""
                     ALTER TABLE discount_promotionrule DROP COLUMN variants_dirty
@@ -27,13 +28,5 @@ class Migration(migrations.Migration):
                     field=models.BooleanField(default=False),
                 )
             ],
-        ),
-        migrations.RunSQL(
-            """
-            ALTER TABLE discount_promotionrule
-            ALTER COLUMN variants_dirty
-            SET DEFAULT false;
-            """,
-            migrations.RunSQL.noop,
         ),
     ]

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -52,8 +52,9 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
         product = models.Product.objects.prefetched_for_webhook(single_object=True).get(
             pk=instance.pk
         )
-        listings = product.channel_listings.all()
-        channel_ids = [listing.channel_id for listing in listings]
+        channel_ids = set(
+            product.channel_listings.all().values_list("channel_id", flat=True)
+        )
         cls.call_event(mark_active_promotion_rules_as_dirty, channel_ids)
 
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -14,7 +14,6 @@ from ..attribute.models import Attribute
 from ..celeryconf import app
 from ..core.exceptions import PreorderAllocationError
 from ..discount.models import Promotion, PromotionRule
-from ..discount.utils import mark_active_promotion_rules_as_dirty
 from ..plugins.manager import get_plugins_manager
 from ..warehouse.management import deactivate_preorder_for_variant
 from ..webhook.event_types import WebhookEventAsyncType
@@ -36,8 +35,8 @@ PRODUCTS_BATCH_SIZE = 300
 VARIANTS_UPDATE_BATCH = 500
 # Results in update time ~0.2s
 DISCOUNTED_PRODUCT_BATCH = 2000
-# Results in update time ~1.5s
-PROMOTION_RULE_BATCH_SIZE = 250
+# Results in update time ~2s when 600 channels exist
+PROMOTION_RULE_BATCH_SIZE = 100
 
 
 def _variants_in_batches(variants_qs):
@@ -115,15 +114,15 @@ def _get_channel_to_products_map(rule_to_variant_list):
         [rule_to_variant.promotionrule_id for rule_to_variant in rule_to_variant_list]
     )
     PromotionChannel = PromotionRule.channels.through
-    promotion_channel_qs = PromotionChannel.objects.using(
-        settings.DATABASE_CONNECTION_REPLICA_NAME
-    ).filter(promotionrule_id__in=rule_ids)
-    rule_to_channels_map = defaultdict(set)
-    for promotion_channel in promotion_channel_qs:
-        rule_to_channels_map[promotion_channel.promotionrule_id].add(
-            promotion_channel.channel_id
-        )
+    promotion_channel_qs = (
+        PromotionChannel.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+        .filter(promotionrule_id__in=rule_ids)
+        .values_list("promotionrule_id", "channel_id")
+    )
 
+    rule_to_channels_map = defaultdict(set)
+    for promotionrule_id, channel_id in promotion_channel_qs.iterator():
+        rule_to_channels_map[promotionrule_id].add(channel_id)
     channel_to_products_map = defaultdict(set)
     for rule_to_variant in rule_to_variant_list:
         channel_ids = rule_to_channels_map[rule_to_variant.promotionrule_id]
@@ -199,11 +198,7 @@ def update_products_discounted_prices_for_promotion_task(
 
     # In case of triggered the task by old server worker, mark all active promotions as
     # dirty. This will make the same re-calculation as the old task.
-    from ..channel.models import Channel
-
-    mark_active_promotion_rules_as_dirty(
-        Channel.objects.all().values_list("id", flat=True)
-    )
+    PromotionRule.objects.filter(variants_dirty=False).update(variants_dirty=True)
 
 
 @app.task


### PR DESCRIPTION
I want to merge this change because it provides changes in price recalculation logic:
- unify the migration after moving the feature to 3.18
- improve the performance based on the local tests

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
