### PR TITLE
Throw a ValidationError on `CheckoutRemovePromoCode` mutation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `stocks` to a `Warehouse` - #15771 by @teddyondieki
 - Deprecate the `taxTypes` query - #15802 by @maarcingebala
 - Change permissions for `checkout` and `checkouts` queries. Add `HANDLE_PAYMENTS` to required permissions - #16010 by @Air-t
+- Change the `CheckoutRemovePromoCode` mutation behavior to throw a `ValidationError` when the promo code is not detached from the checkout. - #16109 by @Air-t
 
 ### Saleor Apps
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -42,7 +42,7 @@ from ..discount.utils import (
 )
 from ..giftcard.utils import (
     add_gift_card_code_to_checkout,
-    remove_gift_card_code_from_checkout,
+    remove_gift_card_code_from_checkout_or_error,
 )
 from ..plugins.manager import PluginsManager
 from ..product import models as product_models
@@ -815,33 +815,36 @@ def add_voucher_to_checkout(
         delete_gift_line(checkout_info.checkout, lines)
 
 
-def remove_promo_code_from_checkout(
+def remove_promo_code_from_checkout_or_error(
     checkout_info: "CheckoutInfo", promo_code: str
-) -> bool:
-    """Remove gift card or voucher data from checkout.
+) -> None:
+    """Remove gift card or voucher data from checkout or raise an error."""
 
-    Return information whether promo code was removed.
-    """
     if promo_code_is_voucher(promo_code):
-        return remove_voucher_code_from_checkout(checkout_info, promo_code)
+        remove_voucher_code_from_checkout_or_error(checkout_info, promo_code)
     elif promo_code_is_gift_card(promo_code):
-        return remove_gift_card_code_from_checkout(checkout_info.checkout, promo_code)
-    return False
+        remove_gift_card_code_from_checkout_or_error(checkout_info.checkout, promo_code)
+    else:
+        raise ValidationError(
+            "Promo code does not exists.",
+            code=CheckoutErrorCode.NOT_FOUND.value,
+        )
 
 
-def remove_voucher_code_from_checkout(
+def remove_voucher_code_from_checkout_or_error(
     checkout_info: "CheckoutInfo", voucher_code: str
-) -> bool:
-    """Remove voucher data from checkout by code.
+) -> None:
+    """Remove voucher data from checkout by code or raise an error."""
 
-    Return information whether promo code was removed.
-    """
     existing_voucher = checkout_info.voucher
     if existing_voucher and existing_voucher.code == voucher_code:
         remove_voucher_from_checkout(checkout_info.checkout)
         checkout_info.voucher = None
-        return True
-    return False
+    else:
+        raise ValidationError(
+            "Cannot remove a voucher not attached to this checkout.",
+            code=CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.value,
+        )
 
 
 def remove_voucher_from_checkout(checkout: Checkout):

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -836,14 +836,13 @@ def remove_voucher_code_from_checkout_or_error(
 ) -> None:
     """Remove voucher data from checkout by code or raise an error."""
 
-    existing_voucher = checkout_info.voucher
-    if existing_voucher and existing_voucher.code == voucher_code:
+    if checkout_info.voucher and voucher_code in checkout_info.voucher.promo_codes:
         remove_voucher_from_checkout(checkout_info.checkout)
         checkout_info.voucher = None
     else:
         raise ValidationError(
             "Cannot remove a voucher not attached to this checkout.",
-            code=CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.value,
+            code=CheckoutErrorCode.INVALID.value,
         )
 
 

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -133,6 +133,10 @@ class Voucher(ModelWithMetadata):
         code_instance = self.codes.last()
         return code_instance.code if code_instance else None
 
+    @property
+    def promo_codes(self):
+        return list(self.codes.values_list("code", flat=True))
+
     def get_discount(self, channel: Channel):
         """Return proper discount amount for given channel.
 

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -151,7 +151,7 @@ def test_remove_gift_card_code_from_checkout_no_checkout_gift_cards(
     assert error.value.message == (
         "Cannot remove a gift card not attached to this checkout."
     )
-    assert error.value.code == CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value
+    assert error.value.code == CheckoutErrorCode.INVALID.value
 
 
 @pytest.mark.parametrize(

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -66,7 +66,7 @@ def remove_gift_card_code_from_checkout_or_error(
     else:
         raise ValidationError(
             "Cannot remove a gift card not attached to this checkout.",
-            code=CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value,
+            code=CheckoutErrorCode.INVALID.value,
         )
 
 

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -150,7 +150,6 @@ class CheckoutRemovePromoCode(BaseMutation):
         promo_code_pk: int,
     ) -> None:
         """Detach promo code from the checkout based on the id or raise an error."""
-
         if object_type == str(Voucher) and checkout.voucher_code is not None:
             node = cls._get_node_by_pk(info, graphene_type=Voucher, pk=promo_code_pk)
             if node is None:
@@ -162,7 +161,7 @@ class CheckoutRemovePromoCode(BaseMutation):
                         )
                     }
                 )
-            if checkout.voucher_code == node.code:
+            if checkout.voucher_code in node.promo_codes:
                 remove_voucher_from_checkout(checkout)
             else:
                 raise ValidationError(


### PR DESCRIPTION
It also fixes previously broken logic for `Voucher.code` to look just for the last `VoucherCode.code`. Now mutation checks if given `promo_code` or `promo_code_id` are included in possible `Voucher.codes` codes.

Port: https://github.com/saleor/saleor/pull/16095
Fixes: https://linear.app/saleor/issue/SHOPX-761/bug-removing-non-existing-voucher-from-a-checkout-doesnt-return-error
Fixes: https://linear.app/saleor/issue/SHOPX-865/issue-with-calling-checkoutremovepromocodewith-promocodeid


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined
