### PR TITLE
Change value type from float to str in test

### DIFF
--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -652,7 +652,7 @@ def test_external_shipping_method_called_only_once_during_tax_calculations(
     mock_send_webhook_request_sync.side_effect = (
         [
             {
-                "amount": 1337.0,
+                "amount": "1337.0",
                 "currency": "USD",
                 "id": external_method_id,
                 "name": "Shipping app method 1",
@@ -660,10 +660,10 @@ def test_external_shipping_method_called_only_once_during_tax_calculations(
         ],
         {
             "lines": [
-                {"tax_rate": 0, "total_gross_amount": 21.6, "total_net_amount": 20}
+                {"tax_rate": 0, "total_gross_amount": "21.6", "total_net_amount": 20}
             ],
-            "shipping_price_gross_amount": 1443.96,
-            "shipping_price_net_amount": 1337,
+            "shipping_price_gross_amount": "1443.96",
+            "shipping_price_net_amount": "1337",
             "shipping_tax_rate": 0,
         },
     )


### PR DESCRIPTION
I want to merge this change because test was producing warning because of value type.
```python
saleor/checkout/tests/test_calculations.py::test_external_shipping_method_called_only_once_during_tax_calculations
  /app/saleor/saleor/webhook/transport/shipping.py:72: RuntimeWarning: float passed as value to Money, consider using Decimal
    price=Money(method_amount, method_currency),
```

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
