### PR TITLE
Handle a celery task error when the job_id for an AppInstall is missing in the db

### DIFF
--- a/saleor/app/tasks.py
+++ b/saleor/app/tasks.py
@@ -18,7 +18,13 @@ logger = logging.getLogger(__name__)
 
 @celeryconf.app.task
 def install_app_task(job_id, activate=False):
-    app_installation = AppInstallation.objects.get(id=job_id)
+    try:
+        app_installation = AppInstallation.objects.get(id=job_id)
+    except AppInstallation.DoesNotExist:
+        logger.warning(
+            "Failed to install app. AppInstallation not found for job_id: %s.", job_id
+        )
+        return
     try:
         app, _ = install_app(app_installation, activate=activate)
         app_installation.delete()

--- a/saleor/app/tests/test_app_tasks.py
+++ b/saleor/app/tests/test_app_tasks.py
@@ -24,6 +24,16 @@ def test_install_app_task(app_installation):
 
 
 @pytest.mark.vcr
+def test_install_app_task_job_id_does_not_exist():
+    # given & when
+    nonexistent_job_id = 5435435345
+    install_app_task(nonexistent_job_id, activate=True)
+
+    # then
+    assert not App.objects.exists()
+
+
+@pytest.mark.vcr
 def test_install_app_task_wrong_format_of_target_token_url():
     app_installation = AppInstallation.objects.create(
         app_name="External App",

--- a/saleor/app/tests/test_app_tasks.py
+++ b/saleor/app/tests/test_app_tasks.py
@@ -25,10 +25,14 @@ def test_install_app_task(app_installation):
 
 
 def test_install_app_task_job_id_does_not_exist(caplog):
-    # given & when
+    # given
     nonexistent_job_id = 5435435345
+
+    # when
     install_app_task(nonexistent_job_id, activate=True)
 
+    # then
+    assert not App.objects.exists()
     assert caplog.record_tuples == [
         (
             ANY,
@@ -37,9 +41,6 @@ def test_install_app_task_job_id_does_not_exist(caplog):
             f"{nonexistent_job_id}.",
         )
     ]
-
-    # then
-    assert not App.objects.exists()
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
I want to merge this change because it's adding a logger when celery would have a task crash on rare cases where `job_id` is missing.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
