### PR TITLE
Optimize SQL queries for fetching product variants

### DIFF
--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -560,7 +560,6 @@ class ProductQueries(graphene.ObjectType):
                 ids=ids,
                 channel=channel_obj,
                 limited_channel_access=limited_channel_access,
-                requestor_has_access_to_all=has_required_permissions,
                 requestor=requestor,
             )
             kwargs["channel"] = qs.channel_slug

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -803,9 +803,6 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
     @staticmethod
     def __resolve_references(roots: list["ProductVariant"], info):
         requestor = get_user_or_app_from_context(info.context)
-        requestor_has_access_to_all = has_one_of_permissions(
-            requestor, ALL_PRODUCTS_PERMISSIONS
-        )
 
         channels = defaultdict(set)
         roots_ids = []
@@ -819,7 +816,6 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
             limited_channel_access = False if channel_slug is None else True
             qs = resolve_product_variants(
                 info,
-                requestor_has_access_to_all,
                 requestor,
                 ids=ids,
                 channel=channels_map.get(channel_slug),

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -327,7 +327,7 @@ class ProductVariantQueryset(models.QuerySet):
         # - have a variant channel listing for this channel and the price is not null
         # - have a product channel listing for this channel and the product is published
         #  and visible in listings
-        variants = ProductVariant.objects.filter(
+        variants = ProductVariant.objects.using(self.db).filter(
             channel_listings__channel_id=channel.id,
             channel_listings__price_amount__isnull=False,
         )

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -306,7 +306,7 @@ class ProductVariantQueryset(models.QuerySet):
         channel: Optional[Channel],
         limited_channel_access: bool,
     ):
-        from .models import ALL_PRODUCTS_PERMISSIONS, ProductVariant
+        from .models import ALL_PRODUCTS_PERMISSIONS
 
         # User with product permissions can see all variants. If channel is given,
         # filter variants with product channel listings for this channel.
@@ -327,7 +327,7 @@ class ProductVariantQueryset(models.QuerySet):
         # - have a variant channel listing for this channel and the price is not null
         # - have a product channel listing for this channel and the product is published
         #  and visible in listings
-        variants = ProductVariant.objects.using(self.db).filter(
+        variants = self.filter(
             channel_listings__channel_id=channel.id,
             channel_listings__price_amount__isnull=False,
         )


### PR DESCRIPTION
Optimize SQL queries made by the `productVariants` GraphQL field:

```graphql
{
  productVariants(first: 21, channel: "default-channel") {
    edges {
      node {
        id
        name
        sku
      }
    }
  }
}
```

Currently when running the query we perform quite heavy and complex SQL queries. There are two cases when this resolver is used and runs two different queries - one for authenticated user with product permissions, the other for anonymous users (customers). Below are examples of query plans for these two cases for Saleor 3.18 before and after optimizations made in this PR.

Query plans below generated using DB with:
- channels: 1300
- products: 71k
- product variants: 73k
- product channel listings: 81k
- product variant channel listings: 80k

### Case 1 - authenticated user with product permissions.

Before
- plan: https://explain.dalibo.com/plan/h8f0e274ff66gb6h
- total cost: 46,400
- buffer usage: ~2,3 GB
- avg execution time (10 runs): 115ms

After
- plan: https://explain.dalibo.com/plan/559bgda5fa2dgc6d
- total cost: **21,400 (2.16x better)**
- buffer usage: **62 MB (37x better)**
- - avg execution time (10 runs): 63ms

### Case 2 - anonymous user

Before:
- plan: https://explain.dalibo.com/plan/26ea5d4b139d2cga
- total cost: 525,000
- buffer usage: ~75 MB
- avg execution time (10 runs): 96ms

After:
- plan: https://explain.dalibo.com/plan/72gce3484149gd22
- cost: **9,740 (54x better)**
- buffer usage: **~1 GB (13x worse)**
- avg execution time (10 runs): 72ms

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
