### PR TITLE
Prevent circular calls in sync events for `order.discounts` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop `OrderBulkCreateInput.voucher` field. Use `OrderBulkCreateInput.voucherCode` instead. - #14553 by @zedzior
 - Add new `type` field to `PromotionCreateInput`, the field will be required from 3.20 - #14696 by @IKarbowiak, @zedzior
 - Do not stack promotion rules within the promotion. Only the best promotion rule will be applied within the promotion. Previously discounts from all rules within the promotion that gives the best discount were applied to the variant's price - #15309 by @korycins
+- Disable the `order.discounts` field in sync events to prevent circular calls - #16111 by @zedzior
 
 ### GraphQL API
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1495,6 +1495,7 @@ class Order(ModelObjectType[models.Order]):
         return root.id
 
     @staticmethod
+    @prevent_sync_event_circular_query
     def resolve_discounts(root: models.Order, info):
         def with_manager(manager):
             fetch_order_prices_if_expired(root, manager)


### PR DESCRIPTION
I want to merge this change because it prevents circular calls in sync events for `order.discounts` field.

Internal discussion: https://saleorcommerce.slack.com/archives/C06DU38BB39/p1717663238903859
Issue: https://linear.app/saleor/issue/MERX-546/fix-orderdiscounts-resolver
