### PR TITLE
Fix mixing up attribute values because of the same slug value

### DIFF
--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -69,8 +69,9 @@ def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
     values = AttributeValue.objects.filter(lookup)
 
     for value in values:
-        values_map[value.attribute_id].add(value.slug)
-        slug_value_to_value_map[value.slug] = value
+        attr_id = value.attribute_id
+        values_map[attr_id].add(value.slug)
+        slug_value_to_value_map[attr_id, value.slug] = value
 
     for attribute_id, attr_values in attr_val_map.items():
         if values_map[attribute_id] != {v.slug for v in attr_values}:
@@ -79,7 +80,7 @@ def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
         # id set. This is needed as `ignore_conflicts=True` flag in `bulk_create
         # is used in `AttributeValueManager`
         attr_val_map[attribute_id] = [
-            slug_value_to_value_map[v.slug] for v in attr_values
+            slug_value_to_value_map[attribute_id, v.slug] for v in attr_values
         ]
 
 

--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -7,6 +7,7 @@ from ....attribute import AttributeInputType
 from ....attribute.models import AttributeValue
 from ....page.error_codes import PageErrorCode
 from ....product.error_codes import ProductErrorCode
+from ..enums import AttributeValueBulkActionEnum
 from ..utils import (
     AttributeAssignmentMixin,
     AttrValuesForSelectableFieldInput,
@@ -2165,3 +2166,34 @@ def test_prepare_attribute_values_that_gives_the_same_slug(color_attribute):
     assert result[0] == existing_value
     assert result[1].name == new_value
     assert result[2].name == new_value_2
+
+
+def test_attribute_assignment_mixin_pre_save_multiselect_external_reference_action(
+    color_attribute,
+):
+    # given
+    color_attribute.input_type = AttributeInputType.MULTISELECT
+    color_attribute.save(update_fields=["input_type"])
+
+    values = AttrValuesInput(
+        global_id=graphene.Node.to_global_id("Attribute", color_attribute.pk),
+        content_type=None,
+        references=[],
+        multiselect=[
+            AttrValuesForSelectableFieldInput(
+                external_reference=value.external_reference
+            )
+            for value in color_attribute.values.all()
+        ],
+    )
+
+    # when
+    result = AttributeAssignmentMixin._pre_save_multiselect_values(
+        None, color_attribute, values
+    )
+
+    # then
+    assert result == [
+        (AttributeValueBulkActionEnum.NONE, value)
+        for value in color_attribute.values.all()
+    ]

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -565,7 +565,7 @@ class AttributeAssignmentMixin:
                     raise ValidationError(
                         "Attribute value with given externalReference can't be found"
                     )
-                return value
+                attribute_values.append(value)
 
             if attr_value.id:
                 _, attr_value_id = from_global_id_or_error(attr_value.id)


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/15981

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
