### PR TITLE
Remove `Voucher.code` usage from codebase.

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -306,22 +306,15 @@ def _create_line_for_order(
         prices_entered_with_tax,
     )
 
-    line_voucher_code = None
-    if checkout_line_info.voucher:
-        line_voucher_code = checkout_line_info.voucher.code
-    order_voucher_code = None
-    if checkout_info.voucher:
-        order_voucher_code = checkout_info.voucher.code
-
     discount_price = undiscounted_unit_price - unit_price
     if prices_entered_with_tax:
         discount_amount = discount_price.gross
     else:
         discount_amount = discount_price.net
 
-    unit_discount_reason = _get_unit_discount_reason(
-        line_voucher_code, order_voucher_code
-    )
+    voucher_code = checkout_info.checkout.voucher_code
+    is_line_voucher_code = bool(checkout_line_info.voucher)
+    unit_discount_reason = _get_unit_discount_reason(voucher_code, is_line_voucher_code)
 
     tax_class = None
     if product.tax_class_id:
@@ -348,7 +341,7 @@ def _create_line_for_order(
         undiscounted_total_price=undiscounted_total_price,  # money field not supported by mypy_django_plugin # noqa: E501
         total_price=total_line_price,
         tax_rate=tax_rate,
-        voucher_code=line_voucher_code,
+        voucher_code=voucher_code if is_line_voucher_code else None,
         unit_discount=discount_amount,  # money field not supported by mypy_django_plugin # noqa: E501
         unit_discount_reason=unit_discount_reason,
         unit_discount_value=discount_amount.amount,  # we store value as fixed discount
@@ -392,15 +385,14 @@ def _create_line_for_order(
 
 
 def _get_unit_discount_reason(
-    line_voucher_code: Optional[str],
-    order_voucher_code: Optional[str],
+    voucher_code: Optional[str], is_line_voucher_code
 ) -> Optional[str]:
-    unit_discount_reason = None
-    if line_voucher_code:
-        unit_discount_reason = f"Voucher code: {line_voucher_code}"
-    elif order_voucher_code:
-        unit_discount_reason = f"Entire order voucher code: {order_voucher_code}"
-    return unit_discount_reason
+    if not voucher_code:
+        return None
+    return (
+        f"{'Voucher code' if is_line_voucher_code else 'Entire order voucher code'}: "
+        f"{voucher_code}"
+    )
 
 
 def _create_order_line_discounts(

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -187,6 +187,21 @@ def get_voucher_code_instance(
     return code_instance
 
 
+def get_active_voucher_code(voucher, channel_slug):
+    """Return an active VoucherCode instance.
+
+    This method along with `Voucher.code` should be removed in Saleor 4.0.
+    """
+
+    voucher_queryset = Voucher.objects.active_in_channel(timezone.now(), channel_slug)
+    if not voucher_queryset.filter(pk=voucher.pk).exists():
+        raise InvalidPromoCode()
+    voucher_code = VoucherCode.objects.filter(voucher=voucher, is_active=True).first()
+    if not voucher_code:
+        raise InvalidPromoCode()
+    return voucher_code
+
+
 def apply_voucher_to_line(
     voucher_info: "VoucherInfo",
     lines_info: Iterable["LineInfo"],

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -118,9 +118,9 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineIn
 
                 lines_info_map = defaultdict(list)
                 voucher_infos_map = {
-                    voucher_info.voucher.code: voucher_info
+                    voucher_info.voucher_code: voucher_info
                     for voucher_info in voucher_infos
-                    if voucher_info
+                    if voucher_info is not None and voucher_info.voucher_code
                 }
                 for checkout, lines in zip(checkouts, checkout_lines):
                     lines_info_map[checkout.pk].extend(

--- a/saleor/graphql/discount/mutations/bulk_mutations.py
+++ b/saleor/graphql/discount/mutations/bulk_mutations.py
@@ -2,10 +2,11 @@ from typing import Optional
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.db.models import Exists, OuterRef, QuerySet
+from django.db.models import Exists, OuterRef, QuerySet, Subquery
 
 from ....discount import models
 from ....discount.error_codes import DiscountErrorCode
+from ....discount.models import VoucherCode
 from ....permission.enums import DiscountPermissions
 from ....product.utils.product import (
     get_channel_to_products_map_from_rules,
@@ -147,8 +148,12 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):
         manager = get_plugin_manager_promise(info.context).get()
-        vouchers = list(queryset)
-        codes = [voucher.code for voucher in vouchers]
+        vouchers = queryset.annotate(
+            last_code=Subquery(
+                VoucherCode.objects.filter(voucher=OuterRef("pk")).values("code")[:1]
+            )
+        )
+        codes = [voucher.last_code for voucher in vouchers]
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.VOUCHER_DELETED)
         queryset.delete()
 

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -10,7 +10,11 @@ from ....core.taxes import TaxError
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....discount.models import Voucher, VoucherCode
-from ....discount.utils import get_voucher_code_instance, increase_voucher_usage
+from ....discount.utils import (
+    get_active_voucher_code,
+    get_voucher_code_instance,
+    increase_voucher_usage,
+)
 from ....order import OrderOrigin, OrderStatus, events, models
 from ....order.error_codes import OrderErrorCode
 from ....order.search import update_order_search_vector
@@ -277,7 +281,7 @@ class DraftOrderCreate(
         if channel.include_draft_order_in_voucher_usage:
             # Validate voucher when it's included in voucher usage calculation
             try:
-                code_instance = get_voucher_code_instance(voucher.code, channel.slug)
+                code_instance = get_active_voucher_code(voucher, channel.slug)
             except ValidationError:
                 raise ValidationError(
                     {


### PR DESCRIPTION
I want to merge this change because it moves forward `Voucher.code` deprecation after adding a separate `VoucherCode` model for code instances

Fixes: https://linear.app/saleor/issue/SHOPX-890/bug-deprecate-usage-of-a-vouchercode-occurrences-in-codebase

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
