### PR TITLE
Add allow_writer usages in tasks

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -17,6 +17,7 @@ from requests import HTTPError, Response
 from .. import schema_version
 from ..app.headers import AppHeaders, DeprecatedAppHeaders
 from ..celeryconf import app
+from ..core.db.connection import allow_writer
 from ..core.http_client import HTTPClient
 from ..core.utils import build_absolute_uri, get_domain
 from ..permission.enums import get_permission_names
@@ -150,6 +151,7 @@ def _set_brand_data(brand_obj: Optional[Union[App, AppInstallation]], logo: File
 
 
 @app.task(bind=True, retry_backoff=2700, retry_kwargs={"max_retries": 5})
+@allow_writer()
 def fetch_brand_data_task(
     self, brand_data: dict, *, app_installation_id=None, app_id=None
 ):

--- a/saleor/celeryconf.py
+++ b/saleor/celeryconf.py
@@ -1,13 +1,31 @@
 import logging
 import os
 
-from celery import Celery
+from celery import Celery, Task
 from celery.signals import setup_logging
 from django.conf import settings
+from django.db import connections
 
 from .plugins import discover_plugins_modules
 
 CELERY_LOGGER_NAME = "celery"
+
+
+class RestrictWriterDBTask(Task):
+    """Task that restricts write operations to the writer database.
+
+    Depending on the configuration, this task logs warning or raises an error when it
+    detects a writer DB query that is not wrapped in `allow_writer` context manager.
+    """
+
+    def __call__(self, *args, **kwargs):
+        from saleor.core.db.connection import _restrict_writer
+
+        # TODO: Make the wrapper configurable to either log a warning or raise an error
+        with connections[settings.DATABASE_CONNECTION_DEFAULT_NAME].execute_wrapper(
+            _restrict_writer
+        ):
+            return super().__call__(*args, **kwargs)
 
 
 @setup_logging.connect
@@ -23,7 +41,7 @@ def setup_celery_logging(loglevel=None, **kwargs):
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")
 
-app = Celery("saleor")
+app = Celery("saleor", task_cls=RestrictWriterDBTask)
 
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()

--- a/saleor/checkout/migrations/tasks/saleor3_14.py
+++ b/saleor/checkout/migrations/tasks/saleor3_14.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from django.db.models.expressions import Exists, OuterRef, Q
 
 from ....celeryconf import app
+from ....core.db.connection import allow_writer
 from ....payment.models import TransactionItem
 from ...models import Checkout
 
@@ -11,6 +12,7 @@ BATCH_SIZE = 2000
 
 
 @app.task
+@allow_writer()
 def update_transaction_modified_at_in_checkouts():
     checkouts_without_modified_at = Checkout.objects.filter(
         Exists(TransactionItem.objects.filter(checkout_id=OuterRef("pk"))),
@@ -41,6 +43,7 @@ def update_transaction_modified_at_in_checkouts():
 
 
 @app.task
+@allow_writer()
 def update_checkout_refundable():
     with_transactions = TransactionItem.objects.filter(
         Q(checkout_id=OuterRef("pk"))

--- a/saleor/core/db/tests/test_connection.py
+++ b/saleor/core/db/tests/test_connection.py
@@ -7,10 +7,10 @@ from ....graphql.context import SaleorContext
 from ....tests.models import Book
 from ..connection import (
     UnsafeWriterAccessError,
-    _log_writer_usage,
-    _restrict_writer,
     allow_writer,
     allow_writer_in_context,
+    log_writer_usage,
+    restrict_writer,
 )
 
 
@@ -65,14 +65,14 @@ def test_restrict_writer_raises_error(settings):
     connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
 
     with pytest.raises(UnsafeWriterAccessError):
-        with connection.execute_wrapper(_restrict_writer):
+        with connection.execute_wrapper(restrict_writer):
             Book.objects.first()
 
 
 def test_restrict_writer_in_allow_writer(settings):
     connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
 
-    with connection.execute_wrapper(_restrict_writer):
+    with connection.execute_wrapper(restrict_writer):
         with allow_writer():
             Book.objects.first()
 
@@ -80,7 +80,7 @@ def test_restrict_writer_in_allow_writer(settings):
 def test_log_writer_usage(settings, caplog):
     connection = connections[settings.DATABASE_CONNECTION_DEFAULT_NAME]
 
-    with connection.execute_wrapper(_log_writer_usage):
+    with connection.execute_wrapper(log_writer_usage):
         Book.objects.first()
 
     assert caplog.records

--- a/saleor/csv/events.py
+++ b/saleor/csv/events.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
+from ..core.db.connection import allow_writer
 from . import ExportEvents
 from .models import ExportEvent
 
@@ -9,6 +10,7 @@ if TYPE_CHECKING:
     from .models import ExportFile
 
 
+@allow_writer()
 def export_started_event(
     *,
     export_file: "ExportFile",
@@ -20,6 +22,7 @@ def export_started_event(
     )
 
 
+@allow_writer()
 def export_success_event(
     *,
     export_file: "ExportFile",
@@ -31,6 +34,7 @@ def export_success_event(
     )
 
 
+@allow_writer()
 def export_failed_event(
     *,
     export_file: "ExportFile",
@@ -48,6 +52,7 @@ def export_failed_event(
     )
 
 
+@allow_writer()
 def export_deleted_event(
     *,
     export_file: "ExportFile",
@@ -59,6 +64,7 @@ def export_deleted_event(
     )
 
 
+@allow_writer()
 def export_file_sent_event(*, export_file_id: int, user_id: int) -> None:
     ExportEvent.objects.create(
         export_file_id=export_file_id,
@@ -67,6 +73,7 @@ def export_file_sent_event(*, export_file_id: int, user_id: int) -> None:
     )
 
 
+@allow_writer()
 def export_failed_info_sent_event(*, export_file_id: int, user_id: int) -> None:
     ExportEvent.objects.create(
         export_file_id=export_file_id,

--- a/saleor/csv/tasks.py
+++ b/saleor/csv/tasks.py
@@ -7,9 +7,10 @@ from django.db.models import Q
 from django.db.models.expressions import Exists, OuterRef
 from django.utils import timezone
 
-from ..celeryconf import RestrictWriterDBTask, app
+from ..celeryconf import app
 from ..core import JobStatus
 from ..core.db.connection import allow_writer
+from ..core.tasks import RestrictWriterDBTask
 from . import events
 from .models import ExportEvent, ExportFile
 from .notifications import send_export_failed_info

--- a/saleor/csv/tasks.py
+++ b/saleor/csv/tasks.py
@@ -1,6 +1,5 @@
 from typing import Optional, Union
 
-import celery
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.files.storage import default_storage
@@ -8,8 +7,9 @@ from django.db.models import Q
 from django.db.models.expressions import Exists, OuterRef
 from django.utils import timezone
 
-from ..celeryconf import app
+from ..celeryconf import RestrictWriterDBTask, app
 from ..core import JobStatus
+from ..core.db.connection import allow_writer
 from . import events
 from .models import ExportEvent, ExportFile
 from .notifications import send_export_failed_info
@@ -18,7 +18,7 @@ from .utils.export import export_gift_cards, export_products, export_voucher_cod
 task_logger = get_task_logger(__name__)
 
 
-class ExportTask(celery.Task):
+class ExportTask(RestrictWriterDBTask):
     # should be updated when new export task is added
     TASK_NAME_TO_DATA_TYPE_MAPPING = {
         "export-products": "products",
@@ -66,7 +66,12 @@ def export_products_task(
     file_type: str,
     delimiter: str = ",",
 ):
-    export_file = ExportFile.objects.get(pk=export_file_id)
+    with allow_writer():
+        # Read the ExportFile instance from the writer instead of replica as it might
+        # not be replicated yet.
+        export_file = ExportFile.objects.select_related("app", "user").get(
+            pk=export_file_id
+        )
     export_products(export_file, scope, export_info, file_type, delimiter)
 
 
@@ -77,7 +82,12 @@ def export_gift_cards_task(
     file_type: str,
     delimiter: str = ",",
 ):
-    export_file = ExportFile.objects.get(pk=export_file_id)
+    with allow_writer():
+        # Read the ExportFile instance from the writer instead of replica as it might
+        # not be replicated yet.
+        export_file = ExportFile.objects.select_related("app", "user").get(
+            pk=export_file_id
+        )
     export_gift_cards(export_file, scope, file_type, delimiter)
 
 
@@ -88,11 +98,17 @@ def export_voucher_codes_task(
     voucher_id: Optional[int],
     ids: list[int],
 ):
-    export_file = ExportFile.objects.get(pk=export_file_id)
+    with allow_writer():
+        # Read the ExportFile instance from the writer instead of replica as it might
+        # not be replicated yet.
+        export_file = ExportFile.objects.select_related("app", "user").get(
+            pk=export_file_id
+        )
     export_voucher_codes(export_file, file_type, voucher_id, ids)
 
 
 @app.task
+@allow_writer()
 def delete_old_export_files():
     now = timezone.now()
 

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -7,6 +7,7 @@ import petl as etl
 from django.conf import settings
 from django.utils import timezone
 
+from ...core.db.connection import allow_writer
 from ...discount.models import VoucherCode
 from ...giftcard.models import GiftCard
 from ...product.models import Product
@@ -56,7 +57,6 @@ def export_products(
 
     save_csv_file_in_export_file(export_file, temporary_file, file_name)
     temporary_file.close()
-
     send_export_download_link_notification(export_file, "products")
 
 
@@ -87,7 +87,6 @@ def export_gift_cards(
 
     save_csv_file_in_export_file(export_file, temporary_file, file_name)
     temporary_file.close()
-
     send_export_download_link_notification(export_file, "gift cards")
 
 
@@ -291,6 +290,7 @@ def append_to_file(
         etl.io.xlsx.appendxlsx(table, temporary_file.name)
 
 
+@allow_writer()
 def save_csv_file_in_export_file(
     export_file: "ExportFile", temporary_file: IO[bytes], file_name: str
 ):

--- a/saleor/giftcard/search.py
+++ b/saleor/giftcard/search.py
@@ -4,6 +4,7 @@ from django.contrib.postgres.search import SearchQuery
 from django.db.models import Q, QuerySet, Value, prefetch_related_objects
 
 from ..account.models import User
+from ..core.db.connection import allow_writer
 from ..core.postgres import FlatConcatSearchVector, NoValidationSearchVector
 from .models import GiftCard
 
@@ -50,6 +51,7 @@ def mark_gift_cards_search_index_as_dirty_by_users(users: list[User]):
     mark_gift_cards_search_index_as_dirty(gift_cards)
 
 
+@allow_writer()
 def update_gift_cards_search_vector(gift_cards: list[GiftCard]):
     prefetch_related_objects(gift_cards, *GIFTCARD_FIELDS_TO_PREFETCH)
     for gift_card in gift_cards:

--- a/saleor/giftcard/tasks.py
+++ b/saleor/giftcard/tasks.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from ..celeryconf import app
+from ..core.db.connection import allow_writer
 from .events import gift_cards_deactivated_event
 from .models import GiftCard
 from .search import update_gift_cards_search_vector
@@ -12,6 +13,7 @@ GIFT_CARD_BATCH_SIZE = 300
 
 
 @app.task
+@allow_writer()
 def deactivate_expired_cards_task():
     today = timezone.now().date()
     gift_cards = GiftCard.objects.filter(expiry_date__lt=today, is_active=True)

--- a/saleor/giftcard/tests/test_tasks.py
+++ b/saleor/giftcard/tests/test_tasks.py
@@ -5,7 +5,20 @@ from django.utils import timezone
 
 from .. import GiftCardEvents
 from ..models import GiftCard
-from ..tasks import deactivate_expired_cards_task
+from ..tasks import deactivate_expired_cards_task, update_gift_cards_search_vector_task
+
+
+def test_update_gift_cards_search_vector_task(gift_card):
+    # given
+    gift_card.search_index_dirty = True
+    gift_card.save(update_fields=["search_index_dirty"])
+
+    # when
+    update_gift_cards_search_vector_task()
+
+    # then
+    gift_card.refresh_from_db()
+    assert not gift_card.search_index_dirty
 
 
 def test_deactivate_expired_cards_task(

--- a/saleor/giftcard/tests/test_tasks.py
+++ b/saleor/giftcard/tests/test_tasks.py
@@ -14,7 +14,7 @@ def test_update_gift_cards_search_vector_task(gift_card):
     gift_card.save(update_fields=["search_index_dirty"])
 
     # when
-    update_gift_cards_search_vector_task()
+    update_gift_cards_search_vector_task.delay()
 
     # then
     gift_card.refresh_from_db()

--- a/saleor/payment/migrations/tasks/saleor3_19.py
+++ b/saleor/payment/migrations/tasks/saleor3_19.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from django.db.models import Exists, OuterRef
 
 from ....celeryconf import app
+from ....core.db.connection import allow_writer
 from ... import ChargeStatus
 from ...models import Payment
 
@@ -10,6 +11,7 @@ PAYMENT_BATCH_SIZE = 3000
 
 
 @app.task
+@allow_writer()
 def fix_invalid_atobarai_payments_task():
     """Fix the invalid payemnts for atobarai gateway.
 

--- a/saleor/payment/tasks.py
+++ b/saleor/payment/tasks.py
@@ -10,6 +10,7 @@ from ..celeryconf import app
 from ..channel.models import Channel
 from ..checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from ..checkout.models import Checkout
+from ..core.db.connection import allow_writer
 from ..payment.models import TransactionEvent, TransactionItem
 from ..plugins.manager import get_plugins_manager
 from . import PaymentError, TransactionAction, TransactionEventType
@@ -43,6 +44,7 @@ def checkouts_with_funds_to_release():
 
 
 @app.task
+@allow_writer()
 def transaction_release_funds_for_checkout_task():
     CHECKOUT_BATCH_SIZE = int(settings.CHECKOUT_BATCH_FOR_RELEASING_FUNDS)
     TRANSACTION_BATCH_SIZE = int(settings.TRANSACTION_BATCH_FOR_RELEASING_FUNDS)

--- a/saleor/plugins/admin_email/tasks.py
+++ b/saleor/plugins/admin_email/tasks.py
@@ -1,4 +1,5 @@
 from ...celeryconf import app
+from ...core.db.connection import allow_writer
 from ...csv.events import export_failed_info_sent_event, export_file_sent_event
 from ...graphql.core.utils import from_global_id_or_none
 from ..email_common import EmailConfig, send_email
@@ -30,10 +31,11 @@ def send_email_with_link_to_download_file_task(
         template_str=template,
         context=payload,
     )
-    export_file_sent_event(
-        export_file_id=from_global_id_or_none(payload["export"]["id"]),
-        user_id=from_global_id_or_none(payload["export"].get("user_id")),
-    )
+    with allow_writer():
+        export_file_sent_event(
+            export_file_id=from_global_id_or_none(payload["export"]["id"]),
+            user_id=from_global_id_or_none(payload["export"].get("user_id")),
+        )
 
 
 @app.task(compression="zlib")
@@ -48,10 +50,11 @@ def send_export_failed_email_task(
         template_str=template,
         context=payload,
     )
-    export_failed_info_sent_event(
-        export_file_id=from_global_id_or_none(payload["export"]["id"]),
-        user_id=from_global_id_or_none(payload["export"].get("user_id")),
-    )
+    with allow_writer():
+        export_failed_info_sent_event(
+            export_file_id=from_global_id_or_none(payload["export"]["id"]),
+            user_id=from_global_id_or_none(payload["export"].get("user_id")),
+        )
 
 
 @app.task(compression="zlib")

--- a/saleor/plugins/sendgrid/tasks.py
+++ b/saleor/plugins/sendgrid/tasks.py
@@ -6,6 +6,7 @@ from sendgrid.helpers.mail import Mail
 
 from ...account import events as account_events
 from ...celeryconf import app
+from ...core.db.connection import allow_writer
 from ...giftcard import events as gift_card_events
 from ...graphql.core.utils import from_global_id_or_none
 from ...invoice import events as invoice_events
@@ -62,7 +63,8 @@ def send_password_reset_email_task(payload: dict, configuration: dict):
         template_id=configuration.account_password_reset_template_id,
         payload=payload,
     )
-    account_events.customer_password_reset_link_sent_event(user_id=user_id)
+    with allow_writer():
+        account_events.customer_password_reset_link_sent_event(user_id=user_id)
 
 
 @app.task(
@@ -79,13 +81,14 @@ def send_request_email_change_email_task(payload: dict, configuration: dict):
         template_id=configuration.account_change_email_request_template_id,
         payload=payload,
     )
-    account_events.customer_email_change_request_event(
-        user_id=from_global_id_or_none(user_id),
-        parameters={
-            "old_email": payload.get("old_email"),
-            "new_email": payload["recipient_email"],
-        },
-    )
+    with allow_writer():
+        account_events.customer_email_change_request_event(
+            user_id=from_global_id_or_none(user_id),
+            parameters={
+                "old_email": payload.get("old_email"),
+                "new_email": payload["recipient_email"],
+            },
+        )
 
 
 @app.task(
@@ -106,10 +109,10 @@ def send_user_change_email_notification_task(payload: dict, configuration: dict)
         "old_email": payload["old_email"],
         "new_email": payload["new_email"],
     }
-
-    account_events.customer_email_changed_event(
-        user_id=from_global_id_or_none(user_id), parameters=event_parameters
-    )
+    with allow_writer():
+        account_events.customer_email_changed_event(
+            user_id=from_global_id_or_none(user_id), parameters=event_parameters
+        )
 
 
 @app.task(
@@ -156,18 +159,19 @@ def send_invoice_email_task(payload: dict, configuration: dict):
         template_id=configuration.invoice_ready_template_id,
         payload=payload,
     )
-    invoice_events.notification_invoice_sent_event(
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        invoice_id=from_global_id_or_none(payload["invoice"]["id"]),
-        customer_email=payload["recipient_email"],
-    )
-    order_events.event_invoice_sent_notification(
-        order_id=from_global_id_or_none(payload["invoice"]["order_id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        email=payload["recipient_email"],
-    )
+    with allow_writer():
+        invoice_events.notification_invoice_sent_event(
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            invoice_id=from_global_id_or_none(payload["invoice"]["id"]),
+            customer_email=payload["recipient_email"],
+        )
+        order_events.event_invoice_sent_notification(
+            order_id=from_global_id_or_none(payload["invoice"]["order_id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            email=payload["recipient_email"],
+        )
 
 
 @app.task(
@@ -184,11 +188,12 @@ def send_order_confirmation_email_task(payload: dict, configuration: dict):
         template_id=configuration.order_confirmation_template_id,
         payload=payload,
     )
-    order_events.event_order_confirmation_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["order"].get("user_id")),
-        customer_email=payload["recipient_email"],
-    )
+    with allow_writer():
+        order_events.event_order_confirmation_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["order"].get("user_id")),
+            customer_email=payload["recipient_email"],
+        )
 
 
 @app.task(
@@ -204,20 +209,21 @@ def send_fulfillment_confirmation_email_task(payload: dict, configuration: dict)
         template_id=configuration.order_fulfillment_confirmation_template_id,
         payload=payload,
     )
-    order_events.event_fulfillment_confirmed_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=payload["recipient_email"],
-    )
-
-    if payload.get("digital_lines"):
-        order_events.event_fulfillment_digital_links_notification(
+    with allow_writer():
+        order_events.event_fulfillment_confirmed_notification(
             order_id=from_global_id_or_none(payload["order"]["id"]),
             user_id=from_global_id_or_none(payload["requester_user_id"]),
             app_id=from_global_id_or_none(payload["requester_app_id"]),
             customer_email=payload["recipient_email"],
         )
+
+        if payload.get("digital_lines"):
+            order_events.event_fulfillment_digital_links_notification(
+                order_id=from_global_id_or_none(payload["order"]["id"]),
+                user_id=from_global_id_or_none(payload["requester_user_id"]),
+                app_id=from_global_id_or_none(payload["requester_app_id"]),
+                customer_email=payload["recipient_email"],
+            )
 
 
 @app.task(
@@ -248,11 +254,12 @@ def send_payment_confirmation_email_task(payload: dict, configuration: dict):
         template_id=configuration.order_payment_confirmation_template_id,
         payload=payload,
     )
-    order_events.event_payment_confirmed_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["order"].get("user_id")),
-        customer_email=payload["recipient_email"],
-    )
+    with allow_writer():
+        order_events.event_payment_confirmed_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["order"].get("user_id")),
+            customer_email=payload["recipient_email"],
+        )
 
 
 @app.task(
@@ -268,12 +275,13 @@ def send_order_canceled_email_task(payload: dict, configuration: dict):
         template_id=configuration.order_canceled_template_id,
         payload=payload,
     )
-    order_events.event_order_cancelled_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=payload["recipient_email"],
-    )
+    with allow_writer():
+        order_events.event_order_cancelled_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            customer_email=payload["recipient_email"],
+        )
 
 
 @app.task(
@@ -289,12 +297,13 @@ def send_order_refund_email_task(payload: dict, configuration: dict):
         template_id=configuration.order_refund_confirmation_template_id,
         payload=payload,
     )
-    order_events.event_order_refunded_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=payload["recipient_email"],
-    )
+    with allow_writer():
+        order_events.event_order_refunded_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            customer_email=payload["recipient_email"],
+        )
 
 
 @app.task(
@@ -316,10 +325,11 @@ def send_gift_card_email_task(payload: dict, configuration: dict):
         "app_id": from_global_id_or_none(payload["requester_app_id"]),
         "email": payload["recipient_email"],
     }
-    if payload["resending"] is True:
-        gift_card_events.gift_card_resent_event(**email_data)
-    else:
-        gift_card_events.gift_card_sent_event(**email_data)
+    with allow_writer():
+        if payload["resending"] is True:
+            gift_card_events.gift_card_resent_event(**email_data)
+        else:
+            gift_card_events.gift_card_sent_event(**email_data)
 
 
 @app.task(
@@ -335,12 +345,13 @@ def send_order_confirmed_email_task(payload: dict, configuration: dict):
         template_id=configuration.order_confirmed_template_id,
         payload=payload,
     )
-    order_events.event_order_confirmed_notification(
-        order_id=from_global_id_or_none(payload.get("order", {}).get("id")),
-        user_id=from_global_id_or_none(payload.get("requester_user_id")),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=payload["recipient_email"],
-    )
+    with allow_writer():
+        order_events.event_order_confirmed_notification(
+            order_id=from_global_id_or_none(payload.get("order", {}).get("id")),
+            user_id=from_global_id_or_none(payload.get("requester_user_id")),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            customer_email=payload["recipient_email"],
+        )
 
 
 @app.task(

--- a/saleor/plugins/user_email/tasks.py
+++ b/saleor/plugins/user_email/tasks.py
@@ -1,5 +1,6 @@
 from ...account import events as account_events
 from ...celeryconf import app
+from ...core.db.connection import allow_writer
 from ...giftcard import events as gift_card_events
 from ...graphql.core.utils import from_global_id_or_none
 from ...invoice import events as invoice_events
@@ -34,9 +35,10 @@ def send_password_reset_email_task(recipient_email, payload, config, subject, te
         subject=subject,
         template_str=template,
     )
-    account_events.customer_password_reset_link_sent_event(
-        user_id=from_global_id_or_none(user_id)
-    )
+    with allow_writer():
+        account_events.customer_password_reset_link_sent_event(
+            user_id=from_global_id_or_none(user_id)
+        )
 
 
 @app.task(compression="zlib")
@@ -53,13 +55,14 @@ def send_request_email_change_email_task(
         subject=subject,
         template_str=template,
     )
-    account_events.customer_email_change_request_event(
-        user_id=from_global_id_or_none(user_id),
-        parameters={
-            "old_email": payload.get("old_email"),
-            "new_email": recipient_email,
-        },
-    )
+    with allow_writer():
+        account_events.customer_email_change_request_event(
+            user_id=from_global_id_or_none(user_id),
+            parameters={
+                "old_email": payload.get("old_email"),
+                "new_email": recipient_email,
+            },
+        )
 
 
 @app.task(compression="zlib")
@@ -80,10 +83,10 @@ def send_user_change_email_notification_task(
         "old_email": payload.get("old_email"),
         "new_email": payload.get("new_email"),
     }
-
-    account_events.customer_email_changed_event(
-        user_id=from_global_id_or_none(user_id), parameters=event_parameters
-    )
+    with allow_writer():
+        account_events.customer_email_changed_event(
+            user_id=from_global_id_or_none(user_id), parameters=event_parameters
+        )
 
 
 @app.task(compression="zlib")
@@ -91,7 +94,6 @@ def send_account_delete_confirmation_email_task(
     recipient_email, payload, config, subject, template
 ):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -106,7 +108,6 @@ def send_set_user_password_email_task(
     recipient_email, payload, config, subject, template
 ):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -119,7 +120,6 @@ def send_set_user_password_email_task(
 @app.task(compression="zlib")
 def send_gift_card_email_task(recipient_email, payload, config, subject, template):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -133,17 +133,17 @@ def send_gift_card_email_task(recipient_email, payload, config, subject, templat
         "app_id": from_global_id_or_none(payload["requester_app_id"]),
         "email": payload["recipient_email"],
     }
-    if payload["resending"] is True:
-        gift_card_events.gift_card_resent_event(**email_data)
-    else:
-        gift_card_events.gift_card_sent_event(**email_data)
+    with allow_writer():
+        if payload["resending"] is True:
+            gift_card_events.gift_card_resent_event(**email_data)
+        else:
+            gift_card_events.gift_card_sent_event(**email_data)
 
 
 @app.task(compression="zlib")
 def send_invoice_email_task(recipient_email, payload, config, subject, template):
     """Send an invoice to user of related order with URL to download it."""
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -151,18 +151,19 @@ def send_invoice_email_task(recipient_email, payload, config, subject, template)
         subject=subject,
         template_str=template,
     )
-    invoice_events.notification_invoice_sent_event(
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        invoice_id=from_global_id_or_none(payload["invoice"]["id"]),
-        customer_email=payload["recipient_email"],
-    )
-    order_events.event_invoice_sent_notification(
-        order_id=from_global_id_or_none(payload["invoice"]["order_id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        email=payload["recipient_email"],
-    )
+    with allow_writer():
+        invoice_events.notification_invoice_sent_event(
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            invoice_id=from_global_id_or_none(payload["invoice"]["id"]),
+            customer_email=payload["recipient_email"],
+        )
+        order_events.event_invoice_sent_notification(
+            order_id=from_global_id_or_none(payload["invoice"]["order_id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            email=payload["recipient_email"],
+        )
 
 
 @app.task(compression="zlib")
@@ -171,7 +172,6 @@ def send_order_confirmation_email_task(
 ):
     """Send order confirmation email."""
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -179,11 +179,12 @@ def send_order_confirmation_email_task(
         subject=subject,
         template_str=template,
     )
-    order_events.event_order_confirmation_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["order"].get("user_id")),
-        customer_email=recipient_email,
-    )
+    with allow_writer():
+        order_events.event_order_confirmation_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["order"].get("user_id")),
+            customer_email=recipient_email,
+        )
 
 
 @app.task(compression="zlib")
@@ -191,7 +192,6 @@ def send_fulfillment_confirmation_email_task(
     recipient_email, payload, config, subject, template
 ):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -199,20 +199,21 @@ def send_fulfillment_confirmation_email_task(
         subject=subject,
         template_str=template,
     )
-    order_events.event_fulfillment_confirmed_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=recipient_email,
-    )
-
-    if payload.get("digital_lines"):
-        order_events.event_fulfillment_digital_links_notification(
+    with allow_writer():
+        order_events.event_fulfillment_confirmed_notification(
             order_id=from_global_id_or_none(payload["order"]["id"]),
             user_id=from_global_id_or_none(payload["requester_user_id"]),
             app_id=from_global_id_or_none(payload["requester_app_id"]),
             customer_email=recipient_email,
         )
+
+        if payload.get("digital_lines"):
+            order_events.event_fulfillment_digital_links_notification(
+                order_id=from_global_id_or_none(payload["order"]["id"]),
+                user_id=from_global_id_or_none(payload["requester_user_id"]),
+                app_id=from_global_id_or_none(payload["requester_app_id"]),
+                customer_email=recipient_email,
+            )
 
 
 @app.task(compression="zlib")
@@ -220,7 +221,6 @@ def send_fulfillment_update_email_task(
     recipient_email, payload, config, subject, template
 ):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -235,7 +235,6 @@ def send_payment_confirmation_email_task(
     recipient_email, payload, config, subject, template
 ):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -243,17 +242,17 @@ def send_payment_confirmation_email_task(
         subject=subject,
         template_str=template,
     )
-    order_events.event_payment_confirmed_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["order"].get("user_id")),
-        customer_email=recipient_email,
-    )
+    with allow_writer():
+        order_events.event_payment_confirmed_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["order"].get("user_id")),
+            customer_email=recipient_email,
+        )
 
 
 @app.task(compression="zlib")
 def send_order_canceled_email_task(recipient_email, payload, config, subject, template):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -261,18 +260,18 @@ def send_order_canceled_email_task(recipient_email, payload, config, subject, te
         subject=subject,
         template_str=template,
     )
-    order_events.event_order_cancelled_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=recipient_email,
-    )
+    with allow_writer():
+        order_events.event_order_cancelled_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            customer_email=recipient_email,
+        )
 
 
 @app.task(compression="zlib")
 def send_order_refund_email_task(recipient_email, payload, config, subject, template):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -280,12 +279,13 @@ def send_order_refund_email_task(recipient_email, payload, config, subject, temp
         subject=subject,
         template_str=template,
     )
-    order_events.event_order_refunded_notification(
-        order_id=from_global_id_or_none(payload["order"]["id"]),
-        user_id=from_global_id_or_none(payload["requester_user_id"]),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=recipient_email,
-    )
+    with allow_writer():
+        order_events.event_order_refunded_notification(
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            customer_email=recipient_email,
+        )
 
 
 @app.task(compression="zlib")
@@ -293,7 +293,6 @@ def send_order_confirmed_email_task(
     recipient_email, payload, config, subject, template
 ):
     email_config = EmailConfig(**config)
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
@@ -301,9 +300,10 @@ def send_order_confirmed_email_task(
         subject=subject,
         template_str=template,
     )
-    order_events.event_order_confirmed_notification(
-        order_id=from_global_id_or_none(payload.get("order", {}).get("id")),
-        user_id=from_global_id_or_none(payload.get("requester_user_id")),
-        app_id=from_global_id_or_none(payload["requester_app_id"]),
-        customer_email=recipient_email,
-    )
+    with allow_writer():
+        order_events.event_order_confirmed_notification(
+            order_id=from_global_id_or_none(payload.get("order", {}).get("id")),
+            user_id=from_global_id_or_none(payload.get("requester_user_id")),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
+            customer_email=recipient_email,
+        )

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -251,7 +251,8 @@ ENABLE_RESTRICT_WRITER_MIDDLEWARE = get_bool_from_env(
 if ENABLE_RESTRICT_WRITER_MIDDLEWARE:
     MIDDLEWARE = ["saleor.core.db.connection.log_writer_usage_middleware"] + MIDDLEWARE
 
-CELERY_RESTRICT_WRITER_METHOD = "saleor.core.db.connection._log_writer_usage"
+# Restrict inexplicit writer DB usage in Celery tasks
+CELERY_RESTRICT_WRITER_METHOD = "saleor.core.db.connection.log_writer_usage"
 
 INSTALLED_APPS = [
     # External apps that need to go before django's

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -251,6 +251,8 @@ ENABLE_RESTRICT_WRITER_MIDDLEWARE = get_bool_from_env(
 if ENABLE_RESTRICT_WRITER_MIDDLEWARE:
     MIDDLEWARE = ["saleor.core.db.connection.log_writer_usage_middleware"] + MIDDLEWARE
 
+CELERY_RESTRICT_WRITER_METHOD = "saleor.core.db.connection._log_writer_usage"
+
 INSTALLED_APPS = [
     # External apps that need to go before django's
     "storages",

--- a/saleor/shipping/tasks.py
+++ b/saleor/shipping/tasks.py
@@ -5,11 +5,13 @@ from django.utils import timezone
 
 from ..celeryconf import app
 from ..checkout.models import Checkout
+from ..core.db.connection import allow_writer
 from ..order import ORDER_EDITABLE_STATUS
 from ..order.models import Order
 
 
 @app.task
+@allow_writer()
 def drop_invalid_shipping_methods_relations_for_given_channels(
     shipping_method_ids: Iterable[Union[str, int]],
     channel_ids: Iterable[Union[str, int]],

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -103,4 +103,4 @@ ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME = "order_events_queue"
 
 # Raise error when using writer DB in Celery tasks, without explicit "allow_writer"
 # context manager.
-CELERY_RESTRICT_WRITER_METHOD = "saleor.core.db.connection._restrict_writer"
+CELERY_RESTRICT_WRITER_METHOD = "saleor.core.db.connection.restrict_writer"

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -100,3 +100,7 @@ MIDDLEWARE.insert(0, "saleor.core.db.connection.restrict_writer_middleware")  # 
 
 CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME = "checkout_events_queue"
 ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME = "order_events_queue"
+
+# Raise error when using writer DB in Celery tasks, without explicit "allow_writer"
+# context manager.
+CELERY_RESTRICT_WRITER_METHOD = "saleor.core.db.connection._restrict_writer"

--- a/saleor/warehouse/tasks.py
+++ b/saleor/warehouse/tasks.py
@@ -4,12 +4,14 @@ from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from ..celeryconf import app
+from ..core.db.connection import allow_writer
 from .models import Allocation, PreorderReservation, Reservation, Stock
 
 task_logger = get_task_logger(__name__)
 
 
 @app.task
+@allow_writer()
 def delete_empty_allocations_task():
     count, _ = Allocation.objects.filter(quantity_allocated=0).delete()
     if count:
@@ -17,6 +19,7 @@ def delete_empty_allocations_task():
 
 
 @app.task
+@allow_writer()
 def delete_expired_reservations_task():
     stock_reservations, _ = Reservation.objects.filter(
         reserved_until__lt=timezone.now()
@@ -34,6 +37,7 @@ def delete_expired_reservations_task():
 
 
 @app.task
+@allow_writer()
 def update_stocks_quantity_allocated_task():
     stocks_to_update = []
     for mismatched_stock in Stock.objects.annotate(

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -235,6 +235,7 @@ def trigger_webhooks_async(
     retry_backoff=10,
     retry_kwargs={"max_retries": 5},
 )
+@allow_writer()
 def send_webhook_request_async(self, event_delivery_id):
     delivery = get_delivery_for_webhook(event_delivery_id)
     if not delivery:
@@ -341,6 +342,7 @@ def send_observability_events(webhooks: list[WebhookData], events: list[bytes]):
 
 
 @app.task(queue=OBSERVABILITY_QUEUE_NAME)
+@allow_writer()
 def observability_send_events():
     with observability.opentracing_trace("send_events_task", "task"):
         if webhooks := observability.get_webhooks():
@@ -352,6 +354,7 @@ def observability_send_events():
 
 
 @app.task(queue=OBSERVABILITY_QUEUE_NAME)
+@allow_writer()
 def observability_reporter_task():
     with observability.opentracing_trace("reporter_task", "task"):
         if webhooks := observability.get_webhooks():

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
     retry_backoff=10,
     retry_kwargs={"max_retries": 5},
 )
+@allow_writer()
 def handle_transaction_request_task(self, delivery_id, request_event_id):
     request_event = TransactionEvent.objects.filter(id=request_event_id).first()
     if not request_event:


### PR DESCRIPTION
- Add `RestrictWriterDBTask` base class for all Celery tasks, to ensure that no unrestricted writer queries are made.
- Wrap Celery tasks with `allow_writer`.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
