### PR TITLE
Allow query checkout for all users.

### DIFF
--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -1,5 +1,10 @@
 from ...checkout import models
-from ...permission.enums import AccountPermissions, CheckoutPermissions
+from ...core.exceptions import PermissionDenied
+from ...permission.enums import (
+    AccountPermissions,
+    CheckoutPermissions,
+    PaymentPermissions,
+)
 from ..core.context import get_database_connection_name
 from ..core.tracing import traced_resolver
 from ..core.utils import from_global_id_or_error
@@ -34,22 +39,13 @@ def resolve_checkout(info, token, id):
         .filter(token=token)
         .first()
     )
-
     if checkout is None:
         return None
-
-    # resolve checkout in active channel
+    # always return checkout for active channel
     if checkout.channel.is_active:
-        # resolve checkout for anonymous customer
-        if not checkout.user:
-            return checkout
+        return checkout
 
-        # resolve checkout for logged-in customer
-        user = info.context.user
-        if user and checkout.user == user:
-            return checkout
-
-    # resolve checkout for staff user
+    # resolve checkout for staff or app
     requester = get_user_or_app_from_context(info.context)
 
     if not requester:
@@ -57,7 +53,14 @@ def resolve_checkout(info, token, id):
 
     has_manage_checkout = requester.has_perm(CheckoutPermissions.MANAGE_CHECKOUTS)
     has_impersonate_user = requester.has_perm(AccountPermissions.IMPERSONATE_USER)
-    if has_manage_checkout or has_impersonate_user:
+    has_handle_payments = requester.has_perm(PaymentPermissions.HANDLE_PAYMENTS)
+    if has_manage_checkout or has_impersonate_user or has_handle_payments:
         return checkout
 
-    return None
+    raise PermissionDenied(
+        permissions=[
+            CheckoutPermissions.MANAGE_CHECKOUTS,
+            AccountPermissions.IMPERSONATE_USER,
+            PaymentPermissions.HANDLE_PAYMENTS,
+        ]
+    )

--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -46,16 +46,12 @@ def resolve_checkout(info, token, id):
         return checkout
 
     # resolve checkout for staff or app
