### PR TITLE
Allow deleting and updating order lines without allocation

### DIFF
--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -53,9 +53,10 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
         cls.validate(info, order, line)
 
         db_id = line.id
+        line_allocation = line.allocations.first()
         warehouse_pk = (
-            line.allocations.first().stock.warehouse.pk
-            if order.is_unconfirmed()
+            line_allocation.stock.warehouse.pk
+            if line_allocation and order.is_unconfirmed()
             else None
         )
         with traced_atomic_transaction():

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -72,9 +72,11 @@ class OrderLineUpdate(
     @classmethod
     def save(cls, info: ResolveInfo, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
+
+        line_allocation = instance.allocations.first()
         warehouse_pk = (
-            instance.allocations.first().stock.warehouse.pk
-            if instance.order.is_unconfirmed()
+            line_allocation.stock.warehouse.pk
+            if line_allocation and instance.order.is_unconfirmed()
             else None
         )
         app = get_app_promise(info.context).get()

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -132,6 +132,7 @@ def test_order_line_remove_no_line_allocations(
     permission_group_manage_orders,
     staff_api_client,
 ):
+    # given
     query = ORDER_LINE_DELETE_MUTATION
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_with_lines
@@ -142,7 +143,10 @@ def test_order_line_remove_no_line_allocations(
     line_id = graphene.Node.to_global_id("OrderLine", line.id)
     variables = {"id": line_id}
 
+    # when
     response = staff_api_client.post_graphql(query, variables)
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["orderLineDelete"]
     assert OrderEvent.objects.count() == 1

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -123,6 +123,40 @@ def test_order_line_remove(
     )
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_order_line_remove_no_line_allocations(
+    order_updated_webhook_mock,
+    draft_order_updated_webhook_mock,
+    order_with_lines,
+    permission_group_manage_orders,
+    staff_api_client,
+):
+    query = ORDER_LINE_DELETE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.save(update_fields=["status"])
+    line = order.lines.first()
+    line.allocations.all().delete()
+    line_id = graphene.Node.to_global_id("OrderLine", line.id)
+    variables = {"id": line_id}
+
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["orderLineDelete"]
+    assert OrderEvent.objects.count() == 1
+    assert OrderEvent.objects.last().type == order_events.OrderEvents.REMOVED_PRODUCTS
+    assert data["orderLine"]["id"] == line_id
+    assert line not in order.lines.all()
+    assert_proper_webhook_called_once(
+        order,
+        order.status,
+        draft_order_updated_webhook_mock,
+        order_updated_webhook_mock,
+    )
+
+
 def test_order_line_remove_by_usr_no_channel_access(
     order_with_lines,
     permission_group_all_perms_channel_USD_only,


### PR DESCRIPTION
I want to merge this change because OrderLineDelete and OrderLineUpdate were crashing when they didn't have an allocation e.g. for Orders coming from an import from external services.

The outcome was a 500 error.

Fixes SHOPX-681 and SHOPX-684.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

No changes to docs as this is fixing a 500 bug.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
