### PR TITLE
Prevent performing both transaction and payment checkout process at the same time

### DIFF
--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -119,7 +119,7 @@ def test_create_order_captured_payment_creates_expected_events(
     assert payment_captured_event.order is order
     # ensure a date was set
     assert payment_captured_event.date
-    # should not have any additional parameters
+    # should have additional parameters
     assert "amount" in payment_captured_event.parameters.keys()
     assert "payment_id" in payment_captured_event.parameters.keys()
     assert "payment_gateway" in payment_captured_event.parameters.keys()
@@ -133,8 +133,8 @@ def test_create_order_captured_payment_creates_expected_events(
     assert order_fully_paid_event.order is order
     # ensure a date was set
     assert order_fully_paid_event.date
-    # should not have any additional parameters
-    assert not order_fully_paid_event.parameters
+    # should have payment_gateway in additional parameters
+    assert "payment_gateway" in order_fully_paid_event.parameters
 
     expected_order_payload = {
         "order": get_default_order_payload(order, checkout.redirect_url),
@@ -267,7 +267,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     assert payment_captured_event.order is order
     # ensure a date was set
     assert payment_captured_event.date
-    # should not have any additional parameters
+    # should have additional parameters
     assert "amount" in payment_captured_event.parameters.keys()
     assert "payment_id" in payment_captured_event.parameters.keys()
     assert "payment_gateway" in payment_captured_event.parameters.keys()
@@ -281,8 +281,8 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     assert order_fully_paid_event.order is order
     # ensure a date was set
     assert order_fully_paid_event.date
-    # should not have any additional parameters
-    assert not order_fully_paid_event.parameters
+    # should have payment_gateway in additional parameters
+    assert "payment_gateway" in order_fully_paid_event.parameters
 
     expected_order_payload = {
         "order": get_default_order_payload(order, checkout.redirect_url),

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -891,7 +891,7 @@ def is_fully_paid(
     return total_paid >= checkout_total.amount
 
 
-def cancel_active_payments(checkout: Checkout):
+def cancel_active_payments(checkout: Checkout) -> None:
     checkout.payments.filter(is_active=True).update(is_active=False)
 
 

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -87,6 +87,7 @@ class OrderConfirm(ModelMutation):
                         authorized_payment,
                         manager,
                         site.settings,
+                        payment.gateway,  # type: ignore
                     )
                 )
             transaction.on_commit(

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -99,7 +99,12 @@ def test_order_confirm(
     )
     order_info = fetch_order_info(order_unconfirmed)
     handle_fully_paid_order_mock.assert_called_once_with(
-        ANY, order_info, staff_api_client.user, None, site_settings
+        ANY,
+        order_info,
+        staff_api_client.user,
+        None,
+        site_settings,
+        payment_txn_preauth.gateway,
     )
 
 
@@ -364,5 +369,10 @@ def test_order_confirm_by_app(
     )
     order_info = fetch_order_info(order_unconfirmed)
     handle_fully_paid_order_mock.assert_called_once_with(
-        ANY, order_info, None, app_api_client.app, site_settings
+        ANY,
+        order_info,
+        None,
+        app_api_client.app,
+        site_settings,
+        payment_txn_preauth.gateway,
     )

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -299,6 +299,13 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         token=None,
     ):
         checkout = get_checkout(cls, info, checkout_id=checkout_id, token=token, id=id)
+        if checkout.is_checkout_locked():
+            raise ValidationError(
+                "Payment cannot be created - the checkout completion is currently "
+                "in progress. Please wait until the process is finished "
+                f"(max {settings.CHECKOUT_COMPLETION_LOCK_TIME} seconds).",
+                code=PaymentErrorCode.CHECKOUT_COMPLETION_IN_PROGRESS.value,
+            )
 
         cls.validate_checkout_email(checkout)
 

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -299,13 +299,6 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         token=None,
     ):
         checkout = get_checkout(cls, info, checkout_id=checkout_id, token=token, id=id)
-        if checkout.is_checkout_locked():
-            raise ValidationError(
-                "Payment cannot be created - the checkout completion is currently "
-                "in progress. Please wait until the process is finished "
-                f"(max {settings.CHECKOUT_COMPLETION_LOCK_TIME} seconds).",
-                code=PaymentErrorCode.CHECKOUT_COMPLETION_IN_PROGRESS.value,
-            )
 
         cls.validate_checkout_email(checkout)
 

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -5,6 +5,7 @@ import graphene
 import mock
 import pytest
 import pytz
+from django.utils import timezone
 from freezegun import freeze_time
 
 from .....channel import TransactionFlowStrategy
@@ -18,7 +19,7 @@ from .....payment.interface import (
     TransactionProcessActionData,
     TransactionSessionData,
 )
-from .....payment.models import TransactionEvent
+from .....payment.models import Payment, TransactionEvent
 from ....core.enums import TransactionProcessErrorCode
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
@@ -1130,7 +1131,6 @@ def test_transaction_process_for_disabled_app(
 
     # then
     content = get_graphql_content(response)
-    content = get_graphql_content(response)
     data = content["data"]["transactionProcess"]
     assert (
         data["errors"][0]["code"]
@@ -1211,3 +1211,140 @@ def test_updates_checkout_last_transaction_modified_at(
     assert (
         checkout.last_transaction_modified_at != previous_last_transaction_modified_at
     )
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_for_locked_checkout(
+    mocked_process,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    transaction_item_generator,
+):
+    # given
+    expected_amount = Decimal("10.00")
+
+    checkout = checkout_with_prices
+    checkout.completing_started_at = timezone.now()
+    checkout.save(update_fields=["completing_started_at"])
+
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout_with_prices.pk, app=webhook_app
+    )
+    TransactionEvent.objects.create(
+        transaction=transaction_item,
+        amount_value=expected_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = expected_amount
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = PaymentGatewayData(
+        app_identifier=expected_app_identifier, data=expected_response
+    )
+    expected_data = {"some": "json-data"}
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "data": expected_data,
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionProcess"]
+    assert len(data["errors"]) == 1
+    assert (
+        data["errors"][0]["code"]
+        == TransactionProcessErrorCode.CHECKOUT_COMPLETION_IN_PROGRESS.name
+    )
+    assert data["errors"][0]["field"] == "id"
+    mocked_process.assert_not_called()
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_for_checkout_with_payments(
+    mocked_process,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    transaction_item_generator,
+):
+    # given
+    expected_amount = Decimal("10.00")
+
+    checkout = checkout_with_prices
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    # create payments
+    payments = Payment.objects.bulk_create(
+        [
+            Payment(
+                gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+            ),
+            Payment(
+                gateway="mirumee.payments.dummy", is_active=False, checkout=checkout
+            ),
+        ]
+    )
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout_with_prices.pk, app=webhook_app
+    )
+    TransactionEvent.objects.create(
+        transaction=transaction_item,
+        amount_value=expected_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = expected_amount
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = PaymentGatewayData(
+        app_identifier=expected_app_identifier, data=expected_response
+    )
+    expected_data = {"some": "json-data"}
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "data": expected_data,
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    checkout.refresh_from_db()
+    _assert_fields(
+        content=content,
+        source_object=checkout,
+        expected_amount=expected_amount,
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_process=mocked_process,
+        charged_value=expected_amount,
+        data=expected_data,
+        returned_data=expected_response["data"],
+    )
+    assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+    for payment in payments:
+        payment.refresh_from_db()
+        assert payment.is_active is False

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -21931,6 +21931,7 @@ enum TransactionInitializeErrorCode @doc(category: "Payments") {
   INVALID
   NOT_FOUND
   UNIQUE
+  CHECKOUT_COMPLETION_IN_PROGRESS
 }
 
 """
@@ -21973,6 +21974,7 @@ enum TransactionProcessErrorCode @doc(category: "Payments") {
   TRANSACTION_ALREADY_PROCESSED
   MISSING_PAYMENT_APP_RELATION
   MISSING_PAYMENT_APP
+  CHECKOUT_COMPLETION_IN_PROGRESS
 }
 
 """

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -117,6 +117,7 @@ def order_created(
             payment=payment,
             manager=manager,
             site_settings=site_settings,
+            gateway=payment.gateway if payment else None,
         )
 
     channel = order_info.channel
@@ -147,11 +148,12 @@ def handle_fully_paid_order(
     user: Optional[User] = None,
     app: Optional["App"] = None,
     site_settings: Optional["SiteSettings"] = None,
+    gateway: Optional[str] = None,
 ):
     from ..giftcard.utils import fulfill_non_shippable_gift_cards
 
     order = order_info.order
-    events.order_fully_paid_event(order=order, user=user, app=app)
+    events.order_fully_paid_event(order=order, user=user, app=app, gateway=gateway)
     if order_info.customer_email:
         send_payment_confirmation(order_info, manager)
         if utils.order_needs_automatic_fulfillment(order_info.lines_data):
@@ -360,6 +362,7 @@ def order_charged(
     payment: Optional["Payment"],
     manager: "PluginsManager",
     site_settings: Optional["SiteSettings"] = None,
+    gateway: Optional[str] = None,
 ):
     order = order_info.order
     if payment and amount is not None:
@@ -368,7 +371,7 @@ def order_charged(
         )
     call_event(manager.order_paid, order)
     if order.charge_status in [OrderChargeStatus.FULL, OrderChargeStatus.OVERCHARGED]:
-        handle_fully_paid_order(manager, order_info, user, app, site_settings)
+        handle_fully_paid_order(manager, order_info, user, app, site_settings, gateway)
     else:
         call_event(manager.order_updated, order)
 

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -374,10 +374,21 @@ def order_manually_marked_as_paid_event(
 
 
 def order_fully_paid_event(
-    *, order: Order, user: Optional[User], app: Optional[App]
+    *,
+    order: Order,
+    user: Optional[User],
+    app: Optional[App],
+    gateway: Optional[str] = None
 ) -> OrderEvent:
+    parameters = {}
+    if gateway:
+        parameters = {"payment_gateway": gateway}
     return OrderEvent.objects.create(
-        order=order, type=OrderEvents.ORDER_FULLY_PAID, user=user, app=app
+        order=order,
+        type=OrderEvents.ORDER_FULLY_PAID,
+        user=user,
+        app=app,
+        parameters=parameters,
     )
 
 

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -147,6 +147,25 @@ def test_handle_fully_paid_order_no_email(mock_send_payment_confirmation, order)
     assert not mock_send_payment_confirmation.called
 
 
+@patch("saleor.order.actions.send_payment_confirmation")
+def test_handle_fully_paid_order_with_gateway(mock_send_payment_confirmation, order):
+    # given
+    manager = get_plugins_manager(allow_replica=False)
+
+    order.payments.add(Payment.objects.create())
+    order_info = fetch_order_info(order)
+
+    # when
+    handle_fully_paid_order(manager, order_info, gateway="mirumee.payments.dummy")
+
+    # then
+    event_order_paid = order.events.get()
+    assert event_order_paid.type == OrderEvents.ORDER_FULLY_PAID
+    assert event_order_paid.parameters == {"payment_gateway": "mirumee.payments.dummy"}
+
+    mock_send_payment_confirmation.assert_called_once_with(order_info, manager)
+
+
 @patch("saleor.giftcard.utils.send_gift_card_notification")
 @patch("saleor.order.actions.send_payment_confirmation")
 def test_handle_fully_paid_order_gift_cards_created(

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -74,6 +74,7 @@ class TransactionInitializeErrorCode(Enum):
     INVALID = "invalid"
     NOT_FOUND = "not_found"
     UNIQUE = "unique"
+    CHECKOUT_COMPLETION_IN_PROGRESS = "checkout_completion_in_progress"
 
 
 class TransactionProcessErrorCode(Enum):
@@ -83,3 +84,4 @@ class TransactionProcessErrorCode(Enum):
     TRANSACTION_ALREADY_PROCESSED = "transaction_already_processed"
     MISSING_PAYMENT_APP_RELATION = "missing_payment_app_relation"
     MISSING_PAYMENT_APP = "missing_payment_app"
+    CHECKOUT_COMPLETION_IN_PROGRESS = "checkout_completion_in_progress"


### PR DESCRIPTION
Adjust the checkout process to prevent performing both transaction and payment checkout process at the same time.

- Add validation in `transactionInitialize` and `transactionProcess` mutations - raise an error when the checkout is currently during the complete process.
- Adjust the checkout flow selection:
  - choose the transaction flow if:
      - the checkout is fully authorized (checkout.authorize_status == CheckoutAuthorizeStatus.FULL)
      - OR the checkout is not fully authorized, has transactions and there is no active payment object
      - OR checkout amount is 0 and channel has `TRANSACTION_FLOW` chosen as `marked_as_paid_strategy`
  - choose the payment flow
      - there are no transactions
      - OR checkout is not fully authorized and has active payment

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
