### PR TITLE
ProductsQueryset manager execute duplicated channel queries 

### DIFF
--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 
 from ...attribute import AttributeInputType
 from ...attribute.models import Attribute, AttributeValue
+from ...channel.models import Channel
 from ...permission.utils import has_one_of_permissions
 from ...product import models
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
@@ -42,7 +43,13 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
     if not value:
         return qs
 
-    product_qs = models.Product.objects.visible_to_user(requestor, channel_slug)
+    channel = None
+    if channel_slug is not None:
+        channel = Channel.objects.filter(slug=str(channel_slug)).first()
+    limited_channel_access = False if channel_slug is None else True
+    product_qs = models.Product.objects.visible_to_user(
+        requestor, channel, limited_channel_access
+    )
 
     if field == "in_category":
         _type, category_id = from_global_id_or_error(value, "Category")
@@ -55,7 +62,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
         product_qs = product_qs.filter(category__in=tree)
 
         if not has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
-            product_qs = product_qs.annotate_visible_in_listings(channel_slug).exclude(
+            product_qs = product_qs.annotate_visible_in_listings(channel).exclude(
                 visible_in_listings=False
             )
 

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -173,7 +173,7 @@ def validate_product_is_published(order: "Order", errors: T_ERRORS):
     variant_ids = [line.variant_id for line in order.lines.all()]
     unpublished_product = Product.objects.filter(
         variants__id__in=variant_ids
-    ).not_published(order.channel.slug)
+    ).not_published(order.channel)
     if unpublished_product.exists():
         errors["lines"].append(
             ValidationError(
@@ -197,7 +197,7 @@ def validate_product_is_published_in_channel(
         )
     variant_ids = [variant.id for variant in variants]
     unpublished_product = list(
-        Product.objects.filter(variants__id__in=variant_ids).not_published(channel.slug)
+        Product.objects.filter(variants__id__in=variant_ids).not_published(channel)
     )
     if unpublished_product:
         unpublished_variants = ProductVariant.objects.filter(
@@ -316,9 +316,9 @@ def prepare_insufficient_stock_order_validation_errors(exc):
                 "Insufficient product stock.",
                 code=OrderErrorCode.INSUFFICIENT_STOCK.value,
                 params={
-                    "order_lines": [order_line_global_id]
-                    if order_line_global_id
-                    else [],
+                    "order_lines": (
+                        [order_line_global_id] if order_line_global_id else []
+                    ),
                     "warehouse": warehouse_global_id,
                 },
             )

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -5,6 +5,7 @@ from ...permission.utils import has_one_of_permissions
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ...product.search import search_products
 from ..channel import ChannelContext, ChannelQsContext
+from ..channel.dataloaders import ChannelBySlugLoader
 from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
@@ -422,19 +423,33 @@ class ProductQueries(graphene.ObjectType):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
 
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
-        product = resolve_product(
-            info,
-            id=id,
-            slug=slug,
-            external_reference=external_reference,
-            channel_slug=channel,
-            requestor=requestor,
-        )
+        def _resolve_product(channel_obj):
+            product = resolve_product(
+                info,
+                id=id,
+                slug=slug,
+                external_reference=external_reference,
+                channel=channel_obj,
+                limited_channel_access=limited_channel_access,
+                requestor=requestor,
+            )
 
-        return ChannelContext(node=product, channel_slug=channel) if product else None
+            return (
+                ChannelContext(node=product, channel_slug=channel) if product else None
+            )
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_product)
+            )
+        else:
+            return _resolve_product(None)
 
     @staticmethod
     @traced_resolver
@@ -446,16 +461,28 @@ class ProductQueries(graphene.ObjectType):
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
-        qs = resolve_products(info, requestor, channel_slug=channel)
-        if search:
-            qs = ChannelQsContext(
-                qs=search_products(qs.qs, search), channel_slug=channel
+
+        def _resolve_products(channel_obj):
+            qs = resolve_products(info, requestor, channel_obj, limited_channel_access)
+            if search:
+                qs = ChannelQsContext(
+                    qs=search_products(qs.qs, search), channel_slug=channel
+                )
+            kwargs["channel"] = channel
+            qs = filter_connection_queryset(qs, kwargs)
+            return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_products)
             )
