### PR TITLE
Fix introspection query detection code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Prevent name overwriting of Product Variants when Updating Product Types - #15670 by @teddyondieki
 - Added support for the `BrokerProperties` custom header to webhooks to support Azure Service Bus - #15899 by @patrys
 - Extend valid address values - #15877 by @zedzior
+- Fixed a rare crash in the introspection query detection code - #15966 by @patrys
 
 # 3.19.0
 

--- a/saleor/graphql/utils/validators.py
+++ b/saleor/graphql/utils/validators.py
@@ -1,4 +1,12 @@
 from django.core.exceptions import ValidationError
+from graphql import GraphQLDocument
+from graphql.error import GraphQLError
+from graphql.language.ast import (
+    Field,
+    FragmentDefinition,
+    InlineFragment,
+    OperationDefinition,
+)
 
 from ..core.utils import get_duplicates_items
 
@@ -23,3 +31,78 @@ def check_for_duplicates(
         error = ValidationError(message=error_msg, params=params)
 
     return error
+
+
+def __queries_or_introspection_in_selections(selections: list, is_query: bool):
+    found_queries = False
+    found_introspection = False
+    for selection in selections:
+        if isinstance(selection, Field):
+            selection_name = str(selection.name.value)
+            if is_query and selection_name == "__schema":
+                found_introspection = True
+            else:
+                found_queries = True
+        if isinstance(selection, InlineFragment):
+            (
+                sub_queries,
+                sub_introspection,
+            ) = __queries_or_introspection_in_inline_fragment(
+                selection, is_query=is_query
+            )
+            found_queries = found_queries or sub_queries
+            found_introspection = found_introspection or sub_introspection
+    return found_queries, found_introspection
+
+
+def __queries_or_introspection_in_inline_fragment(
+    fragment: InlineFragment, is_query: bool
+):
+    if fragment.type_condition and fragment.type_condition.name.value == "__Schema":
+        return False, True
+    selections = fragment.selection_set.selections
+    if (fragment.type_condition and fragment.type_condition.name.value == "Query") or (
+        is_query and not fragment.type_condition
+    ):
+        return __queries_or_introspection_in_selections(selections, is_query=True)
+    else:
+        return __queries_or_introspection_in_selections(selections, is_query=False)
+
+
+def __queries_or_introspection_in_operation_definition(definition: OperationDefinition):
+    if definition.operation != "query":
+        return False, False
+    selections = definition.selection_set.selections
+    return __queries_or_introspection_in_selections(selections, is_query=True)
+
+
+def __queries_or_introspection_in_fragment_definition(definition: FragmentDefinition):
+    selections = definition.selection_set.selections
+    if definition.type_condition and definition.type_condition.name.value == "Query":
+        return __queries_or_introspection_in_selections(selections, is_query=True)
+    return __queries_or_introspection_in_selections(selections, is_query=False)
+
+
+def check_if_query_contains_only_schema(document: GraphQLDocument):
+    found_queries = False
+    found_introspection = False
+    for definition in document.document_ast.definitions:
+        if isinstance(definition, OperationDefinition):
+            (
+                sub_queries,
+                sub_introspection,
+            ) = __queries_or_introspection_in_operation_definition(definition)
+            found_queries = found_queries or sub_queries
+            found_introspection = found_introspection or sub_introspection
+        if isinstance(definition, FragmentDefinition):
+            (
+                sub_queries,
+                sub_introspection,
+            ) = __queries_or_introspection_in_fragment_definition(definition)
+            found_queries = found_queries or sub_queries
+            found_introspection = found_introspection or sub_introspection
+    if found_introspection and found_queries:
+        raise GraphQLError(
+            "Queries and introspection cannot be mixed in the same request."
+        )
+    return found_introspection

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -28,6 +28,7 @@ from .context import clear_context, get_context_value
 from .core.validators.query_cost import validate_query_cost
 from .query_cost_map import COST_MAP
 from .utils import format_error, query_fingerprint, query_identifier
+from .utils.validators import check_if_query_contains_only_schema
 
 INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
 
@@ -250,20 +251,6 @@ class GraphQLView(View):
         except (ValueError, GraphQLSyntaxError) as e:
             return None, ExecutionResult(errors=[e], invalid=True)
 
-    def check_if_query_contains_only_schema(self, document: GraphQLDocument):
-        query_with_schema = False
-        for definition in document.document_ast.definitions:
-            selections = definition.selection_set.selections
-            selection_count = len(selections)
-            for selection in selections:
-                selection_name = str(selection.name.value)
-                if selection_name == "__schema":
-                    query_with_schema = True
-                    if selection_count > 1:
-                        msg = "`__schema` must be fetched in separate query"
-                        raise GraphQLError(msg)
-        return query_with_schema
-
     def execute_graphql_request(self, request: HttpRequest, data: dict):
         with opentracing.global_tracer().start_active_span("graphql_query") as scope:
             span = scope.span
@@ -288,9 +275,7 @@ class GraphQLView(View):
             span.set_tag("graphql.query_identifier", query_identifier(document))
             span.set_tag("graphql.query_fingerprint", query_fingerprint(document))
             try:
-                query_contains_schema = self.check_if_query_contains_only_schema(
-                    document
-                )
+                query_contains_schema = check_if_query_contains_only_schema(document)
             except GraphQLError as e:
                 return ExecutionResult(errors=[e], invalid=True)
 


### PR DESCRIPTION
Previous code would crash for certain queries and it was easy to trick by using fragments.

I changed the error string to explain the intent and used slightly better grammar.

Fixes PE-245

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
