### PR TITLE
Fix `OrderLinesCreate` when order has no shipping address.

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -1207,3 +1207,34 @@ def test_order_lines_create_with_custom_price_force_new_line_and_catalogue_disco
         == custom_price - reward_value
     )
     assert discounted_line_data["unitDiscount"]["amount"] == reward_value
+
+
+def test_order_lines_create_no_shipping_address(
+    order_with_lines,
+    permission_group_manage_orders,
+    staff_api_client,
+    variant_with_many_stocks,
+):
+    # given
+    query = ORDER_LINES_CREATE_MUTATION
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.shipping_address = None
+    order.save(update_fields=["status", "shipping_address"])
+
+    variant = variant_with_many_stocks
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    quantity = 1
+    variables = {"orderId": order_id, "variantId": variant_id, "quantity": quantity}
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderLinesCreate"]
+    assert not data["errors"]
+    assert data["orderLines"][0]["productSku"] == variant.sku
+    assert data["orderLines"][0]["quantity"] == quantity

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -18,6 +18,7 @@ from ..core.exceptions import (
     PreorderAllocationError,
 )
 from ..core.tracing import traced_atomic_transaction
+from ..core.utils.country import get_active_country
 from ..order.fetch import OrderLineInfo
 from ..order.models import OrderLine
 from ..plugins.manager import PluginsManager
@@ -433,9 +434,13 @@ def increase_allocations(
     Allocation.objects.filter(pk__in=allocation_pks_to_delete).delete()
     Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
 
+    order = lines_info[0].line.order  # type: ignore[index]
+    country_code = get_active_country(
+        channel, order.shipping_address, order.billing_address
+    )
     allocate_stocks(
         lines_info,
-        lines_info[0].line.order.shipping_address.country.code,  # type: ignore
+        country_code,
         channel,
         manager,
     )


### PR DESCRIPTION
Issue: https://linear.app/saleor/issue/MERX-427/attributeerror-nonetype-object-has-no-attribute-country

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
