### PR TITLE
Clean up order discounts

### DIFF
--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -247,6 +247,8 @@ def checkout_total(
 
     It should be used as a based value when no flat rate/tax plugin/tax app is active.
     """
+    from ..discount.utils import is_order_level_voucher
+
     currency = checkout_info.checkout.currency
     subtotal = base_checkout_subtotal(lines, checkout_info.channel, currency)
     shipping_price = base_checkout_delivery_price(checkout_info, lines)
@@ -255,10 +257,8 @@ def checkout_total(
     # order promotion discount and entire_order voucher discount with
     # apply_once_per_order set to False are not included in the total price yet
     discounted_object_promotion = bool(checkout_info.discounts)
-    discount_not_included = discounted_object_promotion or (
+    discount_not_included = discounted_object_promotion or is_order_level_voucher(
         checkout_info.voucher
-        and checkout_info.voucher.type == VoucherType.ENTIRE_ORDER
-        and not checkout_info.voucher.apply_once_per_order
     )
     # Discount is subtracted from both gross and net values, which may cause negative
     # net value if we are having a discount that covers whole price.

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -24,6 +24,7 @@ from ..checkout.models import Checkout
 from ..core.exceptions import InsufficientStock
 from ..core.taxes import zero_money
 from ..core.utils.promo_code import InvalidPromoCode
+from ..discount.models import VoucherType
 from ..order.fetch import DraftOrderLineInfo
 from ..order.models import Order
 from ..product.models import (
@@ -56,12 +57,21 @@ from .models import (
 
 if TYPE_CHECKING:
     from ..account.models import User
+    from ..discount.models import Voucher
     from ..plugins.manager import PluginsManager
     from ..product.managers import ProductVariantQueryset
     from ..product.models import VariantChannelListingPromotionRule
 
 CatalogueInfo = defaultdict[str, set[Union[int, str]]]
 CATALOGUE_FIELDS = ["categories", "collections", "products", "variants"]
+
+
+def is_order_level_voucher(voucher: Optional[Voucher]):
+    return bool(
+        voucher
+        and voucher.type == VoucherType.ENTIRE_ORDER
+        and not voucher.apply_once_per_order
+    )
 
 
 def increase_voucher_usage(

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -7,6 +7,7 @@ from promise import Promise
 from ....checkout import base_calculations
 from ....checkout.models import Checkout, CheckoutLine
 from ....core.prices import quantize_price
+from ....discount import DiscountType
 from ....discount.utils import is_order_level_voucher
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
@@ -412,6 +413,10 @@ class TaxableObject(BaseObjectType):
             return [
                 {"name": discount.name, "amount": discount.amount}
                 for discount in discounts
+                if (
+                    discount.type == DiscountType.MANUAL
+                    or is_order_level_voucher(discount.voucher)
+                )
             ]
 
         return (

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -7,7 +7,7 @@ from promise import Promise
 from ....checkout import base_calculations
 from ....checkout.models import Checkout, CheckoutLine
 from ....core.prices import quantize_price
-from ....discount import VoucherType
+from ....discount.utils import is_order_level_voucher
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
 from ....tax.utils import get_charge_taxes
@@ -398,11 +398,7 @@ class TaxableObject(BaseObjectType):
                 return (
                     [{"name": discount_name, "amount": checkout.discount}]
                     if checkout.discount
-                    and (
-                        checkout_info.voucher
-                        and checkout_info.voucher.type == VoucherType.ENTIRE_ORDER
-                        and not checkout_info.voucher.apply_once_per_order
-                    )
+                    and is_order_level_voucher(checkout_info.voucher)
                     else []
                 )
 

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -75,10 +75,24 @@ class TaxableObjectLine(BaseObjectType):
     product_sku = graphene.String(description="The product sku.")
 
     unit_price = graphene.Field(
-        Money, description="Price of the single item in the order line.", required=True
+        Money,
+        description=(
+            "Price of the single item in the order line. "
+            "The price includes catalogue promotions, specific product "
+            "and applied once per order voucher discounts. "
+            "The price does not include the entire order discount."
+        ),
+        required=True,
     )
     total_price = graphene.Field(
-        Money, description="Price of the order line.", required=True
+        Money,
+        description=(
+            "Price of the order line. "
+            "The price includes catalogue promotions, specific product "
+            "and applied once per order voucher discounts. "
+            "The price does not include the entire order discount."
+        ),
+        required=True,
     )
 
     class Meta:
@@ -415,6 +429,9 @@ class TaxableObject(BaseObjectType):
                 for discount in discounts
                 if (
                     discount.type == DiscountType.MANUAL
+                    # TODO: apply_once_per_order voucher are included for now, as the
+                    # discount for such vouchers is currently not propagated to the
+                    # draft order lines
                     or (
                         discount.voucher
                         and discount.voucher.type == VoucherType.ENTIRE_ORDER

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -388,8 +388,8 @@ class TaxableObject(BaseObjectType):
                 ]
             ).then(calculate_shipping_price)
 
-        # TODO: after adding `undiscounted_base_shipping_price` to Order model,
-        # the `root.base_shipping_price` should be used
+        # TODO (SHOPX-875): after adding `undiscounted_base_shipping_price` to
+        # Order model, the `root.base_shipping_price` should be used
         def shipping_price_with_discount(tax_config):
             return (
                 root.shipping_price_gross
@@ -429,9 +429,9 @@ class TaxableObject(BaseObjectType):
                 for discount in discounts
                 if (
                     discount.type == DiscountType.MANUAL
-                    # TODO: apply_once_per_order voucher are included for now, as the
-                    # discount for such vouchers is currently not propagated to the
-                    # draft order lines
+                    # TODO (SHOPX-873): apply_once_per_order voucher are included
+                    # for now, as the discount for such vouchers is currently not
+                    # propagated to the draft order lines
                     or (
                         discount.voucher
                         and discount.voucher.type == VoucherType.ENTIRE_ORDER

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -7,7 +7,7 @@ from promise import Promise
 from ....checkout import base_calculations
 from ....checkout.models import Checkout, CheckoutLine
 from ....core.prices import quantize_price
-from ....discount import DiscountType
+from ....discount import DiscountType, VoucherType
 from ....discount.utils import is_order_level_voucher
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
@@ -415,7 +415,10 @@ class TaxableObject(BaseObjectType):
                 for discount in discounts
                 if (
                     discount.type == DiscountType.MANUAL
-                    or is_order_level_voucher(discount.voucher)
+                    or (
+                        discount.voucher
+                        and discount.voucher.type == VoucherType.ENTIRE_ORDER
+                    )
                 )
             ]
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -36098,10 +36098,14 @@ type TaxableObjectLine @doc(category: "Taxes") {
   """The product sku."""
   productSku: String
 
-  """Price of the single item in the order line."""
+  """
+  Price of the single item in the order line. The price includes catalogue promotions, specific product and applied once per order voucher discounts. The price does not include the entire order discount.
+  """
   unitPrice: Money!
 
-  """Price of the order line."""
+  """
+  Price of the order line. The price includes catalogue promotions, specific product and applied once per order voucher discounts. The price does not include the entire order discount.
+  """
   totalPrice: Money!
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -36054,7 +36054,9 @@ type TaxableObject @doc(category: "Taxes") {
   """The currency of the object."""
   currency: String!
 
-  """The price of shipping method."""
+  """
+  The price of shipping method, includes shipping voucher discount if applied.
+  """
   shippingPrice: Money!
 
   """The address data."""

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -81,12 +81,14 @@ def propagate_order_discount_on_order_prices(
     discount.
     """
     base_subtotal = base_order_subtotal(order, lines)
+    # TODO: add undiscounted_base_shipping_price field to Order model, and use it here
     base_shipping_price = order.base_shipping_price
     subtotal = base_subtotal
     shipping_price = base_shipping_price
     currency = order.currency
     order_discounts_to_update = []
 
+    shipping_voucher_discount = None
     for order_discount in order.discounts.all():
         subtotal_before_discount = subtotal
         shipping_price_before_discount = shipping_price
@@ -99,6 +101,8 @@ def propagate_order_discount_on_order_prices(
                     currency=currency,
                     price_to_discount=subtotal,
                 )
+            elif voucher and voucher.type == VoucherType.SHIPPING:
+                shipping_voucher_discount = order_discount
         elif order_discount.type == DiscountType.ORDER_PROMOTION:
             subtotal = apply_discount_to_value(
                 value=order_discount.value,
@@ -146,6 +150,15 @@ def propagate_order_discount_on_order_prices(
 
     if order_discounts_to_update:
         OrderDiscount.objects.bulk_update(order_discounts_to_update, ["amount_value"])
+
+    # Apply shipping voucher discount
+    if shipping_voucher_discount:
+        shipping_price = apply_discount_to_value(
+            value=shipping_voucher_discount.value,
+            value_type=shipping_voucher_discount.value_type,
+            currency=currency,
+            price_to_discount=shipping_price,
+        )
 
     return subtotal, shipping_price
 
@@ -294,6 +307,9 @@ def assign_order_prices(
     subtotal: Money,
     shipping_price: Money,
 ):
+    # TODO: set order.base_shipping_price as this price should include
+    # the shipping discount - must be done together with adding
+    # undiscounted_base_shipping_price to Order model
     order.shipping_price_net_amount = shipping_price.amount
     order.shipping_price_gross_amount = shipping_price.amount
     order.total_net_amount = subtotal.amount + shipping_price.amount

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -81,7 +81,8 @@ def propagate_order_discount_on_order_prices(
     discount.
     """
     base_subtotal = base_order_subtotal(order, lines)
-    # TODO: add undiscounted_base_shipping_price field to Order model, and use it here
+    # TODO (SHOPX-875): add undiscounted_base_shipping_price field to Order model,
+    # and use it here
     base_shipping_price = order.base_shipping_price
     subtotal = base_subtotal
     shipping_price = base_shipping_price
@@ -307,7 +308,7 @@ def assign_order_prices(
     subtotal: Money,
     shipping_price: Money,
 ):
-    # TODO: set order.base_shipping_price as this price should include
+    # TODO (SHOPX-875): set order.base_shipping_price as this price should include
     # the shipping discount - must be done together with adding
     # undiscounted_base_shipping_price to Order model
     order.shipping_price_net_amount = shipping_price.amount

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -213,6 +213,8 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
         gross_amount_field="shipping_price_gross_amount",
         currency_field="currency",
     )
+    # Price with applied shipping voucher discount
+    # (for draft order - price without discount - TO FIX)
     base_shipping_price_amount = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -214,7 +214,8 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
         currency_field="currency",
     )
     # Price with applied shipping voucher discount
-    # (for draft order - price without discount - TO FIX)
+    # (for draft order - price without discount)
+    # FIXME (SHOPX-875)
     base_shipping_price_amount = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,

--- a/saleor/order/tests/test_apply_order_discount.py
+++ b/saleor/order/tests/test_apply_order_discount.py
@@ -223,6 +223,49 @@ def test_apply_order_discounts_manual_discount(order_with_lines):
     assert order_discount.amount_value == discount_amount
 
 
+def test_apply_order_discounts_shipping_voucher(
+    order_with_lines, voucher_free_shipping
+):
+    # given
+    order = order_with_lines
+    lines = order.lines.all()
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    discount_amount = shipping_price.amount
+    order_discount = order.discounts.create(
+        type=DiscountType.VOUCHER,
+        value_type=DiscountValueType.FIXED,
+        value=discount_amount,
+        name="Voucher",
+        translated_name="VoucherPL",
+        currency=currency,
+        amount_value=discount_amount,
+        voucher=voucher_free_shipping,
+    )
+
+    # when
+    discounted_subtotal, discounted_shipping_price = apply_order_discounts(order, lines)
+
+    # then
+    assert discounted_shipping_price == zero_money(currency)
+    assert discounted_subtotal == subtotal
+    assert order.subtotal_net_amount == discounted_subtotal.amount
+    assert order.subtotal_gross_amount == discounted_subtotal.amount
+    assert order.total_net == discounted_subtotal + discounted_shipping_price
+    assert order.total_gross == discounted_subtotal + discounted_shipping_price
+    assert order.shipping_price_net == discounted_shipping_price
+    assert order.shipping_price_gross == discounted_shipping_price
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    order_discount.refresh_from_db()
+    # OrderDiscount has amount value only from not applied discounts
+    assert order_discount.amount_value == 0
+
+
 def test_apply_order_discounts_zero_discount(order_with_lines):
     # given
     order = order_with_lines

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -19,6 +19,7 @@ from ...checkout.utils import is_shipping_required
 from ...core.http_client import HTTPClient
 from ...core.taxes import TaxError
 from ...discount import DiscountType, VoucherType
+from ...discount.utils import is_order_level_voucher
 from ...order import base_calculations as base_order_calculations
 from ...order.utils import get_total_order_discount_excluding_shipping
 from ...shipping.models import ShippingMethod
@@ -289,11 +290,7 @@ def generate_request_data_from_checkout_lines(
     prices_entered_with_tax = checkout_info.tax_configuration.prices_entered_with_tax
 
     voucher = checkout_info.voucher
-    is_entire_order_discount = (
-        voucher.type == VoucherType.ENTIRE_ORDER
-        if voucher and not voucher.apply_once_per_order
-        else False
-    )
+    is_entire_order_discount = is_order_level_voucher(voucher)
     applicable_checkout_discount = (
         bool(checkout_info.discounts) or is_entire_order_discount
     )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -511,8 +511,7 @@ def test_order_calculate_taxes_free_shipping_voucher(
         "taxBase": {
             "address": {"id": to_global_id_or_none(order.shipping_address)},
             "currency": "USD",
-            # FIXME
-            "discounts": [{"amount": {"amount": 0.0}}],
+            "discounts": [],
             "channel": {"id": to_global_id_or_none(order.channel)},
             "lines": ANY,
             "pricesEnteredWithTax": True,

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -371,25 +371,22 @@ def test_calculate_order_shipping_voucher_on_shipping(
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
     currency = order.currency
-    discount_amount = Decimal("5.0")
 
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
     order.shipping_method_name = method.name
     order.shipping_method = method
-    order.base_shipping_price = method.channel_listings.get(
-        channel=order.channel
-    ).price - Money(discount_amount, currency)
     order.voucher = voucher_shipping_type
     order.save()
+
+    voucher_listing = voucher_shipping_type.channel_listings.get(channel=order.channel)
 
     order.discounts.create(
         type=DiscountType.VOUCHER,
         value_type=DiscountValueType.FIXED,
-        value=discount_amount,
         name=voucher_shipping_type.code,
         currency=currency,
-        amount_value=discount_amount,
+        value=voucher_listing.discount_value,
         voucher=voucher_shipping_type,
     )
     channel = order.channel
@@ -404,7 +401,7 @@ def test_calculate_order_shipping_voucher_on_shipping(
     # then
     price = order.shipping_price
     price = quantize_price(price, price.currency)
-    expected_gross_amount = shipping_price.amount - discount_amount
+    expected_gross_amount = shipping_price.amount - voucher_listing.discount_value
     assert price == TaxedMoney(
         net=quantize_price(
             Money(expected_gross_amount / Decimal("1.23"), currency), currency

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -32,6 +32,7 @@ from ..core.utils.anonymization import (
 )
 from ..core.utils.json_serializer import CustomJsonEncoder
 from ..discount import VoucherType
+from ..discount.utils import is_order_level_voucher
 from ..order import FulfillmentStatus, OrderStatus
 from ..order.models import Fulfillment, FulfillmentLine, Order, OrderLine
 from ..order.utils import get_order_country
@@ -1282,10 +1283,8 @@ def generate_checkout_payload_for_tax_calculation(
     # order promotion discount and entire_order voucher discount with
     # apply_once_per_order set to False is not already included in the total price
     discounted_object_promotion = bool(checkout_info.discounts)
-    discount_not_included = discounted_object_promotion or (
+    discount_not_included = discounted_object_promotion or is_order_level_voucher(
         checkout_info.voucher
-        and checkout_info.voucher.type == VoucherType.ENTIRE_ORDER
-        and not checkout_info.voucher.apply_once_per_order
     )
     if not checkout.discount_amount:
         discounts = []
@@ -1407,9 +1406,8 @@ def generate_order_payload_for_tax_calculation(order: "Order"):
     discounts = order.discounts.all()
     discounts_dict = []
     for discount in discounts:
-        if discount.voucher and discount.voucher.type == VoucherType.ENTIRE_ORDER:
-            if discount.voucher.apply_once_per_order:
-                continue
+        if is_order_level_voucher(discount.voucher):
+            continue
         quantize_price_fields(discount, ("amount_value",), order.currency)
         discount_amount = quantize_price(discount.amount_value, order.currency)
         discounts_dict.append({"name": discount.name, "amount": discount_amount})

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -444,6 +444,10 @@ def test_generate_order_payload_for_tax_calculation_voucher_discounts(
         "metadata": order.metadata,
         "discounts": [
             {
+                "name": discount_1.name,
+                "amount": str(quantize_price(discount_1.amount_value, currency)),
+            },
+            {
                 "name": discount_2.name,
                 "amount": str(quantize_price(discount_2.amount_value, currency)),
             },


### PR DESCRIPTION
 - Fix applying shipping voucher
- Update `TaxableObject.shipping_price` resolver for `Order`
- Update `TaxableObject.discounts` resolver - only discounts not applied yet should be returned - `ENTIRE_ORDER voucher` and `manual discounts` (for now it will also return the `apply_once_per_order` voucher as it's not included in line prices for draft orders)
- Update descriptions for `unit_price` and `total_price` on `TaxableObjectLine` type

Internal issue: https://linear.app/saleor/issue/SHOPX-845/discounts-api-returns-empty-response-when-there-are-discounts-applied

Fixes https://github.com/saleor/saleor/issues/14884

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
