### PR TITLE
Fix discounts resolver to work like in docs

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -1432,6 +1432,9 @@ def generate_order_payload_for_tax_calculation(order: "Order"):
     discounts = order.discounts.all()
     discounts_dict = []
     for discount in discounts:
+        if discount.voucher and discount.voucher.type == VoucherType.ENTIRE_ORDER:
+            if discount.voucher.apply_once_per_order:
+                continue
         quantize_price_fields(discount, ("amount_value",), order.currency)
         discount_amount = quantize_price(discount.amount_value, order.currency)
         discounts_dict.append({"name": discount.name, "amount": discount_amount})

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -21,7 +21,7 @@ from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...checkout.models import CheckoutLine
 from ...core.prices import quantize_price
 from ...core.utils.json_serializer import CustomJsonEncoder
-from ...discount import DiscountType, DiscountValueType, RewardValueType
+from ...discount import DiscountType, DiscountValueType, RewardValueType, VoucherType
 from ...discount.models import CheckoutDiscount, CheckoutLineDiscount
 from ...graphql.utils import get_user_or_app_from_context
 from ...order import FulfillmentLineData, OrderOrigin
@@ -308,6 +308,7 @@ def test_generate_order_payload_for_tax_calculation(
     order_for_payload,
     prices_entered_with_tax,
 ):
+    # given
     order = order_for_payload
 
     tax_configuration = order.channel.tax_configuration
@@ -322,7 +323,10 @@ def test_generate_order_payload_for_tax_calculation(
     discount_1, discount_2 = list(order.discounts.all())
     user = order.user
 
+    # when
     payload = json.loads(generate_order_payload_for_tax_calculation(order))[0]
+
+    # then
     currency = order.currency
 
     assert payload == {
@@ -363,6 +367,82 @@ def test_generate_order_payload_for_tax_calculation(
                 "name": discount_1.name,
                 "amount": str(quantize_price(discount_1.amount_value, currency)),
             },
+            {
+                "name": discount_2.name,
+                "amount": str(quantize_price(discount_2.amount_value, currency)),
+            },
+        ],
+        "lines": json.loads(order_lines),
+    }
+    mocked_order_lines.assert_called_once()
+
+
+@freeze_time()
+@pytest.mark.parametrize("prices_entered_with_tax", [True, False])
+@mock.patch("saleor.webhook.payloads._generate_order_lines_payload_for_tax_calculation")
+def test_generate_order_payload_for_tax_calculation_voucher_discounts(
+    mocked_order_lines, order_for_payload, prices_entered_with_tax, voucher
+):
+    # given
+    order = order_for_payload
+
+    tax_configuration = order.channel.tax_configuration
+    tax_configuration.prices_entered_with_tax = prices_entered_with_tax
+    tax_configuration.save(update_fields=["prices_entered_with_tax"])
+    tax_configuration.country_exceptions.all().delete()
+
+    order_lines = '"order_lines"'
+    mocked_order_lines.return_value = order_lines
+
+    order = order_for_payload
+    discount_1, discount_2 = list(order.discounts.all())
+    voucher.type = VoucherType.ENTIRE_ORDER
+    voucher.apply_once_per_order = True
+    voucher.save()
+    discount_1.voucher = voucher
+    discount_1.save()
+    user = order.user
+
+    # when
+    payload = json.loads(generate_order_payload_for_tax_calculation(order))[0]
+
+    # then
+    currency = order.currency
+
+    assert payload == {
+        "type": "Order",
+        "id": graphene.Node.to_global_id("Order", order.id),
+        "channel": {
+            "id": graphene.Node.to_global_id("Channel", order.channel_id),
+            "type": "Channel",
+            "slug": order.channel.slug,
+            "currency_code": order.channel.currency_code,
+        },
+        "address": {
+            "id": graphene.Node.to_global_id("Address", order.shipping_address_id),
+            "type": "Address",
+            "first_name": order.shipping_address.first_name,
+            "last_name": order.shipping_address.last_name,
+            "company_name": order.shipping_address.company_name,
+            "street_address_1": order.shipping_address.street_address_1,
+            "street_address_2": order.shipping_address.street_address_2,
+            "city": order.shipping_address.city,
+            "city_area": order.shipping_address.city_area,
+            "postal_code": order.shipping_address.postal_code,
+            "country": order.shipping_address.country.code,
+            "country_area": order.shipping_address.country_area,
+            "phone": str(order.shipping_address.phone),
+        },
+        "user_id": graphene.Node.to_global_id("User", user.pk),
+        "user_public_metadata": user.metadata,
+        "included_taxes_in_prices": prices_entered_with_tax,
+        "currency": order.currency,
+        "shipping_name": order.shipping_method.name,
+        "shipping_amount": str(
+            quantize_price(order.base_shipping_price_amount, currency)
+        ),
+        "metadata": order.metadata,
+        "discounts": [
             {
                 "name": discount_2.name,
                 "amount": str(quantize_price(discount_2.amount_value, currency)),


### PR DESCRIPTION
I want to merge this change because it fixes discounts resolver to work like in docs
more context: https://linear.app/saleor/issue/SHOPX-325/bug-discounts-field-behaviour-on-calculatetaxes-event-is-inconsistent

⚠️ This is a port of https://github.com/saleor/saleor/pull/15863
⚠️ There is already merged part in https://github.com/saleor/saleor/pull/15885 but it lacks same for webhooks, this PR compensates that.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
