### PR TITLE
Read replica in tests - add docstrings

### DIFF
--- a/saleor/tests/utils.py
+++ b/saleor/tests/utils.py
@@ -9,18 +9,30 @@ from ..core.db.connection import allow_writer
 
 
 class FakeDbReplicaConnection:
+    """A class used to create a fake replica DB connection for use in tests.
+
+    This class serves as a wrapper around the writer DB connection (alias "default")
+    that simulates a replica DB connection by identifying itself with a replica alias
+    and overriding cursor creation methods. It effectively results in one DB connection
+    identified by two separate aliases, but with shared transactions.
+    """
+
     def __init__(self, replica_conn):
         self.replica_conn = replica_conn
         self.writer_conn = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
 
     def cursor(self, *args, **kwargs):
         with allow_writer():
+            # Cursor creation is wrapped in allow_writer as it is effectively created
+            # using the writer DB connection
             cursor = self.writer_conn.cursor(*args, **kwargs)
             cursor.db = self
         return cursor
 
     def chunked_cursor(self, *args, **kwargs):
         with allow_writer():
+            # Cursor creation is wrapped in allow_writer as it is effectively created
+            # using the writer DB connection
             cursor = self.writer_conn.chunked_cursor(*args, **kwargs)
             cursor.db = self
         return cursor
@@ -32,6 +44,13 @@ class FakeDbReplicaConnection:
 
 
 def prepare_test_db_connections():
+    """Override the replica DB connection with a fake one for testing purposes.
+
+    This function allows simulation of replica DB usage in tests while using Django's
+    TestCase, avoiding the need for the slower TransactionTestCase. For more details,
+    refer to the Django documentation:
+    https://docs.djangoproject.com/en/4.2/topics/testing/advanced/#testing-primary-replica-configurations
+    """
     replica = settings.DATABASE_CONNECTION_REPLICA_NAME
     connections[replica] = FakeDbReplicaConnection(connections[replica])  # type: ignore
 


### PR DESCRIPTION
This PR adds docstrings to the `FakeDbReplicaConnection` class and the `prepare_test_db_connections` function to document their purpose and usage. The added docstrings explain the rationale behind their introduction and how they simulate the read replica for testing purposes.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
