### PR TITLE
Valid address items extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Calculate order promotions in draft orders - #15459 by @zedzior
 - Prevent name overwriting of Product Variants when Updating Product Types - #15670 by @teddyondieki
 - Added support for the `BrokerProperties` custom header to webhooks to support Azure Service Bus - #15899 by @patrys
+- Extend valid address values - #15877 by @zedzior
 
 # 3.19.0
 

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -202,9 +202,8 @@ class CountryAwareAddressForm(AddressForm):
         if custom_names := VALID_ADDRESS_EXTENSION_MAP.get(country_code):
             for field_name, mapping in custom_names.items():
                 actual_value = data.get(field_name, "").strip().lower()
-                mapping_adjusted = {k.strip().lower(): v for k, v in mapping.items()}
-                if actual_value in mapping_adjusted:
-                    data[field_name] = mapping_adjusted[actual_value]
+                if actual_value in mapping:
+                    data[field_name] = mapping[actual_value]
 
 
 def get_address_form_class(country_code):

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -7,6 +7,7 @@ from django.forms import BoundField
 from django.forms.models import ModelFormMetaclass
 from django_countries import countries
 
+from .i18n_custom_names import custom_address_names_map
 from .models import Address
 from .validators import validate_possible_number
 from .widgets import DatalistTextWidget
@@ -179,6 +180,7 @@ class CountryAwareAddressForm(AddressForm):
             if street_address_1 or street_address_2:
                 data["street_address"] = f"{street_address_1}\n{street_address_2}"
 
+            self.substitute_invalid_values(data)
             normalized_data = i18naddress.normalize_address(data)
             if getattr(self, "enable_normalization", True):
                 data = normalized_data
@@ -190,6 +192,19 @@ class CountryAwareAddressForm(AddressForm):
     def clean(self):
         data = super().clean()
         return self.validate_address(data)
+
+    @staticmethod
+    def substitute_invalid_values(data):
+        """Map invalid address names to the values accepted by i18naddress package."""
+        country_code = data["country_code"]
+        if not country_code:
+            return
+
+        if custom_names := custom_address_names_map.get(country_code):
+            for field_name, mapping in custom_names.items():
+                actual_value = data.get(field_name)
+                if actual_value in mapping:
+                    data[field_name] = mapping[actual_value]
 
 
 def get_address_form_class(country_code):

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -7,7 +7,7 @@ from django.forms import BoundField
 from django.forms.models import ModelFormMetaclass
 from django_countries import countries
 
-from .i18n_custom_names import custom_address_names_map
+from .i18n_custom_names import CUSTOM_ADDRESS_NAME_MAP
 from .models import Address
 from .validators import validate_possible_number
 from .widgets import DatalistTextWidget
@@ -199,8 +199,7 @@ class CountryAwareAddressForm(AddressForm):
         country_code = data["country_code"]
         if not country_code:
             return
-
-        if custom_names := custom_address_names_map.get(country_code):
+        if custom_names := CUSTOM_ADDRESS_NAME_MAP.get(country_code):
             for field_name, mapping in custom_names.items():
                 actual_value = data.get(field_name)
                 if actual_value in mapping:

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -7,7 +7,7 @@ from django.forms import BoundField
 from django.forms.models import ModelFormMetaclass
 from django_countries import countries
 
-from .i18n_custom_names import CUSTOM_ADDRESS_NAME_MAP
+from .i18n_valid_address_extension import VALID_ADDRESS_EXTENSION_MAP
 from .models import Address
 from .validators import validate_possible_number
 from .widgets import DatalistTextWidget
@@ -199,7 +199,7 @@ class CountryAwareAddressForm(AddressForm):
         country_code = data["country_code"]
         if not country_code:
             return
-        if custom_names := CUSTOM_ADDRESS_NAME_MAP.get(country_code):
+        if custom_names := VALID_ADDRESS_EXTENSION_MAP.get(country_code):
             for field_name, mapping in custom_names.items():
                 actual_value = data.get(field_name)
                 if actual_value in mapping:

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -201,9 +201,10 @@ class CountryAwareAddressForm(AddressForm):
             return
         if custom_names := VALID_ADDRESS_EXTENSION_MAP.get(country_code):
             for field_name, mapping in custom_names.items():
-                actual_value = data.get(field_name)
-                if actual_value in mapping:
-                    data[field_name] = mapping[actual_value]
+                actual_value = data.get(field_name, "").strip().lower()
+                mapping_adjusted = {k.strip().lower(): v for k, v in mapping.items()}
+                if actual_value in mapping_adjusted:
+                    data[field_name] = mapping_adjusted[actual_value]
 
 
 def get_address_form_class(country_code):

--- a/saleor/account/i18n_custom_names.py
+++ b/saleor/account/i18n_custom_names.py
@@ -1,13 +1,15 @@
+from enum import Enum
+
 from ..graphql.account.enums import CountryCodeEnum
 
 
