### PR TITLE
Feature branch: Skip address validation.

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 
 import i18naddress
@@ -13,6 +14,7 @@ from .widgets import DatalistTextWidget
 
 COUNTRY_FORMS = {}
 UNKNOWN_COUNTRIES = set()
+ADDRESS_FIELDS_TO_LOG = ["country_area", "city_area", "city", "postal_code"]
 
 AREA_TYPE = {
     "area": "Area",
@@ -36,6 +38,8 @@ AREA_TYPE = {
     "village_township": "Village/township",
     "zip": "ZIP code",
 }
+
+logger = logging.getLogger(__name__)
 
 
 class PossiblePhoneNumberFormField(forms.CharField):
@@ -185,11 +189,23 @@ class CountryAwareAddressForm(AddressForm):
                 del data["sorting_code"]
         except i18naddress.InvalidAddressError as exc:
             self.add_field_errors(exc.errors)
+            self.log_errors()
         return data
 
     def clean(self):
         data = super().clean()
         return self.validate_address(data)
+
+    def log_errors(self):
+        errors = self.errors
+        fields = {}
+        for field, _ in errors.items():
+            fields[field] = (
+                self.data.get(field) if field in ADDRESS_FIELDS_TO_LOG else "invalid"
+            )
+        fields["skip_validation"] = self.data.get("skip_validation")
+        fields["country"] = self.data.get("country")
+        logger.warning("Invalid address input: %s", fields)
 
 
 def get_address_form_class(country_code):

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1025,3 +1025,22 @@ def get_checkout_metadata(checkout: "Checkout"):
         return checkout.metadata_storage
     else:
         return CheckoutMetadata(checkout=checkout)
+
+
+def log_address_if_validation_skipped_for_checkout(
+    checkout_info: "CheckoutInfo", logger
+):
+    address = get_address_for_checkout_taxes(checkout_info)
+    if address and address.validation_skipped:
+        logger.warning(
+            "Fetching tax data for checkout with address validation skipped. "
+            "Address ID: %s",
+            address.id,
+        )
+
+
+def get_address_for_checkout_taxes(
+    checkout_info: "CheckoutInfo",
+) -> Optional["Address"]:
+    shipping_address = checkout_info.delivery_method_info.shipping_address
+    return shipping_address or checkout_info.billing_address

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -171,7 +171,6 @@ class I18nMixin:
 
         if skip_validation := address_data.get("skip_validation", False):
             cls.can_skip_address_validation(info)
-            cls._meta.exclude.append("phone")  # type: ignore[attr-defined]
             format_check = False
 
         address_form = cls._validate_address_form(

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -41,6 +41,18 @@ SKIP_ADDRESS_VALIDATION_PERMISSION_MAP: dict[str, list[BasePermissionEnum]] = {
         CheckoutPermissions.HANDLE_CHECKOUTS,
         AuthorizationFilters.AUTHENTICATED_APP,
     ],
+    "accountAddressCreate": [
+        AuthorizationFilters.AUTHENTICATED_APP,
+        AccountPermissions.IMPERSONATE_USER,
+    ],
+    "accountUpdate": [
+        AuthorizationFilters.AUTHENTICATED_APP,
+        AccountPermissions.IMPERSONATE_USER,
+    ],
+    "accountAddressUpdate": [
+        AccountPermissions.MANAGE_USERS,
+        AuthorizationFilters.AUTHENTICATED_APP,
+    ],
 }
 
 

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -103,7 +103,9 @@ class I18nMixin:
             instance=instance,
             enable_normalization=enable_normalization,
         )
+        validation_skipped = False
         if not address_form.is_valid():
+            validation_skipped = True
             errors = cls.attach_params_to_address_form_errors(
                 address_form, params, format_check, required_check
             )
@@ -114,6 +116,7 @@ class I18nMixin:
             address_form.cleaned_data["metadata"] = {}
         if address_form.cleaned_data["private_metadata"] is None:
             address_form.cleaned_data["private_metadata"] = {}
+        address_form.cleaned_data["validation_skipped"] = validation_skipped
 
         return address_form
 
@@ -169,7 +172,7 @@ class I18nMixin:
                 }
             )
 
-        if skip_validation := address_data.get("skip_validation", False):
+        if address_data.get("skip_validation"):
             cls.can_skip_address_validation(info)
             format_check = False
 
@@ -182,7 +185,6 @@ class I18nMixin:
         )
         address_data = address_form.cleaned_data
 
-        address_data["validation_skipped"] = skip_validation
         if not instance:
             instance = Address()
 

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -172,15 +172,16 @@ class I18nMixin:
         if skip_validation := address_data.get("skip_validation", False):
             cls.can_skip_address_validation(info)
             cls._meta.exclude.append("phone")  # type: ignore[attr-defined]
-        else:
-            address_form = cls._validate_address_form(
-                address_data,
-                address_type,
-                format_check=format_check,
-                required_check=required_check,
-                enable_normalization=enable_normalization,
-            )
-            address_data = address_form.cleaned_data
+            format_check = False
+
+        address_form = cls._validate_address_form(
+            address_data,
+            address_type,
+            format_check=format_check,
+            required_check=required_check,
+            enable_normalization=enable_normalization,
+        )
+        address_data = address_form.cleaned_data
 
         address_data["validation_skipped"] = skip_validation
         if not instance:

--- a/saleor/graphql/account/mixins.py
+++ b/saleor/graphql/account/mixins.py
@@ -1,5 +1,45 @@
+from ...account import models
+from ...account.error_codes import AccountErrorCode
+from ...app.models import App
+from ...core.exceptions import PermissionDenied
+from ...permission.enums import AccountPermissions
+from ..core.utils import raise_validation_error
+from ..utils import get_user_or_app_from_context
+
+
 class AddressMetadataMixin:
     @classmethod
     def construct_instance(cls, instance, cleaned_data):
         cls.update_metadata(instance, cleaned_data.pop("metadata", list()))  # type: ignore[attr-defined] # noqa: E501
         return super().construct_instance(instance, cleaned_data)  # type: ignore[misc] # noqa: E501
