### PR TITLE
Unassign shipping address on CheckoutDeliveryMethodUpdate with C&C

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -104,6 +104,11 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )
 
+        # Clear checkout shipping address if it was C&C before.
+        if checkout.collection_point_id:
+            checkout.shipping_address = None
+            checkout.save(update_fields=["shipping_address"])
+
         cls._update_delivery_method(
             manager,
             checkout_info,
@@ -143,6 +148,11 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
         cls._check_delivery_method(
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )
+
+        # Clear checkout shipping address if it was C&C before.
+        if checkout.collection_point_id:
+            checkout.shipping_address = None
+            checkout.save(update_fields=["shipping_address"])
 
         cls._update_delivery_method(
             manager,


### PR DESCRIPTION
I want to merge this change because it unassigns the checkout address after delivery method is changed from C&C to standard delivery method.

more context: https://linear.app/saleor/issue/SHOPX-568/switching-from-clickandcollect-to-shipping-automatically-pre-fills-the

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
