### PR TITLE
Transaction id validation in `getTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Improved GraphQL ID validation messages - #14447 by @patrys
 - Add `voucher` to `checkout` query - #14512 by @zedzior
 - Fix draft order voucher assignment - #14336 by @IKarbowiak
+- `getTransaction` will now return an error when queried with an ID of a wrong type - #16042 by @aniav
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Improved GraphQL ID validation messages - #14447 by @patrys
 - Add `voucher` to `checkout` query - #14512 by @zedzior
 - Fix draft order voucher assignment - #14336 by @IKarbowiak
-- `getTransaction` will now return an error when queried with an ID of a wrong type - #16042 by @aniav
 
 ### Other changes
 

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -99,8 +99,8 @@ class PaymentQueries(graphene.ObjectType):
         if token:
             return resolve_transaction(info, str(token))
         _, id = from_global_id_or_error(
-            global_id=id, only_type=TransactionItem, raise_error=True
-        )  # type: ignore[arg-type]
+            global_id=str(id), only_type=TransactionItem, raise_error=True
+        )
         return resolve_transaction(info, id)
 
 

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -98,7 +98,9 @@ class PaymentQueries(graphene.ObjectType):
         # If token is provided we ignore the id input.
         if token:
             return resolve_transaction(info, str(token))
-        _, id = from_global_id_or_error(id, TransactionItem)  # type: ignore[arg-type]
+        _, id = from_global_id_or_error(
+            global_id=id, only_type=TransactionItem, raise_error=True
+        )  # type: ignore[arg-type]
         return resolve_transaction(info, id)
 
 


### PR DESCRIPTION
I want to merge this change because `getTransaction` is triggering a 500 error when there is an ID of a wrong type passed as input.

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
