### PR TITLE
Product dataloader optimizations

### DIFF
--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -417,7 +417,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(72):
+    with django_assert_num_queries(71):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -435,7 +435,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(72):
+    with django_assert_num_queries(71):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -566,7 +566,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(94):
+    with django_assert_num_queries(93):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then
@@ -821,7 +821,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(93):
+    with django_assert_num_queries(92):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -835,7 +835,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(93):
+    with django_assert_num_queries(92):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -1080,7 +1080,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(92):
+    with django_assert_num_queries(91):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -1093,7 +1093,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(92):
+    with django_assert_num_queries(91):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,
@@ -1143,7 +1143,7 @@ def test_add_checkout_lines_catalogue_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(84):
+    with django_assert_num_queries(83):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1228,7 +1228,7 @@ def test_add_checkout_lines_multiple_catalogue_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(84):
+    with django_assert_num_queries(83):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1263,7 +1263,7 @@ def test_add_checkout_lines_order_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(87):
+    with django_assert_num_queries(86):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1297,7 +1297,7 @@ def test_add_checkout_lines_gift_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(114):
+    with django_assert_num_queries(113):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -211,8 +211,6 @@ class ProductVariantsByProductIdAndChannel(
     context_key = "productvariant_by_product_and_channel"
 
     def batch_load(self, keys: Iterable[tuple[int, str]]):
-        _, channel_slugs = zip(*keys)
-
         product_ids_by_channel = defaultdict(list)
         for product_id, channel_slug in keys:
             product_ids_by_channel[channel_slug].append(product_id)
@@ -243,7 +241,7 @@ class ProductVariantsByProductIdAndChannel(
 
         return (
             ChannelBySlugLoader(self.context)
-            .load_many(channel_slugs)
+            .load_many(product_ids_by_channel.keys())
             .then(with_channels)
         )
 

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -24,6 +24,7 @@ from ...core.dataloaders import BaseThumbnailBySizeAndFormatLoader, DataLoader
 
 ProductIdAndChannelSlug = tuple[int, str]
 VariantIdAndChannelSlug = tuple[int, str]
+VariantIdAndChannelId = tuple[int, int]
 
 
 class CategoryByIdLoader(DataLoader[int, Category]):
@@ -294,40 +295,64 @@ class VariantChannelListingByVariantIdLoader(DataLoader):
         ]
 
 
-class VariantChannelListingByVariantIdAndChannelLoader(
+class VariantChannelListingByVariantIdAndChannelSlugLoader(
     DataLoader[VariantIdAndChannelSlug, ProductVariantChannelListing]
 ):
-    context_key = "variantchannelisting_by_variant_and_channel"
-    field = ""
+    context_key = "variantchannelisting_by_variant_and_channelslug"
+
+    def batch_load(self, keys):
+        channel_slugs = [channel_slug for _, channel_slug in keys]
+
+        def with_channels(channels):
+            channel_map = {c.slug: c.id for c in channels}
+            variant_id_channel_id_keys = [
+                (variant_id, channel_map[channel_slug])
+                for (variant_id, channel_slug) in keys
+            ]
+            return VariantChannelListingByVariantIdAndChannelIdLoader(
+                self.context
+            ).load_many(variant_id_channel_id_keys)
+
+        return (
+            ChannelBySlugLoader(self.context)
+            .load_many(channel_slugs)
+            .then(with_channels)
+        )
+
+
+class VariantChannelListingByVariantIdAndChannelIdLoader(
+    DataLoader[VariantIdAndChannelId, ProductVariantChannelListing]
+):
+    context_key = "variantchannelisting_by_variant_and_channelid"
 
     def batch_load(self, keys):
         # Split the list of keys by channel first. A typical query will only touch
         # a handful of unique countries but may access thousands of product variants
         # so it's cheaper to execute one query per channel.
-        variant_channel_listing_by_channel: defaultdict[str, list[int]] = defaultdict(
+        variant_channel_listing_by_channel: defaultdict[int, list[int]] = defaultdict(
             list
         )
-        for variant_id, channel in keys:
-            variant_channel_listing_by_channel[channel].append(variant_id)
+        for variant_id, channel_id in keys:
+            variant_channel_listing_by_channel[channel_id].append(variant_id)
 
         # For each channel execute a single query for all product variants.
         variant_channel_listing_by_variant_and_channel: defaultdict[
-            VariantIdAndChannelSlug, Optional[ProductVariantChannelListing]
+            VariantIdAndChannelId, Optional[ProductVariantChannelListing]
         ] = defaultdict()
-        for channel, variant_ids in variant_channel_listing_by_channel.items():
-            variant_channel_listings = self.batch_load_channel(channel, variant_ids)
+        for channel_id, variant_ids in variant_channel_listing_by_channel.items():
+            variant_channel_listings = self.batch_load_channel(channel_id, variant_ids)
             for variant_id, variant_channel_listing in variant_channel_listings:
                 variant_channel_listing_by_variant_and_channel[
-                    (variant_id, channel)
+                    (variant_id, channel_id)
                 ] = variant_channel_listing
 
         return [variant_channel_listing_by_variant_and_channel[key] for key in keys]
 
     def batch_load_channel(
-        self, channel: str, variant_ids: Iterable[int]
+        self, channel_id: int, variant_ids: Iterable[int]
     ) -> Iterable[tuple[int, Optional[ProductVariantChannelListing]]]:
         filter = {
-            f"channel__{self.field}": channel,
+            "channel_id": channel_id,
             "variant_id__in": variant_ids,
             "price_amount__isnull": False,
         }
@@ -349,20 +374,6 @@ class VariantChannelListingByVariantIdAndChannelLoader(
             (variant_id, variant_channel_listings_map.get(variant_id))
             for variant_id in variant_ids
         ]
-
-
-class VariantChannelListingByVariantIdAndChannelSlugLoader(
-    VariantChannelListingByVariantIdAndChannelLoader
-):
-    context_key = "variantchannelisting_by_variant_and_channelslug"
-    field = "slug"
-
-
-class VariantChannelListingByVariantIdAndChannelIdLoader(
-    VariantChannelListingByVariantIdAndChannelLoader
-):
-    context_key = "variantchannelisting_by_variant_and_channelid"
-    field = "id"
 
 
 class VariantsChannelListingByProductIdAndChannelSlugLoader(


### PR DESCRIPTION
Optimize product-related dataloaders to remove unnecessary joins by reusing existing dataloaders.

1. Removed JOIN on channel table in `VariantChannelListingByVariantIdAndChannelSlugLoader`:

Old:
```sql
SELECT "product_productvariantchannellisting"."id",
       COALESCE(SUM("warehouse_preorderallocation"."quantity"), 0) AS "preorder_quantity_allocated"
FROM "product_productvariantchannellisting"
INNER JOIN "channel_channel" ON ("product_productvariantchannellisting"."channel_id" = "channel_channel"."id")
LEFT OUTER JOIN "warehouse_preorderallocation" ON ("product_productvariantchannellisting"."id" = "warehouse_preorderallocation"."product_variant_channel_listing_id")
WHERE ("channel_channel"."slug" = \'default-channel\'
       AND "product_productvariantchannellisting"."price_amount" IS NOT NULL
       AND "product_productvariantchannellisting"."variant_id" IN (384))
GROUP BY "product_productvariantchannellisting"."id"
ORDER BY "product_productvariantchannellisting"."id" ASC
```

New:
```sql
SELECT "product_productvariantchannellisting"."id",
       COALESCE(SUM("warehouse_preorderallocation"."quantity"), 0) AS "preorder_quantity_allocated"
FROM "product_productvariantchannellisting"
LEFT OUTER JOIN "warehouse_preorderallocation" ON ("product_productvariantchannellisting"."id" = "warehouse_preorderallocation"."product_variant_channel_listing_id")
WHERE ("product_productvariantchannellisting"."channel_id" = 1
       AND "product_productvariantchannellisting"."price_amount" IS NOT NULL
       AND "product_productvariantchannellisting"."variant_id" IN (384))
GROUP BY "product_productvariantchannellisting"."id"
ORDER BY "product_productvariantchannellisting"."id" ASC
```

2. Removed JOIN in `ProductVariantsByProductIdAndChannel` in favor of EXISTS:

```sql
SELECT *
FROM "product_productvariant"
WHERE (EXISTS
         (SELECT (1) AS "a"
          FROM "product_productvariantchannellisting" U0
          WHERE (U0."channel_id" = 1
                 AND U0."price_amount" IS NOT NULL
                 AND U0."variant_id" = "product_productvariant"."id")
          LIMIT 1)
       AND "product_productvariant"."product_id" IN (152))
ORDER BY "product_productvariant"."sort_order" ASC,
         "product_productvariant"."sku" ASC
```


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
