### PR TITLE
Fix `OrderLinesCreate` when order has no shipping address 3.14

### DIFF
--- a/saleor/core/utils/country.py
+++ b/saleor/core/utils/country.py
@@ -1,0 +1,36 @@
+from typing import TYPE_CHECKING, Optional
+
+from ...account.models import Address
+from ...channel.models import Channel
+
+if TYPE_CHECKING:
+    from ...graphql.account.types import AddressInput
+
+
+def get_active_country(
+    channel: "Channel",
+    shipping_address: Optional["Address"] = None,
+    billing_address: Optional["Address"] = None,
+    address_data: Optional["AddressInput"] = None,
+):
+    """Get country code for orders, checkouts and tax calculations.
+
+    For checkouts and orders, there are following rules for determining the country
+    code that should be used for tax calculations:
+    - use country code from shipping address if it's provided in the first place
+    - use country code from billing address if shipping address is not provided
+    - if both shipping and billing addresses are not provided use the default country
+    from channel
+
+    To get country code from address data from mutation input use address_data parameter
+    """
+    if address_data is not None:
+        return address_data.country
+
+    if shipping_address:
+        return shipping_address.country.code
+
+    if billing_address:
+        return billing_address.country.code
+
+    return channel.default_country.code

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -806,3 +806,34 @@ def test_order_lines_create_with_custom_price(
     assert data["orderLines"][0]["productVariantId"] == variant.get_global_id()
     assert data["orderLines"][0]["quantity"] == quantity
     assert data["orderLines"][0]["isPriceOverridden"] is True
+
+
+def test_order_lines_create_no_shipping_address(
+    order_with_lines,
+    permission_group_manage_orders,
+    staff_api_client,
+    variant_with_many_stocks,
+):
+    # given
+    query = ORDER_LINES_CREATE_MUTATION
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.shipping_address = None
+    order.save(update_fields=["status", "shipping_address"])
+
+    variant = variant_with_many_stocks
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    quantity = 1
+    variables = {"orderId": order_id, "variantId": variant_id, "quantity": quantity}
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderLinesCreate"]
+    assert not data["errors"]
+    assert data["orderLines"][0]["productSku"] == variant.sku
+    assert data["orderLines"][0]["quantity"] == quantity

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -17,6 +17,7 @@ from ..core.exceptions import (
     PreorderAllocationError,
 )
 from ..core.tracing import traced_atomic_transaction
+from ..core.utils.country import get_active_country
 from ..order.fetch import OrderLineInfo
 from ..order.models import OrderLine
 from ..plugins.manager import PluginsManager
@@ -432,9 +433,13 @@ def increase_allocations(
     Allocation.objects.filter(pk__in=allocation_pks_to_delete).delete()
     Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
 
+    order = lines_info[0].line.order  # type: ignore[index]
+    country_code = get_active_country(
+        channel, order.shipping_address, order.billing_address
+    )
     allocate_stocks(
         lines_info,
-        lines_info[0].line.order.shipping_address.country.code,  # type: ignore
+        country_code,
         channel,
         manager,
     )


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/16182
It also ports part of: https://github.com/saleor/saleor/pull/13159

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
