### PR TITLE
add missing filtering for active plugins on manager

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2290,13 +2290,14 @@ class PluginsManager(PaymentInterface):
         plugins: Optional[list["BasePlugin"]] = None,
     ):
         if plugins is None:
-            plugins = self.get_plugins(channel_slug=channel_slug)
-        for plugin in plugins:
-            result = self.__run_method_on_single_plugin(
-                plugin, method_name, None, *args
-            )
-            if result is not None:
-                return result
+            plugins = self.get_plugins(channel_slug=channel_slug, active_only=True)
+        if plugins:
+            for plugin in plugins:
+                result = self.__run_method_on_single_plugin(
+                    plugin, method_name, None, *args
+                )
+                if result is not None:
+                    return result
         return None
 
     def _get_all_plugin_configs(self):

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1582,3 +1582,40 @@ def test_get_plugin_invalid_channel():
 
     # then
     assert plugin is None
+
+
+@pytest.mark.parametrize(
+    ("plugins", "calls"),
+    [
+        ([], 0),
+        (["saleor.plugins.tests.sample_plugins.PluginInactive"], 0),
+        (["saleor.plugins.tests.sample_plugins.PluginSample"], 1),
+        (
+            [
+                "saleor.plugins.tests.sample_plugins.PluginInactive",
+                "saleor.plugins.tests.sample_plugins.PluginSample",
+            ],
+            1,
+        ),
+    ],
+)
+def test_run_plugin_method_until_first_success_for_active_plugins_only(
+    channel_USD, plugins, calls
+):
+    # given
+    manager = PluginsManager(plugins=plugins)
+    manager._ensure_channel_plugins_loaded(channel_slug=channel_USD.slug)
+
+    # when
+    with patch.object(
+        PluginsManager,
+        "_PluginsManager__run_method_on_single_plugin",
+        return_value=None,
+    ) as mock_run_method:
+        result = manager._PluginsManager__run_plugin_method_until_first_success(
+            "some_method", channel_slug=None
+        )
+
+    # then
+    assert result is None
+    assert mock_run_method.call_count == calls


### PR DESCRIPTION
I want to merge this change because it fixes filtering for active plugins in the manager method.
This also fixes part of the RecursionError

Port: https://github.com/saleor/saleor/pull/15943
Fixes: https://linear.app/saleor/issue/SHOPX-665/fix-for-run-plugin-method-until-first-success

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
