### PR TITLE
Fix issuingPrincipal field resolution

### DIFF
--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2399,6 +2399,7 @@ class WebhookPlugin(BasePlugin):
                 channel=request_delete_data.channel,
             ),
             timeout=WEBHOOK_SYNC_TIMEOUT,
+            requestor=self.requestor,
         )
         if response_data:
             invalidate_cache_for_stored_payment_methods(
@@ -2436,6 +2437,7 @@ class WebhookPlugin(BasePlugin):
                     subscribable_object=list_payment_method_data,
                     request_timeout=WEBHOOK_SYNC_TIMEOUT,
                     cache_timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+                    requestor=self.requestor,
                 )
                 if response_data:
                     previous_value.extend(
@@ -2470,6 +2472,7 @@ class WebhookPlugin(BasePlugin):
             False,
             subscribable_object=request_data,
             timeout=WEBHOOK_SYNC_TIMEOUT,
+            requestor=self.requestor,
         )
         return response_data
 
@@ -2702,6 +2705,7 @@ class WebhookPlugin(BasePlugin):
                 webhook,
                 False,
                 subscribable_object=payment,
+                requestor=self.requestor,
             )
             if response_data is None:
                 continue
@@ -2754,6 +2758,7 @@ class WebhookPlugin(BasePlugin):
             allow_replica=False,
             subscribable_object=subscribable_object,
             request=request,
+            requestor=self.requestor,
         )
         error_msg = None
         if response_data is None:
@@ -2841,6 +2846,7 @@ class WebhookPlugin(BasePlugin):
             webhook=webhook,
             allow_replica=False,
             subscribable_object=transaction_session_data,
+            requestor=self.requestor,
         )
         error_msg = None
         if response_data is None:
@@ -2897,6 +2903,7 @@ class WebhookPlugin(BasePlugin):
                 webhook=webhook,
                 allow_replica=False,
                 subscribable_object=checkout,
+                requestor=self.requestor,
             )
             if response_data:
                 app_gateways = parse_list_payment_gateways_response(
@@ -3042,6 +3049,7 @@ class WebhookPlugin(BasePlugin):
             allow_replica=False,
             subscribable_object=subscriptable_object,
             request=request_context,
+            requestor=self.requestor,
         )
         return parse_tax_data(response)
 
@@ -3109,6 +3117,7 @@ class WebhookPlugin(BasePlugin):
                     subscribable_object=checkout,
                     request_timeout=WEBHOOK_SYNC_TIMEOUT,
                     cache_timeout=CACHE_TIME_SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+                    requestor=self.requestor,
                 )
 
                 if response_data:

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1966,6 +1966,21 @@ TRANSACTION_ITEM_METADATA_UPDATED = """
     """
 
 
