### PR TITLE
Always validate address phone field.

### DIFF
--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -171,7 +171,6 @@ class I18nMixin:
 
         if skip_validation := address_data.get("skip_validation", False):
             cls.can_skip_address_validation(info)
-            cls._meta.exclude.append("phone")  # type: ignore[attr-defined]
             format_check = False
 
         address_form = cls._validate_address_form(

--- a/saleor/graphql/account/tests/mutations/staff/test_address_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_address_update.py
@@ -18,7 +18,6 @@ ADDRESS_UPDATE_MUTATION = """
                     key
                     value
                 }
-                phone
             }
             user {
                 id
@@ -186,12 +185,12 @@ def test_address_update_address_with_skipped_validation(
     # given
     query = ADDRESS_UPDATE_MUTATION
     address_obj = customer_user.addresses.first()
-    address_obj.phone = "invalid phone number"
+    address_obj.postal_code = "invalid postal code"
     address_obj.validation_skipped = True
-    address_obj.save(update_fields=["phone", "validation_skipped"])
+    address_obj.save(update_fields=["postal_code", "validation_skipped"])
 
     address_data = graphql_address_data
-    valid_phone = address_data["phone"]
+    valid_postal_code = address_data["postalCode"]
     variables = {
         "addressId": graphene.Node.to_global_id("Address", address_obj.id),
         "address": address_data,
@@ -206,7 +205,7 @@ def test_address_update_address_with_skipped_validation(
     # then
     data = content["data"]["addressUpdate"]
     assert not data["errors"]
-    assert data["address"]["phone"] == valid_phone
+    assert data["address"]["postalCode"] == valid_postal_code
     address_obj.refresh_from_db()
-    assert address_obj.phone == valid_phone
+    assert address_obj.postal_code == valid_postal_code
     assert address_obj.validation_skipped is False

--- a/saleor/graphql/account/tests/test_i18n.py
+++ b/saleor/graphql/account/tests/test_i18n.py
@@ -175,7 +175,6 @@ def test_skip_validation_multiple_invalid_fields(
         "country": "US",
         "city": invalid_name,
         "countryArea": invalid_name,
-        "phone": invalid_name,
         "metadata": [{"key": "public", "value": "public_value"}],
         "skipValidation": True,
     }
@@ -191,10 +190,8 @@ def test_skip_validation_multiple_invalid_fields(
     data = content["data"]["addressCreate"]
     assert not data["errors"]
     assert data["address"]["country"]["code"] == "US"
-    assert data["address"]["phone"] == invalid_name
     assert data["address"]["postalCode"] == invalid_name
     db_address = Address.objects.get(first_name=invalid_name)
-    assert db_address.phone == invalid_name
     assert db_address.postal_code == invalid_name
     assert db_address.country_area == invalid_name
     assert db_address.city == invalid_name

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -4420,10 +4420,10 @@ def test_checkout_complete_with_invalid_address(
         "redirectUrl": "https://www.example.com",
     }
 
-    invalid_phone = "invalid phone"
-    address.phone = invalid_phone
+    invalid_postal_code = "invalid postal code"
+    address.postal_code = invalid_postal_code
     address.validation_skipped = True
-    address.save(update_fields=["validation_skipped", "phone"])
+    address.save(update_fields=["validation_skipped", "postal_code"])
 
     checkout.billing_address = address
     checkout.shipping_address = address
@@ -4455,5 +4455,5 @@ def test_checkout_complete_with_invalid_address(
     # then
     assert not content["errors"]
     order = Order.objects.get(checkout_token=checkout.token)
-    assert order.shipping_address.phone == invalid_phone
-    assert order.billing_address.phone == invalid_phone
+    assert order.shipping_address.postal_code == invalid_postal_code
+    assert order.billing_address.postal_code == invalid_postal_code

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -2418,7 +2418,7 @@ MUTATION_CHECKOUT_CREATE_WITH_ADDRESSES = """
             postalCode
           }
           billingAddress {
-            phone
+            postalCode
           }
         }
         errors {
@@ -2538,8 +2538,8 @@ def test_checkout_create_skip_validation_billing_address_by_app(
     variant = stock.product_variant
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     billing_address = graphql_address_data_skipped_validation
-    invalid_phone = "invalid_phone"
-    billing_address["phone"] = invalid_phone
+    invalid_postal_code = "invalid_postal_code"
+    billing_address["postalCode"] = invalid_postal_code
 
     variables = {
         "checkoutInput": {
@@ -2561,7 +2561,7 @@ def test_checkout_create_skip_validation_billing_address_by_app(
     # then
     data = content["data"]["checkoutCreate"]
     assert not data["errors"]
-    assert data["checkout"]["billingAddress"]["phone"] == invalid_phone
+    assert data["checkout"]["billingAddress"]["postalCode"] == invalid_postal_code
     new_checkout = Checkout.objects.first()
-    assert new_checkout.billing_address.phone == invalid_phone
+    assert new_checkout.billing_address.postal_code == invalid_postal_code
     assert new_checkout.billing_address.validation_skipped is True


### PR DESCRIPTION
I want to merge this change because I want to always validate `phone` field, even when providing input with `validation_skipped` flag. 

The field is not required in any of countries so it is possible to skip it entirely.  

Issue: https://linear.app/saleor/issue/MERX-488/adjust-the-code-responsible-for-validating-addressphone-field
Part of: https://github.com/saleor/saleor/pull/16052

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
