### PR TITLE
Improve validation for email plugins, add support for env var USER_EMAIL_URL

### DIFF
--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -264,6 +264,24 @@ def validate_default_email_configuration(
                 ),
             }
         )
+
+    errors = []
+    for field in ("host", "port"):
+        if not configuration[field]:
+            errors.append(
+                ValidationError(
+                    {
+                        field: ValidationError(
+                            f"Missing {field} value.",
+                            code=PluginErrorCode.PLUGIN_MISCONFIGURED.value,
+                        )
+                    }
+                )
+            )
+
+    if errors:
+        raise ValidationError(errors)
+
     config = EmailConfig(
         host=configuration["host"],
         port=configuration["port"],

--- a/saleor/plugins/user_email/tests/test_plugin.py
+++ b/saleor/plugins/user_email/tests/test_plugin.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from django.core.exceptions import ValidationError
 from django.core.mail.backends.smtp import EmailBackend
+from django.test import override_settings
 
 from ....core.notify_events import NotifyEventType
 from ....graphql.tests.utils import get_graphql_content
@@ -76,8 +77,12 @@ def test_event_map():
         NotifyEventType.SEND_GIFT_CARD,
     ],
 )
+@patch("saleor.plugins.user_email.plugin.UserEmailPlugin._add_missing_configuration")
 @patch("saleor.plugins.user_email.plugin.get_user_event_map")