+LIST_STORED_PAYMENT_METHODS = """
+  subscription {
+    event {
+      ... on ListStoredPaymentMethods {
+        issuingPrincipal {
+          ... on Node {
+            id
+          }
+        }
+      }
+    }
+  }
+"""
+
+
 MULTIPLE_EVENTS = """
 subscription{
   event{

--- a/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
+++ b/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -11,6 +12,9 @@ from ....webhook.transport.list_stored_payment_methods import (
     get_list_stored_payment_methods_from_response,
 )
 from ....webhook.transport.utils import generate_cache_key_for_webhook
+from .subscription_webhooks.subscription_queries import (
+    LIST_STORED_PAYMENT_METHODS as LIST_STORED_PAYMENT_METHODS_SUBSCRIPTION,
+)
 
 LIST_STORED_PAYMENT_METHODS = """
 subscription {
@@ -76,6 +80,100 @@ def test_list_stored_payment_methods_with_static_payload(
         webhook_list_stored_payment_methods_response,
         timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
     )
+
+    assert response
+    assert response == get_list_stored_payment_methods_from_response(
+        list_stored_payment_methods_app,
+        webhook_list_stored_payment_methods_response,
+        channel_USD.currency_code,
+    )
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.cache.get")
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+def test_list_stored_payment_methods_subscription_issuing_principal(
+    mock_request,
+    mocked_cache_get,
+    channel_USD,
+    customer_user,
+    webhook_plugin,
+    list_stored_payment_methods_app,
+    webhook_list_stored_payment_methods_response,
+):
+    # given
+    mock_request.return_value = webhook_list_stored_payment_methods_response
+    mocked_cache_get.return_value = None
+    webhook = list_stored_payment_methods_app.webhooks.first()
+    webhook.subscription_query = LIST_STORED_PAYMENT_METHODS_SUBSCRIPTION
+    webhook.save(update_fields=["subscription_query"])
+
+    plugin = webhook_plugin()
+    plugin.requestor = customer_user
+
+    data = ListStoredPaymentMethodsRequestData(
+        channel=channel_USD,
+        user=customer_user,
+    )
+
+    # when
+    response = plugin.list_stored_payment_methods(data, [])
+
+    # then
+    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    delivery_subscription_payload = json.loads(delivery.payload.payload)
+    assert delivery_subscription_payload == {
+        "issuingPrincipal": {"id": graphene.Node.to_global_id("User", customer_user.pk)}
+    }
+
+    assert response
+    assert response == get_list_stored_payment_methods_from_response(
+        list_stored_payment_methods_app,
+        webhook_list_stored_payment_methods_response,
+        channel_USD.currency_code,
+    )
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.cache.get")
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+def test_list_stored_payment_methods_subscription_issuing_principal_as_app(
+    mock_request,
+    mocked_cache_get,
+    channel_USD,
+    customer_user,
+    webhook_plugin,
+    list_stored_payment_methods_app,
+    webhook_list_stored_payment_methods_response,
+):
+    # given
+    mock_request.return_value = webhook_list_stored_payment_methods_response
+    mocked_cache_get.return_value = None
+    webhook = list_stored_payment_methods_app.webhooks.first()
+    webhook.subscription_query = LIST_STORED_PAYMENT_METHODS_SUBSCRIPTION
+    webhook.save(update_fields=["subscription_query"])
+
+    plugin = webhook_plugin()
+    plugin.requestor = list_stored_payment_methods_app
+
+    data = ListStoredPaymentMethodsRequestData(
+        channel=channel_USD,
+        user=customer_user,
+    )
+
+    # when
+    response = plugin.list_stored_payment_methods(data, [])
+
+    # then
+    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    delivery_subscription_payload = json.loads(delivery.payload.payload)
+    assert delivery_subscription_payload == {
+        "issuingPrincipal": {
+            "id": graphene.Node.to_global_id("App", list_stored_payment_methods_app.pk)
+        }
+    }
 
     assert response
     assert response == get_list_stored_payment_methods_from_response(

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -174,6 +174,7 @@ def trigger_webhook_sync_if_not_cached(
     request_timeout=None,
     cache_timeout=None,
     request=None,
+    requestor=None,
 ) -> Optional[dict]:
     """Get response for synchronous webhook.
 
@@ -194,6 +195,7 @@ def trigger_webhook_sync_if_not_cached(
             subscribable_object=subscribable_object,
             timeout=request_timeout,
             request=request,
+            requestor=requestor,
         )
         if response_data is not None:
             cache.set(
@@ -270,6 +272,7 @@ def trigger_webhook_sync(
     subscribable_object=None,
     timeout=None,
     request=None,
+    requestor=None,
 ) -> Optional[dict[Any, Any]]:
     """Send a synchronous webhook request."""
     if webhook.subscription_query:
@@ -277,6 +280,7 @@ def trigger_webhook_sync(
             event_type=event_type,
             subscribable_object=subscribable_object,
             webhook=webhook,
+            requestor=requestor,
             request=request,
             allow_replica=allow_replica,
         )


### PR DESCRIPTION
I want to merge this change because it fixes resolution of `issuingPrincipal` field in subscription queries.
Internal issue: https://linear.app/saleor/issue/SHOPX-862/bug-issuingprincipal-field-is-null-in-response-from-subscription

Resolves https://github.com/saleor/saleor/issues/13634

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
