### PR TITLE
Add validation when VoucherCode is used in Voucher input

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -273,6 +273,18 @@ class DraftOrderCreate(
         if voucher is None:
             cleaned_input["voucher_code"] = None
             return
+
+        if isinstance(voucher, VoucherCode):
+            raise ValidationError(
+                {
+                    "voucher": ValidationError(
+                        "You cannot use voucherCode in the voucher input. "
+                        "Please use voucherCode instead.",
+                        code=OrderErrorCode.INVALID_VOUCHER.value,
+                    )
+                }
+            )
+
         code_instance = None
         if channel.include_draft_order_in_voucher_usage:
             # Validate voucher when it's included in voucher usage calculation

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -279,7 +279,7 @@ class DraftOrderCreate(
                 {
                     "voucher": ValidationError(
                         "You cannot use voucherCode in the voucher input. "
-                        "Please use voucherCode instead.",
+                        "Please use voucherCode input instead with a valid voucher code.",
                         code=OrderErrorCode.INVALID_VOUCHER.value,
                     )
                 }

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -425,7 +425,7 @@ def test_draft_order_create_with_voucher_code_in_voucher_input(
     assert error["code"] == OrderErrorCode.INVALID_VOUCHER.name
     assert (
         error["message"] == "You cannot use voucherCode in the voucher input. "
-        "Please use voucherCode instead."
+        "Please use voucherCode input instead with a valid voucher code."
     )
 
 


### PR DESCRIPTION
I want to merge this change because if someone sends VoucherCode in Voucher input it would explode by trying to fetch `channel_listings`.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
