### PR TITLE
Add missing locks for price recalculation

### DIFF
--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.utils import timezone
 
@@ -181,8 +182,12 @@ def update_variant_relations_for_active_promotion_rules_task():
         channel_to_product_map = _get_channel_to_products_map(
             existing_variant_relation + new_rule_to_variant_list
         )
+        with transaction.atomic():
+            _promotion_rules = list(
+                PromotionRule.objects.select_for_update(of=("self",)).filter(pk__in=ids)
+            )
+            PromotionRule.objects.filter(pk__in=ids).update(variants_dirty=False)
 
-        PromotionRule.objects.filter(pk__in=ids).update(variants_dirty=False)
         mark_products_in_channels_as_dirty(channel_to_product_map, allow_replica=True)
         update_variant_relations_for_active_promotion_rules_task.delay()
 
@@ -220,9 +225,15 @@ def recalculate_discounted_price_for_products_task():
             settings.DATABASE_CONNECTION_REPLICA_NAME
         ).filter(id__in=products_ids)
         update_discounted_prices_for_promotion(products, only_dirty_products=True)
-        ProductChannelListing.objects.filter(id__in=listing_ids).update(
-            discounted_price_dirty=False
-        )
+        with transaction.atomic():
+            _channel_listings = list(
+                ProductChannelListing.objects.select_for_update(of=("self",)).filter(
+                    id__in=listing_ids
+                )
+            )
+            ProductChannelListing.objects.filter(id__in=listing_ids).update(
+                discounted_price_dirty=False
+            )
         recalculate_discounted_price_for_products_task.delay()
 
 

--- a/saleor/product/utils/product.py
+++ b/saleor/product/utils/product.py
@@ -123,11 +123,12 @@ def mark_products_in_channels_as_dirty(
 
     if listing_ids_to_update:
         with transaction.atomic():
-            _channel_listings = list(
-                ProductChannelListing.objects.select_for_update(of=("self",)).filter(
-                    id__in=listing_ids_to_update
-                )
+            channel_listing_ids = list(
+                ProductChannelListing.objects.select_for_update(of=("self",))
+                .filter(id__in=listing_ids_to_update, discounted_price_dirty=False)
+                .order_by("pk")
+                .values_list("id", flat=True)
             )
-            ProductChannelListing.objects.filter(id__in=listing_ids_to_update).update(
+            ProductChannelListing.objects.filter(id__in=channel_listing_ids).update(
                 discounted_price_dirty=True
             )

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -117,11 +117,13 @@ def _update_or_create_listings(
 ):
     if changed_products_listings_to_update:
         ProductChannelListing.objects.bulk_update(
-            changed_products_listings_to_update, ["discounted_price_amount"]
+            sorted(changed_products_listings_to_update, key=lambda listing: listing.id),
+            ["discounted_price_amount"],
         )
     if changed_variants_listings_to_update:
         ProductVariantChannelListing.objects.bulk_update(
-            changed_variants_listings_to_update, ["discounted_price_amount"]
+            sorted(changed_variants_listings_to_update, key=lambda listing: listing.id),
+            ["discounted_price_amount"],
         )
     if changed_variant_listing_promotion_rule_to_create:
         _create_variant_listing_promotion_rule(
@@ -129,7 +131,11 @@ def _update_or_create_listings(
         )
     if changed_variant_listing_promotion_rule_to_update:
         VariantChannelListingPromotionRule.objects.bulk_update(
-            changed_variant_listing_promotion_rule_to_update, ["discount_amount"]
+            sorted(
+                changed_variant_listing_promotion_rule_to_update,
+                key=lambda listing: listing.id,
+            ),
+            ["discount_amount"],
         )
 
 


### PR DESCRIPTION
I want to merge this change because it adds missing locks for logic responsible for price recalculations

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
