### PR TITLE
Add transaction items limit to TransactionSessionBase

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/payment_gateway_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/payment_gateway_initialize.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from .....payment.interface import PaymentGatewayData
 from ....core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
@@ -65,7 +66,9 @@ class PaymentGatewayInitialize(TransactionSessionBase):
             "Initializes a payment gateway session. It triggers the webhook "
             "`PAYMENT_GATEWAY_INITIALIZE_SESSION`, to the requested `paymentGateways`. "
             "If `paymentGateways` is not provided, the webhook will be send to all "
-            "subscribed payment gateways." + ADDED_IN_313 + PREVIEW_FEATURE
+            "subscribed payment gateways. "
+            f"There is a limit of {settings.TRANSACTION_ITEMS_LIMIT} transaction items "
+            "per checkout / order." + ADDED_IN_313 + PREVIEW_FEATURE
         )
         error_type_class = common_types.PaymentGatewayInitializeError
 

--- a/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Optional
 
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from .....app.models import App
@@ -92,8 +93,8 @@ class TransactionInitialize(TransactionSessionBase):
         description = (
             "Initializes a transaction session. It triggers the webhook "
             "`TRANSACTION_INITIALIZE_SESSION`, to the requested `paymentGateways`. "
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
+            f"There is a limit of {settings.TRANSACTION_ITEMS_LIMIT} transaction "
+            "items per checkout / order." + ADDED_IN_313 + PREVIEW_FEATURE
         )
         error_type_class = common_types.TransactionInitializeError
 

--- a/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize.py
@@ -1,11 +1,14 @@
 from decimal import Decimal
 
 import mock
+from django.conf import settings
+from django.test import override_settings
 
 from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....payment.interface import PaymentGatewayData
-from ....core.enums import PaymentGatewayConfigErrorCode
+from .....payment.models import TransactionItem
+from ....core.enums import PaymentGatewayConfigErrorCode, TransactionInitializeErrorCode
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
 
@@ -76,6 +79,40 @@ def test_for_checkout_without_payment_gateways(
         "errors": [],
     }
     mocked_initialize.assert_called_once_with(checkout.total.gross.amount, [], checkout)
