### PR TITLE
Allow account mutations to be run by app.

### DIFF
--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -41,6 +41,18 @@ SKIP_ADDRESS_VALIDATION_PERMISSION_MAP: dict[str, list[BasePermissionEnum]] = {
         CheckoutPermissions.HANDLE_CHECKOUTS,
         AuthorizationFilters.AUTHENTICATED_APP,
     ],
+    "accountAddressCreate": [
+        AuthorizationFilters.AUTHENTICATED_APP,
+        AccountPermissions.IMPERSONATE_USER,
+    ],
+    "accountUpdate": [
+        AuthorizationFilters.AUTHENTICATED_APP,
+        AccountPermissions.IMPERSONATE_USER,
+    ],
+    "accountAddressUpdate": [
+        AccountPermissions.MANAGE_USERS,
+        AuthorizationFilters.AUTHENTICATED_APP,
+    ],
 }
 
 

--- a/saleor/graphql/account/mixins.py
+++ b/saleor/graphql/account/mixins.py
@@ -1,5 +1,45 @@
+from ...account import models
+from ...account.error_codes import AccountErrorCode
+from ...app.models import App
+from ...core.exceptions import PermissionDenied
+from ...permission.enums import AccountPermissions
+from ..core.utils import raise_validation_error
+from ..utils import get_user_or_app_from_context
+
+
 class AddressMetadataMixin:
     @classmethod
     def construct_instance(cls, instance, cleaned_data):
         cls.update_metadata(instance, cleaned_data.pop("metadata", list()))  # type: ignore[attr-defined] # noqa: E501
         return super().construct_instance(instance, cleaned_data)  # type: ignore[misc] # noqa: E501
+
+
+class AppImpersonateMixin:
+    @classmethod
+    def get_user_instance(cls, info, customer_id):
+        requester = get_user_or_app_from_context(info.context)
+        user = None
+        if isinstance(requester, models.User):
+            if customer_id:
+                raise_validation_error(
+                    field="customerId",
+                    code=AccountErrorCode.INVALID,
+                    message="This field can be used by apps only.",
+                )
+            user = requester
+        elif isinstance(requester, App):
+            if not requester.has_perm(AccountPermissions.IMPERSONATE_USER):
+                raise PermissionDenied(
+                    permissions=[AccountPermissions.IMPERSONATE_USER]
+                )
+            if not customer_id:
+                raise_validation_error(
+                    field="customerId",
+                    code=AccountErrorCode.REQUIRED,
+                    message="This field is required when the mutation is run by app.",
+                )
+            else:
+                user = cls.get_node_or_error(  # type: ignore[attr-defined]
+                    info, customer_id, only_type="User", field="customerId"
+                )
+        return user

--- a/saleor/graphql/account/mutations/account/account_address_create.py
+++ b/saleor/graphql/account/mutations/account/account_address_create.py
@@ -38,15 +38,31 @@ class AccountAddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
                 "of that type."
             ),
         )
+        customer_id = graphene.ID(
+            required=False,
+            description=(
+                "ID of customer the application is impersonating. "
+                "The field can be used and is required by apps only. "
+                "Requires IMPERSONATE_USER and AUTHENTICATED_APP permission."
+            ),
+        )
 
     class Meta:
-        description = "Create a new address for the customer."
+        auto_permission_message = False
+        description = (
+            "Create a new address for the customer.\n\n"
+            "Requires one of following set of permissions: "
+            "AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER."
+        )
         doc_category = DOC_CATEGORY_USERS
         model = models.Address
         object_type = Address
         error_type_class = AccountError
         error_type_field = "account_errors"
