### PR TITLE
Fix mixing up attibute values because of the same slug value

### DIFF
--- a/saleor/attribute/tests/test_utils.py
+++ b/saleor/attribute/tests/test_utils.py
@@ -1,7 +1,44 @@
 import pytest
 
 from ...product.models import ProductType
-from ..utils import associate_attribute_values_to_instance
+from .. import AttributeInputType, AttributeType
+from ..models import Attribute, AttributeValue
+from ..utils import (
+    associate_attribute_values_to_instance,
+    validate_attribute_owns_values,
+)
+
+
+@pytest.fixture
+def attribute_1():
+    attr = Attribute.objects.create(
+        slug="attribute-1",
+        name="Attribute 1",
+        input_type=AttributeInputType.DROPDOWN,
+        type=AttributeType.PRODUCT_TYPE,
+    )
+    AttributeValue.objects.create(
+        attribute=attr,
+        name="Value 1",
+        slug="value-1",
+    )
+    return attr
+
+
+@pytest.fixture
+def attribute_2():
+    attr = Attribute.objects.create(
+        slug="attribute-2",
+        name="Attribute 2",
+        input_type=AttributeInputType.DROPDOWN,
+        type=AttributeType.PRODUCT_TYPE,
+    )
+    AttributeValue.objects.create(
+        attribute=attr,
+        name="Value 1",
+        slug="value-1",
+    )
+    return attr
 
 
 def test_associate_attribute_to_non_product_instance(color_attribute):
@@ -186,4 +223,21 @@ def test_associate_attribute_to_instance_duplicated_values(
     assert set(product.attributevalues.values_list("value_id", "product_id")) == {
         (new_color_value.pk, product.id),
         (multiselect_value.pk, product.id),
+    }
+
+
+def test_validate_attribute_owns_values(attribute_1, attribute_2):
+    # given
+    attr_val_map = {
+        attribute_1.id: [attribute_1.values.first()],
+        attribute_2.id: [attribute_2.values.first()],
+    }
+
+    # when
+    validate_attribute_owns_values(attr_val_map)
+
+    # then
+    assert attr_val_map == {
+        attribute_1.id: [attribute_1.values.first()],
+        attribute_2.id: [attribute_2.values.first()],
     }

--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -76,8 +76,9 @@ def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
     values = AttributeValue.objects.filter(lookup)
 
     for value in values:
-        values_map[value.attribute_id].add(value.slug)
-        slug_value_to_value_map[value.slug] = value
+        attr_id = value.attribute_id
+        values_map[attr_id].add(value.slug)
+        slug_value_to_value_map[attr_id, value.slug] = value
 
     for attribute_id, attr_values in attr_val_map.items():
         if values_map[attribute_id] != {v.slug for v in attr_values}:
@@ -86,7 +87,7 @@ def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
         # id set. This is needed as `ignore_conflicts=True` flag in `bulk_create
         # is used in `AttributeValueManager`
         attr_val_map[attribute_id] = [
-            slug_value_to_value_map[v.slug] for v in attr_values
+            slug_value_to_value_map[attribute_id, v.slug] for v in attr_values
         ]
 
 


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/15958

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
