### PR TITLE
Save Atobarai gateway response in transaction object

### DIFF
--- a/saleor/payment/gateways/np_atobarai/api_helpers.py
+++ b/saleor/payment/gateways/np_atobarai/api_helpers.py
@@ -73,15 +73,16 @@ def _request(
 def np_request(
     config: "ApiConfig", method: str, path: str = "", json: Optional[dict] = None
 ) -> NPResponse:
+    response_data = {}
     try:
         response = _request(config, method, path, json)
         response_data = response.json()
         if "errors" in response_data:
-            return NPResponse({}, response_data["errors"][0]["codes"])
-        return NPResponse(response_data["results"][0], [])
+            return NPResponse({}, response_data["errors"][0]["codes"], response_data)
+        return NPResponse(response_data["results"][0], [], response_data)
     except requests.RequestException:
         logger.warning("Cannot connect to NP Atobarai.", exc_info=True)
-        return NPResponse({}, [NP_CONNECTION_ERROR])
+        return NPResponse({}, [NP_CONNECTION_ERROR], response_data)
 
 
 def handle_unrecoverable_state(

--- a/saleor/payment/gateways/np_atobarai/api_types.py
+++ b/saleor/payment/gateways/np_atobarai/api_types.py
@@ -18,10 +18,11 @@ from .const import (
 class NPResponse(NamedTuple):
     result: dict
     error_codes: list[str]
+    raw_response: dict
 
 
 def error_np_response(error_message: str) -> NPResponse:
-    return NPResponse({}, [error_message])
+    return NPResponse({}, [error_message], {})
 
 
 @dataclass
@@ -51,11 +52,15 @@ class PaymentResult:
 
 
 def error_payment_result(error_message: str) -> PaymentResult:
-    return PaymentResult(status=PaymentStatus.FAILED, errors=[error_message])
+    return PaymentResult(
+        status=PaymentStatus.FAILED, errors=[error_message], raw_response={}
+    )
 
 
-def errors_payment_result(errors: list[str]) -> PaymentResult:
-    return PaymentResult(status=PaymentStatus.FAILED, errors=errors)
+def errors_payment_result(errors: list[str], response: dict) -> PaymentResult:
+    return PaymentResult(
+        status=PaymentStatus.FAILED, errors=errors, raw_response=response
+    )
 
 
 def get_api_config(connection_params: dict) -> ApiConfig:

--- a/saleor/payment/gateways/np_atobarai/tests/test_api.py
+++ b/saleor/payment/gateways/np_atobarai/tests/test_api.py
@@ -30,10 +30,11 @@ def test_refund_payment(
     payment_data.amount = payment_dummy.captured_amount
     psp_reference = "18121200001"
     payment_data.psp_reference = psp_reference
+    response_value = {"results": [{"np_transaction_id": psp_reference}]}
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(return_value={"results": [{"np_transaction_id": psp_reference}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -42,6 +43,7 @@ def test_refund_payment(
 
     # then
     assert gateway_response.is_success
+    assert gateway_response.raw_response == response_value
 
 
 def test_refund_payment_no_order(np_atobarai_plugin, np_payment_data, payment_dummy):
@@ -59,17 +61,18 @@ def test_refund_payment_no_order(np_atobarai_plugin, np_payment_data, payment_du
 
 
 @patch("saleor.payment.gateways.np_atobarai.api_helpers.requests.request")
-def test_refund_payment_payment_not_created(
+def test_refund_payment_no_psp_reference_payment_not_created(
     mocked_request, np_atobarai_plugin, np_payment_data, payment_dummy
 ):
     # given
     plugin = np_atobarai_plugin()
     payment_data = np_payment_data
     payment_data.amount = payment_dummy.captured_amount
+    response_value = {"results": [{"np_transaction_id": "18121200001"}]}
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(return_value={"results": [{"np_transaction_id": "18121200001"}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -78,6 +81,7 @@ def test_refund_payment_payment_not_created(
 
     # then
     assert not gateway_response.is_success
+    assert not gateway_response.raw_response
 
 
 @patch.object(HTTPSession, "request")
@@ -210,10 +214,11 @@ def test_report_fulfillment(mocked_request, config, fulfillment, payment_dummy):
     psp_reference = "18121200001"
     payment_dummy.psp_reference = psp_reference
     payment_dummy.save(update_fields=["psp_reference"])
+    response_value = {"results": [{"np_transaction_id": psp_reference}]}
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(return_value={"results": [{"np_transaction_id": psp_reference}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -235,10 +240,11 @@ def test_report_fulfillment_invalid_shipping_company_code(
     psp_reference = "18121200001"
     payment_dummy.psp_reference = psp_reference
     payment_dummy.save(update_fields=["psp_reference"])
+    response_value = {"results": [{"np_transaction_id": psp_reference}]}
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(return_value={"results": [{"np_transaction_id": psp_reference}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
     fulfillment.store_value_in_private_metadata(
@@ -298,10 +304,11 @@ def test_report_fulfillment_np_errors(
     payment_dummy.psp_reference = psp_reference
     payment_dummy.save(update_fields=["psp_reference"])
     error_codes = ["EPRO0101", "EPRO0102"]
+    response_value = {"errors": [{"codes": error_codes}]}
     response = Mock(
         spec=requests.Response,
         status_code=400,
-        json=Mock(return_value={"errors": [{"codes": error_codes}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -349,10 +356,11 @@ def test_report_fulfillment_already_captured(
 ):
     # given
     payment_dummy.psp_reference = "123123123"
+    response_value = {"errors": [{"codes": ["E0100115"]}]}
     response = Mock(
         spec=requests.Response,
         status_code=400,
-        json=Mock(return_value={"errors": [{"codes": ["E0100115"]}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -497,19 +505,18 @@ def test_change_transaction_success(
     mocked_request, config, payment_dummy, np_payment_data
 ):
     # given
+    response_value = {
+        "results": [
+            {
+                "authori_result": "00",
+                "np_transaction_id": payment_dummy.psp_reference,
+            }
+        ]
+    }
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(
-            return_value={
-                "results": [
-                    {
-                        "authori_result": "00",
-                        "np_transaction_id": payment_dummy.psp_reference,
-                    }
-                ]
-            }
-        ),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -520,6 +527,8 @@ def test_change_transaction_success(
 
     # then
     assert payment_response.status == PaymentStatus.SUCCESS
+    assert payment_response.raw_response == response_value
+    assert payment_response.raw_response == response_value
 
 
 @patch("saleor.payment.gateways.np_atobarai.api.cancel")
@@ -529,23 +538,22 @@ def test_change_transaction_pending(
 ):
     # given
     transaction_id = "123"
+    response_value = {
+        "results": [
+            {
+                "authori_result": "10",
+                "np_transaction_id": transaction_id,
+                "authori_hold": [
+                    "RE009",
+                    "REE021",
+                ],
+            }
+        ]
+    }
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(
-            return_value={
-                "results": [
-                    {
-                        "authori_result": "10",
-                        "np_transaction_id": transaction_id,
-                        "authori_hold": [
-                            "RE009",
-                            "REE021",
-                        ],
-                    }
-                ]
-            }
-        ),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -557,6 +565,7 @@ def test_change_transaction_pending(
     # then
     mocked_cancel.assert_called_once_with(config, transaction_id)
     assert payment_response.status == PaymentStatus.FAILED
+    assert payment_response.raw_response == response_value
 
 
 @patch.object(HTTPSession, "request")
@@ -564,10 +573,11 @@ def test_change_transaction_post_fulfillment(
     mocked_request, config, payment_dummy, np_payment_data
 ):
     # given
+    response_value = {"errors": [{"codes": ["E0100115"]}]}
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(return_value={"errors": [{"codes": ["E0100115"]}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -578,6 +588,7 @@ def test_change_transaction_post_fulfillment(
 
     # then
     assert payment_response.status == PaymentStatus.FOR_REREGISTRATION
+    assert payment_response.raw_response == response_value
 
 
 @patch.object(HTTPSession, "request")
@@ -585,10 +596,11 @@ def test_change_transaction_failed(
     mocked_request, config, payment_dummy, np_payment_data
 ):
     # given
+    response_value = {"errors": [{"codes": ["E0100050"]}]}
     response = Mock(
         spec=requests.Response,
         status_code=200,
-        json=Mock(return_value={"errors": [{"codes": ["E0100050"]}]}),
+        json=Mock(return_value=response_value),
     )
     mocked_request.return_value = response
 
@@ -600,6 +612,7 @@ def test_change_transaction_failed(
     # then
     assert payment_response.status == PaymentStatus.FAILED
     assert payment_response.errors
+    assert payment_response.raw_response == response_value
 
 
 @patch("saleor.payment.gateways.np_atobarai.api.report")
@@ -618,14 +631,29 @@ def test_reregister_transaction_success(
     shipping_company_code = "50000"
     payment_dummy.psp_reference = "123"
     new_psp_reference = "234"
-    mocked_cancel.return_value = NPResponse(result={}, error_codes=[])
+    mocked_cancel.return_value = NPResponse(result={}, error_codes=[], raw_response={})
+    transaction_id = "18121200001"
+    register_response_value = {
+        "results": [
+            {
+                "shop_transaction_id": "abc1234567890",
+                "np_transaction_id": transaction_id,
+                "authori_result": "00",
+                "authori_required_date": "2018-12-12T12:00:00+09:00",
+            }
+        ]
+    }
     mocked_register.return_value = NPResponse(
         result={
             "np_transaction_id": new_psp_reference,
         },
         error_codes=[],
+        raw_response=register_response_value,
     )
-    mocked_report.return_value = NPResponse(result={}, error_codes=[])
+    report_response_value = {"results": [{"np_transaction_id": transaction_id}]}
+    mocked_report.return_value = NPResponse(
+        result={}, error_codes=[], raw_response=report_response_value
+    )
 
     # when
     goods, billed_amount = get_goods_with_refunds(
@@ -654,6 +682,7 @@ def test_reregister_transaction_success(
     )
     assert payment_response.status == PaymentStatus.SUCCESS
     assert payment_response.psp_reference == new_psp_reference
+    assert payment_response.raw_response == report_response_value
 
 
 def test_reregister_transaction_no_psp_reference(payment_dummy, np_payment_data):
@@ -680,7 +709,9 @@ def test_reregister_transaction_cancel_error(
     # given
     payment_dummy.psp_reference = "123"
     error_codes = ["1", "2", "3"]
-    mocked_cancel.return_value = NPResponse(result={}, error_codes=error_codes)
+    mocked_cancel.return_value = NPResponse(
+        result={}, error_codes=error_codes, raw_response={}
+    )
 
     # when
     payment_response = api.reregister_transaction_for_partial_return(
@@ -709,14 +740,17 @@ def test_reregister_transaction_report_error(
     payment_dummy.psp_reference = "123"
     new_psp_reference = "234"
     error_codes = ["1", "2", "3"]
-    mocked_cancel.return_value = NPResponse(result={}, error_codes=[])
+    mocked_cancel.return_value = NPResponse(result={}, error_codes=[], raw_response={})
     mocked_register.return_value = NPResponse(
         result={
             "np_transaction_id": new_psp_reference,
         },
         error_codes=[],
+        raw_response={},
     )
-    mocked_report.return_value = NPResponse(result={}, error_codes=error_codes)
+    mocked_report.return_value = NPResponse(
+        result={}, error_codes=error_codes, raw_response={}
+    )
 
     # when
     payment_response = api.reregister_transaction_for_partial_return(
@@ -745,9 +779,11 @@ def test_reregister_transaction_general_error(
 ):
     # given
     payment_dummy.psp_reference = "123"
-    mocked_cancel.return_value = NPResponse(result={}, error_codes=[])
+    mocked_cancel.return_value = NPResponse(result={}, error_codes=[], raw_response={})
     error_codes = ["1", "2", "3"]
-    mocked_register.return_value = NPResponse(result={}, error_codes=error_codes)
+    mocked_register.return_value = NPResponse(
+        result={}, error_codes=error_codes, raw_response={}
+    )
 
     # when
     payment_response = api.reregister_transaction_for_partial_return(
@@ -772,8 +808,10 @@ def test_register_transaction_pending(
         "np_transaction_id": transaction_id,
         "authori_hold": errors,
     }
-    mocked_register.return_value = NPResponse(result=register_result, error_codes=[])
-    mocked_cancel.return_value = NPResponse(result={}, error_codes=[])
+    mocked_register.return_value = NPResponse(
+        result=register_result, error_codes=[], raw_response={}
+    )
+    mocked_cancel.return_value = NPResponse(result={}, error_codes=[], raw_response={})
 
     # when
     payment_response = api.register_transaction(config, np_payment_data)
@@ -798,9 +836,13 @@ def test_register_transaction_pending_unrecoverable(
         "np_transaction_id": transaction_id,
         "authori_hold": errors,
     }
-    mocked_register.return_value = NPResponse(result=register_result, error_codes=[])
+    mocked_register.return_value = NPResponse(
+        result=register_result, error_codes=[], raw_response=register_result
+    )
     cancel_errors = ["1", "2", "3"]
-    mocked_cancel.return_value = NPResponse(result={}, error_codes=cancel_errors)
+    mocked_cancel.return_value = NPResponse(
+        result={}, error_codes=cancel_errors, raw_response={}
+    )
 
     # when
     payment_response = api.register_transaction(config, np_payment_data)
@@ -811,6 +853,7 @@ def test_register_transaction_pending_unrecoverable(
     assert payment_response.status == PaymentStatus.PENDING
     assert payment_response.errors == [f"TR#{e}" for e in errors]
     assert caplog.record_tuples == [(ANY, logging.ERROR, ANY)]
+    assert payment_response.raw_response == register_result
 
 
 def test_cancel_transaction_no_payment(np_payment_data):


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/15908

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