-        permissions = (AuthorizationFilters.AUTHENTICATED_USER,)
+        permissions = (
+            AuthorizationFilters.AUTHENTICATED_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        )
         webhook_events_info = [
             WebhookEventInfo(
                 type=WebhookEventAsyncType.CUSTOMER_UPDATED,

--- a/saleor/graphql/account/mutations/account/account_address_create.py
+++ b/saleor/graphql/account/mutations/account/account_address_create.py
@@ -10,6 +10,7 @@ from .....core.tracing import traced_atomic_transaction
 from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import ModelMutation
 from ....core.types import AccountError
@@ -46,6 +47,7 @@ class AccountAddressCreate(
                 "ID of customer the application is impersonating. "
                 "The field can be used and is required by apps only. "
                 "Requires IMPERSONATE_USER and AUTHENTICATED_APP permission."
+                + ADDED_IN_319
             ),
         )
 

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -7,7 +7,7 @@ from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.mixins import AddressMetadataMixin
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_314
+from ....core.descriptions import ADDED_IN_314, ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
@@ -48,6 +48,7 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
                 "ID of customer the application is impersonating. "
                 "The field can be used and is required by apps only. "
                 "Requires IMPERSONATE_USER and AUTHENTICATED_APP permission."
+                + ADDED_IN_319
             ),
         )
 

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
@@ -249,7 +249,7 @@ def test_account_address_create_by_app(
     assert data["address"]["firstName"] == new_first_name
 
 
-def test_account_address_create_by_app_no_permssions(
+def test_account_address_create_by_app_no_permissions(
     app_api_client, graphql_address_data, customer_user
 ):
     # given

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
@@ -25,6 +25,7 @@ mutation($addressInput: AddressInput!, $addressType: AddressTypeEnum, $customerI
             key
             value
         }
+        firstName
     }
     user {
         email

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
@@ -17,6 +17,7 @@ ACCOUNT_ADDRESS_UPDATE_MUTATION = """
                     key
                     value
                 }
+                postalCode
             }
             user {
                 id
@@ -204,3 +205,57 @@ def test_account_address_update_by_app(
     address_obj.refresh_from_db()
     assert address_obj.city == address_data["city"].upper()
     assert address_obj.validation_skipped is False
+
+
+def test_account_address_update_by_app_skip_validation(
+    app_api_client,
+    customer_user,
+    graphql_address_data_skipped_validation,
+    permission_manage_users,
+):
+    # given
+    query = ACCOUNT_ADDRESS_UPDATE_MUTATION
+    address_obj = customer_user.addresses.first()
+    invalid_postal_code = "invalid postal code"
+    address_data = graphql_address_data_skipped_validation
+    address_data["postalCode"] = invalid_postal_code
+
+    variables = {
+        "addressId": graphene.Node.to_global_id("Address", address_obj.id),
+        "address": address_data,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountAddressUpdate"]
+    assert data["address"]["postalCode"] == invalid_postal_code
+    address_obj.refresh_from_db()
+    assert address_obj.postal_code == invalid_postal_code
+    assert address_obj.validation_skipped is True
+
+
+def test_account_address_update_by_app_skip_validation_no_permissions(
+    app_api_client, customer_user, graphql_address_data_skipped_validation
+):
+    # given
+    query = ACCOUNT_ADDRESS_UPDATE_MUTATION
+    address_obj = customer_user.addresses.first()
+    invalid_postal_code = "invalid postal code"
+    address_data = graphql_address_data_skipped_validation
+    address_data["postalCode"] = invalid_postal_code
+
+    variables = {
+        "addressId": graphene.Node.to_global_id("Address", address_obj.id),
+        "address": address_data,
+    }
+
+    # when
+    response = app_api_client.post_graphql(query, variables)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
@@ -168,13 +168,9 @@ def test_customer_update_address_skip_validation(
 
     # when
     response = user_api_client.post_graphql(query, variables)
-    content = get_graphql_content(response)
 
     # then
-    data = content["data"]["accountAddressUpdate"]
-    assert not data["user"]
-    assert data["errors"][0]["field"] == "skipValidation"
-    assert data["errors"][0]["code"] == "INVALID"
+    assert_no_permission(response)
 
 
 def test_account_address_update_by_app(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20140,15 +20140,20 @@ type Mutation {
   ): AccountRegister @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, NOTIFY_USER, ACCOUNT_CONFIRMATION_REQUESTED], syncEvents: [])
 
   """
-  Updates the account of the logged-in user. 
+  Updates the account of the logged-in user.
   
-  Requires one of the following permissions: AUTHENTICATED_USER.
+  Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
   
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
   """
   accountUpdate(
+    """
+    ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
+    """
+    customerId: ID
+
     """Fields required to update the account of the logged-in user."""
     input: AccountInput!
   ): AccountUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, CUSTOMER_METADATA_UPDATED], syncEvents: [])
@@ -31475,9 +31480,9 @@ input AccountRegisterInput @doc(category: "Users") {
 }
 
 """
-Updates the account of the logged-in user. 
+Updates the account of the logged-in user.
 
-Requires one of the following permissions: AUTHENTICATED_USER.
+Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
 
 Triggers the following webhook events:
 - CUSTOMER_UPDATED (async): A customer account was updated.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20073,6 +20073,8 @@ type Mutation {
   accountAddressCreate(
     """
     ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
+    
+    Added in Saleor 3.19.
     """
     customerId: ID
 
@@ -20151,6 +20153,8 @@ type Mutation {
   accountUpdate(
     """
     ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
+    
+    Added in Saleor 3.19.
     """
     customerId: ID
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20062,15 +20062,20 @@ type Mutation {
   ): ConfirmEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, NOTIFY_USER, ACCOUNT_EMAIL_CHANGED], syncEvents: [])
 
   """
-  Create a new address for the customer. 
+  Create a new address for the customer.
   
-  Requires one of the following permissions: AUTHENTICATED_USER.
+  Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
   
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - ADDRESS_CREATED (async): An address was created.
   """
   accountAddressCreate(
+    """
+    ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
+    """
+    customerId: ID
+
     """Fields required to create address."""
     input: AddressInput!
 
@@ -31365,9 +31370,9 @@ type ConfirmEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: 
 }
 
 """
-Create a new address for the customer. 
+Create a new address for the customer.
 
-Requires one of the following permissions: AUTHENTICATED_USER.
+Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
 
 Triggers the following webhook events:
 - CUSTOMER_UPDATED (async): A customer account was updated.


### PR DESCRIPTION
I want to merge this change because it allows `accountAddressCreate` and `accountUpdate` to be run by apps. It also enables address validation skipping for the account mutations.

Issue: https://linear.app/saleor/issue/MERX-487/allow-account-mutations-to-be-run-by-apps
Part of: https://github.com/saleor/saleor/pull/16052

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
