### PR TITLE
Fix failing products boolean filter

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -220,10 +220,14 @@ def _clean_product_attributes_boolean_filter_input(
         for attr in attributes
     }
 
-    for attr_slug, val in filter_value:
-        attr_pk = values_map[attr_slug]["pk"]
-        value_pk = values_map[attr_slug]["values"].get(val)
-        if value_pk:
+    for attr_slug, value in filter_value:
+        if attr_slug not in values_map:
+            raise ValueError(f"Unknown attribute name: {attr_slug}")
+        attr_pk = values_map[attr_slug].get("pk")
+        value_pk = values_map[attr_slug]["values"].get(value)
+        if not value_pk:
+            raise ValueError(f"Requested value for attribute {attr_slug} doesn't exist")
+        if attr_pk and value_pk:
             queries[attr_pk] += [value_pk]
 
 

--- a/saleor/graphql/product/tests/queries/test_products_query_with_filter.py
+++ b/saleor/graphql/product/tests/queries/test_products_query_with_filter.py
@@ -265,6 +265,75 @@ def test_products_query_with_filter_boolean_attributes(
     }
 
 
+@pytest.mark.parametrize(
+    "filter_value",
+    [
+        False,
+        True,
+    ],
+)
+def test_products_query_with_filter_non_existing_boolean_attributes(
+    filter_value,
+    query_products_with_filter,
+    staff_api_client,
+    product,
+    permission_manage_products,
+):
+    # given
+
+    variables = {
+        "filter": {
+            "attributes": [{"slug": "non-existing-atr", "boolean": filter_value}]
+        }
+    }
+
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    # when
+    response = staff_api_client.post_graphql(query_products_with_filter, variables)
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["products"]["edges"]
+    assert len(products) == 0
+
+
+@pytest.mark.parametrize(
+    "filter_value",
+    [
+        False,
+        True,
+    ],
+)
+def test_products_query_with_filter_boolean_attributes_not_assigned_to_product(
+    filter_value,
+    query_products_with_filter,
+    staff_api_client,
+    product,
+    category,
+    boolean_attribute,
+    permission_manage_products,
+):
+    # given
+    boolean_attribute.values.all().delete()
+    product.product_type.product_attributes.add(boolean_attribute)
+
+    variables = {
+        "filter": {
+            "attributes": [{"slug": boolean_attribute.slug, "boolean": filter_value}]
+        }
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    # when
+    response = staff_api_client.post_graphql(query_products_with_filter, variables)
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["products"]["edges"]
+    assert len(products) == 0
+
+
 def test_products_query_with_filter_by_attributes_values_and_range(
     query_products_with_filter,
     staff_api_client,


### PR DESCRIPTION
I want to merge this change because it fixes the case when filtering via the boolean attribute, that doesn't exist on Saleor side.
```graphql
{
  products(
    first: 12
    channel: "default-channel"
    filter: {attributes: {slug: "bb", boolean: true}}
  ) {
    edges {
      node {
        id
      }
    }
  }
}
```
Could raise an unhandled exception when bb attribute doesn't exist.

Covers https://linear.app/saleor/issue/MERX-417/passing-non-existing-attribute-slug-crashes-product-filtering

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
