### PR TITLE
Throw a ValidationError on `CheckoutRemovePromoCode` mutation if code was not removed.

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -808,12 +808,8 @@ def remove_promo_code_from_checkout_or_error(
         remove_gift_card_code_from_checkout_or_error(checkout_info.checkout, promo_code)
     else:
         raise ValidationError(
-            {
-                "promo_code": ValidationError(
-                    "Promo code does not exists.",
-                    code=CheckoutErrorCode.NOT_FOUND.value,
-                )
-            }
+            "Promo code does not exists.",
+            code=CheckoutErrorCode.NOT_FOUND.value,
         )
 
 
@@ -828,12 +824,8 @@ def remove_voucher_code_from_checkout_or_error(
         checkout_info.voucher = None
     else:
         raise ValidationError(
-            {
-                "promo_code": ValidationError(
-                    "Cannot remove a voucher not attached to this checkout.",
-                    code=CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.value,
-                )
-            }
+            "Cannot remove a voucher not attached to this checkout.",
+            code=CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.value,
         )
 
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -38,7 +38,7 @@ from ..discount.utils import (
 )
 from ..giftcard.utils import (
     add_gift_card_code_to_checkout,
-    remove_gift_card_code_from_checkout,
+    remove_gift_card_code_from_checkout_or_error,
 )
 from ..plugins.manager import PluginsManager
 from ..product import models as product_models
@@ -797,33 +797,44 @@ def add_voucher_to_checkout(
         delete_gift_line(checkout_info.checkout, lines)
 
 
-def remove_promo_code_from_checkout(
+def remove_promo_code_from_checkout_or_error(
     checkout_info: "CheckoutInfo", promo_code: str
-) -> bool:
-    """Remove gift card or voucher data from checkout.
+) -> None:
+    """Remove gift card or voucher data from checkout or raise an error."""
 
-    Return information whether promo code was removed.
-    """
     if promo_code_is_voucher(promo_code):
-        return remove_voucher_code_from_checkout(checkout_info, promo_code)
+        remove_voucher_code_from_checkout_or_error(checkout_info, promo_code)
     elif promo_code_is_gift_card(promo_code):
-        return remove_gift_card_code_from_checkout(checkout_info.checkout, promo_code)
-    return False
+        remove_gift_card_code_from_checkout_or_error(checkout_info.checkout, promo_code)
+    else:
+        raise ValidationError(
+            {
+                "promo_code": ValidationError(
+                    "Promo code does not exists.",
+                    code=CheckoutErrorCode.NOT_FOUND.value,
+                )
+            }
+        )
 
 
-def remove_voucher_code_from_checkout(
+def remove_voucher_code_from_checkout_or_error(
     checkout_info: "CheckoutInfo", voucher_code: str
-) -> bool:
-    """Remove voucher data from checkout by code.
+) -> None:
+    """Remove voucher data from checkout by code or raise an error."""
 
-    Return information whether promo code was removed.
-    """
     existing_voucher = checkout_info.voucher
     if existing_voucher and existing_voucher.code == voucher_code:
         remove_voucher_from_checkout(checkout_info.checkout)
         checkout_info.voucher = None
-        return True
-    return False
+    else:
+        raise ValidationError(
+            {
+                "promo_code": ValidationError(
+                    "Cannot remove a voucher not attached to this checkout.",
+                    code=CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.value,
+                )
+            }
+        )
 
 
 def remove_voucher_from_checkout(checkout: Checkout):

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -147,12 +147,11 @@ def test_remove_gift_card_code_from_checkout_no_checkout_gift_cards(
         remove_gift_card_code_from_checkout_or_error(checkout, gift_card.code)
 
     # then
-    validation_error = error.value.args[0]["promo_code"]
     assert checkout.gift_cards.count() == 0
-    assert validation_error.message == (
+    assert error.value.message == (
         "Cannot remove a gift card not attached to this checkout."
     )
-    assert validation_error.code == CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value
+    assert error.value.code == CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value
 
 
 @pytest.mark.parametrize(

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 import graphene
 import pytest
 from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from freezegun import freeze_time
 
+from ...checkout.error_codes import CheckoutErrorCode
 from ...core import TimePeriodType
 from ...core.exceptions import GiftCardNotApplicable
 from ...core.utils.json_serializer import CustomJsonEncoder
@@ -32,7 +34,7 @@ from ..utils import (
     gift_cards_create,
     is_gift_card_expired,
     order_has_gift_card_lines,
-    remove_gift_card_code_from_checkout,
+    remove_gift_card_code_from_checkout_or_error,
 )
 
 
@@ -128,7 +130,7 @@ def test_remove_gift_card_code_from_checkout(checkout, gift_card):
     assert checkout.gift_cards.count() == 1
 
     # when
-    remove_gift_card_code_from_checkout(checkout, gift_card.code)
+    remove_gift_card_code_from_checkout_or_error(checkout, gift_card.code)
 
     # then
     assert checkout.gift_cards.count() == 0
@@ -141,10 +143,16 @@ def test_remove_gift_card_code_from_checkout_no_checkout_gift_cards(
     assert checkout.gift_cards.count() == 0
 
     # when
-    remove_gift_card_code_from_checkout(checkout, gift_card.code)
+    with pytest.raises(ValidationError) as error:
+        remove_gift_card_code_from_checkout_or_error(checkout, gift_card.code)
 
     # then
+    validation_error = error.value.args[0]["promo_code"]
     assert checkout.gift_cards.count() == 0
+    assert validation_error.message == (
+        "Cannot remove a gift card not attached to this checkout."
+    )
+    assert validation_error.code == CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value
 
 
 @pytest.mark.parametrize(

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
 from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models.expressions import Exists, OuterRef
 from django.utils import timezone
 
+from ..checkout.error_codes import CheckoutErrorCode
 from ..checkout.models import Checkout
 from ..core.exceptions import GiftCardNotApplicable
 from ..core.tracing import traced_atomic_transaction
@@ -53,16 +55,23 @@ def add_gift_card_code_to_checkout(
     checkout.save(update_fields=["last_change"])
 
 
-def remove_gift_card_code_from_checkout(checkout: Checkout, gift_card_code: str):
-    """Remove gift card data from checkout by code.
+def remove_gift_card_code_from_checkout_or_error(
+    checkout: Checkout, gift_card_code: str
+) -> None:
+    """Remove gift card data from checkout by code or raise an error."""
 
-    Return information whether promo code was removed.
-    """
     if gift_card := checkout.gift_cards.filter(code=gift_card_code).first():
         checkout.gift_cards.remove(gift_card)
         checkout.save(update_fields=["last_change"])
-        return True
-    return False
+    else:
+        raise ValidationError(
+            {
+                "promo_code": ValidationError(
+                    "Cannot remove a gift card not attached to this checkout.",
+                    code=CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value,
+                )
+            }
+        )
 
 
 def deactivate_gift_card(gift_card: GiftCard):

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -65,12 +65,8 @@ def remove_gift_card_code_from_checkout_or_error(
         checkout.save(update_fields=["last_change"])
     else:
         raise ValidationError(
-            {
-                "promo_code": ValidationError(
-                    "Cannot remove a gift card not attached to this checkout.",
-                    code=CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value,
-                )
-            }
+            "Cannot remove a gift card not attached to this checkout.",
+            code=CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value,
         )
 
 

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -9,7 +9,7 @@ from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import (
     invalidate_checkout,
-    remove_promo_code_from_checkout,
+    remove_promo_code_from_checkout_or_error,
     remove_voucher_from_checkout,
 )
 from ....webhook.event_types import WebhookEventAsyncType
@@ -84,31 +84,28 @@ class CheckoutRemovePromoCode(BaseMutation):
             "promo_code", promo_code, "promo_code_id", promo_code_id
         )
 
-        object_type, promo_code_pk = cls.clean_promo_code_id(promo_code_id)
-
         checkout = get_checkout(cls, info, checkout_id=checkout_id, token=token, id=id)
 
         manager = get_plugin_manager_promise(info.context).get()
         checkout_info = fetch_checkout_info(checkout, [], manager)
 
-        removed = False
         if promo_code:
-            removed = remove_promo_code_from_checkout(checkout_info, promo_code)
+            remove_promo_code_from_checkout_or_error(checkout_info, promo_code)
         else:
-            removed = cls.remove_promo_code_by_id(
+            object_type, promo_code_pk = cls.clean_promo_code_id(promo_code_id)
+            cls.remove_promo_code_by_id_or_error(
                 info, checkout, object_type, promo_code_pk
             )
-
-        if removed:
-            lines, _ = fetch_checkout_lines(checkout)
-            invalidate_checkout(
-                checkout_info,
-                lines,
-                manager,
-                recalculate_discount=True,
-                save=True,
-            )
-            cls.call_event(manager.checkout_updated, checkout)
+        # if this step is reached, it means promo code was removed
+        lines, _ = fetch_checkout_lines(checkout)
+        invalidate_checkout(
+            checkout_info,
+            lines,
+            manager,
+            recalculate_discount=True,
+            save=True,
+        )
+        cls.call_event(manager.checkout_updated, checkout)
 
         return CheckoutRemovePromoCode(checkout=checkout)
 
@@ -142,19 +139,15 @@ class CheckoutRemovePromoCode(BaseMutation):
         return object_type, promo_code_pk
 
     @classmethod
-    def remove_promo_code_by_id(
+    def remove_promo_code_by_id_or_error(
         cls,
         info: ResolveInfo,
         checkout: models.Checkout,
         object_type: str,
         promo_code_pk: int,
-    ) -> bool:
-        """Detach promo code from the checkout based on the id.
+    ) -> None:
+        """Detach promo code from the checkout based on the id or raise an error."""
 
-        Return a boolean value that indicates whether this function changed
-        the checkout object which then controls whether hooks such as
-        `checkout_updated` are triggered.
-        """
         if object_type == str(Voucher) and checkout.voucher_code is not None:
             node = cls._get_node_by_pk(info, graphene_type=Voucher, pk=promo_code_pk)
             if node is None:
@@ -168,9 +161,14 @@ class CheckoutRemovePromoCode(BaseMutation):
                 )
             if checkout.voucher_code == node.code:
                 remove_voucher_from_checkout(checkout)
-                return True
+            else:
+                raise ValidationError(
+                    {
+                        "promo_code_id": ValidationError(
+                            "Couldn't remove a promo code from a checkout.",
+                            code=CheckoutErrorCode.NOT_FOUND.value,
+                        )
+                    }
+                )
         else:
             checkout.gift_cards.remove(promo_code_pk)
-            return True
-
-        return False

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -90,7 +90,10 @@ class CheckoutRemovePromoCode(BaseMutation):
         checkout_info = fetch_checkout_info(checkout, [], manager)
 
         if promo_code:
-            remove_promo_code_from_checkout_or_error(checkout_info, promo_code)
+            try:
+                remove_promo_code_from_checkout_or_error(checkout_info, promo_code)
+            except ValidationError as error:
+                raise ValidationError({"promo_code": error})
         else:
             object_type, promo_code_pk = cls.clean_promo_code_id(promo_code_id)
             cls.remove_promo_code_by_id_or_error(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import patch
 
 import graphene
 from django.utils import timezone
@@ -8,6 +9,7 @@ from .....checkout import base_calculations
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....discount import RewardValueType
+from .....discount.models import Voucher
 from .....plugins.manager import get_plugins_manager
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
@@ -56,7 +58,11 @@ def _mutate_checkout_remove_promo_code(client, variables):
     return content["data"]["checkoutRemovePromoCode"]
 
 
-def test_checkout_remove_voucher_code(api_client, checkout_with_voucher):
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_voucher_code(
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher
+):
+    # given
     assert checkout_with_voucher.voucher_code is not None
     previous_checkout_last_change = checkout_with_voucher.last_change
 
@@ -65,19 +71,77 @@ def test_checkout_remove_voucher_code(api_client, checkout_with_voucher):
         "promoCode": checkout_with_voucher.voucher_code,
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     checkout_with_voucher.refresh_from_db()
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_voucher.token)
     assert data["checkout"]["voucherCode"] is None
     assert checkout_with_voucher.voucher_code is None
     assert checkout_with_voucher.last_change != previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_voucher)
 
 
-def test_checkout_remove_voucher_code_with_inactive_channel(
-    api_client, checkout_with_voucher
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_voucher_code_voucher_not_exists_anymore(
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher
 ):
+    # given
+    assert checkout_with_voucher.voucher_code is not None
+    previous_checkout_last_change = checkout_with_voucher.last_change
+    Voucher.objects.all().delete()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_voucher),
+        "promoCode": checkout_with_voucher.voucher_code,
+    }
+
+    # when
+    data = _mutate_checkout_remove_promo_code(api_client, variables)
+
+    # then
+    assert data["errors"][0]["field"] == "promoCode"
+    assert data["errors"][0]["code"] == CheckoutErrorCode.NOT_FOUND.name
+    assert data["errors"][0]["message"] == "Promo code does not exists."
+
+    checkout_with_voucher.refresh_from_db()
+    assert checkout_with_voucher.last_change == previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_promo_code_id_voucher_not_exists_anymore(
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher, voucher
+):
+    # given
+    assert checkout_with_voucher.voucher_code is not None
+    previous_checkout_last_change = checkout_with_voucher.last_change
+    Voucher.objects.all().delete()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_voucher),
+        "promoCodeId": graphene.Node.to_global_id("Voucher", voucher.id),
+    }
+
+    # when
+    data = _mutate_checkout_remove_promo_code(api_client, variables)
+
+    # then
+    assert data["errors"][0]["field"] == "promoCodeId"
+    assert data["errors"][0]["code"] == CheckoutErrorCode.NOT_FOUND.name
+
+    checkout_with_voucher.refresh_from_db()
+    assert checkout_with_voucher.last_change == previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_voucher_code_with_inactive_channel(
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher
+):
+    # given
     checkout_with_voucher.price_expiration = timezone.now() + timedelta(days=2)
     checkout_with_voucher.save(update_fields=["price_expiration"])
     previous_checkout_last_change = checkout_with_voucher.last_change
@@ -91,8 +155,10 @@ def test_checkout_remove_voucher_code_with_inactive_channel(
         "promoCode": checkout_with_voucher.voucher_code,
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"][0]["field"] == "promoCode"
     assert data["errors"][0]["code"] == CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.name
     assert data["errors"][0]["message"] == (
@@ -101,9 +167,14 @@ def test_checkout_remove_voucher_code_with_inactive_channel(
 
     checkout_with_voucher.refresh_from_db()
     assert checkout_with_voucher.last_change == previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_not_called()
 
 
-def test_checkout_remove_gift_card_code(api_client, checkout_with_gift_card):
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_gift_card_code(
+    checkout_updated_webhook_mock, api_client, checkout_with_gift_card
+):
+    # given
     assert checkout_with_gift_card.gift_cards.count() == 1
     previous_checkout_last_change = checkout_with_gift_card.last_change
 
@@ -112,18 +183,26 @@ def test_checkout_remove_gift_card_code(api_client, checkout_with_gift_card):
         "promoCode": checkout_with_gift_card.gift_cards.first().code,
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["checkout"]["token"] == str(checkout_with_gift_card.token)
     assert data["checkout"]["giftCards"] == []
     assert not checkout_with_gift_card.gift_cards.all().exists()
     checkout_with_gift_card.refresh_from_db()
     assert checkout_with_gift_card.last_change != previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_gift_card)
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_gift_card_code_from_wrong_checkout(
-    api_client, checkout_with_gift_card, gift_card_with_metadata
+    checkout_updated_webhook_mock,
+    api_client,
+    checkout_with_gift_card,
+    gift_card_with_metadata,
 ):
+    # given
     assert checkout_with_gift_card.gift_cards.count() == 1
     previous_checkout_last_change = checkout_with_gift_card.last_change
 
@@ -132,8 +211,10 @@ def test_checkout_remove_gift_card_code_from_wrong_checkout(
         "promoCode": gift_card_with_metadata.code,
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"][0]["field"] == "promoCode"
     assert data["errors"][0]["code"] == CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.name
     assert data["errors"][0]["message"] == (
@@ -144,11 +225,17 @@ def test_checkout_remove_gift_card_code_from_wrong_checkout(
 
     checkout_with_gift_card.refresh_from_db()
     assert checkout_with_gift_card.last_change == previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_one_of_gift_cards(
-    api_client, checkout_with_gift_card, gift_card_created_by_staff
+    checkout_updated_webhook_mock,
+    api_client,
+    checkout_with_gift_card,
+    gift_card_created_by_staff,
 ):
+    # given
     checkout_with_gift_card.gift_cards.add(gift_card_created_by_staff)
     checkout_with_gift_card.save()
     previous_checkout_last_change = checkout_with_gift_card.last_change
@@ -160,17 +247,24 @@ def test_checkout_remove_one_of_gift_cards(
         "promoCode": gift_card_first.code,
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     checkout_gift_cards = checkout_with_gift_card.gift_cards
     assert data["checkout"]["token"] == str(checkout_with_gift_card.token)
     assert checkout_gift_cards.filter(code=gift_card_last.code).exists()
     assert not checkout_gift_cards.filter(code=gift_card_first.code).exists()
     checkout_with_gift_card.refresh_from_db()
     assert checkout_with_gift_card.last_change != previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_gift_card)
 
 
-def test_checkout_remove_promo_code_invalid_promo_code(api_client, checkout_with_item):
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_promo_code_invalid_promo_code(
+    checkout_updated_webhook_mock, api_client, checkout_with_item
+):
+    # given
     checkout_with_item.price_expiration = timezone.now() + timedelta(days=2)
     checkout_with_item.save(update_fields=["price_expiration"])
     previous_checkout_last_change = checkout_with_item.last_change
@@ -179,29 +273,41 @@ def test_checkout_remove_promo_code_invalid_promo_code(api_client, checkout_with
         "promoCode": "unexisting_code",
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"][0]["field"] == "promoCode"
     assert data["errors"][0]["code"] == CheckoutErrorCode.NOT_FOUND.name
     assert data["errors"][0]["message"] == "Promo code does not exists."
 
     checkout_with_item.refresh_from_db()
     assert checkout_with_item.last_change == previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_not_called()
 
 
-def test_checkout_remove_promo_code_invalid_checkout(api_client, voucher, checkout):
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_promo_code_invalid_checkout(
+    checkout_updated_webhook_mock, api_client, voucher, checkout
+):
+    # given
     variables = {"id": to_global_id_or_none(checkout), "promoCode": voucher.code}
     checkout.delete()
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"]
     assert data["errors"][0]["field"] == "id"
+    checkout_updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_voucher_code_by_id(
-    api_client, checkout_with_voucher, voucher, gift_card
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher, voucher, gift_card
 ):
+    # given
     assert checkout_with_voucher.voucher_code is not None
     checkout_with_voucher.gift_cards.add(gift_card)
 
@@ -210,19 +316,28 @@ def test_checkout_remove_voucher_code_by_id(
         "promoCodeId": graphene.Node.to_global_id("Voucher", voucher.id),
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     checkout_with_voucher.refresh_from_db()
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_voucher.token)
     assert data["checkout"]["voucherCode"] is None
     assert len(data["checkout"]["giftCards"]) == 1
     assert checkout_with_voucher.voucher_code is None
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_voucher)
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_gift_card_by_id(
-    api_client, checkout_with_voucher, gift_card, gift_card_expiry_date
+    checkout_updated_webhook_mock,
+    api_client,
+    checkout_with_voucher,
+    gift_card,
+    gift_card_expiry_date,
 ):
+    # given
     assert checkout_with_voucher.voucher_code is not None
     checkout_with_voucher.gift_cards.add(gift_card, gift_card_expiry_date)
 
@@ -231,8 +346,10 @@ def test_checkout_remove_gift_card_by_id(
         "promoCodeId": graphene.Node.to_global_id("GiftCard", gift_card.id),
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     checkout_with_voucher.refresh_from_db()
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_voucher.token)
@@ -242,11 +359,14 @@ def test_checkout_remove_gift_card_by_id(
     assert gift_cards[0]["id"] == graphene.Node.to_global_id(
         "GiftCard", gift_card_expiry_date.pk
     )
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_voucher)
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_promo_code_id_and_code_given(
-    api_client, checkout_with_voucher, gift_card
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher, gift_card
 ):
+    # given
     assert checkout_with_voucher.voucher_code is not None
 
     variables = {
@@ -255,30 +375,40 @@ def test_checkout_remove_promo_code_id_and_code_given(
         "promoCodeId": graphene.Node.to_global_id("GiftCard", gift_card.id),
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"]
     assert data["errors"][0]["code"] == CheckoutErrorCode.GRAPHQL_ERROR.name
+    checkout_updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_promo_code_no_id_and_code_given(
-    api_client, checkout_with_voucher, gift_card
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher, gift_card
 ):
+    # given
     assert checkout_with_voucher.voucher_code is not None
 
     variables = {
         "id": to_global_id_or_none(checkout_with_voucher),
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"]
     assert data["errors"][0]["code"] == CheckoutErrorCode.GRAPHQL_ERROR.name
+    checkout_updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_promo_code_id_does_not_exist(
-    api_client, checkout_with_voucher, gift_card
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher, gift_card
 ):
+    # given
     assert checkout_with_voucher.voucher_code is not None
 
     variables = {
@@ -286,16 +416,21 @@ def test_checkout_remove_promo_code_id_does_not_exist(
         "promoCodeId": "Abc",
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"]
     assert data["errors"][0]["code"] == CheckoutErrorCode.GRAPHQL_ERROR.name
     assert data["errors"][0]["field"] == "promoCodeId"
+    checkout_updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_promo_code_invalid_object_type(
-    api_client, checkout_with_voucher, gift_card
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher, gift_card
 ):
+    # given
     assert checkout_with_voucher.voucher_code is not None
 
     variables = {
@@ -303,15 +438,19 @@ def test_checkout_remove_promo_code_invalid_object_type(
         "promoCodeId": graphene.Node.to_global_id("Product", gift_card.id),
     }
 
+    # when
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
+    # then
     assert data["errors"]
     assert data["errors"][0]["code"] == CheckoutErrorCode.NOT_FOUND.name
     assert data["errors"][0]["field"] == "promoCodeId"
+    checkout_updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_voucher_code_invalidates_price(
-    api_client, checkout_with_item, voucher
+    checkout_updated_webhook_mock, api_client, checkout_with_item, voucher
 ):
     # given
     checkout_with_item.price_expiration = timezone.now() + timedelta(days=2)
@@ -338,10 +477,15 @@ def test_checkout_remove_voucher_code_invalidates_price(
     assert not data["errors"]
     assert data["checkout"]["subtotalPrice"]["gross"]["amount"] == subtotal.amount
     assert data["checkout"]["totalPrice"]["gross"]["amount"] == expected_total
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_item)
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_voucher_code_order_promotion_discount_applied(
-    api_client, checkout_with_voucher, order_promotion_rule
+    checkout_updated_webhook_mock,
+    api_client,
+    checkout_with_voucher,
+    order_promotion_rule,
 ):
     # given
     checkout = checkout_with_voucher
@@ -371,10 +515,15 @@ def test_checkout_remove_voucher_code_order_promotion_discount_applied(
     assert checkout.discount_amount == reward_value
     assert checkout.last_change != previous_checkout_last_change
     assert checkout.discounts.count() == 1
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_voucher)
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_checkout_remove_voucher_code_gift_reward_applied(
-    api_client, checkout_with_voucher, gift_promotion_rule
+    checkout_updated_webhook_mock,
+    api_client,
+    checkout_with_voucher,
+    gift_promotion_rule,
 ):
     # given
     checkout = checkout_with_voucher
@@ -405,9 +554,12 @@ def test_checkout_remove_voucher_code_gift_reward_applied(
     assert checkout.lines.count() == lines_count + 1 == len(data["checkout"]["lines"])
     gift_line = checkout.lines.get(is_gift=True)
     assert gift_line.discounts.count() == 1
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_voucher)
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_with_active_problems_flow(
+    checkout_updated_webhook_mock,
     api_client,
     checkout_with_problems,
     voucher,
@@ -438,3 +590,4 @@ def test_with_active_problems_flow(
 
     # then
     assert not content["data"]["checkoutRemovePromoCode"]["errors"]
+    checkout_updated_webhook_mock.assert_called_once_with(checkout_with_problems)


### PR DESCRIPTION
I want to merge this change because it throws a `ValidationError` on `CheckoutRemovePromoCode` mutation if the promo code cannot be removed from a `Checkout` object.

Fixes: https://linear.app/saleor/issue/SHOPX-761/bug-removing-non-existing-voucher-from-a-checkout-doesnt-return-error

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
