### PR TITLE
Fix passing args to list_stored_payment_methods

### DIFF
--- a/saleor/graphql/account/tests/queries/test_me.py
+++ b/saleor/graphql/account/tests/queries/test_me.py
@@ -375,9 +375,7 @@ def test_me_query_stored_payment_methods(
     )
 
     # then
-    mocked_list_stored_payment_methods.assert_called_once_with(
-        request_data, channel_slug=channel_USD.slug
-    )
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
     content = get_graphql_content(response)
 
     data = content["data"]["me"]

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -15,6 +15,7 @@ from ...order import OrderStatus
 from ...payment.interface import ListStoredPaymentMethodsRequestData
 from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import AccountPermissions, AppPermission, OrderPermissions
+from ...plugins.manager import PluginsManager
 from ...thumbnail.utils import (
     get_image_or_proxy_url,
     get_thumbnail_format,
@@ -701,15 +702,13 @@ class User(ModelObjectType[models.User]):
         if not requestor or requestor.id != root.id:
             return []
 
-        def get_stored_payment_methods(data):
+        def get_stored_payment_methods(data: tuple[Channel, "PluginsManager"]):
             channel_obj, manager = data
             request_data = ListStoredPaymentMethodsRequestData(
                 user=root,
                 channel=channel_obj,
             )
-            return manager.list_stored_payment_methods(
-                request_data, channel_slug=channel
-            )
+            return manager.list_stored_payment_methods(request_data)
 
         return Promise.all(
             [

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2708,9 +2708,7 @@ def test_checkout_with_stored_payment_methods_empty_response(
     # then
     content = get_graphql_content(response)
 
-    mocked_list_stored_payment_methods.assert_called_once_with(
-        request_data, channel_slug=checkout_with_prices.channel.slug
-    )
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
     assert content["data"]["checkout"]["storedPaymentMethods"] == []
 
 
@@ -2781,9 +2779,7 @@ def test_checkout_with_stored_payment_methods(
     # then
     content = get_graphql_content(response)
 
-    mocked_list_stored_payment_methods.assert_called_once_with(
-        request_data, channel_slug=checkout_with_prices.channel.slug
-    )
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
     assert content["data"]["checkout"]["storedPaymentMethods"] == [
         {
             "id": payment_method_id,

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 import graphene
 from promise import Promise
 
+from ...account.models import User
 from ...checkout import calculations, models, problems
 from ...checkout.base_calculations import (
     calculate_undiscounted_base_line_total_price,
@@ -1282,15 +1283,15 @@ class Checkout(ModelObjectType[models.Checkout]):
         if not requestor or requestor.id != root.user_id:
             return []
 
-        def _resolve_stored_payment_methods(data):
+        def _resolve_stored_payment_methods(
+            data: tuple["Channel", "User", "PluginsManager"],
+        ):
             channel, user, manager = data
             request_data = ListStoredPaymentMethodsRequestData(
                 user=user,
                 channel=channel,
             )
-            return manager.list_stored_payment_methods(
-                request_data, channel_slug=channel.slug
-            )
+            return manager.list_stored_payment_methods(request_data)
 
         manager = get_plugin_manager_promise(info.context)
         channel_loader = ChannelByIdLoader(info.context).load(root.channel_id)


### PR DESCRIPTION
The `list_stored_payment_methods` call was getting an unexpected argument.
Fixes: https://saleor.sentry.io/issues/5282199095/events/7b19b83d90b74f2199c940156dc75709/

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
