### PR TITLE
Use read replica in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,13 @@ from django.core.management import call_command
 from django.db import connections
 from django.test.testcases import TransactionTestCase
 
+from saleor.tests.utils import prepare_test_db_connections
+
+django.test.TransactionTestCase.databases = "__all__"
+django.test.TestCase.databases = "__all__"
+
+prepare_test_db_connections()
+
 pytest_plugins = [
     "saleor.tests.fixtures",
     "saleor.discount.tests.test_utils.fixtures",

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -536,6 +536,7 @@ def fetch_checkout_info(
         collection_point=checkout.collection_point,
         voucher=voucher,
         voucher_code=voucher_code,
+        database_connection_name=database_connection_name,
     )
     return checkout_info
 

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -92,6 +92,7 @@ class CheckoutInfo:
     collection_point: Optional["Warehouse"] = None
     voucher: Optional["Voucher"] = None
     voucher_code: Optional["VoucherCode"] = None
+    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME
 
     @cached_property
     def all_shipping_methods(self) -> list["ShippingMethodData"]:
@@ -101,6 +102,7 @@ class CheckoutInfo:
             self.lines,
             self.shipping_channel_listings,
             self.manager,
+            self.database_connection_name,
         )
         # Filter shipping methods using sync webhooks
         excluded_methods = self.manager.excluded_shipping_methods_for_checkout(

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1046,8 +1046,10 @@ def get_or_create_checkout_metadata(checkout: "Checkout") -> CheckoutMetadata:
         return CheckoutMetadata.objects.create(checkout=checkout)
 
 
+@allow_writer()
 def get_checkout_metadata(checkout: "Checkout"):
     if hasattr(checkout, "metadata_storage"):
+        # TODO: load metadata_storage with dataloader and pass as an argument
         return checkout.metadata_storage
     else:
         return CheckoutMetadata(checkout=checkout)

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -554,6 +554,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
                             collection_point=collection_point,
                             voucher=voucher_code.voucher if voucher_code else None,
                             voucher_code=voucher_code,
+                            database_connection_name=self.database_connection_name,
                         )
                         checkout_info_map[key] = checkout_info
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -221,6 +221,8 @@ def test_checkout_available_payment_gateways_valid_info_sent(
     api_client.post_graphql(query, variables)
 
     # then
+    checkout_info.manager = mock.ANY
+    checkout_info.database_connection_name = mock.ANY
     mocked_list_gateways.assert_called_with(
         currency=currency,
         checkout_info=checkout_info,

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -996,6 +996,7 @@ class Checkout(ModelObjectType[models.Checkout]):
             root.token
         )
 
+        @allow_writer_in_context(info.context)
         def get_available_payment_gateways(results):
             (checkout_info, lines_info) = results
             return manager.list_payment_gateways(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1573,6 +1573,7 @@ class Order(ModelObjectType[models.Order]):
 
     @staticmethod
     def resolve_discounts(root: models.Order, info):
+        @allow_writer_in_context(info.context)
         def with_manager(manager):
             fetch_order_prices_if_expired(root, manager)
             return OrderDiscountsByOrderIDLoader(info.context).load(root.id)

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -60,7 +60,9 @@ def fetch_order_prices_if_expired(
     _update_order_discount_for_voucher(order)
 
     _clear_prefetched_discounts(order, lines)
-    prefetch_related_objects([order], "discounts")
+    with allow_writer():
+        # TODO: Load discounts with a dataloader and pass as argument
+        prefetch_related_objects([order], "discounts")
 
     # handle taxes
     _recalculate_prices(
@@ -111,11 +113,11 @@ def fetch_order_prices_if_expired(
         return order, lines
 
 
+@allow_writer()
 def _update_order_discount_for_voucher(order: Order):
     """Create or delete OrderDiscount instances."""
     if not order.voucher_id:
-        with allow_writer():
-            order.discounts.filter(type=DiscountType.VOUCHER).delete()
+        order.discounts.filter(type=DiscountType.VOUCHER).delete()
 
     elif (
         order.voucher_id

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -98,7 +98,8 @@ class DraftOrderLineInfo:
 
 
 def fetch_draft_order_lines_info(
-    order: "Order", lines: Optional[Iterable["OrderLine"]] = None
+    order: "Order",
+    lines: Optional[Iterable["OrderLine"]] = None,
 ) -> list[DraftOrderLineInfo]:
     prefetch_related_fields = [
         "discounts__promotion_rule__promotion",

--- a/saleor/plugins/views.py
+++ b/saleor/plugins/views.py
@@ -1,14 +1,17 @@
 from django.http import HttpResponse
 
+from ..core.db.connection import allow_writer
 from ..graphql.core import SaleorContext
 from .manager import get_plugins_manager
 
 
+@allow_writer()
 def handle_plugin_webhook(request: SaleorContext, plugin_id: str) -> HttpResponse:
     manager = get_plugins_manager(allow_replica=False)
     return manager.webhook_endpoint_without_channel(request, plugin_id)
 
 
+@allow_writer()
 def handle_global_plugin_webhook(
     request: SaleorContext, plugin_id: str
 ) -> HttpResponse:
@@ -16,6 +19,7 @@ def handle_global_plugin_webhook(
     return manager.webhook(request, plugin_id, channel_slug=None)
 
 
+@allow_writer()
 def handle_plugin_per_channel_webhook(
     request: SaleorContext, plugin_id: str, channel_slug: str
 ) -> HttpResponse:

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -113,6 +113,9 @@ DATABASES = {
         conn_max_age=DB_CONN_MAX_AGE,
     ),
 }
+DATABASES[DATABASE_CONNECTION_REPLICA_NAME]["TEST"] = {
+    "MIRROR": DATABASE_CONNECTION_DEFAULT_NAME
+}
 
 DATABASE_ROUTERS = ["saleor.core.db_routers.PrimaryReplicaRouter"]
 

--- a/saleor/shipping/utils.py
+++ b/saleor/shipping/utils.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional
 
 from django_countries import countries
 
+from ..core.db.connection import allow_writer
 from ..plugins.base_plugin import ExcludedShippingMethod
 from .interface import ShippingMethodData
 
@@ -41,7 +42,9 @@ def convert_to_shipping_method_data(
 
     if not tax_class:
         # Tax class should be passed as argument, this is a fallback.
-        tax_class = shipping_method.tax_class
+        # TODO: load tax_class with data loader and pass as an argument
+        with allow_writer():
+            tax_class = shipping_method.tax_class
 
     return ShippingMethodData(
         id=str(shipping_method.id),

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -93,7 +93,7 @@ FdkAmFzQhgLtnEtnb+eBI7DNOJEuPLD52Jwnq2pGnJ/LxlqjjWJ5FsQQVSoDHGfM
 8yodVX6OCKwHYrgleLjVWs5ZmaGfGpqcy1YgquiYGVF4x8qBe5bpwHw=
 -----END RSA PRIVATE KEY-----"""
 
-DATABASE_CONNECTION_REPLICA_NAME = DATABASE_CONNECTION_DEFAULT_NAME  # noqa: F405
-
 HTTP_IP_FILTER_ENABLED = False
 HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS = True
+
+MIDDLEWARE.insert(0, "saleor.core.db.connection.restrict_writer_middleware")  # noqa: F405

--- a/saleor/tests/test_db_connections.py
+++ b/saleor/tests/test_db_connections.py
@@ -1,0 +1,16 @@
+import pytest
+from django.conf import settings
+
+from ..app.models import App, AppExtension
+
+
+def test_subqueries_no_allowed_across_different_databases(app_with_extensions):
+    replica = settings.DATABASE_CONNECTION_REPLICA_NAME
+    writer = settings.DATABASE_CONNECTION_DEFAULT_NAME
+    subquery = App.objects.using(replica).all()
+    query = AppExtension.objects.using(writer).filter(app_id__in=subquery)
+
+    with pytest.raises(
+        ValueError, match="Subqueries aren't allowed across different databases."
+    ):
+        list(query)

--- a/saleor/tests/utils.py
+++ b/saleor/tests/utils.py
@@ -30,7 +30,7 @@ class TestDBConnectionWrapper:
 def prepare_test_db_connections():
     replica = settings.DATABASE_CONNECTION_REPLICA_NAME
     default_conn = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
-    connections[replica] = TestDBConnectionWrapper(connections[replica], default_conn)
+    connections[replica] = TestDBConnectionWrapper(connections[replica], default_conn)  # type: ignore
 
 
 def flush_post_commit_hooks():


### PR DESCRIPTION
This PR adds logic for testing writer/reader usage in tests (moved from PR https://github.com/saleor/saleor/pull/15428).
Additionally, added some usages of `allow_writer` as there were recent code changes that added writer DB usages. Some of these places should be refactored to use replica (marked with `TODO` comments, but that can be done in separate PRs). I'll open a ticket to track the newly added todos.

Note: after this PR is merged, Pytest will start failing with an error when it detects usage of writer DB that is not explicitly allowed with either `allow_writer` or `allow_writer_in_context` context managers.

Example test failure:

```shell
saleor/graphql/order/tests/queries/test_order_line.py:757:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

response = <JsonResponse status_code=200, "application/json">

    def get_graphql_content(response, *, ignore_errors: bool = False):
        """Extract GraphQL content from the API response.

        Optionally ignore protocol-level errors, eg. schema errors or lack of
        permissions.
        """
        content = get_graphql_content_from_response(response)
        if not ignore_errors:
>           assert "errors" not in content, content["errors"]
E           AssertionError: [{'message': 'Internal Server Error', 'locations': [{'line': 7, 'column': 29}], 'path': ['orders', 'edges', 0, 'node', 'lines', 0, 'undiscountedUnitPrice'], 'extensions': {'exception': {'code': 'UnsafeWriterAccessError'}}}]

saleor/graphql/tests/utils.py:18: AssertionError
------------------------------------------------------------------------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------------------------------------------------------------------------
2024-05-14 06:06:58,967 ERROR saleor.graphql.errors.unhandled A query failed unexpectedly [PID:1679:MainThread]
Traceback (most recent call last):
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/promise/promise.py", line 87, in try_catch
    return (handler(*args, **kwargs), None)
  File "/Users/marcin/.pyenv/versions/3.9.18/lib/python3.9/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/order/types.py", line 1011, in _resolve_undiscounted_unit_price
    return calculations.order_line_unit(
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/order/calculations.py", line 449, in order_line_unit
    _, lines = fetch_order_prices_if_expired(
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/order/calculations.py", line 63, in fetch_order_prices_if_expired
    prefetch_related_objects([order], "discounts")
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 1730, in prefetch_related_objects
    obj_list, additional_lookups = prefetch_one_level(
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 1855, in prefetch_one_level
    prefetcher.get_prefetch_queryset(instances, lookup.get_current_queryset(level)))
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/fields/related_descriptors.py", line 637, in get_prefetch_queryset
    for rel_obj in queryset:
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 280, in __iter__
    self._fetch_all()
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 1324, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/query.py", line 51, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 1175, in execute_sql
    cursor.execute(sql, params)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/Users/marcin/.pyenv/versions/3.9.18/envs/saleor/lib/python3.9/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/core/db/connection.py", line 101, in _restrict_writer
    raise UnsafeWriterAccessError(f"{UNSAFE_WRITER_ACCESS_MSG} SQL: {sql}")
saleor.core.db.connection.UnsafeWriterAccessError: Unsafe access to the writer DB detected. Call `using()` on the `QuerySet` to utilize a replica DB, or employ the `allow_writer` context manager to explicitly permit access to the writer. SQL: SELECT "discount_orderdiscount"."id", "discount_orderdiscount"."created_at", "discount_orderdiscount"."type", "discount_orderdiscount"."value_type", "discount_orderdiscount"."value", "discount_orderdiscount"."amount_value", "discount_orderdiscount"."currency", "discount_orderdiscount"."name", "discount_orderdiscount"."translated_name", "discount_orderdiscount"."reason", "discount_orderdiscount"."promotion_rule_id", "discount_orderdiscount"."voucher_id", "discount_orderdiscount"."voucher_code", "discount_orderdiscount"."order_id", "discount_orderdiscount"."old_id" FROM "discount_orderdiscount" WHERE "discount_orderdiscount"."order_id" IN (%s) ORDER BY "discount_orderdiscount"."created_at" ASC, "discount_orderdiscount"."id" ASC
```

To determine which line of the code is causing a problem, we need to analyze the stack trace and find the last line of our code before the traces go into Django internals, in the example above it is this line:
```
File "/Users/marcin/mirumee/saleor-platform/saleor/saleor/order/calculations.py", line 63, in fetch_order_prices_if_expired
    prefetch_related_objects([order], "discounts")
```

`prefetch_related_objects` uses writer without explicit permission, which should be analyzed and either wrapped with `allow_writer` context manager or refactored to load data from replica DB.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
