### PR TITLE
Fix order from draft confirmation

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -167,18 +167,9 @@ def test_draft_order_complete_no_automatically_confirm_all_new_orders(
         assert allocation.quantity_allocated == line.quantity_unfulfilled
 
     # ensure there are only 1 event with correct type
-    event_params = {
-        "user": staff_user,
-        "type__in": [
-            order_events.OrderEvents.PLACED_FROM_DRAFT,
-            order_events.OrderEvents.CONFIRMED,
-        ],
-        "parameters": {},
-    }
-    matching_events = OrderEvent.objects.filter(**event_params)
-    assert matching_events.count() == 1
-    assert matching_events[0].type == order_events.OrderEvents.PLACED_FROM_DRAFT
-    assert not OrderEvent.objects.exclude(**event_params).exists()
+    event = OrderEvent.objects.get(user=staff_user)
+    assert event.type == order_events.OrderEvents.PLACED_FROM_DRAFT
+    assert not OrderEvent.objects.exclude(user=staff_user).exists()
 
 
 def test_draft_order_complete_by_user_no_channel_access(

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -120,7 +120,7 @@ def order_created(
         )
 
     channel = order_info.channel
-    if channel.automatically_confirm_all_new_orders or from_draft:
+    if channel.automatically_confirm_all_new_orders:
         order_confirmed(order, user, app, manager)
 
 

--- a/saleor/order/tests/test_actions.py
+++ b/saleor/order/tests/test_actions.py
@@ -6,20 +6,18 @@ from .. import OrderStatus
 from ..actions import order_created
 from ..fetch import OrderInfo
 
-parametrize_order_statuses = [
-    (status, flag) for status, _ in OrderStatus.CHOICES for flag in (True, False)
-]
+parametrize_order_statuses = [(status,) for status, _ in OrderStatus.CHOICES]
 
 
-@pytest.mark.parametrize(("order_status", "flag"), parametrize_order_statuses)
+@pytest.mark.parametrize("order_status", parametrize_order_statuses)
 @patch("saleor.order.actions.order_confirmed")
-def test_order_created_order_confirmed(
-    mock_order_confirmed, order_status, flag, order, customer_user, plugins_manager
+def test_order_created_order_confirmed_with_turned_flag_on(
+    mock_order_confirmed, order_status, order, customer_user, plugins_manager
 ):
     # given
     order.status = order_status
     order.save(update_fields=["status"])
-    order.channel.automatically_confirm_all_new_orders = flag
+    order.channel.automatically_confirm_all_new_orders = True
     order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
     order_info = OrderInfo(
         order=order,
@@ -33,9 +31,31 @@ def test_order_created_order_confirmed(
     order_created(order_info, user=customer_user, app=None, manager=plugins_manager)
 
     # then
-    if flag is True:
-        mock_order_confirmed.assert_called_once_with(
-            order, customer_user, None, plugins_manager
-        )
-    else:
-        mock_order_confirmed.assert_not_called()
+    mock_order_confirmed.assert_called_once_with(
+        order, customer_user, None, plugins_manager
+    )
+
+
+@pytest.mark.parametrize("order_status", parametrize_order_statuses)
+@patch("saleor.order.actions.order_confirmed")
+def test_order_created_order_confirmed_with_turned_flag_off(
+    mock_order_confirmed, order_status, order, customer_user, plugins_manager
+):
+    # given
+    order.status = order_status
+    order.save(update_fields=["status"])
+    order.channel.automatically_confirm_all_new_orders = False
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    order_info = OrderInfo(
+        order=order,
+        customer_email=order.get_customer_email(),
+        channel=order.channel,
+        payment=order.get_last_payment(),
+        lines_data=[],
+    )
+
+    # when
+    order_created(order_info, user=customer_user, app=None, manager=plugins_manager)
+
+    # then
+    mock_order_confirmed.assert_not_called()

--- a/saleor/order/tests/test_actions.py
+++ b/saleor/order/tests/test_actions.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+import pytest
+
+from .. import OrderStatus
+from ..actions import order_created
+from ..fetch import OrderInfo
+
+parametrize_order_statuses = [
+    (status, flag) for status, _ in OrderStatus.CHOICES for flag in (True, False)
+]
+
+
+@pytest.mark.parametrize(("order_status", "flag"), parametrize_order_statuses)
+@patch("saleor.order.actions.order_confirmed")
+def test_order_created_order_confirmed(
+    mock_order_confirmed, order_status, flag, order, customer_user, plugins_manager
+):
+    # given
+    order.status = order_status
+    order.save(update_fields=["status"])
+    order.channel.automatically_confirm_all_new_orders = flag
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    order_info = OrderInfo(
+        order=order,
+        customer_email=order.get_customer_email(),
+        channel=order.channel,
+        payment=order.get_last_payment(),
+        lines_data=[],
+    )
+
+    # when
+    order_created(order_info, user=customer_user, app=None, manager=plugins_manager)
+
+    # then
+    if flag is True:
+        mock_order_confirmed.assert_called_once_with(
+            order, customer_user, None, plugins_manager
+        )
+    else:
+        mock_order_confirmed.assert_not_called()


### PR DESCRIPTION
I want to merge this change because it fixes issue with draft orders being confirmed regardless of value in `automatically_confirm_all_new_orders`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
