### PR TITLE
Fix catalogue discount application on custom price in checkout and draft orders

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -19,7 +19,6 @@ from ..checkout.base_calculations import (
     base_checkout_delivery_price,
     base_checkout_subtotal,
 )
-from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
 from ..checkout.models import Checkout, CheckoutLine
 from ..core.exceptions import InsufficientStock
 from ..core.taxes import zero_money

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -969,16 +969,41 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         )
 
     @staticmethod
-    def resolve_unit_discount_type(root: models.OrderLine, _info):
-        return root.unit_discount_type
+    def resolve_unit_discount_type(root: models.OrderLine, info):
+        def _resolve_unit_discount_type(data):
+            order, lines, manager = data
+            return calculations.order_line_unit_discount_type(
+                order, root, manager, lines
+            )
+
+        order = OrderByIdLoader(info.context).load(root.order_id)
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_discount_type)
 
     @staticmethod
-    def resolve_unit_discount_value(root: models.OrderLine, _info):
-        return root.unit_discount_value
+    def resolve_unit_discount_value(root: models.OrderLine, info):
+        def _resolve_unit_discount_value(data):
+            order, lines, manager = data
+            return calculations.order_line_unit_discount_value(
+                order, root, manager, lines
+            )
+
+        order = OrderByIdLoader(info.context).load(root.order_id)
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_discount_value)
 
     @staticmethod
