### PR TITLE
Fix applying `SPECIFIC_PRODUCT` and `apply_once_per_order` voucher on draft orders

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
 @dataclass
 class CheckoutLineInfo(LineInfo):
     line: "CheckoutLine"
-    product: "Product"
     product_type: "ProductType"
     discounts: list["CheckoutLineDiscount"]
     tax_class: Optional["TaxClass"] = None

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -48,6 +48,8 @@ if TYPE_CHECKING:
 @dataclass
 class CheckoutLineInfo(LineInfo):
     line: "CheckoutLine"
+    variant: "ProductVariant"
+    product: "Product"
     product_type: "ProductType"
     discounts: list["CheckoutLineDiscount"]
     tax_class: Optional["TaxClass"] = None

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -11,7 +11,8 @@ from typing import (
 )
 from uuid import UUID
 
-from ..discount import DiscountType, VoucherType
+from ..core.pricing.interface import LineInfo
+from ..discount import VoucherType
 from ..discount.interface import fetch_variant_rules_info, fetch_voucher_info
 from ..shipping.interface import ShippingMethodData
 from ..shipping.models import ShippingMethod, ShippingMethodChannelListing
@@ -25,7 +26,7 @@ from ..warehouse.models import Warehouse
 if TYPE_CHECKING:
     from ..account.models import Address, User
     from ..channel.models import Channel
-    from ..discount.interface import VariantPromotionRuleInfo
+    from ..checkout.models import CheckoutLine
     from ..discount.models import (
         CheckoutDiscount,
         CheckoutLineDiscount,
@@ -34,7 +35,6 @@ if TYPE_CHECKING:
     )
     from ..plugins.manager import PluginsManager
     from ..product.models import (
-        Collection,
         Product,
         ProductChannelListing,
         ProductType,
@@ -42,36 +42,16 @@ if TYPE_CHECKING:
         ProductVariantChannelListing,
     )
     from ..tax.models import TaxClass, TaxConfiguration
-    from .models import Checkout, CheckoutLine
+    from .models import Checkout
 
 
 @dataclass
-class CheckoutLineInfo:
+class CheckoutLineInfo(LineInfo):
     line: "CheckoutLine"
-    variant: "ProductVariant"
-    channel_listing: "ProductVariantChannelListing"
     product: "Product"
     product_type: "ProductType"
-    collections: list["Collection"]
     discounts: list["CheckoutLineDiscount"]
-    rules_info: list["VariantPromotionRuleInfo"]
-    channel: "Channel"
     tax_class: Optional["TaxClass"] = None
-    voucher: Optional["Voucher"] = None
-
-    def get_promotion_discounts(self) -> list["CheckoutLineDiscount"]:
-        return [
-            discount
-            for discount in self.discounts
-            if discount.type in [DiscountType.PROMOTION, DiscountType.ORDER_PROMOTION]
-        ]
-
-    def get_catalogue_discounts(self) -> list["CheckoutLineDiscount"]:
-        return [
-            discount
-            for discount in self.discounts
-            if discount.type == DiscountType.PROMOTION
-        ]
 
 
 @dataclass
@@ -370,6 +350,7 @@ def fetch_checkout_lines(
                         discounts=discounts,
                         rules_info=rules_info,
                         channel=channel,
+                        voucher=None,
                     )
                 )
             continue
@@ -386,6 +367,7 @@ def fetch_checkout_lines(
                 discounts=discounts,
                 rules_info=rules_info,
                 channel=channel,
+                voucher=None,
             )
         )
 

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -351,6 +351,7 @@ def fetch_checkout_lines(
                         rules_info=rules_info,
                         channel=channel,
                         voucher=None,
+                        voucher_code=None,
                     )
                 )
             continue
@@ -368,6 +369,7 @@ def fetch_checkout_lines(
                 rules_info=rules_info,
                 channel=channel,
                 voucher=None,
+                voucher_code=None,
             )
         )
 
@@ -381,7 +383,7 @@ def fetch_checkout_lines(
             # discount from voucher
             return lines_info, unavailable_variant_pks
         if voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order:
-            voucher_info = fetch_voucher_info(voucher)
+            voucher_info = fetch_voucher_info(voucher, checkout.voucher_code)
             apply_voucher_to_line(voucher_info, lines_info)
     return lines_info, unavailable_variant_pks
 

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -25,7 +25,7 @@ from ..warehouse.models import Warehouse
 if TYPE_CHECKING:
     from ..account.models import Address, User
     from ..channel.models import Channel
-    from ..discount.interface import VariantPromotionRuleInfo, VoucherInfo
+    from ..discount.interface import VariantPromotionRuleInfo
     from ..discount.models import (
         CheckoutDiscount,
         CheckoutLineDiscount,
@@ -307,6 +307,7 @@ def fetch_checkout_lines(
     voucher: Optional["Voucher"] = None,
 ) -> tuple[Iterable[CheckoutLineInfo], Iterable[int]]:
     """Fetch checkout lines as CheckoutLineInfo objects."""
+    from ..discount.utils import apply_voucher_to_line
     from .utils import get_voucher_for_checkout
 
     select_related_fields = ["variant__product__product_type__tax_class"]
@@ -399,7 +400,7 @@ def fetch_checkout_lines(
             return lines_info, unavailable_variant_pks
         if voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order:
             voucher_info = fetch_voucher_info(voucher)
-            apply_voucher_to_checkout_line(voucher_info, lines_info)
+            apply_voucher_to_line(voucher_info, lines_info)
     return lines_info, unavailable_variant_pks
 
 
@@ -444,44 +445,6 @@ def _get_product_channel_listing(
                 product_channel_listing = channel_listing
         product_channel_listing_mapping[product.id] = product_channel_listing
     return product_channel_listing
-
-
-def apply_voucher_to_checkout_line(
-    voucher_info: "VoucherInfo",
-    lines_info: Iterable[CheckoutLineInfo],
-):
-    """Attach voucher to valid checkout lines info.
-
-    Apply a voucher to checkout line info when the voucher has the type
-    SPECIFIC_PRODUCTS or is applied only to the cheapest item.
-    """
-    from .utils import get_discounted_lines
-
-    voucher = voucher_info.voucher
-    discounted_lines_by_voucher: list[CheckoutLineInfo] = []
-    lines_included_in_discount = lines_info
-    if voucher.type == VoucherType.SPECIFIC_PRODUCT:
-        discounted_lines_by_voucher.extend(
-            get_discounted_lines(lines_info, voucher_info)
-        )
-        lines_included_in_discount = discounted_lines_by_voucher
-    if voucher.apply_once_per_order:
-        cheapest_line = _get_the_cheapest_line(lines_included_in_discount)
-        if cheapest_line:
-            discounted_lines_by_voucher = [cheapest_line]
-    for line_info in lines_info:
-        if line_info in discounted_lines_by_voucher:
-            line_info.voucher = voucher
-
-
-def _get_the_cheapest_line(
-    lines_info: Optional[Iterable[CheckoutLineInfo]],
-) -> Optional[CheckoutLineInfo]:
-    if not lines_info:
-        return None
-    return min(
-        lines_info, key=lambda line_info: line_info.channel_listing.discounted_price
-    )
 
 
 def fetch_checkout_info(

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -446,6 +446,7 @@ def test_get_discount_for_checkout_value_entire_order_voucher(
             product_type=line.variant.product.product_type,
             channel=channel_USD,
             voucher=None,
+            voucher_code=None,
         )
         for line in checkout_with_items.lines.all()
     ]
@@ -611,6 +612,7 @@ def test_get_discount_for_checkout_value_specific_product_voucher(
             variant=line.variant,
             product_type=line.variant.product.product_type,
             voucher=None,
+            voucher_code=None,
         )
         for line in checkout_with_items.lines.all()
     ]

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -445,6 +445,7 @@ def test_get_discount_for_checkout_value_entire_order_voucher(
             rules_info=[],
             product_type=line.variant.product.product_type,
             channel=channel_USD,
+            voucher=None,
         )
         for line in checkout_with_items.lines.all()
     ]
@@ -609,6 +610,7 @@ def test_get_discount_for_checkout_value_specific_product_voucher(
             product=line.variant.product,
             variant=line.variant,
             product_type=line.variant.product.product_type,
+            voucher=None,
         )
         for line in checkout_with_items.lines.all()
     ]

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 @dataclass
 class LineInfo:
     line: Union["OrderLine", "CheckoutLine"]
-    variant: "ProductVariant"
-    product: "Product"
+    variant: Optional["ProductVariant"]
+    product: Optional["Product"]
     collections: list["Collection"]
     channel_listing: "ProductVariantChannelListing"
     channel: "Channel"

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -33,7 +33,7 @@ class LineInfo:
 
     def get_promotion_discounts(
         self,
-    ) -> list[Union["OrderLineDiscount", "CheckoutLineDiscount"]]:
+    ):
         return [
             discount
             for discount in self.discounts
@@ -42,7 +42,7 @@ class LineInfo:
 
     def get_catalogue_discounts(
         self,
-    ) -> list[Union["OrderLineDiscount", "CheckoutLineDiscount"]]:
+    ):
         return [
             discount
             for discount in self.discounts
@@ -51,7 +51,7 @@ class LineInfo:
 
     def get_voucher_discounts(
         self,
-    ) -> list[Union["OrderLineDiscount", "CheckoutLineDiscount"]]:
+    ):
         return [
             discount
             for discount in self.discounts

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class LineInfo:
     line: Union["OrderLine", "CheckoutLine"]
     variant: "ProductVariant"
-    product: Optional["Product"]
+    product: "Product"
     collections: list["Collection"]
     channel_listing: "ProductVariantChannelListing"
     channel: "Channel"

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -47,3 +47,12 @@ class LineInfo:
             for discount in self.discounts
             if discount.type == DiscountType.PROMOTION
         ]
