### PR TITLE
Add colon to valid custom header value.

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20580,7 +20580,7 @@ input WebhookCreateInput @doc(category: "Webhooks") {
   query: String
 
   """
-  Custom headers, which will be added to HTTP request. There is a limitation of 5 headers per webhook and 998 characters per header.Only "X-*" and "Authorization*" keys are allowed.
+  Custom headers, which will be added to HTTP request. There is a limitation of 5 headers per webhook and 998 characters per header.Only `X-*`, `Authorization*`, and `BrokerProperties` keys are allowed.
   
   Added in Saleor 3.12.
   

--- a/saleor/graphql/webhook/mutations/webhook_create.py
+++ b/saleor/graphql/webhook/mutations/webhook_create.py
@@ -72,7 +72,7 @@ class WebhookCreateInput(BaseInputObjectType):
         description=f"Custom headers, which will be added to HTTP request. "
         f"There is a limitation of {HEADERS_NUMBER_LIMIT} headers per webhook "
         f"and {HEADERS_LENGTH_LIMIT} characters per header."
-        f'Only "X-*" and "Authorization*" keys are allowed.'
+        f"Only `X-*`, `Authorization*`, and `BrokerProperties` keys are allowed."
         + ADDED_IN_312
         + PREVIEW_FEATURE,
         required=False,

--- a/saleor/webhook/tests/test_webhook_validators.py
+++ b/saleor/webhook/tests/test_webhook_validators.py
@@ -39,8 +39,8 @@ from ..validators import (
             'Key "ke:y" contains invalid character.',
         ),
         (
-            {"Key": "Val:ue"},
-            'Value "Val:ue" contains invalid character.',
+            {"Key": "ż"},
+            'Value "ż" contains invalid character.',
         ),
         (
             {"Key": "X" * HEADERS_LENGTH_LIMIT},

--- a/saleor/webhook/validators.py
+++ b/saleor/webhook/validators.py
@@ -7,7 +7,7 @@ KEY_CHARS_ALLOWED = (
     "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 )
 VALUE_CHARS_ALLOWED = (
-    "!\"#$%&'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "!\"#$%&'()*+,-./0123456789;:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ \t"
 )
 


### PR DESCRIPTION
I want to merge this change, because Saleor doesn't allow to provide colon in webhook's custom header value.

https://linear.app/saleor/issue/MERX-399/fix-custom-webhook-validation

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
