### PR TITLE
Fix order predicate handlers

### DIFF
--- a/saleor/discount/tests/test_utils/test_fetch_promotion_rules_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_fetch_promotion_rules_for_checkout.py
@@ -82,3 +82,37 @@ def test_fetch_promotion_rules_for_checkout_relevant_channel_only(
     # then
     assert len(rules_per_promotion_id) == 1
     assert rules_per_promotion_id == [rule_2]
+
+
+def test_fetch_promotion_rules_for_checkout_inner_or_operator(
+    checkout, checkout_for_cc, order_promotion_rule
+):
+    # given
+    rule = order_promotion_rule
+    rule.order_predicate = {
+        "discountedObjectPredicate": {
+            "OR": [
+                {"baseTotalPrice": {"range": {"gte": "10"}}},
+                {"baseSubtotalPrice": {"range": {"gte": "10"}}},
+            ]
+        }
+    }
+    rule.save(update_fields=["order_predicate"])
+
+    checkout.base_total_amount = 100
+    checkout.base_subtotal_amount = 100
+    checkout.total_gross_amount = 100
+    checkout.save(
+        update_fields=[
+            "total_gross_amount",
+            "base_total_amount",
+            "base_subtotal_amount",
+        ]
+    )
+
+    # when
+    rules_per_promotion_id = fetch_promotion_rules_for_checkout_or_order(checkout)
+
+    # then
+    assert len(rules_per_promotion_id) == 1
+    assert rules_per_promotion_id == [rule]

--- a/saleor/discount/tests/test_utils/test_fetch_promotion_rules_for_order.py
+++ b/saleor/discount/tests/test_utils/test_fetch_promotion_rules_for_order.py
@@ -1,0 +1,96 @@
+from decimal import Decimal
+
+from ... import RewardType, RewardValueType
+from ...models import PromotionRule
+from ...utils import fetch_promotion_rules_for_checkout_or_order
+
+
+def test_fetch_promotion_rules_for_order(order, order_line_JPY, order_promotion_rule):
+    # given
+    rule = order_promotion_rule
+
+    order.subtotal_net_amount = 100
+    order.total_net_amount = 100
+    order.save(update_fields=["subtotal_net_amount", "total_net_amount"])
+
+    # when
+    rules_per_promotion_id = fetch_promotion_rules_for_checkout_or_order(order)
+
+    # then
+    assert len(rules_per_promotion_id) == 1
+    assert rules_per_promotion_id == [rule]
+
+
+def test_fetch_promotion_rules_for_order_no_matching_rule(
+    order,
+    order_line_JPY,
+    order_promotion_rule,
+):
+    # given
+    order.subtotal_net_amount = 10
+    order.total_net_amount = 10
+    order.save(update_fields=["subtotal_net_amount", "total_net_amount"])
+
+    # when
+    rules_per_promotion_id = fetch_promotion_rules_for_checkout_or_order(order)
+
+    # then
+    assert not rules_per_promotion_id
+
+
+def test_fetch_promotion_rules_for_order_relevant_channel_only(
+    order, order_line_JPY, order_promotion_rule
+):
+    # given
+    order_JPY = order_line_JPY.order
+    promotion = order_promotion_rule.promotion
+    order_predicate = {
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 0}}}
+    }
+    rule_1 = order_promotion_rule
+    rule_1.order_predicate = order_predicate
+    rule_1.save(update_fields=["order_predicate"])
+
+    rule_2 = PromotionRule.objects.create(
+        name="Another promotion rule",
+        promotion=promotion,
+        order_predicate=order_predicate,
+        reward_value_type=RewardValueType.PERCENTAGE,
+        reward_value=Decimal("10"),
+        reward_type=RewardType.SUBTOTAL_DISCOUNT,
+    )
+    rule_2.channels.add(order_JPY.channel)
+
+    # when
+    rules_per_promotion_id = fetch_promotion_rules_for_checkout_or_order(order_JPY)
+
+    # then
+    assert len(rules_per_promotion_id) == 1
+    assert rules_per_promotion_id == [rule_2]
+
+
+def test_fetch_promotion_rules_for_checkout_inner_or_operator(
+    order, order_line_JPY, order_promotion_rule
+):
+    # given
+    rule = order_promotion_rule
+    rule.order_predicate = {
+        "discountedObjectPredicate": {
+            "OR": [
+                {"baseTotalPrice": {"range": {"gte": "10"}}},
+                {"baseSubtotalPrice": {"range": {"gte": "10"}}},
+            ]
+        }
+    }
+    rule.save(update_fields=["order_predicate"])
+
+    order.subtotal_net_amount = 100
+    order.total_net_amount = 100
+    order.save(update_fields=["subtotal_net_amount", "total_net_amount"])
+
+    # when
+    rules_per_promotion_id = fetch_promotion_rules_for_checkout_or_order(order)
+
+    # then
+    assert len(rules_per_promotion_id) == 1
+    assert rules_per_promotion_id == [rule]

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -489,13 +489,13 @@ def filter_qs(
     except (NoDefaultChannel, ChannelNotDefined, GraphQLError, KeyError):
         filter_channel = None
     filter_input["channel"] = (
-        args.pop("channel", None)
+        args.get("channel")
         or filter_channel
         or get_default_channel_slug_or_graphql_error(allow_replica)
     )
 
-    for arg_name, arg_value in args.items():
-        filter_input[arg_name] = arg_value
+    if currency := args.get("currency"):
+        filter_input["currency"] = currency
 
     if isinstance(iterable, ChannelQsContext):
         queryset = iterable.qs

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -489,10 +489,13 @@ def filter_qs(
     except (NoDefaultChannel, ChannelNotDefined, GraphQLError, KeyError):
         filter_channel = None
     filter_input["channel"] = (
-        args.get("channel")
+        args.pop("channel", None)
         or filter_channel
         or get_default_channel_slug_or_graphql_error(allow_replica)
     )
+
+    for arg_name, arg_value in args.items():
+        filter_input[arg_name] = arg_value
 
     if isinstance(iterable, ChannelQsContext):
         queryset = iterable.qs

--- a/saleor/graphql/discount/tests/test_utils.py
+++ b/saleor/graphql/discount/tests/test_utils.py
@@ -480,3 +480,28 @@ def test_promotion_rule_should_be_marked_with_dirty_variants_missing_channels(
 
     # then
     assert not result
+
+
+def test_get_variants_for_catalogue_predicate_with_inner_or_operator(
+    product_variant_list,
+):
+    # given
+    variant_1, variant_2 = product_variant_list[:2]
+
+    catalogue_predicate = {
+        "variantPredicate": {
+            "OR": [
+                {"ids": [graphene.Node.to_global_id("ProductVariant", variant_1.id)]},
+                {"ids": [graphene.Node.to_global_id("ProductVariant", variant_2.id)]},
+            ]
+        }
+    }
+
+    # when
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
+
+    # then
+    assert variant_1 in variants
+    assert variant_2 in variants
+    for variant in product_variant_list[2:]:
+        assert variant not in variants

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -316,12 +316,9 @@ def _handle_checkout_predicate(
 ):
     predicate_data = _predicate_to_snake_case(predicate_data)
     if predicate := predicate_data.get("discounted_object_predicate"):
-        if currency:
-            predicate["currency"] = currency
-
         checkouts = where_filter_qs(
             Checkout.objects.filter(pk__in=base_qs.values("pk")),
-            {},
+            {"currency": currency} if currency else {},
             CheckoutDiscountedObjectWhere,
             predicate,
             None,
@@ -342,12 +339,9 @@ def _handle_order_predicate(
 ):
     predicate_data = _predicate_to_snake_case(predicate_data)
     if predicate := predicate_data.get("discounted_object_predicate"):
-        if currency:
-            predicate["currency"] = currency
-
         orders = where_filter_qs(
             Order.objects.filter(pk__in=base_qs.values("pk")),
-            {},
+            {"currency": currency} if currency else {},
             OrderDiscountedObjectWhere,
             predicate,
             None,


### PR DESCRIPTION
I want to merge this change because it refactors order predicate handlers in order to process predicates with inner operators, like:
```
{
    "orderPredicate": {
        "discountedObjectPredicate": {
            "OR": [
                {
                    "baseTotalPrice": {
                        "range": {
                            "gte": "200"
                        }
                    }
                },
                {
                    "baseSubtotalPrice": {
                        "range": {
                            "gte": "153.22"
                        }
                    }
                }
            ]
        }
    }
}
```
Before the change, the predicate raised `Cannot mix operators with other filter inputs` exception, because `_handle_checkout_predicate` and `_handle_order_predicate` functions added `currency` filter.

issue: https://linear.app/saleor/issue/MERX-377/creating-draft-order-rises-cannot-mix-operators-with-other-filter

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