+
+
+@override_settings(TRANSACTION_ITEMS_LIMIT=3)
+def test_for_checkout_transactions_limit_on_gateway_initialize(
+    user_api_client, checkout_with_prices
+):
+    # given
+    TransactionItem.objects.bulk_create(
+        [
+            TransactionItem(
+                checkout=checkout_with_prices, currency=checkout_with_prices.currency
+            )
+            for _ in range(settings.TRANSACTION_ITEMS_LIMIT)
+        ]
+    )
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_prices),
+        "paymentGateways": None,
+    }
+
+    # when
+    response = user_api_client.post_graphql(PAYMENT_GATEWAY_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["paymentGatewayInitialize"]
+    assert data["errors"]
+    error = data["errors"][0]
+    assert error["code"] == TransactionInitializeErrorCode.INVALID.name
+    assert error["field"] == "id"
+    assert error["message"] == (
+        "Checkout transactions limit of " f"{settings.TRANSACTION_ITEMS_LIMIT} reached."
+    )
 
 
 @mock.patch("saleor.plugins.manager.PluginsManager.payment_gateway_initialize_session")

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 
 import mock
 import pytest
+from django.conf import settings
+from django.test import override_settings
 from freezegun import freeze_time
 
 from .....channel import TransactionFlowStrategy
@@ -17,6 +19,7 @@ from .....payment.interface import (
     TransactionSessionData,
     TransactionSessionResult,
 )
+from .....payment.models import TransactionItem
 from ....channel.enums import TransactionFlowStrategyEnum
 from ....core.enums import TransactionInitializeErrorCode
 from ....core.utils import to_global_id_or_none
@@ -231,6 +234,42 @@ def test_for_checkout_without_payment_gateway_data(
     )
     assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+
+
+@override_settings(TRANSACTION_ITEMS_LIMIT=3)
+def test_for_checkout_transactions_limit_on_transaction_initialize(
+    user_api_client, checkout_with_prices
+):
+    # given
+    TransactionItem.objects.bulk_create(
+        [
+            TransactionItem(
+                checkout=checkout_with_prices, currency=checkout_with_prices.currency
+            )
+            for _ in range(settings.TRANSACTION_ITEMS_LIMIT)
+        ]
+    )
+
+    variables = {
+        "action": None,
+        "amount": 99,
+        "id": to_global_id_or_none(checkout_with_prices),
+        "paymentGateway": {"id": "any", "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionInitialize"]
+    assert data["errors"]
+    error = data["errors"][0]
+    assert error["code"] == TransactionInitializeErrorCode.INVALID.name
+    assert error["field"] == "id"
+    assert error["message"] == (
+        "Checkout transactions limit of " f"{settings.TRANSACTION_ITEMS_LIMIT} reached."
+    )
 
 
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15849,7 +15849,7 @@ type Mutation {
   ): TransactionEventReport @doc(category: "Payments")
 
   """
-  Initializes a payment gateway session. It triggers the webhook `PAYMENT_GATEWAY_INITIALIZE_SESSION`, to the requested `paymentGateways`. If `paymentGateways` is not provided, the webhook will be send to all subscribed payment gateways.
+  Initializes a payment gateway session. It triggers the webhook `PAYMENT_GATEWAY_INITIALIZE_SESSION`, to the requested `paymentGateways`. If `paymentGateways` is not provided, the webhook will be send to all subscribed payment gateways. There is a limit of 100 transaction items per checkout / order.
   
   Added in Saleor 3.13.
   
@@ -15869,7 +15869,7 @@ type Mutation {
   ): PaymentGatewayInitialize @doc(category: "Payments")
 
   """
-  Initializes a transaction session. It triggers the webhook `TRANSACTION_INITIALIZE_SESSION`, to the requested `paymentGateways`. 
+  Initializes a transaction session. It triggers the webhook `TRANSACTION_INITIALIZE_SESSION`, to the requested `paymentGateways`. There is a limit of 100 transaction items per checkout / order.
   
   Added in Saleor 3.13.
   
@@ -23469,7 +23469,7 @@ enum TransactionEventReportErrorCode @doc(category: "Payments") {
 }
 
 """
-Initializes a payment gateway session. It triggers the webhook `PAYMENT_GATEWAY_INITIALIZE_SESSION`, to the requested `paymentGateways`. If `paymentGateways` is not provided, the webhook will be send to all subscribed payment gateways.
+Initializes a payment gateway session. It triggers the webhook `PAYMENT_GATEWAY_INITIALIZE_SESSION`, to the requested `paymentGateways`. If `paymentGateways` is not provided, the webhook will be send to all subscribed payment gateways. There is a limit of 100 transaction items per checkout / order.
 
 Added in Saleor 3.13.
 
@@ -23539,7 +23539,7 @@ input PaymentGatewayToInitialize @doc(category: "Payments") {
 }
 
 """
-Initializes a transaction session. It triggers the webhook `TRANSACTION_INITIALIZE_SESSION`, to the requested `paymentGateways`. 
+Initializes a transaction session. It triggers the webhook `TRANSACTION_INITIALIZE_SESSION`, to the requested `paymentGateways`. There is a limit of 100 transaction items per checkout / order.
 
 Added in Saleor 3.13.
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -885,3 +885,8 @@ COMMON_REQUESTS_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
 
 WEBHOOK_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
 WEBHOOK_SYNC_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
+
+
+# Transaction items limit for PaymentGatewayInitialize / TransactionInitialize.
+# That setting limits the allowed number of transaction items for single entity.
+TRANSACTION_ITEMS_LIMIT = 100


### PR DESCRIPTION
I want to merge this change because it adds a limit of transaction items to `TransactionSessionBase`.
This results in adding the limit to the following two mutations:
- `PaymentGatewayInitialize`
- `TransactionInitialize`

⚠️ This is a port of https://github.com/saleor/saleor/pull/15795

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