-        kwargs["channel"] = channel
-        qs = filter_connection_queryset(qs, kwargs)
-        return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+        else:
+            return _resolve_products(None)
 
     @staticmethod
     def resolve_product_type(_root, info: ResolveInfo, *, id):
@@ -487,20 +514,33 @@ class ProductQueries(graphene.ObjectType):
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
 
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
 
-        variant = resolve_variant(
-            info,
-            id,
-            sku,
-            external_reference,
-            channel_slug=channel,
-            requestor=requestor,
-            requestor_has_access_to_all=has_required_permissions,
-        )
+        def _resolve_product_variant(channel_obj):
+            variant = resolve_variant(
+                info,
+                id,
+                sku,
+                external_reference,
+                channel=channel_obj,
+                limited_channel_access=limited_channel_access,
+                requestor=requestor,
+                requestor_has_access_to_all=has_required_permissions,
+            )
+            return (
+                ChannelContext(node=variant, channel_slug=channel) if variant else None
+            )
 
-        return ChannelContext(node=variant, channel_slug=channel) if variant else None
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_product_variant)
+            )
+        else:
+            return _resolve_product_variant(None)
 
     @staticmethod
     def resolve_product_variants(
@@ -510,20 +550,33 @@ class ProductQueries(graphene.ObjectType):
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS
         )
+        limited_channel_access = False if channel is None else True
         if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
-        qs = resolve_product_variants(
-            info,
-            ids=ids,
-            channel_slug=channel,
-            requestor_has_access_to_all=has_required_permissions,
-            requestor=requestor,
-        )
-        kwargs["channel"] = qs.channel_slug
-        qs = filter_connection_queryset(qs, kwargs)
-        return create_connection_slice(
-            qs, info, kwargs, ProductVariantCountableConnection
-        )
+
+        def _resolve_product_variants(channel_obj):
+            qs = resolve_product_variants(
+                info,
+                ids=ids,
+                channel=channel_obj,
+                limited_channel_access=limited_channel_access,
+                requestor_has_access_to_all=has_required_permissions,
+                requestor=requestor,
+            )
+            kwargs["channel"] = qs.channel_slug
+            qs = filter_connection_queryset(qs, kwargs)
+            return create_connection_slice(
+                qs, info, kwargs, ProductVariantCountableConnection
+            )
+
+        if channel:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(channel))
+                .then(_resolve_product_variants)
+            )
+        else:
+            return _resolve_product_variants(None)
 
     @staticmethod
     @traced_resolver

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -741,7 +741,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
@@ -763,7 +763,7 @@ def test_products_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 2

--- a/saleor/graphql/product/tests/benchmark/test_variant.py
+++ b/saleor/graphql/product/tests/benchmark/test_variant.py
@@ -384,7 +384,7 @@ def test_products_variants_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1
@@ -400,7 +400,7 @@ def test_products_variants_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(4):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 4

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -1961,7 +1961,96 @@ def test_query_product_media_by_id_zero_size_value_original_image_returned(
     )
 
 