-def test_notify(mocked_get_event_map, event_type, user_email_plugin):
+def test_notify(
+    mocked_get_event_map, mock_add_missing_configuration, event_type, user_email_plugin
+):
+    # given
     payload = {
         "field1": 1,
         "field2": 2,
@@ -86,13 +91,25 @@ def test_notify(mocked_get_event_map, event_type, user_email_plugin):
     mocked_get_event_map.return_value = {event_type: mocked_event}
 
     plugin = user_email_plugin()
+    mock_add_missing_configuration.reset_mock()
+
+    # when
     plugin.notify(event_type, payload, previous_value=None)
 
-    mocked_event.assert_called_with(payload, asdict(plugin.config), plugin)
+    # then
+    config = asdict(plugin.config)
+    mocked_event.assert_called_with(payload, config, plugin)
+    mock_add_missing_configuration.assert_called_once_with(config)
 
 
+@patch("saleor.plugins.user_email.plugin.UserEmailPlugin._add_missing_configuration")
 @patch("saleor.plugins.user_email.plugin.get_user_event_map")
-def test_notify_event_not_related(mocked_get_event_map, user_email_plugin):
+def test_notify_event_not_related(
+    mocked_get_event_map,
+    mock_add_missing_configuration,
+    user_email_plugin,
+):
+    # given
     event_type = NotifyEventType.STAFF_ORDER_CONFIRMATION
     payload = {
         "field1": 1,
@@ -102,13 +119,24 @@ def test_notify_event_not_related(mocked_get_event_map, user_email_plugin):
     mocked_get_event_map.return_value = {event_type: mocked_event}
 
     plugin = user_email_plugin()
+    mock_add_missing_configuration.reset_mock()
+
+    # when
     plugin.notify(event_type, payload, previous_value=None)
 
+    # then
     assert not mocked_event.called
+    mock_add_missing_configuration.assert_not_called()
 
 
+@patch("saleor.plugins.user_email.plugin.UserEmailPlugin._add_missing_configuration")
 @patch("saleor.plugins.user_email.plugin.get_user_event_map")
-def test_notify_event_missing_handler(mocked_get_event_map, user_email_plugin):
+def test_notify_event_missing_handler(
+    mocked_get_event_map,
+    mock_add_missing_configuration,
+    user_email_plugin,
+):
+    # given
     event_type = NotifyEventType.ORDER_PAYMENT_CONFIRMATION
     payload = {
         "field1": 1,
@@ -118,13 +146,24 @@ def test_notify_event_missing_handler(mocked_get_event_map, user_email_plugin):
     mocked_get_event_map.return_value = mocked_event_map
 
     plugin = user_email_plugin()
+    mock_add_missing_configuration.reset_mock()
+
+    # when
     plugin.notify(event_type, payload, previous_value=None)
 
+    # then
     assert not mocked_event_map.__getitem__.called
+    mock_add_missing_configuration.assert_not_called()
 
 
+@patch("saleor.plugins.user_email.plugin.UserEmailPlugin._add_missing_configuration")
 @patch("saleor.plugins.user_email.plugin.get_user_event_map")
-def test_notify_event_plugin_is_not_active(mocked_get_event_map, user_email_plugin):
+def test_notify_event_plugin_is_not_active(
+    mocked_get_event_map,
+    mock_add_missing_configuration,
+    user_email_plugin,
+):
+    # given
     event_type = NotifyEventType.ORDER_PAYMENT_CONFIRMATION
     payload = {
         "field1": 1,
@@ -132,9 +171,14 @@ def test_notify_event_plugin_is_not_active(mocked_get_event_map, user_email_plug
     }
 
     plugin = user_email_plugin(active=False)
+    mock_add_missing_configuration.reset_mock()
+
+    # when
     plugin.notify(event_type, payload, previous_value=None)
 
+    # then
     assert not mocked_get_event_map.called
+    mock_add_missing_configuration.assert_not_called()
 
 
 def test_save_plugin_configuration_tls_and_ssl_are_mutually_exclusive(
@@ -313,3 +357,69 @@ def test_plugin_manager_doesnt_load_email_templates_from_db(
     # email template from DB but returns default email value.
     assert email_config_item
     assert email_config_item["value"] == DEFAULT_EMAIL_VALUE
+
+
+@override_settings(
+    USER_EMAIL_HOST="test_user_email_host",
+    USER_EMAIL_PORT=1337,
+    USER_EMAIL_USE_TLS=True,
+    USER_EMAIL_USE_SSL=False,
+    USER_EMAIL_HOST_USER="test_user_email_username",
+    USER_EMAIL_HOST_PASSWORD="test_user_email_password",
+)
+def test_adding_missing_configuration_from_settings(user_email_plugin):
+    # given
+    config = {
+        "host": None,
+        "port": None,
+        "use_tls": None,
+        "use_ssl": None,
+        "username": None,
+        "password": None,
+    }
+
+    # when
+    user_email_plugin()._add_missing_configuration(config)
+
+    # then
+    assert config == {
+        "host": "test_user_email_host",
+        "port": 1337,
+        "use_tls": True,
+        "use_ssl": False,
+        "username": "test_user_email_username",
+        "password": "test_user_email_password",
+    }
+
+
+@override_settings(
+    USER_EMAIL_HOST=None,
+    USER_EMAIL_PORT=None,
+    USER_EMAIL_USE_TLS=None,
+    USER_EMAIL_USE_SSL=None,
+    USER_EMAIL_HOST_USER=None,
+    USER_EMAIL_HOST_PASSWORD=None,
+)
+def test_adding_missing_configuration_from_settings_with_defaults(user_email_plugin):
+    # given
+    config = {
+        "host": "",
+        "port": "",
+        "use_tls": "",
+        "use_ssl": "",
+        "username": "",
+        "password": "",
+    }
+
+    # when
+    user_email_plugin()._add_missing_configuration(config)
+
+    # then
+    assert config == {
+        "host": None,
+        "port": None,
+        "use_tls": None,
+        "use_ssl": None,
+        "username": "",
+        "password": "",
+    }

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -126,7 +126,6 @@ if not EMAIL_URL and SENDGRID_USERNAME and SENDGRID_PASSWORD:
     )
 
 email_config = dj_email_url.parse(EMAIL_URL or "")
-user_email_config = dj_email_url.parse(os.environ.get("USER_EMAIL_URL", ""))
 
 EMAIL_FILE_PATH: str = email_config.get("EMAIL_FILE_PATH", "")
 EMAIL_HOST_USER: str = email_config.get("EMAIL_HOST_USER", "")
@@ -137,18 +136,19 @@ EMAIL_BACKEND: str = email_config.get("EMAIL_BACKEND", "")
 EMAIL_USE_TLS: bool = email_config.get("EMAIL_USE_TLS", False)
 EMAIL_USE_SSL: bool = email_config.get("EMAIL_USE_SSL", False)
 
-ENABLE_SSL = get_bool_from_env("ENABLE_SSL", False)
+# providing USER_EMAIL_URL not necessary when UserPluginEmail has SMTP configuration is
+# provided
+user_email_config = dj_email_url.parse(os.environ.get("USER_EMAIL_URL", ""))
 
-USER_EMAIL_HOST_USER: str = user_email_config.get("EMAIL_HOST_USER", "")
-USER_EMAIL_HOST_PASSWORD: str = user_email_config.get("EMAIL_HOST_PASSWORD", "")
-USER_EMAIL_HOST: str = user_email_config.get("EMAIL_HOST", "")
-USER_EMAIL_PORT = user_email_config.get("EMAIL_PORT", "")
-if USER_EMAIL_PORT:
-    USER_EMAIL_PORT = str(USER_EMAIL_PORT)
-USER_EMAIL_BACKEND: str = user_email_config.get("EMAIL_BACKEND", "")
+USER_EMAIL_HOST_USER: str = user_email_config.get("EMAIL_HOST_USER") or ""
+USER_EMAIL_HOST_PASSWORD: str = user_email_config.get("EMAIL_HOST_PASSWORD") or ""
+USER_EMAIL_HOST: str = user_email_config.get("EMAIL_HOST") or ""
+USER_EMAIL_PORT: str = str(user_email_config.get("EMAIL_PORT") or "")
+
 USER_EMAIL_USE_TLS: bool = user_email_config.get("EMAIL_USE_TLS", False)
 USER_EMAIL_USE_SSL: bool = user_email_config.get("EMAIL_USE_SSL", False)
 
+ENABLE_SSL = get_bool_from_env("ENABLE_SSL", False)
 if ENABLE_SSL:
     SECURE_SSL_REDIRECT = not DEBUG
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -126,6 +126,7 @@ if not EMAIL_URL and SENDGRID_USERNAME and SENDGRID_PASSWORD:
     )
 
 email_config = dj_email_url.parse(EMAIL_URL or "")
+user_email_config = dj_email_url.parse(os.environ.get("USER_EMAIL_URL", ""))
 
 EMAIL_FILE_PATH: str = email_config.get("EMAIL_FILE_PATH", "")
 EMAIL_HOST_USER: str = email_config.get("EMAIL_HOST_USER", "")
@@ -137,6 +138,16 @@ EMAIL_USE_TLS: bool = email_config.get("EMAIL_USE_TLS", False)
 EMAIL_USE_SSL: bool = email_config.get("EMAIL_USE_SSL", False)
 
 ENABLE_SSL = get_bool_from_env("ENABLE_SSL", False)
+
+USER_EMAIL_HOST_USER: str = user_email_config.get("EMAIL_HOST_USER", "")
+USER_EMAIL_HOST_PASSWORD: str = user_email_config.get("EMAIL_HOST_PASSWORD", "")
+USER_EMAIL_HOST: str = user_email_config.get("EMAIL_HOST", "")
+USER_EMAIL_PORT = user_email_config.get("EMAIL_PORT", "")
+if USER_EMAIL_PORT:
+    USER_EMAIL_PORT = str(USER_EMAIL_PORT)
+USER_EMAIL_BACKEND: str = user_email_config.get("EMAIL_BACKEND", "")
+USER_EMAIL_USE_TLS: bool = user_email_config.get("EMAIL_USE_TLS", False)
+USER_EMAIL_USE_SSL: bool = user_email_config.get("EMAIL_USE_SSL", False)
 
 if ENABLE_SSL:
     SECURE_SSL_REDIRECT = not DEBUG


### PR DESCRIPTION
I want to merge this change because it improves validation for email plugins. Also it adds support for email url for `UserEmailPlugin` using env variable `USER_EMAIL_URL`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