+
+
+class AppImpersonateMixin:
+    @classmethod
+    def get_user_instance(cls, info, customer_id):
+        requester = get_user_or_app_from_context(info.context)
+        user = None
+        if isinstance(requester, models.User):
+            if customer_id:
+                raise_validation_error(
+                    field="customerId",
+                    code=AccountErrorCode.INVALID,
+                    message="This field can be used by apps only.",
+                )
+            user = requester
+        elif isinstance(requester, App):
+            if not requester.has_perm(AccountPermissions.IMPERSONATE_USER):
+                raise PermissionDenied(
+                    permissions=[AccountPermissions.IMPERSONATE_USER]
+                )
+            if not customer_id:
+                raise_validation_error(
+                    field="customerId",
+                    code=AccountErrorCode.REQUIRED,
+                    message="This field is required when the mutation is run by app.",
+                )
+            else:
+                user = cls.get_node_or_error(  # type: ignore[attr-defined]
+                    info, customer_id, only_type="User", field="customerId"
+                )
+        return user

--- a/saleor/graphql/account/mutations/account/account_address_create.py
+++ b/saleor/graphql/account/mutations/account/account_address_create.py
@@ -10,6 +10,7 @@ from .....core.tracing import traced_atomic_transaction
 from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import ModelMutation
 from ....core.types import AccountError
@@ -17,11 +18,13 @@ from ....core.utils import WebhookEventInfo
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import AddressTypeEnum
 from ...i18n import I18nMixin
-from ...mixins import AddressMetadataMixin
+from ...mixins import AddressMetadataMixin, AppImpersonateMixin
 from ...types import Address, AddressInput, User
 
 
-class AccountAddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
+class AccountAddressCreate(
+    AddressMetadataMixin, ModelMutation, I18nMixin, AppImpersonateMixin
+):
     user = graphene.Field(
         User, description="A user instance for which the address was created."
     )
@@ -38,15 +41,32 @@ class AccountAddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
                 "of that type."
             ),
         )
+        customer_id = graphene.ID(
+            required=False,
+            description=(
+                "ID of customer the application is impersonating. "
+                "The field can be used and is required by apps only. "
+                "Requires IMPERSONATE_USER and AUTHENTICATED_APP permission."
+                + ADDED_IN_319
+            ),
+        )
 
     class Meta:
-        description = "Create a new address for the customer."
+        auto_permission_message = False
+        description = (
+            "Create a new address for the customer.\n\n"
+            "Requires one of following set of permissions: "
+            "AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER."
+        )
         doc_category = DOC_CATEGORY_USERS
         model = models.Address
         object_type = Address
         error_type_class = AccountError
         error_type_field = "account_errors"
-        permissions = (AuthorizationFilters.AUTHENTICATED_USER,)
+        permissions = (
+            AuthorizationFilters.AUTHENTICATED_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        )
         webhook_events_info = [
             WebhookEventInfo(
                 type=WebhookEventAsyncType.CUSTOMER_UPDATED,
@@ -60,17 +80,18 @@ class AccountAddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
-        cls, _root, info: ResolveInfo, /, *, input, type=None
+        cls, _root, info: ResolveInfo, /, *, input, type=None, customer_id=None
     ):
         address_type = type
-        user = info.context.user
-        user = cast(models.User, user)
         cleaned_input = cls.clean_input(info=info, instance=Address(), data=input)
+        user = cls.get_user_instance(info, customer_id)
+        user = cast(models.User, user)
         with traced_atomic_transaction():
             address = cls.validate_address(
                 cleaned_input, address_type=address_type, info=info
             )
             cls.clean_instance(info, address)
+            cleaned_input["user"] = user
             cls.save(info, address, cleaned_input)
             cls._save_m2m(info, address, cleaned_input)
             if address_type:
@@ -80,9 +101,8 @@ class AccountAddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
 
     @classmethod
     def save(cls, info: ResolveInfo, instance, cleaned_input):
+        user = cleaned_input.pop("user")
         super().save(info, instance, cleaned_input)
-        user = info.context.user
-        user = cast(models.User, user)
         remove_the_oldest_user_address_if_address_limit_is_reached(user)
         instance.user_addresses.add(user)
         user.search_document = search.prepare_user_search_document_value(user)

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -7,11 +7,12 @@ from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.mixins import AddressMetadataMixin
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_314
+from ....core.descriptions import ADDED_IN_314, ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
 from ....meta.inputs import MetadataInput
+from ...mixins import AppImpersonateMixin
 from ...types import AddressInput, User
 from ..base import BaseCustomerCreate
 from .base import AccountBaseInput
@@ -35,20 +36,37 @@ class AccountInput(AccountBaseInput):
         doc_category = DOC_CATEGORY_USERS
 
 
-class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate):
+class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixin):
     class Arguments:
         input = AccountInput(
             description="Fields required to update the account of the logged-in user.",
             required=True,
         )
+        customer_id = graphene.ID(
+            required=False,
+            description=(
+                "ID of customer the application is impersonating. "
+                "The field can be used and is required by apps only. "
+                "Requires IMPERSONATE_USER and AUTHENTICATED_APP permission."
+                + ADDED_IN_319
+            ),
+        )
 
     class Meta:
-        description = "Updates the account of the logged-in user."
+        auto_permission_message = False
+        description = (
+            "Updates the account of the logged-in user.\n\n"
+            "Requires one of following set of permissions: "
+            "AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER."
+        )
         doc_category = DOC_CATEGORY_USERS
         exclude = ["password"]
         model = models.User
         object_type = User
