### PR TITLE
Refactor channel by order/checkout line loaders.

### DIFF
--- a/saleor/graphql/channel/dataloaders.py
+++ b/saleor/graphql/channel/dataloaders.py
@@ -29,7 +29,7 @@ class ChannelByOrderIdLoader(DataLoader):
 
     def batch_load(self, keys):
         def with_orders(orders):
-            channel_ids = [order.channel_id for order in orders]
+            channel_ids = [order.channel_id if order else None for order in orders]
             return ChannelByIdLoader(self.context).load_many(channel_ids)
 
         return OrderByIdLoader(self.context).load_many(keys).then(with_orders)

--- a/saleor/graphql/channel/dataloaders.py
+++ b/saleor/graphql/channel/dataloaders.py
@@ -36,7 +36,7 @@ class ChannelByOrderIdLoader(DataLoader):
                     for order in orders
                 ]
 
-            channel_ids = set(order.channel_id if order else None for order in orders)
+            channel_ids = set(order.channel_id for order in orders if order)
             return (
                 ChannelByIdLoader(self.context)
                 .load_many(channel_ids)

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -649,9 +649,7 @@ class ChannelByCheckoutIDLoader(DataLoader):
                     for checkout in checkouts
                 ]
 
-            channel_ids = set(
-                checkout.channel_id if checkout else None for checkout in checkouts
-            )
+            channel_ids = set(checkout.channel_id for checkout in checkouts if checkout)
             return (
                 ChannelByIdLoader(self.context)
                 .load_many(channel_ids)

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -34,7 +34,7 @@ from ..channel import ChannelContext
 from ..channel.dataloaders import ChannelByIdLoader
 from ..channel.types import Channel
 from ..checkout.dataloaders import (
-    ChannelByCheckoutLineIDLoader,
+    ChannelByCheckoutIDLoader,
     CheckoutLinesProblemsByCheckoutIdLoader,
     CheckoutProblemsByCheckoutIdDataloader,
 )
@@ -271,7 +271,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
     @staticmethod
     def resolve_variant(root: models.CheckoutLine, info: ResolveInfo):
         variant = ProductVariantByIdLoader(info.context).load(root.variant_id)
-        channel = ChannelByCheckoutLineIDLoader(info.context).load(root.id)
+        channel = ChannelByCheckoutIDLoader(info.context).load(root.checkout_id)
 
         return Promise.all([variant, channel]).then(
             lambda data: ChannelContext(node=data[0], channel_slug=data[1].slug)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -62,7 +62,7 @@ from ..account.utils import (
 from ..app.dataloaders import AppByIdLoader
 from ..app.types import App
 from ..channel import ChannelContext
-from ..channel.dataloaders import ChannelByIdLoader, ChannelByOrderLineIdLoader
+from ..channel.dataloaders import ChannelByIdLoader, ChannelByOrderIdLoader
 from ..channel.types import Channel
 from ..checkout.utils import prevent_sync_event_circular_query
 from ..core.connection import CountableConnection
@@ -1136,7 +1136,7 @@ class OrderLine(ModelObjectType[models.OrderLine]):
             )
 
         variant = ProductVariantByIdLoader(context).load(root.variant_id)
-        channel = ChannelByOrderLineIdLoader(context).load(root.id)
+        channel = ChannelByOrderIdLoader(context).load(root.order_id)
 
         return Promise.all([variant, channel]).then(requestor_has_access_to_variant)
 


### PR DESCRIPTION
This PR:
1. protects against sentry issue: https://saleor.sentry.io/issues/3334664612/?project=6417854&referrer=Linear
2. simplify variant resolvers, by replacing `ChannelByOrderLineIdLoader` and `ChannelByCheckoutLineIdLoader` with `ChannelByOrderIdLoader` and `ChannelByCheckoutIdLoader` respectively. 

Issue: https://linear.app/saleor/issue/MERX-494/order-query-can-raise-nonetype-object-has-no-attribute-order-id

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
