### PR TITLE
Make pspReference optional in some webhooks responses

### DIFF
--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -247,6 +247,17 @@ FAILED_TRANSACTION_EVENTS = [
 ]
 
 
+OPTIONAL_PSP_REFERENCE_EVENTS = [
+    TransactionEventType.CHARGE_ACTION_REQUIRED,
+    TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
+    TransactionEventType.CHARGE_FAILURE,
+    TransactionEventType.AUTHORIZATION_FAILURE,
+    TransactionEventType.REFUND_FAILURE,
+    TransactionEventType.CHARGE_FAILURE,
+    TransactionEventType.CANCEL_FAILURE,
+]
+
+
 class TokenizedPaymentFlow:
     """Represents possible tokenized payment flows that can be used to process payment.
 

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -1650,12 +1650,9 @@ def test_create_transaction_event_for_transaction_session_not_success_events(
 @pytest.mark.parametrize(
     "response_result",
     [
-        TransactionEventType.AUTHORIZATION_FAILURE,
         TransactionEventType.AUTHORIZATION_SUCCESS,
-        TransactionEventType.AUTHORIZATION_REQUEST,
         TransactionEventType.CHARGE_FAILURE,
         TransactionEventType.CHARGE_SUCCESS,
-        TransactionEventType.CHARGE_REQUEST,
     ],
 )
 def test_create_transaction_event_for_transaction_session_missing_psp_reference(

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -1741,6 +1741,14 @@ def test_create_transaction_event_for_transaction_session_not_success_events(
             TransactionEventType.CHARGE_FAILURE,
             "Message related to the payment",
         ),
+        (
+            TransactionEventType.CHARGE_REQUEST,
+            "Providing `pspReference` is required for CHARGE_REQUEST",
+        ),
+        (
+            TransactionEventType.AUTHORIZATION_REQUEST,
+            "Providing `pspReference` is required for AUTHORIZATION_REQUEST",
+        ),
     ],
 )
 def test_create_transaction_event_for_transaction_session_missing_psp_reference(

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -524,6 +524,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_no_psp_
         type=TransactionEventType.AUTHORIZATION_FAILURE
     )
     assert failed_event.transaction_id == transaction.id
+    assert failed_event.message == "Missing `pspReference` field in the response."
 
 
 @freeze_time("2018-05-31 12:00:01")

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -80,16 +80,12 @@ PSP_REFERENCE_OPTIONAL_MAP = {
         TransactionEventType.CANCEL_FAILURE
     ],
     WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION: [
-        TransactionEventType.CHARGE_REQUEST,
-        TransactionEventType.AUTHORIZATION_REQUEST,
         TransactionEventType.CHARGE_ACTION_REQUIRED,
         TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
         TransactionEventType.CHARGE_FAILURE,
         TransactionEventType.AUTHORIZATION_FAILURE,
     ],
     WebhookEventSyncType.TRANSACTION_PROCESS_SESSION: [
-        TransactionEventType.CHARGE_REQUEST,
-        TransactionEventType.AUTHORIZATION_REQUEST,
         TransactionEventType.CHARGE_ACTION_REQUIRED,
         TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
         TransactionEventType.CHARGE_FAILURE,
@@ -1219,8 +1215,6 @@ def create_transaction_event_for_transaction_session(
     if not response_event.psp_reference and response_event.type not in [
         TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
         TransactionEventType.CHARGE_ACTION_REQUIRED,
-        TransactionEventType.CHARGE_REQUEST,
-        TransactionEventType.AUTHORIZATION_REQUEST,
         TransactionEventType.CHARGE_FAILURE,
         TransactionEventType.AUTHORIZATION_FAILURE,
     ]:

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -69,7 +69,7 @@ logger = logging.getLogger(__name__)
 GENERIC_TRANSACTION_ERROR = "Transaction was unsuccessful"
 ALLOWED_GATEWAY_KINDS = {choices[0] for choices in TransactionKind.CHOICES}
 
-ALLOWED_MISSING_PSP_REFERENCE_MAP = {
+PSP_REFERENCE_OPTIONAL_MAP = {
     WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED: [
         TransactionEventType.REFUND_FAILURE
     ],
@@ -82,6 +82,7 @@ ALLOWED_MISSING_PSP_REFERENCE_MAP = {
     WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION: [
         TransactionEventType.CHARGE_REQUEST,
         TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.CHARGE_ACTION_REQUIRED,
         TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
         TransactionEventType.CHARGE_FAILURE,
         TransactionEventType.AUTHORIZATION_FAILURE,
@@ -1333,9 +1334,7 @@ def _check_missing_psp_reference_for_events(
 ):
     if response.psp_reference:
         return True
-    return request_event.type in ALLOWED_MISSING_PSP_REFERENCE_MAP.get(
-        delivery.event_type, []
-    )
+    return request_event.type in PSP_REFERENCE_OPTIONAL_MAP.get(delivery.event_type, [])
 
 
 def create_transaction_event_from_request_and_webhook_response(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1353,7 +1353,9 @@ def create_transaction_event_from_request_and_webhook_response(
     if not _check_missing_psp_reference_for_events(
         delivery, request_event, transaction_request_response
     ):
-        return create_failed_transaction_event(request_event, cause=error_msg or "")
+        return create_failed_transaction_event(
+            request_event, cause="Missing `pspReference` field in the response."
+        )
 
     psp_reference = transaction_request_response.psp_reference
     request_event.psp_reference = psp_reference

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1218,6 +1218,10 @@ def create_transaction_event_for_transaction_session(
     if not response_event.psp_reference and response_event.type not in [
         TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
         TransactionEventType.CHARGE_ACTION_REQUIRED,
+        TransactionEventType.CHARGE_REQUEST,
+        TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.CHARGE_FAILURE,
+        TransactionEventType.AUTHORIZATION_FAILURE,
     ]:
         return create_failed_transaction_event(
             request_event,

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -77,7 +77,7 @@ def handle_transaction_request_task(self, delivery_id, request_event_id):
         response_data = None
     create_transaction_event_from_request_and_webhook_response(
         request_event,
-        delivery.webhook.app,
+        delivery,
         response_data,
     )
 

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -77,7 +77,7 @@ def handle_transaction_request_task(self, delivery_id, request_event_id):
         response_data = None
     create_transaction_event_from_request_and_webhook_response(
         request_event,
-        delivery,
+        delivery.webhook.app,
         response_data,
     )
 


### PR DESCRIPTION
I want to merge this change because it makes pspReference optional in webhook response assuming the events are in the following cases

- TRANSACTION_REFUND_REQUESTED webhook, events:
  - REFUND_FAILURE
- TRANSACTION_CHARGE_REQUESTED webhook, events:
   - CHARGE_FAILURE
- TRANSACTION_CANCELATION_REQUESTED webhook, events:
   - CANCEL_FAILURE
- TRANSACTION_INITIALIZE_SESSION webhook, events:
   - ~~CHARGE_REQUEST~~
   - ~~AUTHORIZATION_REQUEST~~
   - CHARGE_ACTION_REQUIRED
   - AUTHORIZATION_ACTION_REQUIRED
   - CHARGE_FAILURE
   - AUTHORIZATION_FAILURE
- TRANSACTION_PROCESS_SESSION webhook, events:
  - ~~CHARGE_REQUEST~~
   - ~~AUTHORIZATION_REQUEST~~
   - CHARGE_ACTION_REQUIRED
   - AUTHORIZATION_ACTION_REQUIRED
   - CHARGE_FAILURE
   - AUTHORIZATION_FAILURE

Related internal issue: https://linear.app/saleor/issue/SHOPX-602/make-pspreference-optional-in-initialize-process-charge-refund-cancel


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1277

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
