### PR TITLE
Fix introspection query validator

### DIFF
--- a/saleor/graphql/tests/test_utils.py
+++ b/saleor/graphql/tests/test_utils.py
@@ -223,3 +223,112 @@ def test_check_if_query_contains_only_schema_with_schema_query_and_fragments():
 
     # then
     assert result is True
+
+
+def test_check_if_query_contains_only_schema_with_introspection():
+    # given
+    query = """
+        query IntrospectionQuery {
+            __schema {
+                queryType { name }
+                mutationType { name }
+                subscriptionType { name }
+                types {
+                    ...FullType
+                }
+                directives {
+                    name
+                    description
+                    locations
+                    args {
+                        ...InputValue
+                    }
+                }
+            }
+        }
+        fragment FullType on __Type {
+            kind
+            name
+            description
+            fields(includeDeprecated: true) {
+                name
+                description
+                args {
+                    ...InputValue
+                }
+                type {
+                    ...TypeRef
+                }
+                isDeprecated
+                deprecationReason
+            }
+            inputFields {
+                ...InputValue
+            }
+            interfaces {
+                ...TypeRef
+            }
+            enumValues(includeDeprecated: true) {
+                name
+                description
+                isDeprecated
+                deprecationReason
+            }
+            possibleTypes {
+                ...TypeRef
+            }
+        }
+        fragment InputValue on __InputValue {
+            name
+            description
+            type { ...TypeRef }
+            defaultValue
+        }
+        fragment TypeRef on __Type {
+            kind
+            name
+            ofType {
+                kind
+                name
+                ofType {
+                    kind
+                    name
+                    ofType {
+                        kind
+                        name
+                        ofType {
+                            kind
+                            name
+                            ofType {
+                                kind
+                                name
+                                ofType {
+                                    kind
+                                    name
+                                    ofType {
+                                        kind
+                                        name
+                                        ofType {
+                                            kind
+                                            name
+                                            ofType {
+                                                kind
+                                                name
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    document = backend.document_from_string(schema, query)
+
+    # when
+    result = check_if_query_contains_only_schema(document)
+
+    # then
+    assert result is True

--- a/saleor/graphql/utils/validators.py
+++ b/saleor/graphql/utils/validators.py
@@ -78,8 +78,11 @@ def __queries_or_introspection_in_operation_definition(definition: OperationDefi
 
 def __queries_or_introspection_in_fragment_definition(definition: FragmentDefinition):
     selections = definition.selection_set.selections
-    if definition.type_condition and definition.type_condition.name.value == "Query":
-        return __queries_or_introspection_in_selections(selections, is_query=True)
+    if definition.type_condition:
+        if definition.type_condition.name.value == "Query":
+            return __queries_or_introspection_in_selections(selections, is_query=True)
+        if definition.type_condition.name.value.startswith("__"):
+            return False, True
     return __queries_or_introspection_in_selections(selections, is_query=False)
 
 


### PR DESCRIPTION
Added a missing rule that broke playground introspection after #15966

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