+
+    def get_voucher_discounts(
+        self,
+    ) -> list[Union["OrderLineDiscount", "CheckoutLineDiscount"]]:
+        return [
+            discount
+            for discount in self.discounts
+            if discount.type == DiscountType.VOUCHER
+        ]

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -1,0 +1,49 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Union
+
+from ...discount import DiscountType
+
+if TYPE_CHECKING:
+    from ...channel.models import Channel
+    from ...checkout.models import CheckoutLine
+    from ...discount.interface import VariantPromotionRuleInfo
+    from ...discount.models import CheckoutLineDiscount, OrderLineDiscount, Voucher
+    from ...order.models import OrderLine
+    from ...product.models import (
+        Collection,
+        Product,
+        ProductVariant,
+        ProductVariantChannelListing,
+    )
+
+
+@dataclass
+class LineInfo:
+    line: Union["OrderLine", "CheckoutLine"]
+    variant: "ProductVariant"
+    product: Optional["Product"]
+    collections: list["Collection"]
+    channel_listing: "ProductVariantChannelListing"
+    channel: "Channel"
+    discounts: Iterable[Union["OrderLineDiscount", "CheckoutLineDiscount"]]
+    rules_info: list["VariantPromotionRuleInfo"]
+    voucher: Optional["Voucher"]
+
+    def get_promotion_discounts(
+        self,
+    ) -> list[Union["OrderLineDiscount", "CheckoutLineDiscount"]]:
+        return [
+            discount
+            for discount in self.discounts
+            if discount.type in [DiscountType.PROMOTION, DiscountType.ORDER_PROMOTION]
+        ]
+
+    def get_catalogue_discounts(
+        self,
+    ) -> list[Union["OrderLineDiscount", "CheckoutLineDiscount"]]:
+        return [
+            discount
+            for discount in self.discounts
+            if discount.type == DiscountType.PROMOTION
+        ]

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -29,6 +29,7 @@ class LineInfo:
     discounts: Iterable[Union["OrderLineDiscount", "CheckoutLineDiscount"]]
     rules_info: list["VariantPromotionRuleInfo"]
     voucher: Optional["Voucher"]
+    voucher_code: Optional[str]
 
     def get_promotion_discounts(
         self,

--- a/saleor/discount/interface.py
+++ b/saleor/discount/interface.py
@@ -21,13 +21,16 @@ class VoucherInfo:
     """It contains the voucher's details and PKs of all applicable objects."""
 
     voucher: Voucher
+    voucher_code: Optional[str]
     product_pks: list[int]
     variant_pks: list[int]
     collection_pks: list[int]
     category_pks: list[int]
 
 
-def fetch_voucher_info(voucher: Voucher) -> VoucherInfo:
+def fetch_voucher_info(
+    voucher: Voucher, voucher_code: Optional[str] = None
+) -> VoucherInfo:
     variant_pks = list(variant.id for variant in voucher.variants.all())
     product_pks = list(product.id for product in voucher.products.all())
     category_pks = list(category.id for category in voucher.categories.all())
@@ -35,6 +38,7 @@ def fetch_voucher_info(voucher: Voucher) -> VoucherInfo:
 
     return VoucherInfo(
         voucher=voucher,
+        voucher_code=voucher_code,
         product_pks=product_pks,
         variant_pks=variant_pks,
         collection_pks=collection_pks,

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -662,6 +662,7 @@ def test_get_the_cheapest_line(checkout_with_items, channel_USD):
             product_type=line.variant.product.product_type,
             channel=channel_USD,
             voucher=None,
+            voucher_code=None,
         )
         for line in checkout_with_items.lines.all()
     ]

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -6,6 +6,7 @@ import pytest
 from django.utils import timezone
 from prices import Money, TaxedMoney
 
