### PR TITLE
Set unit_discount_reason on line when the entire order voucher is applied

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -308,9 +308,12 @@ def _create_line_for_order(
         checkout_line_info=checkout_line_info,
     )
 
-    voucher_code = None
+    line_voucher_code = None
     if checkout_line_info.voucher:
-        voucher_code = checkout_line_info.voucher.code
+        line_voucher_code = checkout_line_info.voucher.code
+    order_voucher_code = None
+    if checkout_info.voucher:
+        order_voucher_code = checkout_info.voucher.code
 
     discount_price = undiscounted_unit_price - unit_price
     if prices_entered_with_tax:
@@ -318,9 +321,9 @@ def _create_line_for_order(
     else:
         discount_amount = discount_price.net
 
-    unit_discount_reason = None
-    if voucher_code:
-        unit_discount_reason = f"Voucher code: {voucher_code}"
+    unit_discount_reason = _get_unit_discount_reason(
+        line_voucher_code, order_voucher_code
+    )
 
     tax_class = None
     if product.tax_class_id:
@@ -344,7 +347,7 @@ def _create_line_for_order(
         undiscounted_total_price=undiscounted_total_price,  # money field not supported by mypy_django_plugin # noqa: E501
         total_price=total_line_price,
         tax_rate=tax_rate,
-        voucher_code=voucher_code,
+        voucher_code=line_voucher_code,
         unit_discount=discount_amount,  # money field not supported by mypy_django_plugin # noqa: E501
         unit_discount_reason=unit_discount_reason,
         unit_discount_value=discount_amount.amount,  # we store value as fixed discount
@@ -386,6 +389,26 @@ def _create_line_for_order(
     )
 
     return line_info
+
+
+def _get_unit_discount_reason(
+    line_voucher_code: Optional[str],
+    order_voucher_code: Optional[str],
+) -> Optional[str]:
+    unit_discount_reason = None
+    if line_voucher_code:
+        if unit_discount_reason:
+            unit_discount_reason += f" & Voucher code: {line_voucher_code}"
+        else:
+            unit_discount_reason = f"Voucher code: {line_voucher_code}"
+    elif order_voucher_code:
+        if unit_discount_reason:
+            msg = f" & Entire order voucher code: {order_voucher_code}"
+            unit_discount_reason += msg
+        else:
+            unit_discount_reason = f"Entire order voucher code: {order_voucher_code}"
+
+    return unit_discount_reason
 
 
 def _create_order_line_discounts(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -900,6 +900,11 @@ def test_checkout_with_voucher_complete(
     order_payment = order.payments.first()
     assert order_payment == payment
     assert payment.transactions.count() == 1
+    assert (
+        order_line.unit_discount_amount
+        == (discount_amount / checkout_line_quantity).amount
+    )
+    assert order_line.unit_discount_reason
 
     voucher_percentage.refresh_from_db()
     assert voucher_percentage.used == voucher_used_count + 1
@@ -1158,7 +1163,9 @@ def test_checkout_with_voucher_complete_product_on_promotion(
     assert order_line.sale_id == graphene.Node.to_global_id(
         "Promotion", promotion_without_rules.id
     )
-    assert order_line.unit_discount_reason == f"Promotion: {order_line.sale_id}"
+    assert order_line.unit_discount_reason == (
+        f"Entire order voucher code: {code.code} & Promotion: {order_line.sale_id}"
+    )
 
     assert checkout_line_quantity == order_line.quantity
     assert checkout_line_variant == order_line.variant

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1744,7 +1744,7 @@ def test_checkout_with_voucher_complete_product_on_sale(
     voucher_used_count = voucher_percentage.used
     voucher_percentage.usage_limit = voucher_used_count + 1
     voucher_percentage.save(update_fields=["usage_limit"])
-    code = checkout_with_voucher_percentage.voucher_code
+    code = voucher_percentage.codes.first()
 
     old_sale_id = 1
     promotion_without_rules.old_sale_id = old_sale_id
@@ -1836,12 +1836,12 @@ def test_checkout_with_voucher_complete_product_on_sale(
         "Sale", promotion_without_rules.old_sale_id
     )
     assert order_line.unit_discount_reason == (
-        f"Entire order voucher code: {code} & Sale: {order_line.sale_id}"
+        f"Entire order voucher code: {code.code} & Sale: {order_line.sale_id}"
     )
 
     voucher_percentage.refresh_from_db()
     assert voucher_percentage.used == voucher_used_count + 1
-    code = voucher_percentage.codes.first()
+    code.refresh_from_db()
     assert code.used == voucher_used_count + 1
     assert order.voucher == voucher_percentage
     assert order.voucher.code == code.code

--- a/saleor/tests/e2e/checkout/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
@@ -225,7 +225,9 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     order_line = order_data["lines"][0]
     assert order_line["unitDiscountType"] == "FIXED"
     assert order_line["unitPrice"]["gross"]["amount"] == expected_unit_price
-    assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert order_line["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
     assert order_data["total"]["gross"]["amount"] == total_gross_amount
     assert order_data["subtotal"]["gross"]["amount"] == subtotal_amount
     assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(

--- a/saleor/tests/e2e/checkout/test_checkout_with_promotion_and_voucher.py
+++ b/saleor/tests/e2e/checkout/test_checkout_with_promotion_and_voucher.py
@@ -251,4 +251,6 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
     assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
         product_variant_price
     )
-    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"
+    assert order_line["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Promotion: {promotion_id}"
+    )


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/16059

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
