### PR TITLE
Unassign shipping address on CheckoutDeliveryMethodUpdate from C&C

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -11,6 +11,8 @@ from .....checkout.utils import PRIVATE_META_APP_SHIPPING_ID, invalidate_checkou
 from .....plugins.manager import get_plugins_manager
 from .....shipping import models as shipping_models
 from .....shipping.utils import convert_to_shipping_method_data
+from .....warehouse import WarehouseClickAndCollectOption
+from .....warehouse.models import Stock
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
 
@@ -22,6 +24,10 @@ MUTATION_UPDATE_DELIVERY_METHOD = """
             deliveryMethodId: $deliveryMethodId) {
             checkout {
             id
+            shippingAddress {
+                id
+                firstName
+            }
             deliveryMethod {
                 __typename
                 ... on ShippingMethod {
@@ -834,3 +840,113 @@ def test_with_active_problems_flow(
 
     # then
     assert not content["data"]["checkoutDeliveryMethodUpdate"]["errors"]
+
+
+def test_checkout_delivery_method_update_only_with_token_cleans_shipping_address(
+    api_client,
+    checkout_with_item_for_cc,
+    warehouse,
+):
+    # given
+    warehouse.click_and_collect_option = WarehouseClickAndCollectOption.LOCAL_STOCK
+    warehouse.save(update_fields=["click_and_collect_option"])
+    checkout = checkout_with_item_for_cc
+    checkout.collection_point_id = warehouse.id
+    checkout.save(update_fields=["collection_point_id"])
+
+    # when
+    query = MUTATION_UPDATE_DELIVERY_METHOD
+    response = api_client.post_graphql(query, {"id": to_global_id_or_none(checkout)})
+
+    # then
+    data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
+    assert not data["errors"]
+    assert data["checkout"]["shippingAddress"] is None
+
+
+def test_checkout_delivery_method_update_from_cc_cleans_shipping_address(
+    api_client, checkout_with_item_for_cc, warehouse, shipping_method
+):
+    # given
+    warehouse.click_and_collect_option = WarehouseClickAndCollectOption.LOCAL_STOCK
+    warehouse.save(update_fields=["click_and_collect_option"])
+    checkout = checkout_with_item_for_cc
+    checkout.collection_point_id = warehouse.id
+    checkout.save(update_fields=["collection_point_id"])
+
+    # when
+    query = MUTATION_UPDATE_DELIVERY_METHOD
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+    response = api_client.post_graphql(
+        query, {"id": to_global_id_or_none(checkout), "deliveryMethodId": method_id}
+    )
+
+    # then
+    data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
+    assert not data["errors"]
+    assert data["checkout"]["shippingAddress"] is None
+    assert data["checkout"]["deliveryMethod"]["id"] == method_id
+
+
+def test_checkout_delivery_method_update_from_cc_to_all_warehouses_update_address(
+    api_client, checkout_with_item_for_cc, warehouses_for_cc
+):
+    # given
+    warehouse_cc_local = warehouses_for_cc[2]
+    warehouse_cc_all = warehouses_for_cc[1]
+    test_address_name = "Jimmy"
+    warehouse_cc_all_address = warehouse_cc_all.address
+    warehouse_cc_all_address.first_name = test_address_name
+    warehouse_cc_all_address.save(update_fields=["first_name"])
+    checkout = checkout_with_item_for_cc
+    checkout.collection_point_id = warehouse_cc_local.id
+    checkout.save(update_fields=["collection_point_id", "shipping_method_id"])
+    Stock.objects.create(
+        warehouse=warehouse_cc_all,
+        product_variant=checkout.lines.first().variant,
+        quantity=1,
+    )
+
+    # when
+    query = MUTATION_UPDATE_DELIVERY_METHOD
+    method_id = graphene.Node.to_global_id("Warehouse", warehouse_cc_all.id)
+    response = api_client.post_graphql(
+        query, {"id": to_global_id_or_none(checkout), "deliveryMethodId": method_id}
+    )
+
+    # then
+    data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
+    assert not data["errors"]
+    assert data["checkout"]["shippingAddress"]["firstName"] == test_address_name
+
+
+def test_checkout_delivery_method_update_from_cc_to_all_warehouses_disabled_cc(
+    api_client, checkout_with_item_for_cc, warehouses_for_cc
+):
+    # given
+    warehouse_cc_local = warehouses_for_cc[2]
+    warehouse_cc_all = warehouses_for_cc[1]
+    warehouse_cc_all.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
+    warehouse_cc_all.save(update_fields=["click_and_collect_option"])
+    checkout = checkout_with_item_for_cc
+    checkout.collection_point_id = warehouse_cc_local.id
+    checkout.save(update_fields=["collection_point_id", "shipping_method_id"])
+    Stock.objects.create(
+        warehouse=warehouse_cc_all,
+        product_variant=checkout.lines.first().variant,
+        quantity=1,
+    )
+
+    # when
+    query = MUTATION_UPDATE_DELIVERY_METHOD
+    method_id = graphene.Node.to_global_id("Warehouse", warehouse_cc_all.id)
+    response = api_client.post_graphql(
+        query, {"id": to_global_id_or_none(checkout), "deliveryMethodId": method_id}
+    )
+
+    # then
+    data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "deliveryMethodId"
+    assert errors[0]["code"] == CheckoutErrorCode.DELIVERY_METHOD_NOT_APPLICABLE.name


### PR DESCRIPTION
I want to merge this change because it fixes behavior of C&C with `checkoutShippingMethodUpdate`.
- Switching to a collection point with WarehouseClickAndCollectOption.DISABLED is now forbidden and will raise `ValidationError`.
- Switching from C&C to a standard delivery method now removes the shipping address from the checkout (it used to stay with the warehouse address).
- Switching the delivery method to none (without passing `deliveryMethodId`) now removes the checkout address if there was C&C previously selected.
- Switching from C&C `LOCAL_STOCK` to `ALL_WAREHOUSES` now works - shipping address updates to the new collection point.
- Warehouse is now validated by the variants from checkout.

more context: https://linear.app/saleor/issue/SHOPX-568/switching-from-clickandcollect-to-shipping-automatically-pre-fills-the

Docs PR: https://github.com/saleor/saleor-docs/pull/1153

⚠️ This is a port of https://github.com/saleor/saleor/pull/15975

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
