### PR TITLE
Fix KeyError when event_type was not present in the event dict. (#16035)

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -34493,6 +34493,28 @@ type ShippingZoneMetadataUpdated implements Event @doc(category: "Shipping") {
 }
 
 """
+Event sent when shop metadata is updated.
+
+Added in Saleor 3.15.
+"""
+type ShopMetadataUpdated implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Shop data."""
+  shop: Shop
+}
+
+"""
 Event sent when new staff user is created.
 
 Added in Saleor 3.5.
@@ -35455,28 +35477,6 @@ type TransactionProcessSession implements Event @doc(category: "Payments") {
 
   """Action to proceed for the transaction"""
   action: TransactionProcessAction!
-}
-
-"""
-Event sent when shop metadata is updated.
-
-Added in Saleor 3.15.
-"""
-type ShopMetadataUpdated implements Event {
-  """Time of the event."""
-  issuedAt: DateTime
-
-  """Saleor version that triggered the event."""
-  version: String
-
-  """The user or application that triggered the event."""
-  issuingPrincipal: IssuingPrincipal
-
-  """The application receiving the webhook."""
-  recipient: App
-
-  """Shop data."""
-  shop: Shop
 }
 
 """

--- a/saleor/graphql/webhook/mutations/webhook_trigger.py
+++ b/saleor/graphql/webhook/mutations/webhook_trigger.py
@@ -17,7 +17,7 @@ from ...core.mutations import BaseMutation
 from ...core.types.common import WebhookTriggerError
 from ...core.utils import from_global_id_or_error, raise_validation_error
 from ..subscription_query import SubscriptionQuery
-from ..subscription_types import WEBHOOK_TYPES_MAP
+from ..subscription_types import ASYNC_WEBHOOK_TYPES_MAP
 from ..types import EventDelivery
 
 
@@ -65,10 +65,10 @@ class WebhookTrigger(BaseMutation):
 
     @classmethod
     def validate_event_type(cls, event_type, object_id):
-        event = WEBHOOK_TYPES_MAP[event_type] if event_type else None
+        event = cls._get_async_event_or_raise_error(event_type)
         model, _ = graphene.Node.from_global_id(object_id)
-        model_name = event._meta.root_type  # type: ignore[union-attr]
-        enable_dry_run = event._meta.enable_dry_run  # type: ignore[union-attr]
+        model_name = event._meta.root_type  # type: ignore[unused-ignore]
+        enable_dry_run = event._meta.enable_dry_run  # type: ignore[unused-ignore]
 
         if not (model_name or enable_dry_run) and event_type:
             event_name = event_type[0].upper() + to_camel_case(event_type)[1:]
@@ -83,6 +83,22 @@ class WebhookTrigger(BaseMutation):
                 message="ObjectId doesn't match event type.",
                 code=WebhookTriggerErrorCode.INVALID_ID,
             )
+
+    @classmethod
+    def _get_async_event_or_raise_error(cls, event_type):
+        if event := ASYNC_WEBHOOK_TYPES_MAP.get(event_type):
+            return event
+        event_name = (
+            event_type[0].upper() + to_camel_case(event_type)[1:] if event_type else ""
+        )
+        raise_validation_error(
+            message=(
+                f"Event type: {event_name}, "
+                f"which was parsed from webhook's "
+                f"subscription query, is not supported."
+            ),
+            code=WebhookTriggerErrorCode.TYPE_NOT_SUPPORTED,
+        )
 
     @classmethod
     def validate_permissions(cls, info, event_type):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -2699,7 +2699,50 @@ class ThumbnailCreated(SubscriptionObjectType):
         return image.url if image else None
 
 
-WEBHOOK_TYPES_MAP = {
+SYNC_WEBHOOK_TYPES_MAP = {
+    WebhookEventSyncType.PAYMENT_AUTHORIZE: PaymentAuthorize,
+    WebhookEventSyncType.PAYMENT_CAPTURE: PaymentCaptureEvent,
+    WebhookEventSyncType.PAYMENT_REFUND: PaymentRefundEvent,
+    WebhookEventSyncType.PAYMENT_VOID: PaymentVoidEvent,
+    WebhookEventSyncType.PAYMENT_CONFIRM: PaymentConfirmEvent,
+    WebhookEventSyncType.PAYMENT_PROCESS: PaymentProcessEvent,
+    WebhookEventSyncType.PAYMENT_LIST_GATEWAYS: PaymentListGateways,
+    WebhookEventSyncType.TRANSACTION_CANCELATION_REQUESTED: (
+        TransactionCancelationRequested
+    ),
+    WebhookEventSyncType.TRANSACTION_CHARGE_REQUESTED: TransactionChargeRequested,
+    WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED: TransactionRefundRequested,
+    WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS: OrderFilterShippingMethods,
+    WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS: (
+        CheckoutFilterShippingMethods
+    ),
+    WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT: (
+        ShippingListMethodsForCheckout
+    ),
+    WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES: CalculateTaxes,
+    WebhookEventSyncType.ORDER_CALCULATE_TAXES: CalculateTaxes,
+    WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION: (
+        PaymentGatewayInitializeSession
+    ),
+    WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION: TransactionInitializeSession,
+    WebhookEventSyncType.TRANSACTION_PROCESS_SESSION: TransactionProcessSession,
+    WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS: ListStoredPaymentMethods,
+    WebhookEventSyncType.STORED_PAYMENT_METHOD_DELETE_REQUESTED: (
+        StoredPaymentMethodDeleteRequested
+    ),
+    WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION: (
+        PaymentGatewayInitializeTokenizationSession
+    ),
+    WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION: (
+        PaymentMethodInitializeTokenizationSession
+    ),
+    WebhookEventSyncType.PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION: (
+        PaymentMethodProcessTokenizationSession
+    ),
+}
+
+
+ASYNC_WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED: AccountConfirmationRequested,
     WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: AccountChangeEmailRequested,
     WebhookEventAsyncType.ACCOUNT_EMAIL_CHANGED: AccountEmailChanged,
@@ -2820,6 +2863,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.SHIPPING_ZONE_UPDATED: ShippingZoneUpdated,
     WebhookEventAsyncType.SHIPPING_ZONE_DELETED: ShippingZoneDeleted,
     WebhookEventAsyncType.SHIPPING_ZONE_METADATA_UPDATED: ShippingZoneMetadataUpdated,
+    WebhookEventAsyncType.SHOP_METADATA_UPDATED: ShopMetadataUpdated,
     WebhookEventAsyncType.STAFF_CREATED: StaffCreated,
     WebhookEventAsyncType.STAFF_UPDATED: StaffUpdated,
     WebhookEventAsyncType.STAFF_DELETED: StaffDeleted,
@@ -2838,44 +2882,6 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.WAREHOUSE_DELETED: WarehouseDeleted,
     WebhookEventAsyncType.WAREHOUSE_METADATA_UPDATED: WarehouseMetadataUpdated,
     WebhookEventAsyncType.THUMBNAIL_CREATED: ThumbnailCreated,
-    WebhookEventSyncType.PAYMENT_AUTHORIZE: PaymentAuthorize,
-    WebhookEventSyncType.PAYMENT_CAPTURE: PaymentCaptureEvent,
-    WebhookEventSyncType.PAYMENT_REFUND: PaymentRefundEvent,
-    WebhookEventSyncType.PAYMENT_VOID: PaymentVoidEvent,
-    WebhookEventSyncType.PAYMENT_CONFIRM: PaymentConfirmEvent,
-    WebhookEventSyncType.PAYMENT_PROCESS: PaymentProcessEvent,
-    WebhookEventSyncType.PAYMENT_LIST_GATEWAYS: PaymentListGateways,
-    WebhookEventSyncType.TRANSACTION_CANCELATION_REQUESTED: (
-        TransactionCancelationRequested
-    ),
-    WebhookEventSyncType.TRANSACTION_CHARGE_REQUESTED: TransactionChargeRequested,
-    WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED: TransactionRefundRequested,
-    WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS: OrderFilterShippingMethods,
-    WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS: (
-        CheckoutFilterShippingMethods
-    ),
-    WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT: (
-        ShippingListMethodsForCheckout
-    ),
-    WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES: CalculateTaxes,
-    WebhookEventSyncType.ORDER_CALCULATE_TAXES: CalculateTaxes,
-    WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION: (
-        PaymentGatewayInitializeSession
-    ),
-    WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION: TransactionInitializeSession,
-    WebhookEventSyncType.TRANSACTION_PROCESS_SESSION: TransactionProcessSession,
-    WebhookEventAsyncType.SHOP_METADATA_UPDATED: ShopMetadataUpdated,
-    WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS: ListStoredPaymentMethods,
-    WebhookEventSyncType.STORED_PAYMENT_METHOD_DELETE_REQUESTED: (
-        StoredPaymentMethodDeleteRequested
-    ),
-    WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION: (
-        PaymentGatewayInitializeTokenizationSession
-    ),
-    WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION: (
-        PaymentMethodInitializeTokenizationSession
-    ),
-    WebhookEventSyncType.PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION: (
-        PaymentMethodProcessTokenizationSession
-    ),
 }
+
+WEBHOOK_TYPES_MAP = ASYNC_WEBHOOK_TYPES_MAP | SYNC_WEBHOOK_TYPES_MAP

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
@@ -272,7 +272,7 @@ def test_webhook_trigger_invalid_subscription_query(
     assert 'Unknown type "UndefinedEvent"' in error["message"]
 
 
-def test_webhook_trigger_event_not_supported(
+def test_webhook_trigger_synchronous_event_not_supported(
     staff_api_client,
     permission_manage_orders,
     order,


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/16035
Fixes: https://linear.app/saleor/issue/SHOPX-572/webhooktrigger-mutation-crashes

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