-    def resolve_unit_discount(root: models.OrderLine, _info):
-        return root.unit_discount
+    def resolve_unit_discount(root: models.OrderLine, info):
+        def _resolve_unit_discount(data):
+            order, lines, manager = data
+            return calculations.order_line_unit_discount(order, root, manager, lines)
+
+        order = OrderByIdLoader(info.context).load(root.order_id)
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_discount)
 
     @staticmethod
     @traced_resolver

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -476,6 +476,60 @@ def order_line_tax_rate(
     return order_line.tax_rate
 
 
+def order_line_unit_discount(
+    order: Order,
+    order_line: OrderLine,
+    manager: PluginsManager,
+    lines: Optional[Iterable[OrderLine]] = None,
+    force_update: bool = False,
+) -> Decimal:
+    """Return the unit price of provided line, taxes included.
+
+    It takes into account all plugins.
+    If the prices are expired, call all order price calculation methods
+    and save them in the model directly.
+    """
+    _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order_line = _find_order_line(lines, order_line)
+    return order_line.unit_discount
+
+
+def order_line_unit_discount_value(
+    order: Order,
+    order_line: OrderLine,
+    manager: PluginsManager,
+    lines: Optional[Iterable[OrderLine]] = None,
+    force_update: bool = False,
+) -> Decimal:
+    """Return the unit price of provided line, taxes included.
+
+    It takes into account all plugins.
+    If the prices are expired, call all order price calculation methods
+    and save them in the model directly.
+    """
+    _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order_line = _find_order_line(lines, order_line)
+    return order_line.unit_discount_value
+
+
+def order_line_unit_discount_type(
+    order: Order,
+    order_line: OrderLine,
+    manager: PluginsManager,
+    lines: Optional[Iterable[OrderLine]] = None,
+    force_update: bool = False,
+) -> Optional[str]:
+    """Return the unit price of provided line, taxes included.
+
+    It takes into account all plugins.
+    If the prices are expired, call all order price calculation methods
+    and save them in the model directly.
+    """
+    _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order_line = _find_order_line(lines, order_line)
+    return order_line.unit_discount_type
+
+
 def order_shipping(
     order: Order,
     manager: PluginsManager,

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -483,7 +483,7 @@ def order_line_unit_discount(
     lines: Optional[Iterable[OrderLine]] = None,
     force_update: bool = False,
 ) -> Decimal:
-    """Return the unit price of provided line, taxes included.
+    """Return the line unit discount.
 
     It takes into account all plugins.
     If the prices are expired, call all order price calculation methods
@@ -501,7 +501,7 @@ def order_line_unit_discount_value(
     lines: Optional[Iterable[OrderLine]] = None,
     force_update: bool = False,
 ) -> Decimal:
-    """Return the unit price of provided line, taxes included.
+    """Return the line unit discount value.
 
     It takes into account all plugins.
     If the prices are expired, call all order price calculation methods
@@ -519,7 +519,7 @@ def order_line_unit_discount_type(
     lines: Optional[Iterable[OrderLine]] = None,
     force_update: bool = False,
 ) -> Optional[str]:
-    """Return the unit price of provided line, taxes included.
+    """Return the line unit discount type.
 
     It takes into account all plugins.
     If the prices are expired, call all order price calculation methods

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -378,6 +378,12 @@ def add_variant_to_order(
         old_quantity = line.quantity
         new_quantity = old_quantity + line_data.quantity
         line_info = OrderLineInfo(line=line, quantity=old_quantity)
+        update_fields: list[str] = []
+        if new_quantity and line_data.price_override is not None:
+            update_line_base_unit_prices_with_custom_price(
+                order, line_data, line, update_fields
+            )
+
         change_order_line_quantity(
             user,
             app,
@@ -387,7 +393,11 @@ def add_variant_to_order(
             channel,
             manager=manager,
             send_event=False,
+            update_fields=update_fields,
         )
+
+        if update_fields:
+            line.save(update_fields=update_fields)
 
         if allocate_stock:
             increase_allocations(
@@ -412,6 +422,38 @@ def add_variant_to_order(
             manager,
             allocate_stock,
         )
+
+
+def update_line_base_unit_prices_with_custom_price(
+    order, line_data, line, update_fields
+):
+    channel = order.channel
+    variant = line_data.variant
+    price_override = line_data.price_override
+    rules_info = line_data.rules_info
+    channel_listing = variant.channel_listings.get(channel=channel)
+
+    line.is_price_overridden = True
+    line.base_unit_price = variant.get_price(
+        channel_listing,
+        price_override=price_override,
+        promotion_rules=(
+            [rule_info.rule for rule_info in rules_info] if rules_info else None
+        ),
+    )
+    line.undiscounted_base_unit_price_amount = price_override
+    line.undiscounted_unit_price_gross_amount = price_override
+    line.undiscounted_unit_price_net_amount = price_override
+
+    update_fields.extend(
+        [
+            "is_price_overridden",
+            "undiscounted_base_unit_price_amount",
+            "base_unit_price_amount",
+            "undiscounted_unit_price_gross_amount",
+            "undiscounted_unit_price_net_amount",
+        ]
+    )
 
 
 def add_gift_cards_to_order(
@@ -511,6 +553,7 @@ def change_order_line_quantity(
     channel: "Channel",
     manager: "PluginsManager",
     send_event=True,
+    update_fields=None,
 ):
     """Change the quantity of ordered items in a order line."""
     line = line_info.line
@@ -538,15 +581,17 @@ def change_order_line_quantity(
         line.undiscounted_total_price_net_amount = (
             undiscounted_total_price_net_amount.quantize(Decimal("0.001"))
         )
-        line.save(
-            update_fields=[
-                "quantity",
-                "total_price_net_amount",
-                "total_price_gross_amount",
-                "undiscounted_total_price_gross_amount",
-                "undiscounted_total_price_net_amount",
-            ]
-        )
+        fields = [
+            "quantity",
+            "total_price_net_amount",
+            "total_price_gross_amount",
+            "undiscounted_total_price_gross_amount",
+            "undiscounted_total_price_net_amount",
+        ]
+        if update_fields:
+            update_fields.extend(fields)
+        else:
+            line.save(update_fields=fields)
     else:
         delete_order_line(line_info, manager)
 

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_fixed_promotion.py
@@ -1,0 +1,149 @@
+import pytest
+
+from ......product.tasks import recalculate_discounted_price_for_products_task
+from ....checkout.utils import checkout_lines_update
+from ....product.utils.preparing_product import prepare_product
+from ....promotions.utils import create_promotion, create_promotion_rule
+from ....shop.utils import prepare_default_shop
+from ....utils import assign_permissions
+from ...utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_custom_price_and_fixed_promotion_core_2138(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    shop_permissions,
+    permission_handle_checkouts,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    app_permissions = [permission_handle_checkouts]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
+    )
+
+    promotion_name = "Promotion Fixed"
+    discount_value = 5
+    discount_type = "FIXED"
+    promotion_rule_name = "rule for product"
+    promotion_type = "CATALOGUE"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": "FIXED",
+    }
+    promotion_rule = create_promotion_rule(
+        e2e_staff_api_client,
+        input,
+    )
+    product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
+    assert promotion_rule["channels"][0]["id"] == channel_id
+    assert product_predicate[0] == product_id
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    # Step 1 - checkoutCreate for product on promotion
+    lines = [
+        {"variantId": product_variant_id, "quantity": 2},
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    checkout_line = checkout_data["lines"][0]
+    unit_price = float(product_variant_price) - discount_value
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_line["unitPrice"]["gross"]["amount"] == unit_price
+    assert checkout_line["undiscountedUnitPrice"]["amount"] == float(
+        product_variant_price
+    )
+
+    # Step 2 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+
+    # Step 3 - Set the custom price for the checkout line
+    custom_price = 10
+    line_qty = 1
+    lines = [
+        {"lineId": checkout_line["id"], "quantity": line_qty, "price": custom_price}
+    ]
+    lines_data = checkout_lines_update(e2e_app_api_client, checkout_id, lines)
+    assert len(lines_data["checkout"]["lines"]) == 1
+    line_data = lines_data["checkout"]["lines"][0]
+    assert line_data["undiscountedUnitPrice"]["amount"] == custom_price
+    assert line_data["unitPrice"]["gross"]["amount"] == custom_price - discount_value
+    subtotal_gross_amount = lines_data["checkout"]["subtotalPrice"]["gross"]["amount"]
+    assert subtotal_gross_amount == (custom_price - discount_value) * line_qty
+    total_gross_amount = lines_data["checkout"]["totalPrice"]["gross"]["amount"]
+
+    # Step 4 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client, checkout_id, total_gross_amount
+    )
+
+    # Step 5 - Complete checkout.
+    order_data = checkout_complete(e2e_not_logged_api_client, checkout_id)
+
+    order_line = order_data["lines"][0]
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_data["subtotal"]["gross"]["amount"] == subtotal_gross_amount
+    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(custom_price)
+    assert order_line["unitDiscountType"] == discount_type
+    assert order_line["unitPrice"]["gross"]["amount"] == custom_price - discount_value
+    assert order_line["unitDiscount"]["amount"] == float(discount_value)
+    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_percentage_promotion.py
@@ -1,0 +1,147 @@
+import pytest
+
+from ......product.tasks import recalculate_discounted_price_for_products_task
+from ....checkout.utils import checkout_lines_update
+from ....product.utils.preparing_product import prepare_product
+from ....promotions.utils import create_promotion, create_promotion_rule
+from ....shop.utils import prepare_default_shop
+from ....utils import assign_permissions
+from ...utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_custom_price_and_percentage_promotion_core_2139(
+    e2e_logged_api_client,
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    shop_permissions,
+    permission_handle_checkouts,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    app_permissions = [permission_handle_checkouts]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=19.89
+    )
+
+    promotion_name = "Promotion PERCENTAGE"
+    discount_value = 10
+    discount_type = "PERCENTAGE"
+    promotion_rule_name = "rule for product"
+    promotion_type = "CATALOGUE"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
+
+    promotion_rule = create_promotion_rule(e2e_staff_api_client, input)
+    product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
+    assert promotion_rule["channels"][0]["id"] == channel_id
+    assert product_predicate[0] == product_id
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    # Step 1 - checkoutCreate for product on promotion
+    lines = [
+        {"variantId": product_variant_id, "quantity": 2},
+    ]
+    checkout_data = checkout_create(
+        e2e_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    checkout_line = checkout_data["lines"][0]
+    line_discount = round(float(product_variant_price) * discount_value / 100, 2)
+    unit_price = round(float(product_variant_price) - line_discount, 2)
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_line["unitPrice"]["gross"]["amount"] == unit_price
+    assert checkout_line["undiscountedUnitPrice"]["amount"] == float(
+        product_variant_price
+    )
+
+    # Step 2 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+
+    # Step 3 - Set the custom price for the checkout line
+    custom_price = 10
+    line_qty = 2
+    lines = [
+        {"lineId": checkout_line["id"], "quantity": line_qty, "price": custom_price}
+    ]
+    lines_data = checkout_lines_update(e2e_app_api_client, checkout_id, lines)
+    discount_amount = custom_price * discount_value / 100
+    assert len(lines_data["checkout"]["lines"]) == 1
+    line_data = lines_data["checkout"]["lines"][0]
+    assert line_data["undiscountedUnitPrice"]["amount"] == custom_price
+    assert line_data["unitPrice"]["gross"]["amount"] == custom_price - discount_amount
+    subtotal_gross_amount = lines_data["checkout"]["subtotalPrice"]["gross"]["amount"]
+    assert subtotal_gross_amount == (custom_price - discount_amount) * line_qty
+    total_gross_amount = lines_data["checkout"]["totalPrice"]["gross"]["amount"]
+
+    # Step 4 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_logged_api_client, checkout_id, total_gross_amount
+    )
+
+    # Step 5 - Complete checkout.
+    order_data = checkout_complete(e2e_logged_api_client, checkout_id)
+
+    order_line = order_data["lines"][0]
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(custom_price)
+    assert order_line["unitDiscountType"] == "FIXED"
+    assert order_line["unitPrice"]["gross"]["amount"] == custom_price - discount_amount
+    assert order_line["unitDiscount"]["amount"] == discount_amount
+    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3512,6 +3512,40 @@ def variant_with_many_stocks(variant, warehouses_with_shipping_zone):
 
 
 @pytest.fixture
+def variant_on_promotion(product, channel_USD, promotion_rule) -> ProductVariant:
+    product_variant = ProductVariant.objects.create(
+        product=product, sku="SKU_A", external_reference="SKU_A"
+    )
+    price_amount = Decimal(10)
+    ProductVariantChannelListing.objects.create(
+        variant=product_variant,
+        channel=channel_USD,
+        price_amount=price_amount,
+        discounted_price_amount=price_amount,
+        cost_price_amount=Decimal(1),
+        currency=channel_USD.currency_code,
+    )
+    promotion_rule.variants.add(product_variant)
+    reward_value = promotion_rule.reward_value
+    discount_amount = price_amount * reward_value / 100
+
+    variant_channel_listing = product_variant.channel_listings.get(channel=channel_USD)
+
+    variant_channel_listing.discounted_price_amount = (
+        variant_channel_listing.price_amount - reward_value
+    )
+    variant_channel_listing.save(update_fields=["discounted_price_amount"])
+
+    variant_channel_listing.variantlistingpromotionrule.create(
+        promotion_rule=promotion_rule,
+        discount_amount=discount_amount,
+        currency=channel_USD.currency_code,
+    )
+
+    return product_variant
+
+
+@pytest.fixture
 def preorder_variant_global_threshold(product, channel_USD):
     product_variant = ProductVariant.objects.create(
         product=product, sku="SKU_A_P", is_preorder=True, preorder_global_threshold=10

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3512,7 +3512,9 @@ def variant_with_many_stocks(variant, warehouses_with_shipping_zone):
 
 
 @pytest.fixture
-def variant_on_promotion(product, channel_USD, promotion_rule) -> ProductVariant:
+def variant_on_promotion(
+    product, channel_USD, promotion_rule, warehouse
+) -> ProductVariant:
     product_variant = ProductVariant.objects.create(
         product=product, sku="SKU_A", external_reference="SKU_A"
     )
@@ -3525,6 +3527,10 @@ def variant_on_promotion(product, channel_USD, promotion_rule) -> ProductVariant
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
+    Stock.objects.create(
+        warehouse=warehouse, product_variant=product_variant, quantity=10
+    )
+
     promotion_rule.variants.add(product_variant)
     reward_value = promotion_rule.reward_value
     discount_amount = price_amount * reward_value / 100


### PR DESCRIPTION
- Fix applying catalogue discounts on checkout instances. The `priceOverride` is treated as overridden base price, so it should be the base price on which the catalogue discounts are applied
- Fix applying catalogue discount on draft order instances.

Internal issue: https://linear.app/saleor/issue/SHOPX-909/bug-discount-applied-twice-[cookies]

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: Internal issue to extend the docs: https://linear.app/saleor/issue/SHOPX-918/document-how-saleor-approaches-prices-calculation

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
