### PR TITLE
Fix order status depending on flag

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -114,7 +114,12 @@ class DraftOrderComplete(BaseMutation):
         validate_draft_order(order, country, manager)
         with traced_atomic_transaction():
             cls.update_user_fields(order)
-            order.status = OrderStatus.UNFULFILLED
+            channel = order.channel
+            order.status = (
+                OrderStatus.UNFULFILLED
+                if channel.automatically_confirm_all_new_orders
+                else OrderStatus.UNCONFIRMED
+            )
 
             if not order.is_shipping_required():
                 order.shipping_method_name = None
@@ -129,7 +134,6 @@ class DraftOrderComplete(BaseMutation):
             update_order_display_gross_prices(order)
             order.save()
 
-            channel = order.channel
             cls.setup_voucher_customer(order, channel)
             order_lines_info = []
             for line in order.lines.all():

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -106,6 +106,7 @@ def test_draft_order_complete(
     assert data["status"] == order.status.upper()
     assert data["origin"] == OrderOrigin.DRAFT.upper()
     assert order.search_vector
+    assert order.status == OrderStatus.UNFULFILLED
 
     for line in order.lines.all():
         allocation = line.allocations.get()
@@ -161,6 +162,7 @@ def test_draft_order_complete_no_automatically_confirm_all_new_orders(
     assert data["status"] == order.status.upper()
     assert data["origin"] == OrderOrigin.DRAFT.upper()
     assert order.search_vector
+    assert order.status == OrderStatus.UNCONFIRMED
 
     for line in order.lines.all():
         allocation = line.allocations.get()


### PR DESCRIPTION
I want to merge this change because it fixes state of order during mutation `draftOrderComplete` depending on channel's `automatically_confirm_all_new_orders` flag.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
