### PR TITLE
Fix issue with voucher on draft order when there is no user associated with draft order

### DIFF
--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -277,6 +277,15 @@ def test_add_voucher_usage_by_customer_raise_not_applicable(voucher_customer):
         add_voucher_usage_by_customer(code, customer_email)
 
 
+def test_add_voucher_usage_by_customer_without_customer_email(voucher):
+    # given
+    code = voucher.codes.first()
+
+    # when & then
+    with pytest.raises(NotApplicable):
+        add_voucher_usage_by_customer(code, None)
+
+
 def test_remove_voucher_usage_by_customer(voucher_customer):
     # given
     voucher_customer_count = VoucherCustomer.objects.all().count()

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -106,7 +106,7 @@ def add_voucher_usage_by_customer(
     code: "VoucherCode", customer_email: Optional[str]
 ) -> None:
     if not customer_email:
-        raise NotApplicable("This offer is only valid for signed-in users.")
+        raise NotApplicable("Unable to apply voucher as customer details are missing.")
 
     _, created = VoucherCustomer.objects.get_or_create(
         voucher_code=code, customer_email=customer_email

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -67,7 +67,7 @@ CATALOGUE_FIELDS = ["categories", "collections", "products", "variants"]
 def increase_voucher_usage(
     voucher: "Voucher",
     code: "VoucherCode",
-    customer_email: str,
+    customer_email: Optional[str],
     increase_voucher_customer_usage: bool = True,
 ) -> None:
     if voucher.usage_limit:
@@ -102,7 +102,12 @@ def activate_voucher_code(code: "VoucherCode") -> None:
     code.save(update_fields=["is_active"])
 
 
-def add_voucher_usage_by_customer(code: "VoucherCode", customer_email: str) -> None:
+def add_voucher_usage_by_customer(
+    code: "VoucherCode", customer_email: Optional[str]
+) -> None:
+    if not customer_email:
+        raise NotApplicable("This offer is only valid for signed-in users.")
+
     _, created = VoucherCustomer.objects.get_or_create(
         voucher_code=code, customer_email=customer_email
     )

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -582,6 +582,6 @@ class DraftOrderCreate(
             increase_voucher_usage(
                 voucher,
                 code_instance,
-                instance.user_email or instance.user.email,
+                instance.user_email or instance.user and instance.user.email,
                 increase_voucher_customer_usage=False,
             )


### PR DESCRIPTION
I want to merge this change because it fixes issue with adding voucher to order that is not associated with user

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
