### PR TITLE
Fix handling null slugs in VariantChannelListingByVariantIdAndChannelSlugLoader

### DIFF
--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -24,7 +24,7 @@ from ...core.dataloaders import BaseThumbnailBySizeAndFormatLoader, DataLoader
 
 ProductIdAndChannelSlug = tuple[int, str]
 VariantIdAndChannelSlug = tuple[int, str]
-VariantIdAndChannelId = tuple[int, int]
+VariantIdAndChannelId = tuple[int, Optional[int]]
 
 
 class CategoryByIdLoader(DataLoader[int, Category]):
@@ -302,12 +302,12 @@ class VariantChannelListingByVariantIdAndChannelSlugLoader(
     context_key = "variantchannelisting_by_variant_and_channelslug"
 
     def batch_load(self, keys):
-        channel_slugs = [channel_slug for _, channel_slug in keys]
+        channel_slugs = [channel_slug for _, channel_slug in keys if channel_slug]
 
         def with_channels(channels):
             channel_map = {c.slug: c.id for c in channels}
             variant_id_channel_id_keys = [
-                (variant_id, channel_map[channel_slug])
+                (variant_id, channel_map.get(channel_slug, None))
                 for (variant_id, channel_slug) in keys
             ]
             return VariantChannelListingByVariantIdAndChannelIdLoader(
@@ -330,9 +330,9 @@ class VariantChannelListingByVariantIdAndChannelIdLoader(
         # Split the list of keys by channel first. A typical query will only touch
         # a handful of unique countries but may access thousands of product variants
         # so it's cheaper to execute one query per channel.
-        variant_channel_listing_by_channel: defaultdict[int, list[int]] = defaultdict(
-            list
-        )
+        variant_channel_listing_by_channel: defaultdict[
+            Optional[int], list[int]
+        ] = defaultdict(list)
         for variant_id, channel_id in keys:
             variant_channel_listing_by_channel[channel_id].append(variant_id)
 
@@ -350,7 +350,7 @@ class VariantChannelListingByVariantIdAndChannelIdLoader(
         return [variant_channel_listing_by_variant_and_channel[key] for key in keys]
 
     def batch_load_channel(
-        self, channel_id: int, variant_ids: Iterable[int]
+        self, channel_id: Optional[int], variant_ids: Iterable[int]
     ) -> Iterable[tuple[int, Optional[ProductVariantChannelListing]]]:
         filter = {
             "channel_id": channel_id,

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -16,17 +16,18 @@ from ...utils import create_stocks
 VARIANT_STOCKS_UPDATE_MUTATIONS = """
     mutation ProductVariantStocksUpdate($variantId: ID!, $stocks: [StockInput!]!){
         productVariantStocksUpdate(variantId: $variantId, stocks: $stocks){
-            productVariant{
-                stocks{
+            productVariant {
+                quantityAvailable
+                stocks {
                     quantity
                     quantityAllocated
                     id
-                    warehouse{
+                    warehouse {
                         slug
                     }
                 }
             }
-            errors{
+            errors {
                 code
                 field
                 message
@@ -38,8 +39,12 @@ VARIANT_STOCKS_UPDATE_MUTATIONS = """
 
 
 def test_product_variant_stocks_update(
-    staff_api_client, variant, warehouse, permission_manage_products
+    staff_api_client,
+    preorder_variant_global_threshold,
+    warehouse,
+    permission_manage_products,
 ):
+    variant = preorder_variant_global_threshold
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     second_warehouse = Warehouse.objects.get(pk=warehouse.pk)
     second_warehouse.slug = "second warehouse"


### PR DESCRIPTION
The channel slug can be `null` when a mutation that updates a variant tries to resolve fields handled by this loader, e.g., `quntityAvailable`. This wasn't handled by the datal loader properly which causes a crash. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
