### PR TITLE
Handle zero subtotal case when propagating order discount to lines.

### DIFF
--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -231,7 +231,9 @@ def propagate_order_discount_on_order_lines_prices(
     elif lines_count > 1:
         remaining_discount = subtotal_discount
         for idx, line in enumerate(lines):
-            if idx < lines_count - 1:
+            if not base_subtotal.amount:
+                yield line, zero_money(base_subtotal.currency)
+            elif idx < lines_count - 1:
                 share = (
                     line.base_unit_price_amount * line.quantity / base_subtotal.amount
                 )

--- a/saleor/order/tests/test_apply_order_discount.py
+++ b/saleor/order/tests/test_apply_order_discount.py
@@ -10,6 +10,7 @@ from ...order.base_calculations import (
     apply_order_discounts,
     apply_subtotal_discount_to_order_lines,
 )
+from ..models import OrderLine
 
 
 def test_apply_order_discounts_voucher_entire_order(order_with_lines, voucher):
@@ -178,12 +179,16 @@ def test_apply_order_discounts_manual_discount(order_with_lines):
     assert order_discount.amount_value == discount_amount
 
 
-def test_apply_order_discounts_manual_discount_and_zero_order_total(order):
+def test_apply_order_discounts_zero_discount(order_with_lines):
     # given
+    order = order_with_lines
     lines = order.lines.all()
-    assert not lines
-
     currency = order.currency
+    undiscounted_total = order.base_shipping_price_amount + sum(
+        line.undiscounted_total_price_net_amount for line in lines
+    )
+    undiscounted_total = Money(undiscounted_total, currency)
+
     order.discounts.create(
         type=DiscountType.MANUAL,
         value_type=DiscountValueType.FIXED,
@@ -192,6 +197,53 @@ def test_apply_order_discounts_manual_discount_and_zero_order_total(order):
         translated_name="StaffDiscountPL",
         currency=currency,
         amount_value=0,
+    )
+
+    # when
+    discounted_subtotal, discounted_shipping_price = apply_order_discounts(order, lines)
+
+    # then
+    assert discounted_subtotal + discounted_shipping_price == undiscounted_total
+
+
+def test_apply_order_discounts_subtotal_zero(order_with_lines):
+    # given
+    order = order_with_lines
+    lines = order.lines.all()
+    for line in lines:
+        line.base_unit_price_amount = Decimal(0)
+    OrderLine.objects.bulk_update(lines, fields=["base_unit_price_amount"])
+
+    currency = order.currency
+    order.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.FIXED,
+        value=10,
+        name="StaffDiscount",
+        translated_name="StaffDiscountPL",
+        currency=currency,
+    )
+
+    # when
+    discounted_subtotal, discounted_shipping_price = apply_order_discounts(order, lines)
+
+    # then
+    assert discounted_subtotal + discounted_shipping_price == zero_money(currency)
+
+
+def test_apply_order_discounts_manual_discount_no_lines(order):
+    # given
+    lines = order.lines.all()
+    assert not lines
+
+    currency = order.currency
+    order.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.FIXED,
+        value=10,
+        name="StaffDiscount",
+        translated_name="StaffDiscountPL",
+        currency=currency,
     )
 
     # when


### PR DESCRIPTION
I want to merge this change, because it fixes zero division error when propagating order discount to its lines and subtotal is equal 0.

Issue: https://linear.app/saleor/issue/MERX-377/creating-draft-order-does-now-work

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