+from ...checkout.fetch import CheckoutLineInfo
 from ...discount.interface import VariantPromotionRuleInfo
 from .. import DiscountValueType, RewardValueType, VoucherType
 from ..models import (
@@ -16,6 +17,7 @@ from ..models import (
     VoucherCustomer,
 )
 from ..utils import (
+    _get_the_cheapest_line,
     activate_voucher_code,
     add_voucher_usage_by_customer,
     deactivate_voucher_code,
@@ -637,3 +639,33 @@ def test_is_order_level_voucher_another_type(voucher_type, voucher):
 
     # then
     assert result is False
+
+
+def test_get_the_cheapest_line_no_lines_provided():
+    # when
+    line_info = _get_the_cheapest_line(None)
+    # then
+    assert line_info is None
+
+
+def test_get_the_cheapest_line(checkout_with_items, channel_USD):
+    # given
+    lines = [
+        CheckoutLineInfo(
+            line=line,
+            channel_listing=line.variant.channel_listings.first(),
+            collections=[],
+            product=line.variant.product,
+            variant=line.variant,
+            discounts=list(line.discounts.all()),
+            rules_info=[],
+            product_type=line.variant.product.product_type,
+            channel=channel_USD,
+            voucher=None,
+        )
+        for line in checkout_with_items.lines.all()
+    ]
+    # when
+    line_info = _get_the_cheapest_line(lines)
+    # then
+    assert line_info == lines[0]

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -205,8 +205,7 @@ def apply_voucher_to_line(
         )
         lines_included_in_discount = discounted_lines_by_voucher
     if voucher.apply_once_per_order:
-        cheapest_line = _get_the_cheapest_line(lines_included_in_discount)
-        if cheapest_line:
+        if cheapest_line := _get_the_cheapest_line(lines_included_in_discount):
             discounted_lines_by_voucher = [cheapest_line]
     for line_info in lines_info:
         if line_info in discounted_lines_by_voucher:
@@ -229,6 +228,8 @@ def get_discounted_lines(
                 continue
             line_variant = line_info.variant
             line_product = line_info.product
+            if not line_variant or not line_product:
+                continue
             line_category = line_product.category
             line_collections = set(
                 [collection.pk for collection in line_info.collections]

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -196,8 +196,6 @@ def apply_voucher_to_line(
     Apply a voucher to checkout/order line info when the voucher has the type
     SPECIFIC_PRODUCTS or is applied only to the cheapest item.
     """
-    from .utils import get_discounted_lines
-
     voucher = voucher_info.voucher
     discounted_lines_by_voucher: list["LineInfo"] = []
     lines_included_in_discount = lines_info
@@ -231,8 +229,6 @@ def get_discounted_lines(
                 continue
             line_variant = line_info.variant
             line_product = line_info.product
-            if not line_variant or not line_product:
-                continue
             line_category = line_product.category
             line_collections = set(
                 [collection.pk for collection in line_info.collections]

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -23,7 +23,6 @@ from ..checkout.models import Checkout
 from ..core.exceptions import InsufficientStock
 from ..core.taxes import zero_money
 from ..core.utils.promo_code import InvalidPromoCode
-from ..discount.models import VoucherType
 from ..order.models import Order
 from ..product.models import (
     Product,

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -214,6 +214,7 @@ def apply_voucher_to_line(
     for line_info in lines_info:
         if line_info in discounted_lines_by_voucher:
             line_info.voucher = voucher
+            line_info.voucher_code = voucher_info.voucher_code
 
 
 def get_discounted_lines(
@@ -1057,6 +1058,7 @@ def _handle_gift_reward_for_checkout(
             "product_type": variant.product.product_type,
             "collections": [],
             "voucher": None,
+            "voucher_code": None,
         }
 
         gift_line_info = CheckoutLineInfo(**init_values)
@@ -1551,6 +1553,7 @@ def _handle_gift_reward_for_order(
             "rules_info": [rule_info],
             "channel": order.channel_id,
             "voucher": None,
+            "voucher_code": None,
         }
         gift_line_info = DraftOrderLineInfo(**init_values)
         lines_info.append(gift_line_info)  # type: ignore[attr-defined]
@@ -1686,7 +1689,7 @@ def prepare_line_discount_objects_for_voucher(
             _update_voucher_discount(
                 # discount_amount is 0, when voucher is None
                 line_info.voucher,  # type: ignore[arg-type]
-                line.voucher_code,  # type: ignore[arg-type]
+                line_info.voucher_code,  # type: ignore[arg-type]
                 discount_amount,
                 discount_to_update,
                 updated_fields,
@@ -1703,7 +1706,7 @@ def prepare_line_discount_objects_for_voucher(
                 # discount_amount is 0, when voucher is None
                 "name": f"{line_info.voucher.name}",  # type: ignore
                 "translated_name": None,
-                "reason": "",
+                "reason": f"Voucher code: {line_info.voucher_code}",
                 "voucher": line_info.voucher,
                 "unique_type": DiscountType.VOUCHER,
             }

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -141,6 +141,7 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineIn
                                 tax_class=tax_class_map[line.variant_id],
                                 channel=channels[checkout.channel_id],
                                 rules_info=rules_info_map[line.id],
+                                voucher=None,
                             )
                             for line in lines
                         ]

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -7,7 +7,6 @@ from promise import Promise
 from ...checkout.fetch import (
     CheckoutInfo,
     CheckoutLineInfo,
-    apply_voucher_to_checkout_line,
 )
 from ...checkout.models import Checkout, CheckoutLine, CheckoutMetadata
 from ...checkout.problems import (
@@ -22,6 +21,7 @@ from ...checkout.problems import (
 )
 from ...discount import VoucherType
 from ...discount.interface import VariantPromotionRuleInfo
+from ...discount.utils import apply_voucher_to_line
 from ...payment.models import TransactionItem
 from ...product.models import ProductChannelListing
 from ...warehouse.models import Stock
@@ -157,7 +157,7 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineIn
                         voucher.type == VoucherType.SPECIFIC_PRODUCT
                         or voucher.apply_once_per_order
                     ):
-                        apply_voucher_to_checkout_line(
+                        apply_voucher_to_line(
                             voucher_info=voucher_info,
                             lines_info=lines_info_map[checkout.pk],
                         )

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -142,6 +142,7 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineIn
                                 channel=channels[checkout.channel_id],
                                 rules_info=rules_info_map[line.id],
                                 voucher=None,
+                                voucher_code=None,
                             )
                             for line in lines
                         ]

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -1,8 +1,6 @@
 import graphene
 
 from .....checkout.fetch import (
-    CheckoutLineInfo,
-    _get_the_cheapest_line,
     fetch_checkout_lines,
 )
 from ...mutations.utils import (
@@ -183,33 +181,3 @@ def test_group_on_update_when_one_line_and_mixed_parameters_provided(
     assert expected == group_lines_input_data_on_update(
         lines_data, existing_checkout_lines
     )
-
-
-def test_get_the_cheapest_line_no_lines_provided():
-    # when
-    line_info = _get_the_cheapest_line(None)
-    # then
-    assert line_info is None
-
-
-def test_get_the_cheapest_line(checkout_with_items, channel_USD):
-    # given
-    lines = [
-        CheckoutLineInfo(
-            line=line,
-            channel_listing=line.variant.channel_listings.first(),
-            collections=[],
-            product=line.variant.product,
-            variant=line.variant,
-            discounts=list(line.discounts.all()),
-            rules_info=[],
-            product_type=line.variant.product.product_type,
-            channel=channel_USD,
-            voucher=None,
-        )
-        for line in checkout_with_items.lines.all()
-    ]
-    # when
-    line_info = _get_the_cheapest_line(lines)
-    # then
-    assert line_info == lines[0]

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -205,6 +205,7 @@ def test_get_the_cheapest_line(checkout_with_items, channel_USD):
             rules_info=[],
             product_type=line.variant.product.product_type,
             channel=channel_USD,
+            voucher=None,
         )
         for line in checkout_with_items.lines.all()
     ]

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -7,7 +7,7 @@ from promise import Promise
 from ....checkout import base_calculations
 from ....checkout.models import Checkout, CheckoutLine
 from ....core.prices import quantize_price
-from ....discount import DiscountType, VoucherType
+from ....discount import DiscountType
 from ....discount.utils import is_order_level_voucher
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
@@ -429,13 +429,7 @@ class TaxableObject(BaseObjectType):
                 for discount in discounts
                 if (
                     discount.type == DiscountType.MANUAL
-                    # TODO (SHOPX-873): apply_once_per_order voucher are included
-                    # for now, as the discount for such vouchers is currently not
-                    # propagated to the draft order lines
-                    or (
-                        discount.voucher
-                        and discount.voucher.type == VoucherType.ENTIRE_ORDER
-                    )
+                    or is_order_level_voucher(discount.voucher)
                 )
             ]
 

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -210,6 +210,7 @@ class VoucherInfoByVoucherCodeLoader(DataLoader[str, Optional[VoucherInfo]]):
             voucher_infos.append(
                 VoucherInfo(
                     voucher=voucher_code.voucher,
+                    voucher_code=voucher_code.code,
                     product_pks=product_pks_map.get(voucher_code.voucher_id, []),
                     variant_pks=variant_pks_map.get(voucher_code.voucher_id, []),
                     category_pks=category_pks_map.get(voucher_code.voucher_id, []),

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -331,6 +331,7 @@ class DraftOrderCreate(
             voucher = code_instance.voucher
             cls.clean_voucher_listing(voucher, channel, "voucher_code")
         cleaned_input["voucher"] = voucher
+        cleaned_input["voucher_code"] = voucher_code
         cleaned_input["voucher_code_instance"] = code_instance
 
     @classmethod

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -134,7 +134,7 @@ DRAFT_ORDER_CREATE_MUTATION = """
     """
 
 
-def test_draft_order_create_with_voucher(
+def test_draft_order_create_with_voucher_entire_order(
     staff_api_client,
     permission_group_manage_orders,
     staff_user,
@@ -621,6 +621,290 @@ def test_draft_order_create_percentage_voucher(
     assert order_discount.value_type == DiscountValueType.PERCENTAGE
     assert order_discount.value == voucher_listing.discount_value
     assert order_discount.amount_value == discount_amount
+
+
+def test_draft_order_create_with_voucher_specific_product(
+    staff_api_client,
+    permission_group_manage_orders,
+    customer_user,
+    product_without_shipping,
+    shipping_method,
+    variant,
+    voucher_specific_product_type,
+    channel_USD,
+    graphql_address_data,
+):
+    # given
+    discounted_variant = variant
+    voucher = voucher_specific_product_type
+    code = voucher.codes.first().code
+    query = DRAFT_ORDER_CREATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    variant_0_id = graphene.Node.to_global_id("ProductVariant", discounted_variant.id)
+    discounted_variant_listing = discounted_variant.channel_listings.get(
+        channel=channel_USD
+    )
+    variant_0_qty = 2
+
+    variant_1 = product_without_shipping.variants.first()
+    variant_1_qty = 1
+    channel_listing_1 = variant_1.channel_listings.get(channel=channel_USD)
+
+    variant_1_id = graphene.Node.to_global_id("ProductVariant", variant_1.id)
+    variant_list = [
+        {"variantId": variant_0_id, "quantity": variant_0_qty},
+        {"variantId": variant_1_id, "quantity": variant_1_qty},
+    ]
+    shipping_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+
+    voucher_listing = voucher.channel_listings.get(channel=channel_USD)
+    discount_value = voucher_listing.discount_value
+
+    shipping_address = graphql_address_data
+    redirect_url = "https://www.example.com"
+
+    variables = {
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucherCode": code,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["draftOrderCreate"]["errors"]
+    data = content["data"]["draftOrderCreate"]["order"]
+    assert data["status"] == OrderStatus.DRAFT.upper()
+    assert data["voucher"]["code"] == code
+    assert data["voucherCode"] == code
+    assert data["redirectUrl"] == redirect_url
+
+    shipping_total = shipping_method.channel_listings.get(
+        channel=channel_USD
+    ).get_total()
+    discount_amount = (
+        discounted_variant_listing.discounted_price_amount
+        * variant_0_qty
+        * discount_value
+        / 100
+    )
+    discounted_variant_total = (
+        discounted_variant_listing.discounted_price_amount * variant_0_qty
+        - discount_amount
+    )
+    variant_1_total = channel_listing_1.discounted_price_amount * variant_1_qty
+    order_total = discounted_variant_total + variant_1_total + shipping_total.amount
+    assert data["undiscountedTotal"]["gross"]["amount"] == order_total + discount_amount
+    assert data["total"]["gross"]["amount"] == order_total
+
+    order = Order.objects.first()
+    subtotal = get_subtotal(order.lines.all(), order.currency)
+    assert data["subtotal"]["gross"]["amount"] == subtotal.gross.amount
+
+    assert order.voucher_code == voucher.code
+    assert order.user == customer_user
+    assert order.shipping_method == shipping_method
+    assert order.shipping_method_name == shipping_method.name
+    assert order.search_vector
+    shipping_total = shipping_method.channel_listings.get(
+        channel_id=order.channel_id
+    ).get_total()
+    assert order.base_shipping_price == shipping_total
+
+    lines_data = data["lines"]
+    discounted_line_data, line_1_data = lines_data
+    assert discounted_line_data["productVariantId"] == variant_0_id
+    assert discounted_line_data["quantity"] == variant_0_qty
+    assert (
+        discounted_line_data["unitPrice"]["gross"]["amount"]
+        == discounted_variant_total / variant_0_qty
+    )
+    assert (
+        discounted_line_data["totalPrice"]["gross"]["amount"]
+        == discounted_variant_total
+    )
+    assert (
+        discounted_line_data["unitDiscount"]["amount"]
+        == discount_amount / variant_0_qty
+    )
+    assert discounted_line_data["unitDiscountType"] == DiscountValueType.FIXED.upper()
+    assert discounted_line_data["unitDiscountReason"] == f"Voucher code: {code}"
+
+    assert line_1_data["productVariantId"] == variant_1_id
+    assert line_1_data["quantity"] == variant_1_qty
+    assert (
+        line_1_data["unitPrice"]["gross"]["amount"] == variant_1_total / variant_1_qty
+    )
+    assert line_1_data["totalPrice"]["gross"]["amount"] == variant_1_total
+    assert line_1_data["unitDiscount"]["amount"] == 0
+    assert line_1_data["unitDiscountType"] is None
+    assert line_1_data["unitDiscountReason"] is None
+
+    # TODO (SHOPX-874): Order discount object shouldn't be created
+    assert order.discounts.count() == 1
+
+    discounted_line = order.lines.get(variant=discounted_variant)
+    assert discounted_line.discounts.count() == 1
+    order_line_discount = discounted_line.discounts.first()
+    assert order_line_discount.voucher == voucher
+    assert order_line_discount.type == DiscountType.VOUCHER
+    assert order_line_discount.value_type == DiscountValueType.FIXED
+    assert order_line_discount.value == discount_amount
+    assert order_line_discount.amount_value == discount_amount
+
+
+def test_draft_order_create_with_voucher_apply_once_per_order(
+    staff_api_client,
+    permission_group_manage_orders,
+    customer_user,
+    product_without_shipping,
+    shipping_method,
+    variant,
+    voucher_percentage,
+    channel_USD,
+    graphql_address_data,
+):
+    # given
+    discounted_variant = variant
+    voucher = voucher_percentage
+    voucher.apply_once_per_order = True
+    voucher.save(update_fields=["apply_once_per_order"])
+    code = voucher.codes.first().code
+
+    query = DRAFT_ORDER_CREATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    variant_0_id = graphene.Node.to_global_id("ProductVariant", discounted_variant.id)
+    discounted_variant_listing = discounted_variant.channel_listings.get(
+        channel=channel_USD
+    )
+    variant_0_qty = 2
+
+    variant_1 = product_without_shipping.variants.first()
+    variant_1_qty = 1
+    channel_listing_1 = variant_1.channel_listings.get(channel=channel_USD)
+
+    variant_1_id = graphene.Node.to_global_id("ProductVariant", variant_1.id)
+    variant_list = [
+        {"variantId": variant_0_id, "quantity": variant_0_qty},
+        {"variantId": variant_1_id, "quantity": variant_1_qty},
+    ]
+    shipping_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+
+    voucher_listing = voucher.channel_listings.get(channel=channel_USD)
+    discount_value = voucher_listing.discount_value
+
+    shipping_address = graphql_address_data
+    redirect_url = "https://www.example.com"
+
+    variables = {
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucherCode": code,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["draftOrderCreate"]["errors"]
+    data = content["data"]["draftOrderCreate"]["order"]
+    assert data["status"] == OrderStatus.DRAFT.upper()
+    assert data["voucher"]["code"] == code
+    assert data["voucherCode"] == code
+    assert data["redirectUrl"] == redirect_url
+
+    shipping_total = shipping_method.channel_listings.get(
+        channel=channel_USD
+    ).get_total()
+    discount_amount = (
+        discounted_variant_listing.discounted_price_amount * discount_value / 100
+    )
+    discounted_variant_total = (
+        discounted_variant_listing.discounted_price_amount * variant_0_qty
+        - discount_amount
+    )
+    variant_1_total = channel_listing_1.discounted_price_amount * variant_1_qty
+    order_total = discounted_variant_total + variant_1_total + shipping_total.amount
+    assert data["undiscountedTotal"]["gross"]["amount"] == order_total + discount_amount
+    assert data["total"]["gross"]["amount"] == order_total
+
+    order = Order.objects.first()
+    subtotal = get_subtotal(order.lines.all(), order.currency)
+    assert data["subtotal"]["gross"]["amount"] == subtotal.gross.amount
+
+    assert order.voucher_code == voucher.code
+    assert order.user == customer_user
+    assert order.shipping_method == shipping_method
+    assert order.shipping_method_name == shipping_method.name
+    assert order.search_vector
+    shipping_total = shipping_method.channel_listings.get(
+        channel_id=order.channel_id
+    ).get_total()
+    assert order.base_shipping_price == shipping_total
+
+    lines_data = data["lines"]
+    discounted_line_data, line_1_data = lines_data
+    assert discounted_line_data["productVariantId"] == variant_0_id
+    assert discounted_line_data["quantity"] == variant_0_qty
+    assert (
+        discounted_line_data["unitPrice"]["gross"]["amount"]
+        == discounted_variant_total / variant_0_qty
+    )
+    assert (
+        discounted_line_data["totalPrice"]["gross"]["amount"]
+        == discounted_variant_total
+    )
+    assert (
+        discounted_line_data["unitDiscount"]["amount"]
+        == discount_amount / variant_0_qty
+    )
+    assert discounted_line_data["unitDiscountType"] == DiscountValueType.FIXED.upper()
+    assert discounted_line_data["unitDiscountReason"] == f"Voucher code: {code}"
+
+    assert line_1_data["productVariantId"] == variant_1_id
+    assert line_1_data["quantity"] == variant_1_qty
+    assert (
+        line_1_data["unitPrice"]["gross"]["amount"] == variant_1_total / variant_1_qty
+    )
+    assert line_1_data["totalPrice"]["gross"]["amount"] == variant_1_total
+    assert line_1_data["unitDiscount"]["amount"] == 0
+    assert line_1_data["unitDiscountType"] is None
+    assert line_1_data["unitDiscountReason"] is None
+
+    # TODO (SHOPX-874): Order discount object shouldn't be created
+    assert order.discounts.count() == 1
+
+    discounted_line = order.lines.get(variant=discounted_variant)
+    assert discounted_line.discounts.count() == 1
+    order_line_discount = discounted_line.discounts.first()
+    assert order_line_discount.voucher == voucher
+    assert order_line_discount.type == DiscountType.VOUCHER
+    assert order_line_discount.value_type == DiscountValueType.FIXED
+    assert order_line_discount.value == discount_amount
+    assert order_line_discount.amount_value == discount_amount
 
 
 def test_draft_order_create_by_user_no_channel_access(

--- a/saleor/graphql/order/tests/mutations/test_order_discount.py
+++ b/saleor/graphql/order/tests/mutations/test_order_discount.py
@@ -1045,10 +1045,10 @@ def test_update_order_line_discount(
         - (second_line.base_unit_price - second_line.unit_price.gross)
         * second_line.quantity
     )
-    assert (
-        discount_applied_to_discounted_line
-        == (line_to_discount.base_unit_price - line_to_discount.unit_price.gross)
-        * line_to_discount.quantity
+    assert discount_applied_to_discounted_line == quantize_price(
+        (line_to_discount.base_unit_price - line_to_discount.unit_price.gross)
+        * line_to_discount.quantity,
+        order.currency,
     )
 
     errors = data["errors"]

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1515,7 +1515,9 @@ class Order(ModelObjectType[models.Order]):
                 return None
             for discount in discounts:
                 if discount.type == DiscountType.VOUCHER:
-                    return Money(amount=discount.value, currency=discount.currency)
+                    return Money(
+                        amount=discount.amount_value, currency=discount.currency
+                    )
             return None
 
         return (

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -7,7 +7,7 @@ from ..core.prices import quantize_price
 from ..core.taxes import zero_money
 from ..discount import DiscountType, DiscountValueType, VoucherType
 from ..discount.models import OrderDiscount
-from ..discount.utils import apply_discount_to_value
+from ..discount.utils import apply_discount_to_value, is_order_level_voucher
 from ..shipping.models import ShippingMethodChannelListing
 from .interface import OrderTaxedPricesData
 
@@ -96,11 +96,7 @@ def propagate_order_discount_on_order_prices(
         shipping_price_before_discount = shipping_price
         if order_discount.type == DiscountType.VOUCHER:
             voucher = order_discount.voucher
-            if (
-                voucher
-                and voucher.type == VoucherType.ENTIRE_ORDER
-                and not voucher.apply_once_per_order
-            ):
+            if is_order_level_voucher(voucher):
                 subtotal = apply_discount_to_value(
                     value=order_discount.value,
                     value_type=order_discount.value_type,

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -154,9 +154,6 @@ def propagate_order_discount_on_order_prices(
             order_discount.amount = total_discount_amount
             order_discounts_to_update.append(order_discount)
 
-    if order_discounts_to_update:
-        OrderDiscount.objects.bulk_update(order_discounts_to_update, ["amount_value"])
-
     # Apply shipping voucher discount
     if shipping_voucher_discount:
         shipping_price = apply_discount_to_value(
@@ -165,6 +162,13 @@ def propagate_order_discount_on_order_prices(
             currency=currency,
             price_to_discount=shipping_price,
         )
+        discount_amount = shipping_price_before_discount - shipping_price
+        if shipping_voucher_discount.amount != discount_amount:
+            shipping_voucher_discount.amount = discount_amount
+            order_discounts_to_update.append(shipping_voucher_discount)
+
+    if order_discounts_to_update:
+        OrderDiscount.objects.bulk_update(order_discounts_to_update, ["amount_value"])
 
     return subtotal, shipping_price
 

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -34,6 +34,7 @@ def base_order_subtotal(order: "Order", lines: Iterable["OrderLine"]) -> Money:
         quantity = line.quantity
         base_line_total = line.base_unit_price * quantity
         subtotal += base_line_total
+
     return quantize_price(subtotal, currency)
 
 
@@ -95,7 +96,11 @@ def propagate_order_discount_on_order_prices(
         shipping_price_before_discount = shipping_price
         if order_discount.type == DiscountType.VOUCHER:
             voucher = order_discount.voucher
-            if voucher and voucher.type == VoucherType.ENTIRE_ORDER:
+            if (
+                voucher
+                and voucher.type == VoucherType.ENTIRE_ORDER
+                and not voucher.apply_once_per_order
+            ):
                 subtotal = apply_discount_to_value(
                     value=order_discount.value,
                     value_type=order_discount.value_type,

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -9,7 +9,7 @@ from prices import Money, TaxedMoney
 from ..core.prices import quantize_price
 from ..core.taxes import TaxData, TaxEmptyData, TaxError, zero_taxed_money
 from ..discount import DiscountType
-from ..discount.utils import create_or_update_discount_objects_from_promotion_for_order
+from ..discount.utils import create_or_update_discount_objects_for_order
 from ..payment.model_helpers import get_subtotal
 from ..plugins import PLUGIN_IDENTIFIER_PREFIX
 from ..plugins.manager import PluginsManager
@@ -50,7 +50,7 @@ def fetch_order_prices_if_expired(
 
     # handle promotions
     lines_info: list[DraftOrderLineInfo] = fetch_draft_order_lines_info(order, lines)
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_or_update_discount_objects_for_order(order, lines_info)
     lines = [line_info.line for line_info in lines_info]
     _update_order_discount_for_voucher(order)
 

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -109,7 +109,7 @@ def fetch_draft_order_lines_info(
     channel = order.channel
     for line in lines:
         variant = cast(ProductVariant, line.variant)
-        product = variant.product if variant else None
+        product = variant.product
         variant_channel_listing = get_prefetched_variant_listing(variant, channel.id)
         if not variant_channel_listing:
             continue

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Optional, cast
+from typing import Optional
 from uuid import UUID
 
 from django.db.models import prefetch_related_objects
@@ -108,7 +108,9 @@ def fetch_draft_order_lines_info(
     lines_info = []
     channel = order.channel
     for line in lines:
-        variant = cast(ProductVariant, line.variant)
+        variant = line.variant
+        if not variant:
+            continue
         product = variant.product
         variant_channel_listing = get_prefetched_variant_listing(variant, channel.id)
         if not variant_channel_listing:

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -6,9 +6,14 @@ from uuid import UUID
 from django.db.models import prefetch_related_objects
 
 from ..channel.models import Channel
-from ..discount import DiscountType
-from ..discount.interface import VariantPromotionRuleInfo, fetch_variant_rules_info
+from ..discount import DiscountType, VoucherType
+from ..discount.interface import (
+    VariantPromotionRuleInfo,
+    fetch_variant_rules_info,
+    fetch_voucher_info,
+)
 from ..discount.models import OrderLineDiscount, Voucher
+from ..discount.utils import apply_voucher_to_line
 from ..payment.models import Payment
 from ..product.models import (
     DigitalContent,
@@ -133,6 +138,12 @@ def fetch_draft_order_lines_info(
                 channel=channel,
             )
         )
+    voucher = order.voucher
+    if voucher and (
+        voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order
+    ):
+        voucher_info = fetch_voucher_info(voucher)
+        apply_voucher_to_line(voucher_info, lines_info)
     return lines_info
 
 

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -7,7 +7,7 @@ from django.db.models import prefetch_related_objects
 
 from ..channel.models import Channel
 from ..core.pricing.interface import LineInfo
-from ..discount import VoucherType
+from ..discount import DiscountType, VoucherType
 from ..discount.interface import (
     fetch_variant_rules_info,
     fetch_voucher_info,
@@ -81,6 +81,14 @@ def fetch_order_lines(order: "Order") -> list[OrderLineInfo]:
 class DraftOrderLineInfo(LineInfo):
     line: "OrderLine"
     discounts: list["OrderLineDiscount"]
+
+    def get_manual_line_discount(
+        self,
+    ) -> Optional["OrderLineDiscount"]:
+        for discount in self.discounts:
+            if discount.type == DiscountType.MANUAL:
+                return discount
+        return None
 
 
 def fetch_draft_order_lines_info(

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -130,13 +130,14 @@ def fetch_draft_order_lines_info(
                 rules_info=rules_info,
                 channel=channel,
                 voucher=None,
+                voucher_code=None,
             )
         )
     voucher = order.voucher
     if voucher and (
         voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order
     ):
-        voucher_info = fetch_voucher_info(voucher)
+        voucher_info = fetch_voucher_info(voucher, order.voucher_code)
         apply_voucher_to_line(voucher_info, lines_info)
     return lines_info
 

--- a/saleor/order/tests/benchmark/test_fetch_order_prices.py
+++ b/saleor/order/tests/benchmark/test_fetch_order_prices.py
@@ -41,7 +41,7 @@ def test_fetch_order_prices_catalogue_discount(
     tc.save()
 
     # when
-    with django_assert_num_queries(38):
+    with django_assert_num_queries(40):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then
@@ -136,7 +136,7 @@ def test_fetch_order_prices_multiple_catalogue_discounts(
     tc.save()
 
     # when
-    with django_assert_num_queries(38):
+    with django_assert_num_queries(40):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then

--- a/saleor/order/tests/benchmark/test_fetch_order_prices.py
+++ b/saleor/order/tests/benchmark/test_fetch_order_prices.py
@@ -41,7 +41,7 @@ def test_fetch_order_prices_catalogue_discount(
     tc.save()
 
     # when
-    with django_assert_num_queries(40):
+    with django_assert_num_queries(43):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then
@@ -136,7 +136,7 @@ def test_fetch_order_prices_multiple_catalogue_discounts(
     tc.save()
 
     # when
-    with django_assert_num_queries(40):
+    with django_assert_num_queries(43):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then

--- a/saleor/order/tests/test_apply_order_discount.py
+++ b/saleor/order/tests/test_apply_order_discount.py
@@ -262,8 +262,7 @@ def test_apply_order_discounts_shipping_voucher(
     assert order.undiscounted_total_net == subtotal + shipping_price
     assert order.undiscounted_total_gross == subtotal + shipping_price
     order_discount.refresh_from_db()
-    # OrderDiscount has amount value only from not applied discounts
-    assert order_discount.amount_value == 0
+    assert order_discount.amount_value == shipping_price.amount
 
 
 def test_apply_order_discounts_zero_discount(order_with_lines):

--- a/saleor/order/tests/test_fetch.py
+++ b/saleor/order/tests/test_fetch.py
@@ -34,7 +34,7 @@ def test_fetch_draft_order_lines_info(
     )
 
     # when
-    with django_assert_num_queries(9):
+    with django_assert_num_queries(11):
         lines_info = fetch_draft_order_lines_info(order)
 
     # then

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -1739,6 +1739,211 @@ def test_fetch_order_prices_voucher_apply_once_per_order_percentage(
     assert line_discount.value == discount_amount
 
 
+def test_fetch_order_prices_manual_order_discount_voucher_specific_product(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    unit_discount_amount = Decimal("2")
+    voucher_listing.discount_value = unit_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order discount
+    order_discount_amount = Decimal("10")
+    order_discount = order.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=order_discount_amount,
+        name="Manual order discount",
+        type=DiscountType.MANUAL,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    voucher_discount_amount = unit_discount_amount * discounted_line.quantity
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - order_discount_amount
+    )
+    shipping_discount = shipping_price - order.shipping_price_gross
+    subtotal_order_discount = order_discount_amount - shipping_discount.amount
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - subtotal_order_discount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price - shipping_discount
+    assert order.base_shipping_price == shipping_price
+
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    order_discount.refresh_from_db()
+    assert order_discount.amount_value == order_discount_amount
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == voucher_discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == voucher_discount_amount
+
+
+def test_fetch_order_prices_manual_order_discount_and_voucher_apply_once_per_order(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = Decimal("3")
+    voucher_listing.discount_value = discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.apply_once_per_order = True
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type", "apply_once_per_order"])
+
+    lines = order.lines.all()
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order discount
+    order_discount_amount = Decimal("10")
+    order_discount = order.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=order_discount_amount,
+        name="Manual order discount",
+        type=DiscountType.MANUAL,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    voucher_discount_amount = discount_amount
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - order_discount_amount
+    )
+    shipping_discount = shipping_price - order.shipping_price_gross
+    subtotal_order_discount = order_discount_amount - shipping_discount.amount
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - subtotal_order_discount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price - shipping_discount
+    assert order.base_shipping_price == shipping_price
+
+    unit_discount_amount = discount_amount / discounted_line.quantity
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    order_discount.refresh_from_db()
+    assert order_discount.amount_value == order_discount_amount
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == voucher_discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == voucher_discount_amount
+
+
 def test_fetch_order_prices_catalogue_discount_race_condition(
     order_with_lines_and_catalogue_promotion,
     plugins_manager,

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -1944,6 +1944,232 @@ def test_fetch_order_prices_manual_order_discount_and_voucher_apply_once_per_ord
     assert line_discount.value == voucher_discount_amount
 
 
+def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    unit_discount_amount = Decimal("2")
+    voucher_listing.discount_value = unit_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order line discount
+    manual_line_discount_amount = Decimal("3")
+    manual_line_discount = discounted_line.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=manual_line_discount_amount,
+        name="Manual line discount",
+        type=DiscountType.MANUAL,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line.refresh_from_db()
+    line_1.refresh_from_db()
+    voucher_discount_amount = unit_discount_amount * discounted_line.quantity
+    manual_discount_amount = manual_line_discount_amount * discounted_line.quantity
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - manual_discount_amount
+    )
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - manual_discount_amount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.base_shipping_price == shipping_price
+
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        - unit_discount_amount
+        - manual_line_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert (
+        discounted_line.unit_discount_amount
+        == unit_discount_amount + manual_line_discount_amount
+    )
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 2
+    voucher_line_discount = discounted_line.discounts.get(type=DiscountType.VOUCHER)
+    assert voucher_line_discount.amount_value == voucher_discount_amount
+    assert voucher_line_discount.value_type == DiscountValueType.FIXED
+    assert voucher_line_discount.type == DiscountType.VOUCHER
+    assert voucher_line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert voucher_line_discount.value == voucher_discount_amount
+
+    manual_line_discount.refresh_from_db()
+    assert manual_line_discount.amount_value == manual_discount_amount
+    assert manual_line_discount.type == DiscountType.MANUAL
+
+
+def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_order(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = Decimal("3")
+    voucher_listing.discount_value = discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.apply_once_per_order = True
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type", "apply_once_per_order"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order line discount
+    manual_line_discount_amount = Decimal("3")
+    manual_line_discount = discounted_line.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=manual_line_discount_amount,
+        name="Manual line discount",
+        type=DiscountType.MANUAL,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line.refresh_from_db()
+    line_1.refresh_from_db()
+    voucher_discount_amount = discount_amount
+    manual_discount_amount = manual_line_discount_amount * discounted_line.quantity
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - manual_discount_amount
+    )
+    shipping_discount = shipping_price - order.shipping_price_gross
+    subtotal_order_discount = manual_discount_amount - shipping_discount.amount
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - subtotal_order_discount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price - shipping_discount
+    assert order.base_shipping_price == shipping_price
+
+    unit_discount_amount = discount_amount / discounted_line.quantity
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        - unit_discount_amount
+        - manual_line_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert (
+        discounted_line.unit_discount_amount
+        == manual_line_discount_amount + unit_discount_amount
+    )
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 2
+    voucher_line_discount = discounted_line.discounts.get(type=DiscountType.VOUCHER)
+    assert voucher_line_discount.amount_value == voucher_discount_amount
+    assert voucher_line_discount.value_type == DiscountValueType.FIXED
+    assert voucher_line_discount.type == DiscountType.VOUCHER
+    assert voucher_line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert voucher_line_discount.value == voucher_discount_amount
+
+    manual_line_discount.refresh_from_db()
+    assert manual_line_discount.amount_value == manual_discount_amount
+    assert manual_line_discount.type == DiscountType.MANUAL
+
+
 def test_fetch_order_prices_catalogue_discount_race_condition(
     order_with_lines_and_catalogue_promotion,
     plugins_manager,

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -2080,6 +2080,7 @@ def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_orde
         value=manual_line_discount_amount,
         name="Manual line discount",
         type=DiscountType.MANUAL,
+        reason="Manual line discount",
     )
 
     shipping_price = order.shipping_price.net
@@ -2142,7 +2143,10 @@ def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_orde
         == manual_line_discount_amount + unit_discount_amount
     )
     assert discounted_line.unit_discount_type == DiscountValueType.FIXED
-    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+    assert (
+        discounted_line.unit_discount_reason
+        == f"{manual_line_discount.reason}; Voucher code: {order.voucher_code}"
+    )
 
     assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
     assert (

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -1357,19 +1357,21 @@ def test_fetch_order_prices_manual_line_discount_and_catalogue_discount_flat_rat
 
     line_1 = [line for line in lines if line.quantity == 3][0]
 
-    assert line_1.base_unit_price_amount == variant_1_listing.price_amount
+    assert (
+        line_1.base_unit_price_amount
+        == variant_1_listing.price_amount - manual_discount_value
+    )
     assert manual_discount.line == line_1
     assert manual_discount.value == manual_discount_value
     assert manual_discount.value_type == manual_discount_value_type
     assert manual_discount.type == DiscountType.MANUAL
     assert manual_discount.reason == manual_discount_reason
 
-    # TODO https://github.com/saleor/saleor/issues/15517
-    # line_1_total_net_amount = quantize_price(
-    #     (variant_1_listing.price_amount - manual_discount_value) * line_1.quantity,
-    #     order.currency
-    # )
-    # assert line_1.total_price_net_amount == line_1_total_net_amount
+    line_1_total_net_amount = quantize_price(
+        (variant_1_listing.price_amount - manual_discount_value) * line_1.quantity,
+        order.currency,
+    )
+    assert line_1.total_price_net_amount == line_1_total_net_amount
 
 
 def test_fetch_order_prices_catalogue_discount_race_condition(

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -1464,6 +1464,102 @@ def test_fetch_order_prices_voucher_specific_product_fixed(
     assert line_discount.value == discount_amount
 
 
+def test_fetch_order_prices_voucher_specific_product_discount_line_object_updated(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    unit_discount_amount = Decimal("5")
+    voucher_listing.discount_value = unit_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    line_discount = discounted_line.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=Decimal("0"),
+        name="Manual line discount",
+        type=DiscountType.VOUCHER,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    discount_amount = unit_discount_amount * discounted_line.quantity
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.base_unit_price_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 1
+    line_discount.refresh_from_db()
+    assert line_discount.amount_value == discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == discount_amount
+
+
 def test_fetch_order_prices_voucher_specific_product_percentage(
     order_with_lines, voucher_specific_product_type, plugins_manager
 ):

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -836,6 +836,7 @@ def update_discount_for_order_line(
     if reason is not None:
         order_line.unit_discount_reason = reason
         fields_to_update.append("unit_discount_reason")
+
     if current_value != value or current_value_type != value_type:
         undiscounted_base_unit_price = order_line.undiscounted_base_unit_price
         currency = undiscounted_base_unit_price.currency
@@ -850,6 +851,7 @@ def update_discount_for_order_line(
 
         order_line.unit_discount_type = value_type
         order_line.unit_discount_value = value
+        # TODO: should we save those values?
         order_line.total_price = order_line.unit_price * order_line.quantity
         order_line.undiscounted_unit_price = (
             order_line.unit_price + order_line.unit_discount
@@ -894,7 +896,7 @@ def _update_manual_order_line_discount_object(
     for discount in discounts:
         if discount.type == DiscountType.MANUAL and not discount_to_update:
             discount_to_update = discount
-        else:
+        elif discount.type != DiscountType.VOUCHER:
             discount_to_delete_ids.append(discount.pk)
 
     if discount_to_delete_ids:
@@ -911,6 +913,7 @@ def _update_manual_order_line_discount_object(
             amount_value=amount_value,
             currency=currency,
             reason=reason,
+            unique_type=DiscountType.MANUAL,
         )
     else:
         update_fields = []

--- a/saleor/warehouse/tests/test_preorder_availability.py
+++ b/saleor/warehouse/tests/test_preorder_availability.py
@@ -165,6 +165,7 @@ def test_check_preorder_reserved_threshold_bulk_channel_threshold(
                 rules_info=[],
                 channel=channel_USD,
                 voucher=None,
+                voucher_code=None,
             )
         ],
         check_reservations=True,
@@ -236,6 +237,7 @@ def test_check_preorder_reserved_threshold_bulk_global_threshold(
                 rules_info=[],
                 channel=channel_USD,
                 voucher=None,
+                voucher_code=None,
             )
         ],
         check_reservations=True,

--- a/saleor/warehouse/tests/test_preorder_availability.py
+++ b/saleor/warehouse/tests/test_preorder_availability.py
@@ -164,6 +164,7 @@ def test_check_preorder_reserved_threshold_bulk_channel_threshold(
                 discounts=[],
                 rules_info=[],
                 channel=channel_USD,
+                voucher=None,
             )
         ],
         check_reservations=True,
@@ -234,6 +235,7 @@ def test_check_preorder_reserved_threshold_bulk_global_threshold(
                 discounts=[],
                 rules_info=[],
                 channel=channel_USD,
+                voucher=None,
             )
         ],
         check_reservations=True,


### PR DESCRIPTION
Apply `SPECIFIC_PRODUCT` and `apply_once_per_order` voucher on draft orders.

Fixes: https://github.com/saleor/saleor/issues/15517

Internal issues:
- https://linear.app/saleor/issue/SHOPX-873/voucher-with-apply-once-per-order-not-working-properly
- https://linear.app/saleor/issue/SHOPX-872/specific-products-vouchers-in-draft-order-do-not-work

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
