### PR TITLE
Add Poetry venv to PATH

### DIFF
--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install and configure poetry
         run: |
-          python -m pip install poetry==1.7.0
+          pip install poetry==1.7.0
 
       - name: Restore venv from cache
         id: cached-poetry-dependencies-restore
@@ -54,7 +54,15 @@ jobs:
       - name: Install dependencies
         if: steps.cached-poetry-dependencies-restore.outputs.cache-hit != 'true'
         run: |
-          python -m poetry install --sync --no-root
+          poetry env use python3.9
+          poetry install --sync --no-root
+
+      - name: Add Python Virtual Environment to PATH
+        run: |
+          # Note: requires `poetry env use` to be ran, otherwise poetry
+          # may not be able to find which virtual environment is in use.
+          # Ticket: https://github.com/python-poetry/poetry/issues/7190
+          echo "$(poetry env info -p)"/bin >> $GITHUB_PATH
 
       - name: Cache venv
         uses: actions/cache/save@v4
@@ -66,7 +74,7 @@ jobs:
       - name: Migrate
         run: |
           export DJANGO_SETTINGS_MODULE=saleor.tests.settings
-          python -m poetry run python manage.py migrate
+          python manage.py migrate
 
       - name: Checkout base
         uses: actions/checkout@v4
@@ -76,9 +84,9 @@ jobs:
       # Sync dependencies to ensure consistency with base branch
       - name: Synchronize dependencies
         run: |
-          python -m poetry install --sync --no-root
+          poetry install --sync --no-root
 
       - name: Run tests
         run: |
           export PYTEST_DB_URL=$DATABASE_URL
-          python -m poetry run pytest -n 0 --reuse-db
+          pytest -n 0 --reuse-db


### PR DESCRIPTION
Add Poetry venv to PATH for the test-migrations-compatibility workflow, similarly as it was done for the pytest workflow here: https://github.com/saleor/saleor/pull/14554.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
