### PR TITLE
Fix TypeError when availableActions null is provided to transactionCreate

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -954,6 +954,9 @@ class TransactionCreate(BaseMutation):
                 if "cancel" not in available_actions:
                     available_actions.append("cancel")
                 transaction["available_actions"] = available_actions
+        elif "available_actions" in transaction:
+            # null available_actions is provided, removing it from keys
+            transaction.pop("available_actions")
         return instance
 
     @classmethod


### PR DESCRIPTION
I want to merge this change because it fixes `TypeError` on mutation `transactionCreate` if one passed `availableActions` as `null` in variables.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