-        permissions = (AuthorizationFilters.AUTHENTICATED_USER,)
+        permissions = (
+            AuthorizationFilters.AUTHENTICATED_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        )
         error_type_class = AccountError
         error_type_field = "account_errors"
         support_meta_field = True
@@ -65,7 +83,8 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate):
 
     @classmethod
     def perform_mutation(cls, root, info: ResolveInfo, /, **data):
-        user = info.context.user
+        customer_id = data.get("customer_id")
+        user = cls.get_user_instance(info, customer_id)
         user = cast(models.User, user)
         data["id"] = graphene.Node.to_global_id("User", user.id)
         return super().perform_mutation(root, info, **data)

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
@@ -14,15 +14,19 @@ from .....tests.utils import assert_no_permission, get_graphql_content
 from ..utils import generate_address_webhook_call_args
 
 ACCOUNT_ADDRESS_CREATE_MUTATION = """
-mutation($addressInput: AddressInput!, $addressType: AddressTypeEnum) {
-  accountAddressCreate(input: $addressInput, type: $addressType) {
+mutation($addressInput: AddressInput!, $addressType: AddressTypeEnum, $customerId: ID) {
+  accountAddressCreate(
+    input: $addressInput, type: $addressType, customerId: $customerId
+  ) {
     address {
-        id,
+        id
         city
         metadata {
             key
             value
         }
+        firstName
+        postalCode
     }
     user {
         email
@@ -215,10 +219,170 @@ def test_customer_create_address_skip_validation(
 
     # when
     response = user_api_client.post_graphql(query, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_account_address_create_by_app(
+    app_api_client, graphql_address_data, permission_impersonate_user, customer_user
+):
+    # given
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    new_first_name = "Andrew"
+    graphql_address_data["firstName"] = new_first_name
+    variables = {"addressInput": graphql_address_data, "customerId": customer_id}
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_ADDRESS_CREATE_MUTATION,
+        variables,
+        permissions=[permission_impersonate_user],
+    )
     content = get_graphql_content(response)
 
     # then
     data = content["data"]["accountAddressCreate"]
-    assert not data["user"]
-    assert data["errors"][0]["field"] == "skipValidation"
-    assert data["errors"][0]["code"] == "INVALID"
+    assert not data["errors"]
+    assert data["address"]["firstName"] == new_first_name
+
+
+def test_account_address_create_by_app_no_permissions(
+    app_api_client, graphql_address_data, customer_user
+):
+    # given
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    variables = {"addressInput": graphql_address_data, "customerId": customer_id}
+
+    # when
+    response = app_api_client.post_graphql(ACCOUNT_ADDRESS_CREATE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_account_address_create_by_user_with_customer_id(
+    user_api_client, graphql_address_data, customer_user
+):
+    # given
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    variables = {"addressInput": graphql_address_data, "customerId": customer_id}
+
+    # when
+    response = user_api_client.post_graphql(
+        ACCOUNT_ADDRESS_CREATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountAddressCreate"]
+    assert not data["address"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "customerId"
+    assert errors[0]["code"] == AccountErrorCode.INVALID.name
+
+
+def test_account_address_create_by_app_invalid_customer_id(
+    app_api_client, graphql_address_data, permission_impersonate_user, customer_user
+):
+    # given
+    customer_id = graphene.Node.to_global_id("Address", customer_user.pk)
+    variables = {"addressInput": graphql_address_data, "customerId": customer_id}
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_ADDRESS_CREATE_MUTATION,
+        variables,
+        permissions=[permission_impersonate_user],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountAddressCreate"]
+    assert not data["address"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "customerId"
+    assert errors[0]["code"] == AccountErrorCode.GRAPHQL_ERROR.name
+
+
+def test_account_address_create_by_app_no_customer_id(
+    app_api_client, graphql_address_data, permission_impersonate_user
+):
+    # given
+    variables = {"addressInput": graphql_address_data}
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_ADDRESS_CREATE_MUTATION,
+        variables,
+        permissions=[permission_impersonate_user],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountAddressCreate"]
+    assert not data["address"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "customerId"
+    assert errors[0]["code"] == AccountErrorCode.REQUIRED.name
+
+
+def test_account_address_create_by_app_skip_validation(
+    app_api_client,
+    permission_impersonate_user,
+    customer_user,
+    graphql_address_data_skipped_validation,
+):
+    # given
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    invalid_postal_code = "invalid postal code"
+    address_data = graphql_address_data_skipped_validation
+    address_data["postalCode"] = invalid_postal_code
+    address_type = AddressType.SHIPPING.upper()
+    variables = {
+        "addressInput": address_data,
+        "customerId": customer_id,
+        "addressType": address_type,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_ADDRESS_CREATE_MUTATION,
+        variables,
+        permissions=[permission_impersonate_user],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountAddressCreate"]
+    assert not data["errors"]
+    assert data["address"]["postalCode"] == invalid_postal_code
+    customer_user.refresh_from_db()
+    assert customer_user.default_shipping_address.postal_code == invalid_postal_code
+    assert customer_user.default_shipping_address.validation_skipped is True
+
+
+def test_account_address_create_by_app_skip_validation_no_permissions(
+    app_api_client, customer_user, graphql_address_data_skipped_validation
+):
+    # given
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    invalid_postal_code = "invalid postal code"
+    address_data = graphql_address_data_skipped_validation
+    address_data["postalCode"] = invalid_postal_code
+    address_type = AddressType.SHIPPING.upper()
+    variables = {
+        "addressInput": address_data,
+        "customerId": customer_id,
+        "addressType": address_type,
+    }
+
+    # when
+    response = app_api_client.post_graphql(ACCOUNT_ADDRESS_CREATE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/account/tests/mutations/account/test_account_update.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_update.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import graphene
+
 from ......account.error_codes import AccountErrorCode
 from ......account.models import User
 from ......checkout import AddressType
@@ -14,6 +16,7 @@ ACCOUNT_UPDATE_QUERY = """
         $lastName: String
         $languageCode: LanguageCodeEnum
         $metadata: [MetadataInput!]
+        $customerId: ID
     ) {
         accountUpdate(
           input: {
@@ -22,8 +25,10 @@ ACCOUNT_UPDATE_QUERY = """
             firstName: $firstName,
             lastName: $lastName,
             languageCode: $languageCode,
-            metadata: $metadata
-        }) {
+            metadata: $metadata,
+          },
+          customerId: $customerId
+        ) {
             errors {
                 field
                 code
@@ -40,6 +45,8 @@ ACCOUNT_UPDATE_QUERY = """
                         key
                         value
                     }
+                    city
+                    postalCode
                 }
                 defaultShippingAddress {
                     id
@@ -47,6 +54,7 @@ ACCOUNT_UPDATE_QUERY = """
                         key
                         value
                     }
+                    postalCode
                 }
                 languageCode
                 metadata {
@@ -238,10 +246,173 @@ def test_logged_customer_update_address_skip_validation(
 
     # when
     response = user_api_client.post_graphql(query, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_account_update_by_app(
+    app_api_client, customer_user, permission_impersonate_user, graphql_address_data
+):
+    # given
+    new_city = "WARSZAWA"
+    address_input = graphql_address_data
+    address_input["city"] = new_city
+    user = customer_user
+    user_id = graphene.Node.to_global_id("User", user.pk)
+    assert user.default_billing_address.city != new_city
+    variables = {"billing": address_input, "customerId": user_id}
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_UPDATE_QUERY, variables, permissions=[permission_impersonate_user]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountUpdate"]
+    assert not data["errors"]
+    assert data["user"]["defaultBillingAddress"]["city"] == new_city
+    user.refresh_from_db()
+    assert user.default_billing_address.city == new_city
+
+
+def test_account_update_by_app_no_permissions(
+    app_api_client, graphql_address_data, customer_user
+):
+    # given
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    variables = {"billing": graphql_address_data, "customerId": customer_id}
+
+    # when
+    response = app_api_client.post_graphql(ACCOUNT_UPDATE_QUERY, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_account_update_by_user_with_customer_id(
+    user_api_client, graphql_address_data, customer_user
+):
+    # given
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    variables = {"billing": graphql_address_data, "customerId": customer_id}
+
+    # when
+    response = user_api_client.post_graphql(ACCOUNT_UPDATE_QUERY, variables)
     content = get_graphql_content(response)
 
     # then
     data = content["data"]["accountUpdate"]
     assert not data["user"]
-    assert data["errors"][0]["field"] == "skipValidation"
-    assert data["errors"][0]["code"] == "INVALID"
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "customerId"
+    assert errors[0]["code"] == AccountErrorCode.INVALID.name
+
+
+def test_account_address_create_by_app_invalid_customer_id(
+    app_api_client, graphql_address_data, permission_impersonate_user, customer_user
+):
+    # given
+    customer_id = graphene.Node.to_global_id("Address", customer_user.pk)
+    variables = {"addressInput": graphql_address_data, "customerId": customer_id}
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_UPDATE_QUERY,
+        variables,
+        permissions=[permission_impersonate_user],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountUpdate"]
+    assert not data["user"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "customerId"
+    assert errors[0]["code"] == AccountErrorCode.GRAPHQL_ERROR.name
+
+
+def test_account_address_create_by_app_no_customer_id(
+    app_api_client, graphql_address_data, permission_impersonate_user
+):
+    # given
+    variables = {"billing": graphql_address_data}
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_UPDATE_QUERY,
+        variables,
+        permissions=[permission_impersonate_user],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountUpdate"]
+    assert not data["user"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "customerId"
+    assert errors[0]["code"] == AccountErrorCode.REQUIRED.name
+
+
+def test_account_update_address_by_app_skip_validation(
+    app_api_client,
+    customer_user,
+    graphql_address_data_skipped_validation,
+    permission_impersonate_user,
+):
+    # given
+    query = ACCOUNT_UPDATE_QUERY
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    address_data = graphql_address_data_skipped_validation
+    invalid_postal_code = "invalid_postal_code"
+    address_data["postalCode"] = invalid_postal_code
+    variables = {
+        "shipping": address_data,
+        "billing": address_data,
+        "customerId": customer_id,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_impersonate_user]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountUpdate"]
+    assert not data["errors"]
+    assert data["user"]["defaultBillingAddress"]["postalCode"] == invalid_postal_code
+    assert data["user"]["defaultShippingAddress"]["postalCode"] == invalid_postal_code
+    customer_user.refresh_from_db()
+    assert customer_user.default_billing_address.postal_code == invalid_postal_code
+    assert customer_user.default_billing_address.validation_skipped is True
+    assert customer_user.default_shipping_address.postal_code == invalid_postal_code
+    assert customer_user.default_shipping_address.validation_skipped is True
+
+
+def test_account_update_address_by_app_skip_validation_no_permissions(
+    app_api_client,
+    customer_user,
+    graphql_address_data_skipped_validation,
+):
+    # given
+    query = ACCOUNT_UPDATE_QUERY
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    address_data = graphql_address_data_skipped_validation
+    invalid_postal_code = "invalid_postal_code"
+    address_data["postalCode"] = invalid_postal_code
+    variables = {
+        "shipping": address_data,
+        "billing": address_data,
+        "customerId": customer_id,
+    }
+
+    # when
+    response = app_api_client.post_graphql(query, variables)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/account/tests/mutations/staff/test_address_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_address_update.py
@@ -18,7 +18,6 @@ ADDRESS_UPDATE_MUTATION = """
                     key
                     value
                 }
-                phone
             }
             user {
                 id
@@ -186,12 +185,12 @@ def test_address_update_address_with_skipped_validation(
     # given
     query = ADDRESS_UPDATE_MUTATION
     address_obj = customer_user.addresses.first()
-    address_obj.phone = "invalid phone number"
+    address_obj.postal_code = "invalid postal code"
     address_obj.validation_skipped = True
-    address_obj.save(update_fields=["phone", "validation_skipped"])
+    address_obj.save(update_fields=["postal_code", "validation_skipped"])
 
     address_data = graphql_address_data
-    valid_phone = address_data["phone"]
+    valid_postal_code = address_data["postalCode"]
     variables = {
         "addressId": graphene.Node.to_global_id("Address", address_obj.id),
         "address": address_data,
@@ -206,7 +205,7 @@ def test_address_update_address_with_skipped_validation(
     # then
     data = content["data"]["addressUpdate"]
     assert not data["errors"]
-    assert data["address"]["phone"] == valid_phone
+    assert data["address"]["postalCode"] == valid_postal_code
     address_obj.refresh_from_db()
-    assert address_obj.phone == valid_phone
+    assert address_obj.postal_code == valid_postal_code
     assert address_obj.validation_skipped is False

--- a/saleor/graphql/account/tests/test_i18n.py
+++ b/saleor/graphql/account/tests/test_i18n.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import graphene
@@ -8,6 +9,8 @@ from ....account.models import Address
 from ....checkout import AddressType
 from ...tests.utils import get_graphql_content
 from ..i18n import I18nMixin
+
+logger = logging.getLogger(__name__)
 
 
 def test_validate_address():
@@ -256,7 +259,7 @@ def test_skip_address_validation_with_correct_input_run_normalization(
     address_db = Address.objects.get(id=id)
     assert address_db.city != address_data["city"]
     assert address_db.city == address_data["city"].upper()
-    assert address_db.validation_skipped is True
+    assert address_db.validation_skipped is False
 
 
 def test_skip_address_validation_with_incorrect_input_skip_normalization(
@@ -292,3 +295,36 @@ def test_skip_address_validation_with_incorrect_input_skip_normalization(
     assert address_db.city == address_data["city"]
     assert address_db.postal_code == invalid_name
     assert address_db.validation_skipped is True
+
+
+def test_skip_address_validation_logging(
+    staff_api_client,
+    customer_user,
+    permission_manage_users,
+    graphql_address_data_skipped_validation,
+    caplog,
+):
+    # given
+    query = ADDRESS_CREATE_MUTATION
+    caplog.set_level(logging.WARNING)
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    address_data = graphql_address_data_skipped_validation
+    invalid_name = "wrong name"
+    address_data["country"] = "IE"
+    address_data["postalCode"] = invalid_name
+    address_data["countryArea"] = invalid_name
+    variables = {"user": user_id, "address": address_data}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["addressCreate"]
+    assert not data["errors"]
+    assert "'country_area': 'wrong name'" in caplog.text
+    assert "'postal_code': 'wrong name'" in caplog.text
+    assert "'skip_validation': True" in caplog.text
+    assert "'country': 'IE'" in caplog.text

--- a/saleor/graphql/account/tests/test_i18n.py
+++ b/saleor/graphql/account/tests/test_i18n.py
@@ -4,6 +4,7 @@ import graphene
 import pytest
 from django.core.exceptions import ValidationError
 
+from ....account.models import Address
 from ....checkout import AddressType
 from ...tests.utils import get_graphql_content
 from ..i18n import I18nMixin
@@ -110,7 +111,13 @@ ADDRESS_CREATE_MUTATION = """
                 message
             }
             address {
+                id
                 city
+                postalCode
+                phone
+                country {
+                    code
+                }
             }
         }
     }
@@ -147,3 +154,144 @@ def test_skip_address_validation_mutation_not_supported(
         errors[0]["message"]
         == "This mutation doesn't allow to skip address validation."
     )
+
+
+def test_skip_validation_multiple_invalid_fields(
+    staff_api_client,
+    customer_user,
+    permission_manage_users,
+):
+    # given
+    query = ADDRESS_CREATE_MUTATION
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    invalid_name = "invalid name"
+    address_data = {
+        "firstName": invalid_name,
+        "lastName": invalid_name,
+        "companyName": invalid_name,
+        "streetAddress1": invalid_name,
+        "streetAddress2": invalid_name,
+        "postalCode": invalid_name,
+        "country": "US",
+        "city": invalid_name,
+        "countryArea": invalid_name,
+        "phone": invalid_name,
+        "metadata": [{"key": "public", "value": "public_value"}],
+        "skipValidation": True,
+    }
+    variables = {"user": user_id, "address": address_data}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["addressCreate"]
+    assert not data["errors"]
+    assert data["address"]["country"]["code"] == "US"
+    assert data["address"]["phone"] == invalid_name
+    assert data["address"]["postalCode"] == invalid_name
+    db_address = Address.objects.get(first_name=invalid_name)
+    assert db_address.phone == invalid_name
+    assert db_address.postal_code == invalid_name
+    assert db_address.country_area == invalid_name
+    assert db_address.city == invalid_name
+    assert db_address.validation_skipped is True
+
+
+@pytest.mark.parametrize("street", [None, "", " "])
+def test_skip_address_validation_missing_required_fields(
+    street,
+    staff_api_client,
+    customer_user,
+    permission_manage_users,
+    graphql_address_data_skipped_validation,
+):
+    # given
+    query = ADDRESS_CREATE_MUTATION
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    address_data = graphql_address_data_skipped_validation
+    address_data["streetAddress1"] = street
+    variables = {"user": user_id, "address": address_data}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["addressCreate"]
+    assert not data["address"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "streetAddress1"
+    assert errors[0]["code"] == "REQUIRED"
+
+
+def test_skip_address_validation_with_correct_input_run_normalization(
+    staff_api_client,
+    customer_user,
+    permission_manage_users,
+    graphql_address_data_skipped_validation,
+):
+    # given
+    query = ADDRESS_CREATE_MUTATION
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    address_data = graphql_address_data_skipped_validation
+    variables = {"user": user_id, "address": address_data}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["addressCreate"]
+    assert not data["errors"]
+    assert data["address"]["city"] != address_data["city"]
+    assert data["address"]["city"] == address_data["city"].upper()
+    global_id = data["address"]["id"]
+    _, id = graphene.Node.from_global_id(global_id)
+    address_db = Address.objects.get(id=id)
+    assert address_db.city != address_data["city"]
+    assert address_db.city == address_data["city"].upper()
+    assert address_db.validation_skipped is True
+
+
+def test_skip_address_validation_with_incorrect_input_skip_normalization(
+    staff_api_client,
+    customer_user,
+    permission_manage_users,
+    graphql_address_data_skipped_validation,
+):
+    # given
+    query = ADDRESS_CREATE_MUTATION
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    address_data = graphql_address_data_skipped_validation
+    invalid_name = "invalid name"
+    address_data["postalCode"] = invalid_name
+    variables = {"user": user_id, "address": address_data}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["addressCreate"]
+    assert not data["errors"]
+    assert data["address"]["city"] != address_data["city"].upper()
+    assert data["address"]["city"] == address_data["city"]
+    assert data["address"]["postalCode"] == invalid_name
+    global_id = data["address"]["id"]
+    _, id = graphene.Node.from_global_id(global_id)
+    address_db = Address.objects.get(id=id)
+    assert address_db.city != address_data["city"].upper()
+    assert address_db.city == address_data["city"]
+    assert address_db.postal_code == invalid_name
+    assert address_db.validation_skipped is True

--- a/saleor/graphql/account/tests/test_i18n.py
+++ b/saleor/graphql/account/tests/test_i18n.py
@@ -175,7 +175,6 @@ def test_skip_validation_multiple_invalid_fields(
         "country": "US",
         "city": invalid_name,
         "countryArea": invalid_name,
-        "phone": invalid_name,
         "metadata": [{"key": "public", "value": "public_value"}],
         "skipValidation": True,
     }
@@ -191,10 +190,8 @@ def test_skip_validation_multiple_invalid_fields(
     data = content["data"]["addressCreate"]
     assert not data["errors"]
     assert data["address"]["country"]["code"] == "US"
-    assert data["address"]["phone"] == invalid_name
     assert data["address"]["postalCode"] == invalid_name
     db_address = Address.objects.get(first_name=invalid_name)
-    assert db_address.phone == invalid_name
     assert db_address.postal_code == invalid_name
     assert db_address.country_area == invalid_name
     assert db_address.city == invalid_name

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -4420,10 +4420,10 @@ def test_checkout_complete_with_invalid_address(
         "redirectUrl": "https://www.example.com",
     }
 
-    invalid_phone = "invalid phone"
-    address.phone = invalid_phone
+    invalid_postal_code = "invalid postal code"
+    address.postal_code = invalid_postal_code
     address.validation_skipped = True
-    address.save(update_fields=["validation_skipped", "phone"])
+    address.save(update_fields=["validation_skipped", "postal_code"])
 
     checkout.billing_address = address
     checkout.shipping_address = address
@@ -4455,5 +4455,5 @@ def test_checkout_complete_with_invalid_address(
     # then
     assert not content["errors"]
     order = Order.objects.get(checkout_token=checkout.token)
-    assert order.shipping_address.phone == invalid_phone
-    assert order.billing_address.phone == invalid_phone
+    assert order.shipping_address.postal_code == invalid_postal_code
+    assert order.billing_address.postal_code == invalid_postal_code

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -2418,7 +2418,7 @@ MUTATION_CHECKOUT_CREATE_WITH_ADDRESSES = """
             postalCode
           }
           billingAddress {
-            phone
+            postalCode
           }
         }
         errors {
@@ -2538,8 +2538,8 @@ def test_checkout_create_skip_validation_billing_address_by_app(
     variant = stock.product_variant
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     billing_address = graphql_address_data_skipped_validation
-    invalid_phone = "invalid_phone"
-    billing_address["phone"] = invalid_phone
+    invalid_postal_code = "invalid_postal_code"
+    billing_address["postalCode"] = invalid_postal_code
 
     variables = {
         "checkoutInput": {
@@ -2561,7 +2561,7 @@ def test_checkout_create_skip_validation_billing_address_by_app(
     # then
     data = content["data"]["checkoutCreate"]
     assert not data["errors"]
-    assert data["checkout"]["billingAddress"]["phone"] == invalid_phone
+    assert data["checkout"]["billingAddress"]["postalCode"] == invalid_postal_code
     new_checkout = Checkout.objects.first()
-    assert new_checkout.billing_address.phone == invalid_phone
+    assert new_checkout.billing_address.postal_code == invalid_postal_code
     assert new_checkout.billing_address.validation_skipped is True

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20062,15 +20062,22 @@ type Mutation {
   ): ConfirmEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, NOTIFY_USER, ACCOUNT_EMAIL_CHANGED], syncEvents: [])
 
   """
-  Create a new address for the customer. 
+  Create a new address for the customer.
   
-  Requires one of the following permissions: AUTHENTICATED_USER.
+  Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
   
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - ADDRESS_CREATED (async): An address was created.
   """
   accountAddressCreate(
+    """
+    ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
+    
+    Added in Saleor 3.19.
+    """
+    customerId: ID
+
     """Fields required to create address."""
     input: AddressInput!
 
@@ -20135,15 +20142,22 @@ type Mutation {
   ): AccountRegister @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, NOTIFY_USER, ACCOUNT_CONFIRMATION_REQUESTED], syncEvents: [])
 
   """
-  Updates the account of the logged-in user. 
+  Updates the account of the logged-in user.
   
-  Requires one of the following permissions: AUTHENTICATED_USER.
+  Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
   
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
   """
   accountUpdate(
+    """
+    ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
+    
+    Added in Saleor 3.19.
+    """
+    customerId: ID
+
     """Fields required to update the account of the logged-in user."""
     input: AccountInput!
   ): AccountUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, CUSTOMER_METADATA_UPDATED], syncEvents: [])
@@ -31365,9 +31379,9 @@ type ConfirmEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: 
 }
 
 """
-Create a new address for the customer. 
+Create a new address for the customer.
 
-Requires one of the following permissions: AUTHENTICATED_USER.
+Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
 
 Triggers the following webhook events:
 - CUSTOMER_UPDATED (async): A customer account was updated.
@@ -31470,9 +31484,9 @@ input AccountRegisterInput @doc(category: "Users") {
 }
 
 """
-Updates the account of the logged-in user. 
+Updates the account of the logged-in user.
 
-Requires one of the following permissions: AUTHENTICATED_USER.
+Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
 
 Triggers the following webhook events:
 - CUSTOMER_UPDATED (async): A customer account was updated.

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from decimal import Decimal
 from typing import Optional
@@ -27,6 +28,9 @@ from .base_calculations import apply_order_discounts, base_order_line_total
 from .fetch import DraftOrderLineInfo, fetch_draft_order_lines_info
 from .interface import OrderTaxedPricesData
 from .models import Order, OrderLine
+from .utils import log_address_if_validation_skipped_for_order
+
+logger = logging.getLogger(__name__)
 
 
 def fetch_order_prices_if_expired(
@@ -207,6 +211,8 @@ def _calculate_and_add_tax(
             _recalculate_with_plugins(manager, order, lines, prices_entered_with_tax)
             # Get the taxes calculated with apps and apply to order.
             tax_data = manager.get_taxes_for_order(order, tax_app_identifier)
+            if not tax_data:
+                log_address_if_validation_skipped_for_order(order, logger)
             _apply_tax_data(order, lines, tax_data)
         else:
             _call_plugin_or_tax_app(
@@ -247,6 +253,7 @@ def _call_plugin_or_tax_app(
     else:
         tax_data = manager.get_taxes_for_order(order, tax_app_identifier)
         if tax_data is None:
+            log_address_if_validation_skipped_for_order(order, logger)
             raise TaxEmptyData("Empty tax data.")
         _apply_tax_data(order, lines, tax_data)
 

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -1236,3 +1236,46 @@ def test_fetch_order_data_calls_inactive_plugin(
 
     # then
     assert order_with_lines.tax_error == "Empty tax data."
+
+
+@pytest.mark.parametrize("tax_app_id", [None, "test.app"])
+def test_recalculate_prices_empty_tax_data_logging_address(
+    tax_app_id, draft_order, order_lines, address, caplog
+):
+    # given
+    order = draft_order
+
+    address.validation_skipped = True
+    address.postal_code = "invalid postal code"
+    address.save(update_fields=["postal_code", "validation_skipped"])
+
+    order.shipping_address = address
+    order.billing_address = address
+    order.save(update_fields=["billing_address", "shipping_address"])
+
+    order.channel.tax_configuration.tax_app_id = tax_app_id
+    order.channel.tax_configuration.save()
+
+    zero_money = zero_taxed_money(order.currency)
+    zero_prices = OrderTaxedPricesData(
+        undiscounted_price=zero_money,
+        price_with_discounts=zero_money,
+    )
+    manager_methods = {
+        "calculate_order_line_unit": Mock(side_effect=TaxError()),
+        "calculate_order_line_total": Mock(return_value=zero_prices),
+        "get_order_shipping_tax_rate": Mock(return_value=Decimal("0.00")),
+        "get_order_line_tax_rate": Mock(return_value=Decimal("0.00")),
+        "calculate_order_shipping": Mock(return_value=zero_money),
+        "get_taxes_for_order": Mock(return_value=None),
+    }
+    manager = Mock(**manager_methods)
+
+    # when
+    calculations._recalculate_prices(order, manager, order_lines)
+
+    # then
+    assert (
+        f"Fetching tax data for order with address validation skipped. "
+        f"Address ID: {address.pk}" in caplog.text
+    )

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -1137,3 +1137,21 @@ def update_order_display_gross_prices(order: "Order"):
     order.display_gross_prices = get_display_gross_prices(
         tax_configuration, country_tax_configuration
     )
+
+
+def log_address_if_validation_skipped_for_order(order: "Order", logger):
+    address = get_address_for_order_taxes(order)
+    if address and address.validation_skipped:
+        logger.warning(
+            "Fetching tax data for order with address validation skipped. "
+            "Address ID: %s",
+            address.id,
+        )
+
+
+def get_address_for_order_taxes(order: "Order"):
+    if order.collection_point_id:
+        address = order.collection_point.address  # type: ignore[union-attr]
+    else:
+        address = order.shipping_address or order.billing_address
+    return address

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -15,6 +15,7 @@ from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...checkout import base_calculations
 from ...checkout.fetch import fetch_checkout_lines
+from ...checkout.utils import log_address_if_validation_skipped_for_checkout
 from ...core.taxes import TaxError, TaxType, zero_taxed_money
 from ...order import base_calculations as order_base_calculation
 from ...order.interface import OrderTaxedPricesData
@@ -361,6 +362,7 @@ class AvataxPlugin(BasePlugin):
                 error_code,
                 msg,
             )
+            log_address_if_validation_skipped_for_checkout(checkout_info, logger)
             customer_msg = CustomerErrors.get_error_msg(response.get("error", {}))
             raise TaxError(customer_msg)
         return previous_value

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_get_order_tax_data_address_error_logging.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_get_order_tax_data_address_error_logging.yaml
@@ -1,0 +1,65 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
+      "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "SKU_A", "discounted": false, "description": "Test product"}],
+      "code": "596b2c00-cab7-4c94-8775-b267c45da927", "date": "2024-06-06", "customerCode":
+      0, "discount": null, "addresses": {"singleLocation": {"line1": "T\u0119czowa
+      7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
+      "invalid postal code"}}, "commit": false, "currencyCode": "USD", "email": "test@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '586'
+      User-Agent:
+      - Saleor/3.19
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"error":{"code":"StringLengthError","message":"Field ''postalCode''
+        has an invalid length.","target":"IncorrectData","details":[{"code":"StringLengthError","number":13,"message":"Field
+        ''postalCode'' has an invalid length.","description":"Field ''postalCode''
+        must be between 0 and 11 characters in length.","faultCode":"Client","helpLink":"https://developer.avalara.com/avatax/errors/StringLengthError","severity":"Error"}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Jun 2024 12:24:47 GMT
+      ServerDuration:
+      - '00:00:00.0003073'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - de3ef2ed-f864-4a20-8801-74ec8ccc9490
+      x-correlation-id:
+      - de3ef2ed-f864-4a20-8801-74ec8ccc9490
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_preprocess_order_creation_address_error_logging.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_preprocess_order_creation_address_error_logging.yaml
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "123", "discounted": false, "description": "Test product",
+      "ref1": "123"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR000000", "taxIncluded":
+      true, "itemCode": "Shipping", "discounted": false, "description": null}], "code":
+      "c0693e39-78fc-4516-8c3f-6813012c5b9f", "date": "2024-06-06", "customerCode":
+      0, "discount": null, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2":
+      "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode": "53-601"},
+      "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW", "region":
+      "", "country": "PL", "postalCode": "invalid postal code"}}, "commit": false,
+      "currencyCode": "USD", "email": "user@email.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '856'
+      User-Agent:
+      - Saleor/3.19
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"error":{"code":"StringLengthError","message":"Field ''postalCode''
+        has an invalid length.","target":"IncorrectData","details":[{"code":"StringLengthError","number":13,"message":"Field
+        ''postalCode'' has an invalid length.","description":"Field ''postalCode''
+        must be between 0 and 11 characters in length.","faultCode":"Client","helpLink":"https://developer.avalara.com/avatax/errors/StringLengthError","severity":"Error"}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Jun 2024 12:13:39 GMT
+      ServerDuration:
+      - '00:00:00.0005438'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 86c131e6-dba9-49ff-a50a-9f085f72ccbb
+      x-correlation-id:
+      - 86c131e6-dba9-49ff-a50a-9f085f72ccbb
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 400
+      message: Bad Request
+version: 1


### PR DESCRIPTION
I want to merge this change because it allows to skip the address validation.
Project: https://linear.app/saleor/project/address-validation-skipping-flags-530aa688d867

## To do:
- [x] Allow account mutations to be run by apps ([linear link](https://linear.app/saleor/issue/MERX-487/allow-account-mutations-to-be-run-by-apps)) ([PR](https://github.com/saleor/saleor/pull/16051))
- [x] Do not skip required fields check and normalization ([linear link](https://linear.app/saleor/issue/MERX-501/do-not-skip-required-fields-check-and-normalization)) ([PR](https://github.com/saleor/saleor/pull/16058))
- [x] Log invalid address fields, when skipping the validation ([linear link](https://linear.app/saleor/issue/MERX-489/log-invalid-address-fields-when-skipping-the-validation)) ([PR](https://github.com/saleor/saleor/pull/16091))
- [x] Restore phone field validation ([linear link](https://linear.app/saleor/issue/MERX-488/adjust-the-code-responsible-for-validating-addressphone-field)) ([PR](https://github.com/saleor/saleor/pull/16110))
- [ ] ~~Rename `Address.validation_skipped` field~~ ([linear link](https://linear.app/saleor/issue/MERX-488/adjust-the-code-responsible-for-validating-addressphone-field)) (decided to keep the name (https://saleorcommerce.slack.com/archives/C06DU38BB39/p1718289726082319))

Related PR introducing the skip: https://github.com/saleor/saleor/pull/16008

## AC:
When providing an address input with `skipValidation` flag = True:
- [ ] User can provide any not empty input to all fields except `country` and `phone`. By not empty, I mean other then `None`, `""` and `" "`
- [ ] Required fields are still validated
- [ ] Valid fields are normalized
- In case of invalid input:
  - [ ] created `Address` object has `validation_skipped` flag set to True and invalid field values are saved in database
  - [ ] fields `country_area`, `city_area`, `city`, `postal_code` are logged with invalid value from input (i.e. {"countryArea": "none existing area"}); the other invalid fields should be also present in logs, but with value `invalid` (i.e. {"firstName": "invalid"}, we donn't want to log any personal data)
  - [ ] Logs always include `skip_validation` and `country` input values
- In case of valid input:
  - [ ] created `Address` object has `validation_skipped` flag set to False
  - [ ] there are no logs
- [ ] Create and complete checkout with invalid address
- [ ] When requesting tax calculation with invalid address and request fails then log warning with address ID