### PR TITLE
Read replica usage in tests - tweaks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,12 @@ from django.test.testcases import TransactionTestCase
 
 from saleor.tests.utils import prepare_test_db_connections
 
-django.test.TransactionTestCase.databases = "__all__"
-django.test.TestCase.databases = "__all__"
+TEST_DATABASES = {
+    settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    settings.DATABASE_CONNECTION_REPLICA_NAME,
+}
+django.test.TransactionTestCase.databases = TEST_DATABASES
+django.test.TestCase.databases = TEST_DATABASES
 
 prepare_test_db_connections()
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -111,10 +111,8 @@ DATABASES = {
         # and we need to update docs.
         # default="postgres://saleor_read_only:saleor@localhost:5432/saleor",
         conn_max_age=DB_CONN_MAX_AGE,
+        test_options={"MIRROR": DATABASE_CONNECTION_DEFAULT_NAME},
     ),
-}
-DATABASES[DATABASE_CONNECTION_REPLICA_NAME]["TEST"] = {
-    "MIRROR": DATABASE_CONNECTION_DEFAULT_NAME
 }
 
 DATABASE_ROUTERS = ["saleor.core.db_routers.PrimaryReplicaRouter"]


### PR DESCRIPTION
This PR is just a small refactor to the recently added DB read replica usage in the test

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
