### PR TITLE
Add product name to gift line.

### DIFF
--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_order.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_order.py
@@ -219,6 +219,7 @@ def test_create_order_discount_gift(
     # given
     order = order_with_lines
     variant = variant_with_many_stocks
+    product = variant.product
     channel = order.channel
     promotion = order_promotion_without_rules
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
@@ -269,6 +270,8 @@ def test_create_order_discount_gift(
     assert gift_line.unit_discount_amount == Decimal(0)
     assert gift_line.unit_discount_type == RewardValueType.FIXED
     assert gift_line.unit_discount_value == Decimal(0)
+    assert gift_line.product_name == product.name
+    assert gift_line.product_sku == variant.sku
 
 
 def test_multiple_rules_subtotal_and_catalogue_discount_applied(

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -1002,8 +1002,15 @@ def _get_defaults_for_gift_line(
             "currency": order_or_checkout.currency,
         }
     else:
+        variant = (
+            ProductVariant.objects.filter(id=variant_id)
+            .select_related("product")
+            .first()
+        )
         return {
             "variant_id": variant_id,
+            "product_name": variant.product.name if variant else "",
+            "product_sku": variant.sku if variant else "",
             "quantity": 1,
             "currency": order_or_checkout.currency,
             "unit_price_net_amount": Decimal(0),

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -1005,6 +1005,7 @@ def _get_defaults_for_gift_line(
         variant = (
             ProductVariant.objects.filter(id=variant_id)
             .select_related("product")
+            .only("sku", "product__name")
             .first()
         )
         return {


### PR DESCRIPTION
I want to merge this change because when we create gift line for draft order, order line's product name and sku is missing.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
