### PR TITLE
Set unit_discount_reason on line when the entire order voucher is applied

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -307,9 +307,12 @@ def _create_line_for_order(
     discount = checkout_line_info.get_sale_discount()
     sale_id = discount.sale.id if discount and discount.sale else None
 
-    voucher_code = None
+    line_voucher_code = None
     if checkout_line_info.voucher:
-        voucher_code = checkout_line_info.voucher.code
+        line_voucher_code = checkout_line_info.voucher.code
+    order_voucher_code = None
+    if checkout_info.voucher:
+        order_voucher_code = checkout_info.voucher.code
 
     discount_price = undiscounted_unit_price - unit_price
     if prices_entered_with_tax:
@@ -317,12 +320,9 @@ def _create_line_for_order(
     else:
         discount_amount = discount_price.net
 
-    unit_discount_reason = None
-    if voucher_code:
-        if unit_discount_reason:
-            unit_discount_reason += f" & Voucher code: {voucher_code}"
-        else:
-            unit_discount_reason = f"Voucher code: {voucher_code}"
+    unit_discount_reason = _get_unit_discount_reason(
+        line_voucher_code, order_voucher_code
+    )
 
     tax_class = None
     if product.tax_class_id:
@@ -347,7 +347,7 @@ def _create_line_for_order(
         total_price=total_line_price,
         tax_rate=tax_rate,
         sale_id=graphene.Node.to_global_id("Sale", sale_id) if sale_id else None,
-        voucher_code=voucher_code,
+        voucher_code=line_voucher_code,
         unit_discount=discount_amount,  # money field not supported by mypy_django_plugin # noqa: E501
         unit_discount_reason=unit_discount_reason,
         unit_discount_value=discount_amount.amount,  # we store value as fixed discount
@@ -376,6 +376,26 @@ def _create_line_for_order(
     )
 
     return line_info
+
+
+def _get_unit_discount_reason(
+    line_voucher_code: Optional[str],
+    order_voucher_code: Optional[str],
+) -> Optional[str]:
+    unit_discount_reason = None
+    if line_voucher_code:
+        if unit_discount_reason:
+            unit_discount_reason += f" & Voucher code: {line_voucher_code}"
+        else:
+            unit_discount_reason = f"Voucher code: {line_voucher_code}"
+    elif order_voucher_code:
+        if unit_discount_reason:
+            msg = f" & Entire order voucher code: {order_voucher_code}"
+            unit_discount_reason += msg
+        else:
+            unit_discount_reason = f"Entire order voucher code: {order_voucher_code}"
+
+    return unit_discount_reason
 
 
 def _create_order_line_discounts(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -897,6 +897,11 @@ def test_checkout_with_voucher_complete(
     order_payment = order.payments.first()
     assert order_payment == payment
     assert payment.transactions.count() == 1
+    assert (
+        order_line.unit_discount_amount
+        == (discount_amount / checkout_line_quantity).amount
+    )
+    assert order_line.unit_discount_reason
 
     voucher_percentage.refresh_from_db()
     assert voucher_percentage.used == voucher_used_count + 1

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1622,6 +1622,13 @@ def test_checkout_with_voucher_complete(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
 
+    order_line = order.lines.first()
+    assert (
+        order_line.unit_discount_amount
+        == (discount_amount / order_line.quantity).amount
+    )
+    assert order_line.unit_discount_reason
+
 
 @pytest.mark.integration
 def test_checkout_complete_with_voucher_apply_once_per_order(


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/16059
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
