### PR TITLE
Add validator for required field `name` in attribute bulk mutations.

### DIFF
--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -96,7 +96,11 @@ def clean_values(
         slugs_list = list(attribute.values.values_list("slug", flat=True))
 
     duplicated_names = get_duplicated_values(
-        [unidecode(value_data.name.lower().strip()) for value_data in values]
+        [
+            unidecode(value_data.name.lower().strip())
+            for value_data in values
+            if value_data.name
+        ]
     )
 
     for value_index, value_data in enumerate(values):
@@ -117,6 +121,16 @@ def clean_values(
                     path=f"{path_prefix}.{value_index}.externalReference",
                     message="External reference already exists.",
                     code=error_class.code.UNIQUE.value,
+                )
+            )
+            continue
+
+        if not value_data.name:
+            index_error_map[attribute_index].append(
+                error_class(
+                    path=f"{path_prefix}.{value_index}.name",
+                    message="The field is required.",
+                    code=error_class.code.REQUIRED.value,
                 )
             )
             continue


### PR DESCRIPTION
I want to merge this change, because it handles error when `name` field is not provided in attribute bulk mutations input.
Issue: https://linear.app/saleor/issue/MERX-6/[attributebulkupdate]-attributeerror-nonetype-object-has-no-attribute

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
