### PR TITLE
add missing filtering for active plugins on manager

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2197,13 +2197,14 @@ class PluginsManager(PaymentInterface):
         plugins: Optional[list["BasePlugin"]] = None,
     ):
         if plugins is None:
-            plugins = self.get_plugins(channel_slug=channel_slug)
-        for plugin in plugins:
-            result = self.__run_method_on_single_plugin(
-                plugin, method_name, None, *args
-            )
-            if result is not None:
-                return result
+            plugins = self.get_plugins(channel_slug=channel_slug, active_only=True)
+        if plugins:
+            for plugin in plugins:
+                result = self.__run_method_on_single_plugin(
+                    plugin, method_name, None, *args
+                )
+                if result is not None:
+                    return result
         return None
 
     def _get_all_plugin_configs(self):


### PR DESCRIPTION
I want to merge this change because it fixes filtering for active plugins in the manager method.
This also fixes part of the RecursionError

Fixes: https://linear.app/saleor/issue/SHOPX-665/fix-for-run-plugin-method-until-first-success

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
