### PR TITLE
Cache JWT manager so it's not reimported dynamically

### DIFF
--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from functools import cache
 from os.path import exists, join
 from typing import Optional, Union, cast
 
@@ -71,6 +72,7 @@ class JWTManager(JWTManagerBase):
         return Site.objects.get_current().domain
 
     @classmethod
+    @cache
     def get_private_key(cls) -> rsa.RSAPrivateKey:
         pem = settings.RSA_PRIVATE_KEY
         if not pem:
@@ -127,6 +129,7 @@ class JWTManager(JWTManagerBase):
         return private_key
 
     @classmethod
+    @cache
     def get_public_key(cls) -> rsa.RSAPublicKey:
         global PUBLIC_KEY
 
@@ -194,6 +197,8 @@ class JWTManager(JWTManagerBase):
                 )
                 logger.warning(color_style().WARNING(msg))
 
+        cls.get_private_key.cache_clear()
+        cls.get_public_key.cache_clear()
         try:
             cls.get_private_key()
         except Exception as e:
@@ -204,5 +209,6 @@ class JWTManager(JWTManagerBase):
         return build_absolute_uri(reverse("api"), domain=cls.get_domain())
 
 
+@cache
 def get_jwt_manager() -> JWTManagerBase:
     return import_string(settings.JWT_MANAGER_PATH)


### PR DESCRIPTION
Port of #16135 

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
