### PR TITLE
Fix mixing up attibute values because of the same slug value

### DIFF
--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -76,8 +76,9 @@ def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
     values = AttributeValue.objects.filter(lookup)
 
     for value in values:
-        values_map[value.attribute_id].add(value.slug)
-        slug_value_to_value_map[value.slug] = value
+        attr_id = value.attribute_id
+        values_map[attr_id].add(value.slug)
+        slug_value_to_value_map[attr_id, value.slug] = value
 
     for attribute_id, attr_values in attr_val_map.items():
         if values_map[attribute_id] != {v.slug for v in attr_values}:
@@ -86,7 +87,7 @@ def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
         # id set. This is needed as `ignore_conflicts=True` flag in `bulk_create
         # is used in `AttributeValueManager`
         attr_val_map[attribute_id] = [
-            slug_value_to_value_map[v.slug] for v in attr_values
+            slug_value_to_value_map[attribute_id, v.slug] for v in attr_values
         ]
 
 


### PR DESCRIPTION
I want to merge this change because it fixes issue were when performing mutation `productUpdate` and updating attribute values, if values had the same slug value, only 1 attribute were updated and the rest were not set or were reset.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
