### PR TITLE
Fix TypeError when availableActions null is provided to transactionCreate

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -239,6 +239,8 @@ class TransactionCreate(BaseMutation):
             transaction.get("external_url"),
             error_code=TransactionCreateErrorCode.INVALID.value,
         )
+        if "available_actions" in transaction and not transaction["available_actions"]:
+            transaction.pop("available_actions")
         return instance
 
     @classmethod
@@ -357,11 +359,6 @@ class TransactionCreate(BaseMutation):
                     reference=transaction_event.get("psp_reference"),
                     message=transaction_event.get("message", ""),
                 )
-        if (
-            "available_actions" in transaction_data
-            and not transaction_data["available_actions"]
-        ):
-            transaction_data.pop("available_actions")
         money_data = cls.get_money_data_from_input(transaction_data)
         new_transaction = cls.create_transaction(transaction_data, user=user, app=app)
         if money_data:

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -357,6 +357,11 @@ class TransactionCreate(BaseMutation):
                     reference=transaction_event.get("psp_reference"),
                     message=transaction_event.get("message", ""),
                 )
+        if (
+            "available_actions" in transaction_data
+            and not transaction_data["available_actions"]
+        ):
+            transaction_data.pop("available_actions")
         money_data = cls.get_money_data_from_input(transaction_data)
         new_transaction = cls.create_transaction(transaction_data, user=user, app=app)
         if money_data:

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2016,3 +2016,29 @@ def test_transaction_create_for_checkout_updates_last_transaction_modified_at(
     transaction = checkout_with_items.payment_transactions.first()
 
     assert checkout_with_items.last_transaction_modified_at == transaction.modified_at
+
+
+def test_transaction_create_null_available_actions(
+    checkout_with_items, permission_manage_payments, app_api_client
+):
+    # given
+    authorized_value = Decimal("10")
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+        "transaction": {
+            "pspReference": "PSP reference - 123",
+            "availableActions": None,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    assert checkout_with_items.payment_transactions.first().available_actions == []


### PR DESCRIPTION
I want to merge this change because it fixes `TypeError` on mutation `transactionCreate` if one passed `availableActions` as `null` in variables.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
