### PR TITLE
Fix `CheckoutRemovePromoCode` mutation to look through all `VoucherCode` codes.

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -818,14 +818,13 @@ def remove_voucher_code_from_checkout_or_error(
 ) -> None:
     """Remove voucher data from checkout by code or raise an error."""
 
-    existing_voucher = checkout_info.voucher
-    if existing_voucher and existing_voucher.code == voucher_code:
+    if checkout_info.voucher and voucher_code in checkout_info.voucher.promo_codes:
         remove_voucher_from_checkout(checkout_info.checkout)
         checkout_info.voucher = None
     else:
         raise ValidationError(
             "Cannot remove a voucher not attached to this checkout.",
-            code=CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.value,
+            code=CheckoutErrorCode.INVALID.value,
         )
 
 

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -133,6 +133,10 @@ class Voucher(ModelWithMetadata):
         code_instance = self.codes.last()
         return code_instance.code if code_instance else None
 
+    @property
+    def promo_codes(self):
+        return list(self.codes.values_list("code", flat=True))
+
     def get_discount(self, channel: Channel):
         """Return proper discount amount for given channel.
 

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -151,7 +151,7 @@ def test_remove_gift_card_code_from_checkout_no_checkout_gift_cards(
     assert error.value.message == (
         "Cannot remove a gift card not attached to this checkout."
     )
-    assert error.value.code == CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value
+    assert error.value.code == CheckoutErrorCode.INVALID.value
 
 
 @pytest.mark.parametrize(

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -66,7 +66,7 @@ def remove_gift_card_code_from_checkout_or_error(
     else:
         raise ValidationError(
             "Cannot remove a gift card not attached to this checkout.",
-            code=CheckoutErrorCode.GIFT_CARD_NOT_APPLICABLE.value,
+            code=CheckoutErrorCode.INVALID.value,
         )
 
 

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -150,7 +150,6 @@ class CheckoutRemovePromoCode(BaseMutation):
         promo_code_pk: int,
     ) -> None:
         """Detach promo code from the checkout based on the id or raise an error."""
-
         if object_type == str(Voucher) and checkout.voucher_code is not None:
             node = cls._get_node_by_pk(info, graphene_type=Voucher, pk=promo_code_pk)
             if node is None:
@@ -162,7 +161,7 @@ class CheckoutRemovePromoCode(BaseMutation):
                         )
                     }
                 )
-            if checkout.voucher_code == node.code:
+            if checkout.voucher_code in node.promo_codes:
                 remove_voucher_from_checkout(checkout)
             else:
                 raise ValidationError(


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/16109
Fixes: https://linear.app/saleor/issue/SHOPX-761/bug-removing-non-existing-voucher-from-a-checkout-doesnt-return-error
Fixes: https://linear.app/saleor/issue/SHOPX-865/issue-with-calling-checkoutremovepromocodewith-promocodeid

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