-class AddressFieldsToSubstitute:
+class AddressFieldsToSubstitute(Enum):
     CITY = "city"
     CITY_AREA = "city_area"
     COUNTRY_AREA = "country_area"
 
 
-IE_country_area = {
+IE_COUNTRY_AREA = {
     "Carlow": "Co. Carlow",
     "Cavan": "Co. Cavan",
     "Clare": "Co. Clare",
@@ -36,6 +38,8 @@ IE_country_area = {
     "Wicklow": "Co. Wicklow",
 }
 
-custom_address_names_map = {
-    CountryCodeEnum.IE.value: {AddressFieldsToSubstitute.COUNTRY_AREA: IE_country_area}
+CUSTOM_ADDRESS_NAME_MAP: dict[CountryCodeEnum, dict[str, dict[str, str]]] = {
+    CountryCodeEnum.IE.value: {
+        AddressFieldsToSubstitute.COUNTRY_AREA.value: IE_COUNTRY_AREA
+    }
 }

--- a/saleor/account/i18n_custom_names.py
+++ b/saleor/account/i18n_custom_names.py
@@ -1,0 +1,41 @@
+from ..graphql.account.enums import CountryCodeEnum
+
+
+class AddressFieldsToSubstitute:
+    CITY = "city"
+    CITY_AREA = "city_area"
+    COUNTRY_AREA = "country_area"
+
+
+IE_country_area = {
+    "Carlow": "Co. Carlow",
+    "Cavan": "Co. Cavan",
+    "Clare": "Co. Clare",
+    "Cork": "Co. Cork",
+    "Donegal": "Co. Donegal",
+    "Dublin": "Co. Dublin",
+    "Galway": "Co. Galway",
+    "Kerry": "Co. Kerry",
+    "Kildare": "Co. Kildare",
+    "Kilkenny": "Co. Kilkenny",
+    "Laois": "Co. Laois",
+    "Leitrim": "Co. Leitrim",
+    "Limerick": "Co. Limerick",
+    "Longford": "Co. Longford",
+    "Louth": "Co. Louth",
+    "Mayo": "Co. Mayo",
+    "Meath": "Co. Meath",
+    "Monaghan": "Co. Monaghan",
+    "Offaly": "Co. Offaly",
+    "Roscommon": "Co. Roscommon",
+    "Sligo": "Co. Sligo",
+    "Tipperary": "Co. Tipperary",
+    "Waterford": "Co. Waterford",
+    "Westmeath": "Co. Westmeath",
+    "Wexford": "Co. Wexford",
+    "Wicklow": "Co. Wicklow",
+}
+
+custom_address_names_map = {
+    CountryCodeEnum.IE.value: {AddressFieldsToSubstitute.COUNTRY_AREA: IE_country_area}
+}

--- a/saleor/account/i18n_valid_address_extension.py
+++ b/saleor/account/i18n_valid_address_extension.py
@@ -38,7 +38,7 @@ IE_COUNTRY_AREA = {
     "Wicklow": "Co. Wicklow",
 }
 
-CUSTOM_ADDRESS_NAME_MAP: dict[CountryCodeEnum, dict[str, dict[str, str]]] = {
+VALID_ADDRESS_EXTENSION_MAP: dict[CountryCodeEnum, dict[str, dict[str, str]]] = {
     CountryCodeEnum.IE.value: {
         AddressFieldsToSubstitute.COUNTRY_AREA.value: IE_COUNTRY_AREA
     }

--- a/saleor/account/i18n_valid_address_extension.py
+++ b/saleor/account/i18n_valid_address_extension.py
@@ -36,6 +36,7 @@ IE_COUNTRY_AREA = {
     "Wexford": "Co. Wexford",
     "Wicklow": "Co. Wicklow",
 }
+IE_COUNTRY_AREA = {k.strip().lower(): v for k, v in IE_COUNTRY_AREA.items()}
 
 VALID_ADDRESS_EXTENSION_MAP: dict[str, dict[str, dict[str, str]]] = {
     CountryCodeEnum.IE.value: {

--- a/saleor/account/i18n_valid_address_extension.py
+++ b/saleor/account/i18n_valid_address_extension.py
@@ -4,7 +4,6 @@ from ..graphql.account.enums import CountryCodeEnum
 
 
 class AddressFieldsToSubstitute(Enum):
-    CITY = "city"
     CITY_AREA = "city_area"
     COUNTRY_AREA = "country_area"
 
@@ -38,7 +37,7 @@ IE_COUNTRY_AREA = {
     "Wicklow": "Co. Wicklow",
 }
 
-VALID_ADDRESS_EXTENSION_MAP: dict[CountryCodeEnum, dict[str, dict[str, str]]] = {
+VALID_ADDRESS_EXTENSION_MAP: dict[str, dict[str, dict[str, str]]] = {
     CountryCodeEnum.IE.value: {
         AddressFieldsToSubstitute.COUNTRY_AREA.value: IE_COUNTRY_AREA
     }

--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -9,7 +9,7 @@ from django_countries.fields import Country
 
 from ...order.models import Order
 from .. import forms, i18n
-from ..i18n_custom_names import CUSTOM_ADDRESS_NAME_MAP
+from ..i18n_valid_address_extension import VALID_ADDRESS_EXTENSION_MAP
 from ..models import User
 from ..validators import validate_possible_number
 
@@ -325,7 +325,7 @@ def test_customers_show_staff_with_order(admin_user, channel_USD):
     ],
 )
 @patch.dict(
-    CUSTOM_ADDRESS_NAME_MAP,
+    VALID_ADDRESS_EXTENSION_MAP,
     {"IE": {"country_area": {"Dublin": "Co. Dublin"}, "city_area": {"dummy": "dummy"}}},
 )
 def test_substitute_invalid_values(country_area_input, country_area_output, is_valid):
@@ -348,3 +348,5 @@ def test_substitute_invalid_values(country_area_input, country_area_output, is_v
     assert form.cleaned_data.get("country_area") == country_area_output
     if not is_valid:
         assert "country_area" in errors
+    else:
+        assert not errors

--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -330,7 +330,7 @@ def test_customers_show_staff_with_order(admin_user, channel_USD):
 )
 @patch.dict(
     VALID_ADDRESS_EXTENSION_MAP,
-    {"IE": {"country_area": {"Dublin": "Co. Dublin"}, "city_area": {"dummy": "dummy"}}},
+    {"IE": {"country_area": {"dublin": "Co. Dublin"}, "city_area": {"dummy": "dummy"}}},
 )
 def test_substitute_invalid_values(country_area_input, country_area_output, is_valid):
     # given

--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -322,6 +322,10 @@ def test_customers_show_staff_with_order(admin_user, channel_USD):
         ("Dublin", "Co. Dublin", True),
         ("Co. Dublin", "Co. Dublin", True),
         ("Dummy Area", None, False),
+        ("dublin", "Co. Dublin", True),
+        (" dublin ", "Co. Dublin", True),
+        ("", "", True),
+        (None, "", True),
     ],
 )
 @patch.dict(

--- a/saleor/graphql/warehouse/tests/mutations/test_warehouse_create.py
+++ b/saleor/graphql/warehouse/tests/mutations/test_warehouse_create.py
@@ -349,7 +349,7 @@ def test_create_warehouse_with_address_item_from_valid_address_extension_map(
     staff_api_client, permission_manage_products, shipping_zone
 ):
     # given
-    country_area = "Dublin"
+    country_area = "dublin"
     cleaned_country_area = "Co. Dublin"
     address = {
         "country": "IE",

--- a/saleor/graphql/warehouse/tests/mutations/test_warehouse_create.py
+++ b/saleor/graphql/warehouse/tests/mutations/test_warehouse_create.py
@@ -5,7 +5,7 @@ import graphene
 import pytest
 from django.utils.functional import SimpleLazyObject
 
-from .....account.i18n_custom_names import CUSTOM_ADDRESS_NAME_MAP
+from .....account.i18n_valid_address_extension import VALID_ADDRESS_EXTENSION_MAP
 from .....account.models import Address
 from .....core.utils.json_serializer import CustomJsonEncoder
 from .....warehouse.error_codes import WarehouseErrorCode
@@ -345,7 +345,7 @@ def test_create_warehouse_with_non_unique_external_reference(
     assert error["message"] == "Warehouse with this External reference already exists."
 
 
-def test_create_warehouse_with_address_item_from_custom_address_map(
+def test_create_warehouse_with_address_item_from_valid_address_extension_map(
     staff_api_client, permission_manage_products, shipping_zone
 ):
     # given
@@ -359,9 +359,9 @@ def test_create_warehouse_with_address_item_from_custom_address_map(
         "city": "Dublin",
     }
 
-    custom_ireland_country_areas = CUSTOM_ADDRESS_NAME_MAP["IE"]["country_area"]
-    assert country_area in custom_ireland_country_areas
-    assert custom_ireland_country_areas[country_area] == cleaned_country_area
+    ireland_country_areas_extension = VALID_ADDRESS_EXTENSION_MAP["IE"]["country_area"]
+    assert country_area in ireland_country_areas_extension
+    assert ireland_country_areas_extension[country_area] == cleaned_country_area
 
     variables = {
         "input": {


### PR DESCRIPTION
I want to merge this change, because there is a need to accept some specific address values, which do not pass `i18naddress` package's validation.

The PR adds dedicated map, which will be used to replace input value with the one accepted by `i18naddress` library.

To discuss:
The map embedded in python module will be difficult to maintain. 

Issue: https://linear.app/saleor/issue/MERX-258/bug-location-codes-not-mapped-in-i18n-validation-failing-validation

Docs: https://github.com/saleor/saleor-docs/pull/1151

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
