### PR TITLE
Fix transactionUpdate/transactionCreate with empty metadata

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -136,8 +136,10 @@ class TransactionCreate(BaseMutation):
 
     @classmethod
     def validate_metadata_keys(  # type: ignore[override]
-        cls, metadata_list: list[dict], field_name, error_code
+        cls, metadata_list: Optional[list[dict]], field_name, error_code
     ):
+        if not metadata_list:
+            return
         if metadata_contains_empty_key(metadata_list):
             raise ValidationError(
                 {

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -195,6 +195,63 @@ def test_transaction_create_for_order_by_app(
     assert transaction.external_url == external_url
 
 
+def test_transaction_create_for_order_by_app_metadata_null_value(
+    order_with_lines, permission_manage_payments, app_api_client
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+        TransactionActionEnum.CHARGE.name,
+    ]
+    authorized_value = Decimal("10")
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "metadata": None,
+            "privateMetadata": None,
+            "externalUrl": external_url,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    available_actions = list(set(available_actions))
+
+    transaction = order_with_lines.payment_transactions.first()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]["transaction"]
+    assert data["actions"] == available_actions
+    assert data["pspReference"] == psp_reference
+    assert data["authorizedAmount"]["amount"] == authorized_value
+    assert data["externalUrl"] == external_url
+    assert data["createdBy"]["id"] == to_global_id_or_none(app_api_client.app)
+
+    assert available_actions == list(map(str.upper, transaction.available_actions))
+    assert psp_reference == transaction.psp_reference
+    assert authorized_value == transaction.authorized_value
+    assert transaction.metadata == {}
+    assert transaction.private_metadata == {}
+    assert transaction.app_identifier == app_api_client.app.identifier
+    assert transaction.app == app_api_client.app
+    assert transaction.user is None
+    assert transaction.external_url == external_url
+
+
 def test_transaction_create_for_order_updates_order_total_authorized_by_app(
     order_with_lines, permission_manage_payments, app_api_client
 ):
@@ -345,6 +402,67 @@ def test_transaction_create_for_checkout_by_app(
     assert transaction.private_metadata == {
         private_metadata["key"]: private_metadata["value"]
     }
+    assert transaction.external_url == external_url
+    assert transaction.app_identifier == app_api_client.app.identifier
+    assert transaction.app == app_api_client.app
+    assert transaction.user is None
+
+
+def test_transaction_create_for_checkout_by_app_metadata_null_value(
+    checkout_with_items, permission_manage_payments, app_api_client
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+        TransactionActionEnum.CHARGE.name,
+    ]
+    authorized_value = Decimal("10")
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "metadata": None,
+            "privateMetadata": None,
+            "externalUrl": external_url,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    assert checkout_with_items.charge_status == CheckoutChargeStatus.NONE
+    assert checkout_with_items.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+
+    available_actions = list(set(available_actions))
+
+    transaction = checkout_with_items.payment_transactions.first()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]["transaction"]
+    assert data["actions"] == available_actions
+    assert data["pspReference"] == psp_reference
+    assert data["authorizedAmount"]["amount"] == authorized_value
+    assert data["externalUrl"] == external_url
+    assert data["createdBy"]["id"] == to_global_id_or_none(app_api_client.app)
+
+    assert available_actions == list(map(str.upper, transaction.available_actions))
+    assert psp_reference == transaction.psp_reference
+    assert authorized_value == transaction.authorized_value
+    assert transaction.metadata == {}
+    assert transaction.private_metadata == {}
     assert transaction.external_url == external_url
     assert transaction.app_identifier == app_api_client.app.identifier
     assert transaction.app == app_api_client.app

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -241,6 +241,31 @@ def test_transaction_update_metadata_by_app(
     assert transaction_item_created_by_app.metadata == {meta_key: meta_value}
 
 
+def test_transaction_update_metadata_by_app_null_value(
+    transaction_item_created_by_app, permission_manage_payments, app_api_client
+):
+    # given
+    transaction = transaction_item_created_by_app
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            "metadata": None,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    transaction.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionUpdate"]["transaction"]
+    assert len(data["metadata"]) == 0
+
+
 def test_transaction_update_metadata_incorrect_key_by_app(
     transaction_item_created_by_app, permission_manage_payments, app_api_client
 ):
@@ -298,6 +323,33 @@ def test_transaction_update_private_metadata_by_app(
     assert data["privateMetadata"][0]["key"] == meta_key
     assert data["privateMetadata"][0]["value"] == meta_value
     assert transaction_item_created_by_app.private_metadata == {meta_key: meta_value}
+
+
+def test_transaction_update_private_metadata_by_app_null_value(
+    transaction_item_created_by_app, permission_manage_payments, app_api_client
+):
+    # given
+    transaction = transaction_item_created_by_app
+    transaction.private_metadata = {"key": "value"}
+    transaction.save(update_fields=["private_metadata"])
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            "privateMetadata": None,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    transaction.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionUpdate"]["transaction"]
+    assert len(data["privateMetadata"]) == 1
 
 
 def test_transaction_update_private_metadata_incorrect_key_by_app(


### PR DESCRIPTION
I want to merge this change because it fixes fields metadata and private_metadata breaking when null (allowed by schema) is provided in the mutation (500).

Context: https://linear.app/saleor/issue/SHOPX-550/null-in-metadata-returns-a-internal-server-error-mutation

⚠️ This is a port of https://github.com/saleor/saleor/pull/15875

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