-    requester = get_user_or_app_from_context(info.context)
-
-    if not requester:
-        return None
-
-    has_manage_checkout = requester.has_perm(CheckoutPermissions.MANAGE_CHECKOUTS)
-    has_impersonate_user = requester.has_perm(AccountPermissions.IMPERSONATE_USER)
-    has_handle_payments = requester.has_perm(PaymentPermissions.HANDLE_PAYMENTS)
-    if has_manage_checkout or has_impersonate_user or has_handle_payments:
-        return checkout
+    if requester := get_user_or_app_from_context(info.context):
+        has_manage_checkout = requester.has_perm(CheckoutPermissions.MANAGE_CHECKOUTS)
+        has_impersonate_user = requester.has_perm(AccountPermissions.IMPERSONATE_USER)
+        has_handle_payments = requester.has_perm(PaymentPermissions.HANDLE_PAYMENTS)
+        if has_manage_checkout or has_impersonate_user or has_handle_payments:
+            return checkout
 
     raise PermissionDenied(
         permissions=[

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -1,6 +1,10 @@
 import graphene
 
-from ...permission.enums import AccountPermissions, CheckoutPermissions
+from ...permission.enums import (
+    AccountPermissions,
+    CheckoutPermissions,
+    PaymentPermissions,
+)
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.descriptions import (
@@ -51,6 +55,7 @@ class CheckoutQueries(graphene.ObjectType):
             "query checkouts that belong to other users: "
             f"{CheckoutPermissions.MANAGE_CHECKOUTS.name}, "
             f"{AccountPermissions.IMPERSONATE_USER.name}. "
+            f"{PaymentPermissions.HANDLE_PAYMENTS.name}. "
         ),
         id=graphene.Argument(
             graphene.ID, description="The checkout's ID." + ADDED_IN_34
@@ -75,6 +80,7 @@ class CheckoutQueries(graphene.ObjectType):
         ),
         permissions=[
             CheckoutPermissions.MANAGE_CHECKOUTS,
+            PaymentPermissions.HANDLE_PAYMENTS,
         ],
         description="List of checkouts.",
         doc_category=DOC_CATEGORY_CHECKOUT,

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -51,10 +51,10 @@ class CheckoutQueries(graphene.ObjectType):
     checkout = BaseField(
         Checkout,
         description=(
-            "Look up a checkout by id.\n\nRequires one of the following permissions to "
-            "query checkouts that belong to other users: "
+            "Look up a checkout by id.\n\nRequires one of the following permissions "
+            "to query a checkout, if a checkout is in inactive channel: "
             f"{CheckoutPermissions.MANAGE_CHECKOUTS.name}, "
-            f"{AccountPermissions.IMPERSONATE_USER.name}. "
+            f"{AccountPermissions.IMPERSONATE_USER.name}, "
             f"{PaymentPermissions.HANDLE_PAYMENTS.name}. "
         ),
         id=graphene.Argument(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1175,22 +1175,6 @@ def test_checkout_reservation_date_for_disabled_reservations(
     assert content["data"]["checkout"]["stockReservationExpires"] is None
 
 
-# @pytest.fixture
-# def fake_manager(mocker):
-#     return mocker.Mock(spec=PaymentInterface)
-
-
-# @pytest.fixture
-# def mock_get_manager(mocker, fake_manager):
-#     manager = mocker.patch(
-#         "saleor.payment.gateway.get_plugins_manager",
-#         autospec=True,
-#         return_value=fake_manager,
-#     )
-#     yield fake_manager
-#     manager.assert_called_once()
-
-
 QUERY_CHECKOUT_USER_ID = """
     query getCheckout($id: ID) {
         checkout(id: $id) {
@@ -1202,7 +1186,7 @@ QUERY_CHECKOUT_USER_ID = """
     """
 
 
-def test_anonymous_client_can_fetch_anonymoues_checkout_user(api_client, checkout):
+def test_anonymous_client_can_fetch_anonymous_checkout_user(api_client, checkout):
     # given
     query = QUERY_CHECKOUT_USER_ID
     variables = {"id": to_global_id_or_none(checkout)}
@@ -1216,7 +1200,7 @@ def test_anonymous_client_can_fetch_anonymoues_checkout_user(api_client, checkou
     assert not content["data"]["checkout"]["user"]
 
 
-def test_anonymous_client_cant_fetch_checkout_with_attached_user(
+def test_anonymous_client_cant_fetch_checkout_with_attached_user_with_user_data(
     api_client, checkout, customer_user
 ):
     # given
@@ -1230,8 +1214,25 @@ def test_anonymous_client_cant_fetch_checkout_with_attached_user(
     response = api_client.post_graphql(query, variables)
 
     # then
+    assert_no_permission(response)
+
+
+def test_anonymous_client_can_fetch_checkout_with_attached_user_without_user_data(
+    api_client, checkout, customer_user
+):
+    # given
+    checkout.user = customer_user
+    checkout.save()
+
+    query = QUERY_CHECKOUT
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = api_client.post_graphql(query, variables)
+
+    # then
     content = get_graphql_content(response)
-    assert not content["data"]["checkout"]
+    assert content["data"]["checkout"]
 
 
 def test_authorized_access_to_checkout_user_as_customer(
@@ -1294,6 +1295,58 @@ def test_authorized_access_to_checkout_user_as_staff_no_permission(
         permissions=[permission_manage_checkouts],
         check_no_permissions=False,
     )
+    assert_no_permission(response)
+
+
+def test_query_checkout_as_staff_with_no_permission_for_inactive_channel(
+    staff_api_client,
+    checkout,
+    customer_user,
+    permission_manage_checkouts,
+):
+    # given
+    query = QUERY_CHECKOUT
+    checkout.user = customer_user
+    checkout.save(update_fields=["user"])
+    channel = checkout.channel
+    channel.is_active = False
+    channel.save(update_fields=["is_active"])
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        check_no_permissions=False,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_query_checkout_as_app_with_no_permission_for_inactive_channel(
+    app_api_client,
+    checkout,
+    customer_user,
+    permission_manage_checkouts,
+):
+    # given
+    query = QUERY_CHECKOUT
+    checkout.user = customer_user
+    checkout.save(update_fields=["user"])
+    channel = checkout.channel
+    channel.is_active = False
+    channel.save(update_fields=["is_active"])
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = app_api_client.post_graphql(
+        query,
+        variables,
+        check_no_permissions=False,
+    )
+
+    # then
     assert_no_permission(response)
 
 
@@ -1378,16 +1431,40 @@ def test_query_anonymous_customer_checkout_as_staff_user(
     assert content["data"]["checkout"]["token"] == str(checkout.token)
 
 
-def test_query_anonymous_customer_checkout_as_app(
+def test_query_anonymous_customer_checkout_as_app_manage_checkouts(
     app_api_client, checkout, permission_manage_checkouts
 ):
+    # given
     variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
     response = app_api_client.post_graphql(
         QUERY_CHECKOUT,
         variables,
         permissions=[permission_manage_checkouts],
         check_no_permissions=False,
     )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["token"] == str(checkout.token)
+
+
+def test_query_anonymous_customer_checkout_as_app_handle_payments(
+    app_api_client, checkout, permission_manage_payments
+):
+    # given
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_CHECKOUT,
+        variables,
+        permissions=[permission_manage_payments],
+        check_no_permissions=False,
+    )
+
+    # then
     content = get_graphql_content(response)
     assert content["data"]["checkout"]["token"] == str(checkout.token)
 
@@ -1395,12 +1472,17 @@ def test_query_anonymous_customer_checkout_as_app(
 def test_query_customer_checkout_as_anonymous_customer(
     api_client, checkout, customer_user
 ):
+    # given
     checkout.user = customer_user
     checkout.save(update_fields=["user"])
     variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
     response = api_client.post_graphql(QUERY_CHECKOUT, variables)
+
+    # then
     content = get_graphql_content(response)
-    assert not content["data"]["checkout"]
+    assert content["data"]["checkout"]
 
 
 def test_query_customer_checkout_as_customer(user_api_client, checkout, customer_user):
@@ -1415,26 +1497,75 @@ def test_query_customer_checkout_as_customer(user_api_client, checkout, customer
 def test_query_other_customer_checkout_as_customer(
     user_api_client, checkout, staff_user
 ):
+    # given
     checkout.user = staff_user
     checkout.save(update_fields=["user"])
     variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
     response = user_api_client.post_graphql(QUERY_CHECKOUT, variables)
+
+    # then
     content = get_graphql_content(response)
-    assert not content["data"]["checkout"]
+    assert content["data"]["checkout"]
 
 
-def test_query_customer_checkout_as_staff_user(
+def test_query_other_customer_checkout_as_customer_for_inactive_channel(
+    user_api_client, checkout, staff_user
+):
+    # given
+    checkout.user = staff_user
+    channel = checkout.channel
+    checkout.save(update_fields=["user"])
+    channel.is_active = False
+    channel.save(update_fields=["is_active"])
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = user_api_client.post_graphql(QUERY_CHECKOUT, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_query_customer_checkout_as_staff_user_manage_checkouts(
     app_api_client, checkout, customer_user, permission_manage_checkouts
 ):
+    # given
     checkout.user = customer_user
     checkout.save(update_fields=["user"])
     variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
     response = app_api_client.post_graphql(
         QUERY_CHECKOUT,
         variables,
         permissions=[permission_manage_checkouts],
         check_no_permissions=False,
     )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["token"] == str(checkout.token)
+
+
+def test_query_customer_checkout_as_staff_user_handle_payments(
+    app_api_client, checkout, customer_user, permission_manage_payments
+):
+    # given
+    checkout.user = customer_user
+    checkout.save(update_fields=["user"])
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_CHECKOUT,
+        variables,
+        permissions=[permission_manage_payments],
+        check_no_permissions=False,
+    )
+
+    # then
     content = get_graphql_content(response)
     assert content["data"]["checkout"]["token"] == str(checkout.token)
 
@@ -2048,10 +2179,7 @@ def test_checkout_prices_with_voucher_code_that_doesnt_exist(
     )
 
 
-def test_query_checkouts(
-    checkout_with_item, staff_api_client, permission_manage_checkouts
-):
-    query = """
+CHECKOUTS_QUERY = """
     {
         checkouts(first: 20) {
             edges {
@@ -2061,11 +2189,61 @@ def test_query_checkouts(
             }
         }
     }
-    """
+"""
+
+
+def test_staff_user_can_query_checkouts_with_handle_payments_permission(
+    checkout_with_item, staff_api_client, permission_manage_payments
+):
+    # given
     checkout = checkout_with_item
+
+    # when
     response = staff_api_client.post_graphql(
-        query, {}, permissions=[permission_manage_checkouts]
+        CHECKOUTS_QUERY,
+        {},
+        permissions=[permission_manage_payments],
+        check_no_permissions=False,
     )
+
+    # then
+    content = get_graphql_content(response)
+    received_checkout = content["data"]["checkouts"]["edges"][0]["node"]
+    assert str(checkout.token) == received_checkout["token"]
+
+
+def test_app_can_query_checkouts_with_handle_payments_permission(
+    checkout_with_item, app_api_client, permission_manage_payments
+):
+    # given
+    checkout = checkout_with_item
+
+    # when
+    response = app_api_client.post_graphql(
+        CHECKOUTS_QUERY,
+        {},
+        permissions=[permission_manage_payments],
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    received_checkout = content["data"]["checkouts"]["edges"][0]["node"]
+    assert str(checkout.token) == received_checkout["token"]
+
+
+def test_query_checkouts(
+    checkout_with_item, staff_api_client, permission_manage_checkouts
+):
+    # given
+    checkout = checkout_with_item
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHECKOUTS_QUERY, {}, permissions=[permission_manage_checkouts]
+    )
+
+    # then
     content = get_graphql_content(response)
     received_checkout = content["data"]["checkouts"]["edges"][0]["node"]
     assert str(checkout.token) == received_checkout["token"]
@@ -2096,20 +2274,12 @@ def test_query_with_channel(
 def test_query_without_channel(
     checkouts_list, staff_api_client, permission_manage_checkouts
 ):
-    query = """
-    {
-        checkouts(first: 20) {
-            edges {
-                node {
-                    token
-                }
-            }
-        }
-    }
-    """
+    # when
     response = staff_api_client.post_graphql(
-        query, {}, permissions=[permission_manage_checkouts]
+        CHECKOUTS_QUERY, {}, permissions=[permission_manage_checkouts]
     )
+
+    # then
     content = get_graphql_content(response)
     assert len(content["data"]["checkouts"]["edges"]) == 5
 

--- a/saleor/graphql/meta/tests/queries/test_checkout.py
+++ b/saleor/graphql/meta/tests/queries/test_checkout.py
@@ -44,7 +44,7 @@ def test_query_public_meta_for_other_customer_checkout_as_anonymous_user(
     content = get_graphql_content(response)
 
     # then
-    assert not content["data"]["checkout"]
+    assert content["data"]["checkout"]
 
 
 def test_query_public_meta_for_checkout_as_customer(user_api_client, checkout):
@@ -148,10 +148,9 @@ def test_query_private_meta_for_other_customer_checkout_as_anonymous_user(
 
     # when
     response = api_client.post_graphql(QUERY_CHECKOUT_PRIVATE_META, variables)
-    content = get_graphql_content(response)
 
     # then
-    assert not content["data"]["checkout"]
+    assert_no_permission(response)
 
 
 def test_query_private_meta_for_checkout_as_customer(user_api_client, checkout):

--- a/saleor/graphql/meta/tests/test_meta_queries.py
+++ b/saleor/graphql/meta/tests/test_meta_queries.py
@@ -214,7 +214,7 @@ def test_query_public_meta_for_other_customer_checkout_as_anonymous_user(
     content = get_graphql_content(response)
 
     # then
-    assert not content["data"]["checkout"]
+    assert content["data"]["checkout"]
 
 
 def test_query_public_meta_for_checkout_as_customer(user_api_client, checkout):
@@ -1984,10 +1984,9 @@ def test_query_private_meta_for_other_customer_checkout_as_anonymous_user(
 
     # when
     response = api_client.post_graphql(QUERY_CHECKOUT_PRIVATE_META, variables)
-    content = get_graphql_content(response)
 
     # then
-    assert not content["data"]["checkout"]
+    assert_no_permission(response)
 
 
 def test_query_private_meta_for_checkout_as_customer(user_api_client, checkout):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1287,7 +1287,7 @@ type Query {
   """
   Look up a checkout by id.
   
-  Requires one of the following permissions to query checkouts that belong to other users: MANAGE_CHECKOUTS, IMPERSONATE_USER.
+  Requires one of the following permissions to query checkouts that belong to other users: MANAGE_CHECKOUTS, IMPERSONATE_USER. HANDLE_PAYMENTS.
   """
   checkout(
     """
@@ -1308,7 +1308,7 @@ type Query {
   """
   List of checkouts.
   
-  Requires one of the following permissions: MANAGE_CHECKOUTS.
+  Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   """
   checkouts(
     """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1287,7 +1287,7 @@ type Query {
   """
   Look up a checkout by id.
   
-  Requires one of the following permissions to query checkouts that belong to other users: MANAGE_CHECKOUTS, IMPERSONATE_USER. HANDLE_PAYMENTS.
+  Requires one of the following permissions to query a checkout, if a checkout is in inactive channel: MANAGE_CHECKOUTS, IMPERSONATE_USER, HANDLE_PAYMENTS.
   """
   checkout(
     """


### PR DESCRIPTION
Allow for fetching checkouts or checkout if the channel is inactive with additional permission `HANDLE_PAYMENTS` for apps and staff users. 
Raises `PermissionDenied` error instead of returning `None` while the channel is inactive for the checkout or for checkouts query
Allow to query checkout if the user knows the ID of the checkout

Fixes: https://linear.app/saleor/issue/SHOPX-693/allow-fetching-all-checkouts-with-handle-payments-permission
Fixes: https://linear.app/saleor/issue/SHOPX-694/allow-fetching-checkout-if-id-is-known-even-if-checkout-was-assigned
Fixes: https://linear.app/saleor/issue/SHOPX-688/raise-an-error-in-checkout-query-when-the-permissions-are-missing-for

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
