### PR TITLE
Fix discounts resolver to work like in docs

### DIFF
--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -375,16 +375,16 @@ class TaxableObject(BaseObjectType):
         if isinstance(root, Checkout):
 
             def calculate_checkout_discounts(checkout_info):
-                is_shipping_voucher = (
-                    checkout_info.voucher.type == VoucherType.SHIPPING
-                    if checkout_info.voucher
-                    else False
-                )
                 checkout = checkout_info.checkout
                 discount_name = checkout.discount_name
                 return (
                     [{"name": discount_name, "amount": checkout.discount}]
-                    if checkout.discount and not is_shipping_voucher
+                    if checkout.discount
+                    and (
+                        checkout_info.voucher
+                        and checkout_info.voucher.type == VoucherType.ENTIRE_ORDER
+                        and not checkout_info.voucher.apply_once_per_order
+                    )
                     else []
                 )
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -192,7 +192,7 @@ def test_checkout_calculate_taxes_with_free_shipping_voucher(
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_checkout_calculate_taxes_with_voucher(
+def test_checkout_calculate_taxes_with_entire_order_voucher(
     checkout_with_voucher,
     webhook_app,
     permission_handle_taxes,
@@ -233,6 +233,64 @@ def test_checkout_calculate_taxes_with_voucher(
                     },
                     "totalPrice": {"amount": 30.0},
                     "unitPrice": {"amount": 10.0},
+                    "variantName": "",
+                }
+            ],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": 0.0},
+            "sourceObject": {
+                "id": to_global_id_or_none(checkout_with_voucher),
+                "__typename": "Checkout",
+            },
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_calculate_taxes_with_entire_order_voucher_once_per_order(
+    voucher,
+    checkout_with_voucher,
+    webhook_app,
+    permission_handle_taxes,
+):
+    # given
+    webhook_app.permissions.add(permission_handle_taxes)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+    voucher.apply_once_per_order = True
+    voucher.save()
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(
+        event_type, checkout_with_voucher, webhook
+    )
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": None,
+            "currency": "USD",
+            "discounts": [],
+            "channel": {"id": to_global_id_or_none(checkout_with_voucher.channel)},
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": "Test product",
+                    "productSku": "123",
+                    "quantity": 3,
+                    "sourceLine": {
+                        "id": to_global_id_or_none(checkout_with_voucher.lines.first()),
+                        "__typename": "CheckoutLine",
+                    },
+                    "totalPrice": {"amount": 20.0},
+                    "unitPrice": {"amount": 6.67},
                     "variantName": "",
                 }
             ],


### PR DESCRIPTION
I want to merge this change because it fixes discounts resolver to work like in docs
more context: https://linear.app/saleor/issue/SHOPX-325/bug-discounts-field-behaviour-on-calculatetaxes-event-is-inconsistent

⚠️ This is a port of https://github.com/saleor/saleor/pull/15863

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
