### PR TITLE
Fix KeyError when event_type was not present in the event dict.

### DIFF
--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -2041,7 +2041,7 @@ class ThumbnailCreated(SubscriptionObjectType):
         return image.url if image else None
 
 
-WEBHOOK_TYPES_MAP = {
+ASYNC_WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.ADDRESS_CREATED: AddressCreated,
     WebhookEventAsyncType.ADDRESS_UPDATED: AddressUpdated,
     WebhookEventAsyncType.ADDRESS_DELETED: AddressDeleted,
@@ -2161,6 +2161,9 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.WAREHOUSE_DELETED: WarehouseDeleted,
     WebhookEventAsyncType.WAREHOUSE_METADATA_UPDATED: WarehouseMetadataUpdated,
     WebhookEventAsyncType.THUMBNAIL_CREATED: ThumbnailCreated,
+}
+
+SYNC_WEBHOOK_TYPES_MAP = {
     WebhookEventSyncType.PAYMENT_AUTHORIZE: PaymentAuthorize,
     WebhookEventSyncType.PAYMENT_CAPTURE: PaymentCaptureEvent,
     WebhookEventSyncType.PAYMENT_REFUND: PaymentRefundEvent,
@@ -2188,3 +2191,5 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION: TransactionInitializeSession,
     WebhookEventSyncType.TRANSACTION_PROCESS_SESSION: TransactionProcessSession,
 }
+
+WEBHOOK_TYPES_MAP = ASYNC_WEBHOOK_TYPES_MAP | SYNC_WEBHOOK_TYPES_MAP

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
@@ -202,7 +202,7 @@ def test_webhook_trigger_invalid_subscription_query(
     assert 'Unknown type "UndefinedEvent"' in error["message"]
 
 
-def test_webhook_trigger_event_not_supported(
+def test_webhook_trigger_synchronous_event_not_supported(
     staff_api_client,
     permission_manage_orders,
     order,


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/16035
Fixes: https://linear.app/saleor/issue/SHOPX-572/webhooktrigger-mutation-crashes

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