-def test_query_product_for_federation(api_client, product, channel_USD):
+QUERY_PRODUCT_IN_FEDERATION = """
+query GetProductInFederation($representations: [_Any]) {
+  _entities(representations: $representations) {
+    __typename
+    ... on Product {
+      id
+      name
+    }
+  }
+}
+"""
+
+
+def test_query_product_for_federation(
+    api_client,
+    product,
+    product_in_channel_JPY,
+    shippable_gift_card_product,
+    channel_USD,
+    channel_JPY,
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    shippable_gift_card_product_id = graphene.Node.to_global_id(
+        "Product", shippable_gift_card_product.pk
+    )
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": channel_USD.slug,
+            },
+            {
+                "__typename": "Product",
+                "id": shippable_gift_card_product_id,
+                "channel": channel_USD.slug,
+            },
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": channel_JPY.slug,
+            },
+        ],
+    }
+
+    response = api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [
+        {
+            "__typename": "Product",
+            "id": product_id,
+            "name": product.name,
+        },
+        {
+            "__typename": "Product",
+            "id": shippable_gift_card_product_id,
+            "name": shippable_gift_card_product.name,
+        },
+        {
+            "__typename": "Product",
+            "id": product_id,
+            "name": product.name,
+        },
+    ]
+
+
+def test_query_product_for_federation_as_customer_not_existing_channel(
+    api_client, product, channel_USD
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": "not-existing-channel",
+            },
+        ],
+    }
+
+    response = api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_customer_channel_not_active(
+    api_client, product, channel_USD
+):
+    channel_USD.is_active = False
+    channel_USD.save()
     product_id = graphene.Node.to_global_id("Product", product.pk)
     variables = {
         "representations": [
@@ -1972,19 +2061,99 @@ def test_query_product_for_federation(api_client, product, channel_USD):
             },
         ],
     }
-    query = """
-      query GetProductInFederation($representations: [_Any]) {
-        _entities(representations: $representations) {
-          __typename
-          ... on Product {
-            id
-            name
-          }
-        }
-      }
-    """
 
-    response = api_client.post_graphql(query, variables)
+    response = api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_customer_without_channel(api_client, product):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+            },
+        ],
+    }
+
+    response = api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_staff_user(
+    staff_api_client,
+    staff_user,
+    permission_manage_products,
+    product,
+    product_in_channel_JPY,
+    shippable_gift_card_product,
+    channel_USD,
+    channel_JPY,
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    shippable_gift_card_product_id = graphene.Node.to_global_id(
+        "Product", shippable_gift_card_product.pk
+    )
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": channel_USD.slug,
+            },
+            {
+                "__typename": "Product",
+                "id": shippable_gift_card_product_id,
+                "channel": channel_USD.slug,
+            },
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": channel_JPY.slug,
+            },
+        ],
+    }
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [
+        {
+            "__typename": "Product",
+            "id": product_id,
+            "name": product.name,
+        },
+        {
+            "__typename": "Product",
+            "id": shippable_gift_card_product_id,
+            "name": shippable_gift_card_product.name,
+        },
+        {
+            "__typename": "Product",
+            "id": product_id,
+            "name": product.name,
+        },
+    ]
+
+
+def test_query_product_for_federation_as_staff_user_without_chanel(
+    staff_api_client, staff_user, product, permission_manage_products
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+            },
+        ],
+    }
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
     content = get_graphql_content(response)
     assert content["data"]["_entities"] == [
         {
@@ -1993,6 +2162,48 @@ def test_query_product_for_federation(api_client, product, channel_USD):
             "name": product.name,
         }
     ]
