### PR TITLE
Require manage_order when fetching order with externalReference

### DIFF
--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -4,8 +4,10 @@ import graphene
 from django.core.exceptions import ValidationError
 from graphql import GraphQLError
 
+from ...core.exceptions import PermissionDenied
 from ...order import models
 from ...permission.enums import OrderPermissions
+from ...permission.utils import has_one_of_permissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.descriptions import ADDED_IN_310, DEPRECATED_IN_3X_FIELD
@@ -21,6 +23,7 @@ from ..core.scalars import UUID
 from ..core.types import FilterInputObjectType, TaxedMoney
 from ..core.utils import ext_ref_to_global_id_or_error, from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
+from ..utils import get_user_or_app_from_context
 from .bulk_mutations.draft_orders import DraftOrderBulkDelete, DraftOrderLinesBulkDelete
 from .bulk_mutations.order_bulk_cancel import OrderBulkCancel
 from .bulk_mutations.order_bulk_create import OrderBulkCreate
@@ -105,7 +108,11 @@ class OrderQueries(graphene.ObjectType):
         description="Look up an order by ID or external reference.",
         id=graphene.Argument(graphene.ID, description="ID of an order."),
         external_reference=graphene.Argument(
-            graphene.String, description=f"External ID of an order. {ADDED_IN_310}"
+            graphene.String,
+            description=(
+                f"External ID of an order. {ADDED_IN_310}."
+                "\n\nRequires one of the following permissions: MANAGE_ORDERS."
+            ),
         ),
         doc_category=DOC_CATEGORY_ORDERS,
     )
@@ -165,6 +172,10 @@ class OrderQueries(graphene.ObjectType):
             "id", id, "external_reference", external_reference
         )
         if not id:
+            requester = get_user_or_app_from_context(info.context)
+            permissions = [OrderPermissions.MANAGE_ORDERS]
+            if not has_one_of_permissions(requester, permissions):
+                raise PermissionDenied(permissions=permissions)
             try:
                 id = ext_ref_to_global_id_or_error(models.Order, external_reference)
             except ValidationError:

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -1147,7 +1147,7 @@ QUERY_ORDER_BY_EXTERNAL_REFERENCE = """
 """
 
 
-def test_query_order_by_external_reference(user_api_client, order):
+def test_query_order_by_external_reference_missing_permission(user_api_client, order):
     # given
     query = QUERY_ORDER_BY_EXTERNAL_REFERENCE
     ext_ref = "test-ext-ref"
@@ -1157,6 +1157,29 @@ def test_query_order_by_external_reference(user_api_client, order):
 
     # when
     response = user_api_client.post_graphql(query, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_query_order_by_external_reference(
+    staff_api_client, order, permission_manage_orders
+):
+    # given
+    query = QUERY_ORDER_BY_EXTERNAL_REFERENCE
+    ext_ref = "test-ext-ref"
+    order.external_reference = ext_ref
+    order.save(update_fields=["external_reference"])
+    variables = {"externalReference": ext_ref}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_orders,
+        ],
+    )
     content = get_graphql_content(response)
 
     # then
@@ -1168,7 +1191,7 @@ def test_query_order_by_external_reference(user_api_client, order):
 
 @pytest.mark.parametrize("external_reference", ['" "', "not-existing"])
 def test_query_order_by_not_existing_external_reference(
-    external_reference, user_api_client, order
+    external_reference, staff_api_client, order, permission_manage_orders
 ):
     # given
     query = QUERY_ORDER_BY_EXTERNAL_REFERENCE
@@ -1177,7 +1200,13 @@ def test_query_order_by_not_existing_external_reference(
     variables = {"externalReference": external_reference}
 
     # when
-    response = user_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[
+            permission_manage_orders,
+        ],
+    )
     content = get_graphql_content(response)
 
     # then

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -790,7 +790,9 @@ type Query {
     """
     External ID of an order. 
     
-    Added in Saleor 3.10.
+    Added in Saleor 3.10..
+    
+    Requires one of the following permissions: MANAGE_ORDERS.
     """
     externalReference: String
   ): Order @doc(category: "Orders")


### PR DESCRIPTION
I want to merge this change because it adds missing MANAGE_ORDERS permission when fetching order with query:
```
{
  order(externalReference:"<value>"){
    id
  }
}
```
Port of changes from https://github.com/saleor/saleor/pull/16184
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