+
+
+def test_query_product_for_federation_as_staff_user_not_existing_channel(
+    staff_api_client, staff_user, product, channel_USD, permission_manage_products
+):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": "not-existing-channel",
+            },
+        ],
+    }
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_query_product_for_federation_as_staff_user_channel_not_active(
+    staff_api_client, staff_user, product, channel_USD, permission_manage_products
+):
+    channel_USD.is_active = False
+    channel_USD.save()
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Product",
+                "id": product_id,
+                "channel": "not-existing-channel",
+            },
+        ],
+    }
+
+    staff_user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(QUERY_PRODUCT_IN_FEDERATION, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
 
 
 def test_query_product_media_for_federation(

--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -13,6 +13,7 @@ from ....thumbnail.utils import (
     get_thumbnail_size,
 )
 from ...channel import ChannelContext, ChannelQsContext
+from ...channel.dataloaders import ChannelBySlugLoader
 from ...channel.types import ChannelContextType, ChannelContextTypeWithMetadata
 from ...core import ResolveInfo
 from ...core.connection import (
@@ -142,22 +143,34 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
         search = kwargs.get("search")
 
         requestor = get_user_or_app_from_context(info.context)
-        qs = root.node.products.visible_to_user(  # type: ignore[attr-defined] # mypy does not properly resolve the related manager # noqa: E501
-            requestor, root.channel_slug
-        ).using(
-            get_database_connection_name(info.context)
-        )
+        limited_channel_access = False if root.channel_slug is None else True
 
-        if search:
-            qs = ChannelQsContext(
-                qs=search_products(qs.qs, search), channel_slug=root.channel_slug
+        def _resolve_products(channel):
+            qs = root.node.products.visible_to_user(  # type: ignore[attr-defined] # mypy does not properly resolve the related manager # noqa: E501
+                requestor, channel, limited_channel_access
+            ).using(
+                get_database_connection_name(info.context)
+            )
+
+            if search:
+                qs = ChannelQsContext(
+                    qs=search_products(qs.qs, search), channel_slug=root.channel_slug
+                )
+            else:
+                qs = ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
+
+            kwargs["channel"] = root.channel_slug
+            qs = filter_connection_queryset(qs, kwargs)
+            return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+
+        if root.channel_slug:
+            return (
+                ChannelBySlugLoader(info.context)
+                .load(str(root.channel_slug))
+                .then(_resolve_products)
             )
         else:
-            qs = ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
-
-        kwargs["channel"] = root.channel_slug
-        qs = filter_connection_queryset(qs, kwargs)
-        return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
+            return _resolve_products(None)
 
     @staticmethod
     def resolve_channel_listings(root: ChannelContext[models.Collection], info):

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -1,8 +1,7 @@
 import datetime
-from typing import Union
+from typing import Optional, Union
 
 import pytz
-from django.conf import settings
 from django.contrib.postgres.aggregates import StringAgg
 from django.db import models
 from django.db.models import (
@@ -30,57 +29,66 @@ from ..permission.utils import has_one_of_permissions
 
 
 class ProductsQueryset(models.QuerySet):
-    def published(self, channel_slug: str):
+    def published(self, channel: Channel):
         from .models import ProductChannelListing
 
+        if not channel.is_active:
+            return self.none()
         today = datetime.datetime.now(pytz.UTC)
-        if channel := (
-            Channel.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
-            .filter(slug=str(channel_slug), is_active=True)
-            .first()
-        ):
-            channel_listings = ProductChannelListing.objects.filter(
-                Q(published_at__lte=today) | Q(published_at__isnull=True),
-                channel_id=channel.id,
-                is_published=True,
-            ).values("id")
-            return self.filter(
-                Exists(channel_listings.filter(product_id=OuterRef("pk")))
-            )
-        return self.none()
+        channel_listings = ProductChannelListing.objects.filter(
+            Q(published_at__lte=today) | Q(published_at__isnull=True),
+            channel_id=channel.id,
+            is_published=True,
+        ).values("id")
+        return self.filter(Exists(channel_listings.filter(product_id=OuterRef("pk"))))
 
-    def not_published(self, channel_slug: str):
+    def not_published(self, channel: Channel):
         today = datetime.datetime.now(pytz.UTC)
-        return self.annotate_publication_info(channel_slug).filter(
+        return self.annotate_publication_info(channel).filter(
             Q(published_at__gt=today) & Q(is_published=True)
             | Q(is_published=False)
             | Q(is_published__isnull=True)
         )
 
-    def published_with_variants(self, channel_slug: str):
+    def published_with_variants(self, channel: Channel):
         from .models import ProductVariant, ProductVariantChannelListing
 
-        if channel := (
-            Channel.objects.filter(slug=str(channel_slug), is_active=True).first()
-        ):
-            variant_channel_listings = ProductVariantChannelListing.objects.filter(
-                channel_id=channel.id,
-                price_amount__isnull=False,
-            ).values("id")
-            variants = ProductVariant.objects.filter(
-                Exists(variant_channel_listings.filter(variant_id=OuterRef("pk")))
-            )
-            return self.published(channel_slug).filter(
-                Exists(variants.filter(product_id=OuterRef("pk")))
-            )
-        return self.none()
+        if not channel.is_active:
+            return self.none()
+        variant_channel_listings = ProductVariantChannelListing.objects.filter(
+            channel_id=channel.id,
+            price_amount__isnull=False,
+        ).values("id")
+        variants = ProductVariant.objects.filter(
+            Exists(variant_channel_listings.filter(variant_id=OuterRef("pk")))
+        )
+        return self.published(channel).filter(
+            Exists(variants.filter(product_id=OuterRef("pk")))
+        )
 
-    def visible_to_user(self, requestor: Union["User", "App", None], channel_slug: str):
+    def visible_to_user(
+        self,
+        requestor: Union["User", "App", None],
+        channel: Optional[Channel],
+        limited_channel_access: bool,
+    ):
+        """Determine which products should be visible to user.
+
+        For user without permission we require channel to be passed to determine which
+        products are visible to user.
+        For user with permission we can return:
+        - all products if channel is not passed to query.
+            (channel=None, limited_channel_access=False)
+        - no products if channel is passed but it does not exist.
+            (channel=None, limited_channel_access=True)
+        - all products assigned to channel if channel is passed and exists.
+            (channel=Channel, limited_channel_access=True)
+        """
         from .models import ALL_PRODUCTS_PERMISSIONS, ProductChannelListing
 
         if has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
-            if channel_slug:
-                if channel := Channel.objects.filter(slug=str(channel_slug)).first():
+            if limited_channel_access:
+                if channel:
                     channel_listings = ProductChannelListing.objects.filter(
                         channel_id=channel.id
                     ).values("id")
@@ -89,45 +97,47 @@ class ProductsQueryset(models.QuerySet):
                     )
                 return self.none()
             return self.all()
-        if not channel_slug:
+        if not channel:
             return self.none()
-        return self.published_with_variants(channel_slug)
+        return self.published_with_variants(channel)
 
-    def annotate_publication_info(self, channel_slug: str):
-        return self.annotate_is_published(channel_slug).annotate_published_at(
-            channel_slug
-        )
+    def annotate_publication_info(self, channel: Channel):
+        return self.annotate_is_published(channel).annotate_published_at(channel)
 
-    def annotate_is_published(self, channel_slug: str):
+    def annotate_is_published(self, channel: Channel):
         from .models import ProductChannelListing
 
         query = Subquery(
             ProductChannelListing.objects.filter(
-                product_id=OuterRef("pk"), channel__slug=str(channel_slug)
+                product_id=OuterRef("pk"), channel_id=channel.id
             ).values_list("is_published")[:1]
         )
         return self.annotate(
             is_published=ExpressionWrapper(query, output_field=BooleanField())
         )
 
-    def annotate_published_at(self, channel_slug: str):
+    def annotate_published_at(self, channel: Channel):
         from .models import ProductChannelListing
 
         query = Subquery(
             ProductChannelListing.objects.filter(
-                product_id=OuterRef("pk"), channel__slug=str(channel_slug)
+                product_id=OuterRef("pk"), channel_id=channel.id
             ).values_list("published_at")[:1]
         )
         return self.annotate(
             published_at=ExpressionWrapper(query, output_field=DateTimeField())
         )
 
-    def annotate_visible_in_listings(self, channel_slug):
+    def annotate_visible_in_listings(self, channel: Optional[Channel]):
         from .models import ProductChannelListing
 
+        if not channel:
+            return self.annotate(
+                visible_in_listings=Value(False, output_field=BooleanField())
+            )
         query = Subquery(
             ProductChannelListing.objects.filter(
-                product_id=OuterRef("pk"), channel__slug=str(channel_slug)
+                product_id=OuterRef("pk"), channel_id=channel.id
             ).values_list("visible_in_listings")[:1]
         )
         return self.annotate(
@@ -288,11 +298,15 @@ class ProductVariantQueryset(models.QuerySet):
             ),
         )
 
-    def available_in_channel(self, channel_slug):
-        return self.filter(
-            channel_listings__price_amount__isnull=False,
-            channel_listings__channel__slug=str(channel_slug),
-        )
+    def available_in_channel(self, channel: Optional[Channel]):
+        from .models import ProductVariantChannelListing
+
+        if not channel:
+            return self.none()
+        channel_listings = ProductVariantChannelListing.objects.filter(
+            price_amount__isnull=False, channel_id=channel.id
+        ).values("id")
+        return self.filter(Exists(channel_listings.filter(variant_id=OuterRef("pk"))))
 
     def prefetched_for_webhook(self):
         return self.prefetch_related(

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -174,11 +174,11 @@ def test_available_products_only_published(product_list, channel_USD):
     channel_listing.is_published = False
     channel_listing.save(update_fields=["is_published"])
 
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 2
     assert all(
         [
-            product.channel_listings.get(channel__slug=channel_USD.slug).is_published
+            product.channel_listings.get(channel__slug=channel_USD).is_published
             for product in available_products
         ]
     )
@@ -190,11 +190,11 @@ def test_available_products_only_available(product_list, channel_USD):
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["published_at"])
 
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 2
     assert all(
         [
-            product.channel_listings.get(channel__slug=channel_USD.slug).is_published
+            product.channel_listings.get(channel__slug=channel_USD).is_published
             for product in available_products
         ]
     )
@@ -206,11 +206,11 @@ def test_available_products_available_from_yesterday(product_list, channel_USD):
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["published_at"])
 
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 3
     assert all(
         [
-            product.channel_listings.get(channel__slug=channel_USD.slug).is_published
+            product.channel_listings.get(channel__slug=channel_USD).is_published
             for product in available_products
         ]
     )
@@ -219,7 +219,7 @@ def test_available_products_available_from_yesterday(product_list, channel_USD):
 def test_available_products_available_without_channel_listings(
     product_list, channel_PLN
 ):
-    available_products = models.Product.objects.published(channel_PLN.slug)
+    available_products = models.Product.objects.published(channel_PLN)
     assert available_products.count() == 0
 
 
@@ -230,9 +230,9 @@ def test_available_products_available_with_many_channels(
         product__in=product_list_with_many_channels, channel=channel_PLN
     ).update(is_published=False)
 
-    available_products = models.Product.objects.published(channel_PLN.slug)
+    available_products = models.Product.objects.published(channel_PLN)
     assert available_products.count() == 0
-    available_products = models.Product.objects.published(channel_USD.slug)
+    available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 3
 
 
@@ -248,27 +248,21 @@ def test_available_products_with_variants(product_list, channel_USD):
     product = product_list[0]
     product.variants.all().delete()
 
-    available_products = models.Product.objects.published_with_variants(
-        channel_USD.slug
-    )
+    available_products = models.Product.objects.published_with_variants(channel_USD)
     assert available_products.count() == 2
 
 
 def test_available_products_with_variants_in_many_channels_usd(
     product_list_with_variants_many_channel, channel_USD
 ):
-    available_products = models.Product.objects.published_with_variants(
-        channel_USD.slug
-    )
+    available_products = models.Product.objects.published_with_variants(channel_USD)
     assert available_products.count() == 1
 
 
 def test_available_products_with_variants_in_many_channels_pln(
     product_list_with_variants_many_channel, channel_PLN
 ):
-    available_products = models.Product.objects.published_with_variants(
-        channel_PLN.slug
-    )
+    available_products = models.Product.objects.published_with_variants(channel_PLN)
     assert available_products.count() == 2
 
 
@@ -279,14 +273,14 @@ def test_visible_to_customer_user(customer_user, product_list, channel_USD):
 
     # when
     available_products = models.Product.objects.visible_to_user(
-        customer_user, channel_USD.slug
+        customer_user, channel_USD, True
     )
 
     # then
     assert available_products.count() == len(product_list) - 1
 
 
-def test_visible_to_customer_user_without_channel_slug(
+def test_visible_to_customer_user_without_channel(
     customer_user,
     product_list,
     channel_USD,
@@ -297,7 +291,29 @@ def test_visible_to_customer_user_without_channel_slug(
     product.channel_listings.all().delete()
 
     # when
-    available_products = models.Product.objects.visible_to_user(customer_user, None)
+    available_products = models.Product.objects.visible_to_user(
+        customer_user, None, False
+    )
+
+    # then
+    with django_assert_num_queries(0):
+        assert available_products.count() == 0
+
+
+def test_visible_to_customer_user_with_not_existing_channel_slug_passed(
+    customer_user,
+    product_list,
+    channel_USD,
+    django_assert_num_queries,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    # when
+    available_products = models.Product.objects.visible_to_user(
+        customer_user, None, True
+    )
 
     # then
     with django_assert_num_queries(0):
@@ -317,7 +333,7 @@ def test_visible_to_staff_user(
     staff_user.user_permissions.add(permission_manage_products)
 
     # when
-    available_products = models.Product.objects.visible_to_user(staff_user, None)
+    available_products = models.Product.objects.visible_to_user(staff_user, None, False)
 
     # then
     assert available_products.count() == len(product_list)
@@ -337,11 +353,30 @@ def test_visible_to_staff_user_with_channel(
 
     # when
     available_products = models.Product.objects.visible_to_user(
-        staff_user, channel_USD.slug
+        staff_user, channel_USD, True
     )
 
     # then
     assert available_products.count() == len(product_list) - 1
+
+
+def test_visible_to_staff_user_with_not_existing_channel_slug_passed(
+    staff_user,
+    product_list,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    product = product_list[0]
+    product.channel_listings.all().delete()
+
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    available_products = models.Product.objects.visible_to_user(staff_user, None, True)
+
+    # then
+    assert available_products.count() == 0
 
 
 def test_filter_not_published_product_is_unpublished(product, channel_USD):
@@ -349,7 +384,7 @@ def test_filter_not_published_product_is_unpublished(product, channel_USD):
     channel_listing.is_published = False
     channel_listing.save(update_fields=["is_published"])
 
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 1
 
 
@@ -360,7 +395,7 @@ def test_filter_not_published_product_published_tomorrow(product, channel_USD):
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["is_published", "published_at"])
 
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 1
 
 
@@ -371,12 +406,12 @@ def test_filter_not_published_product_not_published_tomorrow(product, channel_US
     channel_listing.published_at = date_tomorrow
     channel_listing.save(update_fields=["is_published", "published_at"])
 
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 1
 
 
 def test_filter_not_published_product_is_published(product, channel_USD):
-    available_products = models.Product.objects.not_published(channel_USD.slug)
+    available_products = models.Product.objects.not_published(channel_USD)
     assert available_products.count() == 0
 
 
@@ -387,18 +422,18 @@ def test_filter_not_published_product_is_unpublished_other_channel(
         product=product, channel=channel_PLN, is_published=False
     )
 
-    available_products_usd = models.Product.objects.not_published(channel_USD.slug)
+    available_products_usd = models.Product.objects.not_published(channel_USD)
     assert available_products_usd.count() == 0
 
-    available_products_pln = models.Product.objects.not_published(channel_PLN.slug)
+    available_products_pln = models.Product.objects.not_published(channel_PLN)
     assert available_products_pln.count() == 1
 
 
 def test_filter_not_published_product_without_assigned_channel(
     product, channel_USD, channel_PLN
 ):
-    not_available_products_usd = models.Product.objects.not_published(channel_USD.slug)
+    not_available_products_usd = models.Product.objects.not_published(channel_USD)
     assert not_available_products_usd.count() == 0
 
-    not_available_products_pln = models.Product.objects.not_published(channel_PLN.slug)
+    not_available_products_pln = models.Product.objects.not_published(channel_PLN)
     assert not_available_products_pln.count() == 1


### PR DESCRIPTION
I want to merge this change because porting https://github.com/saleor/saleor/pull/15787

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
