### PR TITLE
Fix applying `SPECIFIC_PRODUCT` and `apply_once_per_order` voucher on draft orders

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -13,7 +13,8 @@ from uuid import UUID
 
 from django.conf import settings
 
-from ..discount import DiscountType, VoucherType
+from ..core.pricing.interface import LineInfo
+from ..discount import VoucherType
 from ..discount.interface import fetch_variant_rules_info, fetch_voucher_info
 from ..shipping.interface import ShippingMethodData
 from ..shipping.models import ShippingMethod, ShippingMethodChannelListing
@@ -27,7 +28,7 @@ from ..warehouse.models import Warehouse
 if TYPE_CHECKING:
     from ..account.models import Address, User
     from ..channel.models import Channel
-    from ..discount.interface import VariantPromotionRuleInfo, VoucherInfo
+    from ..checkout.models import CheckoutLine
     from ..discount.models import (
         CheckoutDiscount,
         CheckoutLineDiscount,
@@ -36,7 +37,6 @@ if TYPE_CHECKING:
     )
     from ..plugins.manager import PluginsManager
     from ..product.models import (
-        Collection,
         Product,
         ProductChannelListing,
         ProductType,
@@ -44,36 +44,17 @@ if TYPE_CHECKING:
         ProductVariantChannelListing,
     )
     from ..tax.models import TaxClass, TaxConfiguration
-    from .models import Checkout, CheckoutLine
+    from .models import Checkout
 
 
 @dataclass
-class CheckoutLineInfo:
+class CheckoutLineInfo(LineInfo):
     line: "CheckoutLine"
     variant: "ProductVariant"
-    channel_listing: "ProductVariantChannelListing"
     product: "Product"
     product_type: "ProductType"
-    collections: list["Collection"]
     discounts: list["CheckoutLineDiscount"]
-    rules_info: list["VariantPromotionRuleInfo"]
-    channel: "Channel"
     tax_class: Optional["TaxClass"] = None
-    voucher: Optional["Voucher"] = None
-
-    def get_promotion_discounts(self) -> list["CheckoutLineDiscount"]:
-        return [
-            discount
-            for discount in self.discounts
-            if discount.type in [DiscountType.PROMOTION, DiscountType.ORDER_PROMOTION]
-        ]
-
-    def get_catalogue_discounts(self) -> list["CheckoutLineDiscount"]:
-        return [
-            discount
-            for discount in self.discounts
-            if discount.type == DiscountType.PROMOTION
-        ]
 
 
 @dataclass
@@ -314,6 +295,7 @@ def fetch_checkout_lines(
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ) -> tuple[Iterable[CheckoutLineInfo], Iterable[int]]:
     """Fetch checkout lines as CheckoutLineInfo objects."""
+    from ..discount.utils import apply_voucher_to_line
     from .utils import get_voucher_for_checkout
 
     select_related_fields = ["variant__product__product_type__tax_class"]
@@ -376,6 +358,8 @@ def fetch_checkout_lines(
                         discounts=discounts,
                         rules_info=rules_info,
                         channel=channel,
+                        voucher=None,
+                        voucher_code=None,
                     )
                 )
             continue
@@ -392,6 +376,8 @@ def fetch_checkout_lines(
                 discounts=discounts,
                 rules_info=rules_info,
                 channel=channel,
+                voucher=None,
+                voucher_code=None,
             )
         )
 
@@ -408,8 +394,8 @@ def fetch_checkout_lines(
             # discount from voucher
             return lines_info, unavailable_variant_pks
         if voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order:
-            voucher_info = fetch_voucher_info(voucher)
-            apply_voucher_to_checkout_line(voucher_info, lines_info)
+            voucher_info = fetch_voucher_info(voucher, checkout.voucher_code)
+            apply_voucher_to_line(voucher_info, lines_info)
     return lines_info, unavailable_variant_pks
 
 
@@ -454,44 +440,6 @@ def _get_product_channel_listing(
                 product_channel_listing = channel_listing
         product_channel_listing_mapping[product.id] = product_channel_listing
     return product_channel_listing
-
-
-def apply_voucher_to_checkout_line(
-    voucher_info: "VoucherInfo",
-    lines_info: Iterable[CheckoutLineInfo],
-):
-    """Attach voucher to valid checkout lines info.
-
-    Apply a voucher to checkout line info when the voucher has the type
-    SPECIFIC_PRODUCTS or is applied only to the cheapest item.
-    """
-    from .utils import get_discounted_lines
-
-    voucher = voucher_info.voucher
-    discounted_lines_by_voucher: list[CheckoutLineInfo] = []
-    lines_included_in_discount = lines_info
-    if voucher.type == VoucherType.SPECIFIC_PRODUCT:
-        discounted_lines_by_voucher.extend(
-            get_discounted_lines(lines_info, voucher_info)
-        )
-        lines_included_in_discount = discounted_lines_by_voucher
-    if voucher.apply_once_per_order:
-        cheapest_line = _get_the_cheapest_line(lines_included_in_discount)
-        if cheapest_line:
-            discounted_lines_by_voucher = [cheapest_line]
-    for line_info in lines_info:
-        if line_info in discounted_lines_by_voucher:
-            line_info.voucher = voucher
-
-
-def _get_the_cheapest_line(
-    lines_info: Optional[Iterable[CheckoutLineInfo]],
-) -> Optional[CheckoutLineInfo]:
-    if not lines_info:
-        return None
-    return min(
-        lines_info, key=lambda line_info: line_info.channel_listing.discounted_price
-    )
 
 
 def fetch_checkout_info(

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -445,6 +445,8 @@ def test_get_discount_for_checkout_value_entire_order_voucher(
             rules_info=[],
             product_type=line.variant.product.product_type,
             channel=channel_USD,
+            voucher=None,
+            voucher_code=None,
         )
         for line in checkout_with_items.lines.all()
     ]
@@ -609,6 +611,8 @@ def test_get_discount_for_checkout_value_specific_product_voucher(
             product=line.variant.product,
             variant=line.variant,
             product_type=line.variant.product.product_type,
+            voucher=None,
+            voucher_code=None,
         )
         for line in checkout_with_items.lines.all()
     ]

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -1,0 +1,59 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Union
+
+from ...discount import DiscountType
+
+if TYPE_CHECKING:
+    from ...channel.models import Channel
+    from ...checkout.models import CheckoutLine
+    from ...discount.interface import VariantPromotionRuleInfo
+    from ...discount.models import CheckoutLineDiscount, OrderLineDiscount, Voucher
+    from ...order.models import OrderLine
+    from ...product.models import (
+        Collection,
+        Product,
+        ProductVariant,
+        ProductVariantChannelListing,
+    )
+
+
+@dataclass
+class LineInfo:
+    line: Union["OrderLine", "CheckoutLine"]
+    variant: Optional["ProductVariant"]
+    product: Optional["Product"]
+    collections: list["Collection"]
+    channel_listing: "ProductVariantChannelListing"
+    channel: "Channel"
+    discounts: Iterable[Union["OrderLineDiscount", "CheckoutLineDiscount"]]
+    rules_info: list["VariantPromotionRuleInfo"]
+    voucher: Optional["Voucher"]
+    voucher_code: Optional[str]
+
+    def get_promotion_discounts(
+        self,
+    ):
+        return [
+            discount
+            for discount in self.discounts
+            if discount.type in [DiscountType.PROMOTION, DiscountType.ORDER_PROMOTION]
+        ]
+
+    def get_catalogue_discounts(
+        self,
+    ):
+        return [
+            discount
+            for discount in self.discounts
+            if discount.type == DiscountType.PROMOTION
+        ]
+
+    def get_voucher_discounts(
+        self,
+    ):
+        return [
+            discount
+            for discount in self.discounts
+            if discount.type == DiscountType.VOUCHER
+        ]

--- a/saleor/discount/interface.py
+++ b/saleor/discount/interface.py
@@ -21,13 +21,16 @@ class VoucherInfo:
     """It contains the voucher's details and PKs of all applicable objects."""
 
     voucher: Voucher
+    voucher_code: Optional[str]
     product_pks: list[int]
     variant_pks: list[int]
     collection_pks: list[int]
     category_pks: list[int]
 
 
-def fetch_voucher_info(voucher: Voucher) -> VoucherInfo:
+def fetch_voucher_info(
+    voucher: Voucher, voucher_code: Optional[str] = None
+) -> VoucherInfo:
     variant_pks = list(variant.id for variant in voucher.variants.all())
     product_pks = list(product.id for product in voucher.products.all())
     category_pks = list(category.id for category in voucher.categories.all())
@@ -35,6 +38,7 @@ def fetch_voucher_info(voucher: Voucher) -> VoucherInfo:
 
     return VoucherInfo(
         voucher=voucher,
+        voucher_code=voucher_code,
         product_pks=product_pks,
         variant_pks=variant_pks,
         collection_pks=collection_pks,

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -6,6 +6,7 @@ import pytest
 from django.utils import timezone
 from prices import Money, TaxedMoney
 
+from ...checkout.fetch import CheckoutLineInfo
 from ...discount.interface import VariantPromotionRuleInfo
 from .. import DiscountValueType, RewardValueType, VoucherType
 from ..models import (
@@ -16,6 +17,7 @@ from ..models import (
     VoucherCustomer,
 )
 from ..utils import (
+    _get_the_cheapest_line,
     activate_voucher_code,
     add_voucher_usage_by_customer,
     deactivate_voucher_code,
@@ -637,3 +639,34 @@ def test_is_order_level_voucher_another_type(voucher_type, voucher):
 
     # then
     assert result is False
+
+
+def test_get_the_cheapest_line_no_lines_provided():
+    # when
+    line_info = _get_the_cheapest_line(None)
+    # then
+    assert line_info is None
+
+
+def test_get_the_cheapest_line(checkout_with_items, channel_USD):
+    # given
+    lines = [
+        CheckoutLineInfo(
+            line=line,
+            channel_listing=line.variant.channel_listings.first(),
+            collections=[],
+            product=line.variant.product,
+            variant=line.variant,
+            discounts=list(line.discounts.all()),
+            rules_info=[],
+            product_type=line.variant.product.product_type,
+            channel=channel_USD,
+            voucher=None,
+            voucher_code=None,
+        )
+        for line in checkout_with_items.lines.all()
+    ]
+    # when
+    line_info = _get_the_cheapest_line(lines)
+    # then
+    assert line_info == lines[0]

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -7,7 +7,6 @@ from promise import Promise
 from ...checkout.fetch import (
     CheckoutInfo,
     CheckoutLineInfo,
-    apply_voucher_to_checkout_line,
 )
 from ...checkout.models import Checkout, CheckoutLine, CheckoutMetadata
 from ...checkout.problems import (
@@ -23,6 +22,7 @@ from ...checkout.problems import (
 from ...core.db.connection import allow_writer_in_context
 from ...discount import VoucherType
 from ...discount.interface import VariantPromotionRuleInfo
+from ...discount.utils import apply_voucher_to_line
 from ...payment.models import TransactionItem
 from ...product.models import ProductChannelListing
 from ...warehouse.models import Stock
@@ -143,6 +143,8 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineIn
                                 tax_class=tax_class_map[line.variant_id],
                                 channel=channels[checkout.channel_id],
                                 rules_info=rules_info_map[line.id],
+                                voucher=None,
+                                voucher_code=None,
                             )
                             for line in lines
                         ]
@@ -159,7 +161,7 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineIn
                         voucher.type == VoucherType.SPECIFIC_PRODUCT
                         or voucher.apply_once_per_order
                     ):
-                        apply_voucher_to_checkout_line(
+                        apply_voucher_to_line(
                             voucher_info=voucher_info,
                             lines_info=lines_info_map[checkout.pk],
                         )

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -1,8 +1,6 @@
 import graphene
 
 from .....checkout.fetch import (
-    CheckoutLineInfo,
-    _get_the_cheapest_line,
     fetch_checkout_lines,
 )
 from ...mutations.utils import (
@@ -183,32 +181,3 @@ def test_group_on_update_when_one_line_and_mixed_parameters_provided(
     assert expected == group_lines_input_data_on_update(
         lines_data, existing_checkout_lines
     )
-
-
-def test_get_the_cheapest_line_no_lines_provided():
-    # when
-    line_info = _get_the_cheapest_line(None)
-    # then
-    assert line_info is None
-
-
-def test_get_the_cheapest_line(checkout_with_items, channel_USD):
-    # given
-    lines = [
-        CheckoutLineInfo(
-            line=line,
-            channel_listing=line.variant.channel_listings.first(),
-            collections=[],
-            product=line.variant.product,
-            variant=line.variant,
-            discounts=list(line.discounts.all()),
-            rules_info=[],
-            product_type=line.variant.product.product_type,
-            channel=channel_USD,
-        )
-        for line in checkout_with_items.lines.all()
-    ]
-    # when
-    line_info = _get_the_cheapest_line(lines)
-    # then
-    assert line_info == lines[0]

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -7,7 +7,7 @@ from promise import Promise
 from ....checkout import base_calculations
 from ....checkout.models import Checkout, CheckoutLine
 from ....core.prices import quantize_price
-from ....discount import DiscountType, VoucherType
+from ....discount import DiscountType
 from ....discount.utils import is_order_level_voucher
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
@@ -429,13 +429,7 @@ class TaxableObject(BaseObjectType):
                 for discount in discounts
                 if (
                     discount.type == DiscountType.MANUAL
-                    # TODO (SHOPX-873): apply_once_per_order voucher are included
-                    # for now, as the discount for such vouchers is currently not
-                    # propagated to the draft order lines
-                    or (
-                        discount.voucher
-                        and discount.voucher.type == VoucherType.ENTIRE_ORDER
-                    )
+                    or is_order_level_voucher(discount.voucher)
                 )
             ]
 

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -210,6 +210,7 @@ class VoucherInfoByVoucherCodeLoader(DataLoader[str, Optional[VoucherInfo]]):
             voucher_infos.append(
                 VoucherInfo(
                     voucher=voucher_code.voucher,
+                    voucher_code=voucher_code.code,
                     product_pks=product_pks_map.get(voucher_code.voucher_id, []),
                     variant_pks=variant_pks_map.get(voucher_code.voucher_id, []),
                     category_pks=category_pks_map.get(voucher_code.voucher_id, []),

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -343,6 +343,7 @@ class DraftOrderCreate(
             voucher = code_instance.voucher
             cls.clean_voucher_listing(voucher, channel, "voucher_code")
         cleaned_input["voucher"] = voucher
+        cleaned_input["voucher_code"] = voucher_code
         cleaned_input["voucher_code_instance"] = code_instance
 
     @classmethod

--- a/saleor/graphql/order/tests/mutations/test_order_discount.py
+++ b/saleor/graphql/order/tests/mutations/test_order_discount.py
@@ -1045,10 +1045,10 @@ def test_update_order_line_discount(
         - (second_line.base_unit_price - second_line.unit_price.gross)
         * second_line.quantity
     )
-    assert (
-        discount_applied_to_discounted_line
-        == (line_to_discount.base_unit_price - line_to_discount.unit_price.gross)
-        * line_to_discount.quantity
+    assert discount_applied_to_discounted_line == quantize_price(
+        (line_to_discount.base_unit_price - line_to_discount.unit_price.gross)
+        * line_to_discount.quantity,
+        order.currency,
     )
 
     errors = data["errors"]

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1593,7 +1593,9 @@ class Order(ModelObjectType[models.Order]):
                 return None
             for discount in discounts:
                 if discount.type == DiscountType.VOUCHER:
-                    return Money(amount=discount.value, currency=discount.currency)
+                    return Money(
+                        amount=discount.amount_value, currency=discount.currency
+                    )
             return None
 
         return (

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -12,7 +12,7 @@ from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
 from ..core.taxes import TaxData, TaxEmptyData, TaxError, zero_taxed_money
 from ..discount import DiscountType
-from ..discount.utils import create_or_update_discount_objects_from_promotion_for_order
+from ..discount.utils import create_or_update_discount_objects_for_order
 from ..payment.model_helpers import get_subtotal
 from ..plugins import PLUGIN_IDENTIFIER_PREFIX
 from ..plugins.manager import PluginsManager
@@ -57,7 +57,7 @@ def fetch_order_prices_if_expired(
 
     # handle promotions
     lines_info: list[DraftOrderLineInfo] = fetch_draft_order_lines_info(order, lines)
-    create_or_update_discount_objects_from_promotion_for_order(
+    create_or_update_discount_objects_for_order(
         order, lines_info, database_connection_name
     )
     lines = [line_info.line for line_info in lines_info]

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -1,15 +1,20 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Optional, cast
+from typing import Optional
 from uuid import UUID
 
 from django.db.models import prefetch_related_objects
 
 from ..channel.models import Channel
 from ..core.db.connection import allow_writer
-from ..discount import DiscountType
-from ..discount.interface import VariantPromotionRuleInfo, fetch_variant_rules_info
-from ..discount.models import OrderLineDiscount, Voucher
+from ..core.pricing.interface import LineInfo
+from ..discount import DiscountType, VoucherType
+from ..discount.interface import (
+    fetch_variant_rules_info,
+    fetch_voucher_info,
+)
+from ..discount.models import OrderLineDiscount
+from ..discount.utils import apply_voucher_to_line
 from ..payment.models import Payment
 from ..product.models import (
     DigitalContent,
@@ -74,28 +79,17 @@ def fetch_order_lines(order: "Order") -> list[OrderLineInfo]:
 
 
 @dataclass
-class DraftOrderLineInfo:
+class DraftOrderLineInfo(LineInfo):
     line: "OrderLine"
-    variant: "ProductVariant"
-    channel_listing: "ProductVariantChannelListing"
     discounts: list["OrderLineDiscount"]
-    rules_info: list["VariantPromotionRuleInfo"]
-    channel: "Channel"
-    voucher: Optional["Voucher"] = None
 
-    def get_promotion_discounts(self) -> list["OrderLineDiscount"]:
-        return [
-            discount
-            for discount in self.discounts
-            if discount.type in [DiscountType.PROMOTION, DiscountType.ORDER_PROMOTION]
-        ]
-
-    def get_catalogue_discounts(self) -> list["OrderLineDiscount"]:
-        return [
-            discount
-            for discount in self.discounts
-            if discount.type == DiscountType.PROMOTION
-        ]
+    def get_manual_line_discount(
+        self,
+    ) -> Optional["OrderLineDiscount"]:
+        for discount in self.discounts:
+            if discount.type == DiscountType.MANUAL:
+                return discount
+        return None
 
 
 def fetch_draft_order_lines_info(
@@ -106,6 +100,7 @@ def fetch_draft_order_lines_info(
         "discounts__promotion_rule__promotion",
         "variant__channel_listings__variantlistingpromotionrule__promotion_rule__promotion__translations",
         "variant__channel_listings__variantlistingpromotionrule__promotion_rule__translations",
+        "variant__product__collections",
     ]
     if lines is None:
         with allow_writer():
@@ -121,7 +116,10 @@ def fetch_draft_order_lines_info(
         channel = order.channel
 
     for line in lines:
-        variant = cast(ProductVariant, line.variant)
+        variant = line.variant
+        if not variant:
+            continue
+        product = variant.product
         variant_channel_listing = get_prefetched_variant_listing(variant, channel.id)
         if not variant_channel_listing:
             continue
@@ -135,12 +133,22 @@ def fetch_draft_order_lines_info(
             DraftOrderLineInfo(
                 line=line,
                 variant=variant,
+                product=product,
+                collections=list(product.collections.all()) if product else [],
                 channel_listing=variant_channel_listing,
                 discounts=list(line.discounts.all()),
                 rules_info=rules_info,
                 channel=channel,
+                voucher=None,
+                voucher_code=None,
             )
         )
+    voucher = order.voucher
+    if voucher and (
+        voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order
+    ):
+        voucher_info = fetch_voucher_info(voucher, order.voucher_code)
+        apply_voucher_to_line(voucher_info, lines_info)
     return lines_info
 
 

--- a/saleor/order/tests/benchmark/test_fetch_order_prices.py
+++ b/saleor/order/tests/benchmark/test_fetch_order_prices.py
@@ -41,7 +41,7 @@ def test_fetch_order_prices_catalogue_discount(
     tc.save()
 
     # when
-    with django_assert_num_queries(38):
+    with django_assert_num_queries(43):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then
@@ -136,7 +136,7 @@ def test_fetch_order_prices_multiple_catalogue_discounts(
     tc.save()
 
     # when
-    with django_assert_num_queries(38):
+    with django_assert_num_queries(43):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then

--- a/saleor/order/tests/test_apply_order_discount.py
+++ b/saleor/order/tests/test_apply_order_discount.py
@@ -218,8 +218,7 @@ def test_apply_order_discounts_shipping_voucher(
     assert order.undiscounted_total_net == subtotal + shipping_price
     assert order.undiscounted_total_gross == subtotal + shipping_price
     order_discount.refresh_from_db()
-    # OrderDiscount has amount value only from not applied discounts
-    assert order_discount.amount_value == 0
+    assert order_discount.amount_value == shipping_price.amount
 
 
 def test_apply_order_discounts_zero_discount(order_with_lines):

--- a/saleor/order/tests/test_fetch.py
+++ b/saleor/order/tests/test_fetch.py
@@ -34,7 +34,7 @@ def test_fetch_draft_order_lines_info(
     )
 
     # when
-    with django_assert_num_queries(9):
+    with django_assert_num_queries(11):
         lines_info = fetch_draft_order_lines_info(order)
 
     # then

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -5,6 +5,7 @@ import graphene
 import pytest
 
 from ...core.prices import quantize_price
+from ...core.taxes import zero_money
 from ...discount import DiscountType, DiscountValueType
 from ...discount.models import (
     OrderDiscount,
@@ -1357,19 +1358,916 @@ def test_fetch_order_prices_manual_line_discount_and_catalogue_discount_flat_rat
 
     line_1 = [line for line in lines if line.quantity == 3][0]
 
-    assert line_1.base_unit_price_amount == variant_1_listing.price_amount
+    assert (
+        line_1.base_unit_price_amount
+        == variant_1_listing.price_amount - manual_discount_value
+    )
     assert manual_discount.line == line_1
     assert manual_discount.value == manual_discount_value
     assert manual_discount.value_type == manual_discount_value_type
     assert manual_discount.type == DiscountType.MANUAL
     assert manual_discount.reason == manual_discount_reason
 
-    # TODO https://github.com/saleor/saleor/issues/15517
-    # line_1_total_net_amount = quantize_price(
-    #     (variant_1_listing.price_amount - manual_discount_value) * line_1.quantity,
-    #     order.currency
-    # )
-    # assert line_1.total_price_net_amount == line_1_total_net_amount
+    line_1_total_net_amount = quantize_price(
+        (variant_1_listing.price_amount - manual_discount_value) * line_1.quantity,
+        order.currency,
+    )
+    assert line_1.total_price_net_amount == line_1_total_net_amount
+
+
+def test_fetch_order_prices_voucher_specific_product_fixed(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    unit_discount_amount = Decimal("5")
+    voucher_listing.discount_value = unit_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    discount_amount = unit_discount_amount * discounted_line.quantity
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.base_unit_price_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == discount_amount
+
+
+def test_fetch_order_prices_voucher_specific_product_discount_line_object_updated(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    unit_discount_amount = Decimal("5")
+    voucher_listing.discount_value = unit_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    line_discount = discounted_line.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=Decimal("0"),
+        name="Manual line discount",
+        type=DiscountType.VOUCHER,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    discount_amount = unit_discount_amount * discounted_line.quantity
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.base_unit_price_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 1
+    line_discount.refresh_from_db()
+    assert line_discount.amount_value == discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == discount_amount
+
+
+def test_fetch_order_prices_voucher_specific_product_percentage(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_value = Decimal("10")
+    voucher_listing.discount_value = discount_value
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    discount_amount = (
+        discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+        * discount_value
+        / 100
+    )
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    unit_discount_amount = discount_amount / discounted_line.quantity
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.base_unit_price_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == discount_amount
+    # TODO: should be from voucher probably
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == discount_amount
+
+
+def test_fetch_order_prices_voucher_apply_once_per_order_fixed(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = Decimal("5")
+    voucher_listing.discount_value = discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.apply_once_per_order = True
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type", "apply_once_per_order"])
+
+    lines = order.lines.all()
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    unit_discount_amount = discount_amount / discounted_line.quantity
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.base_unit_price_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == discount_amount
+
+
+def test_fetch_order_prices_voucher_apply_once_per_order_percentage(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_value = Decimal("10")
+    voucher_listing.discount_value = discount_value
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.apply_once_per_order = True
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type", "apply_once_per_order"])
+
+    lines = order.lines.all()
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    discount_amount = (
+        discounted_line.undiscounted_base_unit_price_amount * discount_value / 100
+    )
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    unit_discount_amount = discount_amount / discounted_line.quantity
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.base_unit_price_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == discount_amount
+
+
+def test_fetch_order_prices_manual_order_discount_voucher_specific_product(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    unit_discount_amount = Decimal("2")
+    voucher_listing.discount_value = unit_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order discount
+    order_discount_amount = Decimal("10")
+    order_discount = order.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=order_discount_amount,
+        name="Manual order discount",
+        type=DiscountType.MANUAL,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    voucher_discount_amount = unit_discount_amount * discounted_line.quantity
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - order_discount_amount
+    )
+    shipping_discount = shipping_price - order.shipping_price_gross
+    subtotal_order_discount = order_discount_amount - shipping_discount.amount
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - subtotal_order_discount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price - shipping_discount
+    assert order.base_shipping_price == shipping_price
+
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    order_discount.refresh_from_db()
+    assert order_discount.amount_value == order_discount_amount
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == voucher_discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == voucher_discount_amount
+
+
+def test_fetch_order_prices_manual_order_discount_and_voucher_apply_once_per_order(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = Decimal("3")
+    voucher_listing.discount_value = discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.apply_once_per_order = True
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type", "apply_once_per_order"])
+
+    lines = order.lines.all()
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order discount
+    order_discount_amount = Decimal("10")
+    order_discount = order.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=order_discount_amount,
+        name="Manual order discount",
+        type=DiscountType.MANUAL,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line, line_1 = lines
+    voucher_discount_amount = discount_amount
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - order_discount_amount
+    )
+    shipping_discount = shipping_price - order.shipping_price_gross
+    subtotal_order_discount = order_discount_amount - shipping_discount.amount
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - subtotal_order_discount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price - shipping_discount
+    assert order.base_shipping_price == shipping_price
+
+    unit_discount_amount = discount_amount / discounted_line.quantity
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount - unit_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert discounted_line.unit_discount_amount == unit_discount_amount
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    order_discount.refresh_from_db()
+    assert order_discount.amount_value == order_discount_amount
+
+    assert discounted_line.discounts.count() == 1
+    line_discount = discounted_line.discounts.first()
+    assert line_discount.amount_value == voucher_discount_amount
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.type == DiscountType.VOUCHER
+    assert line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert line_discount.value == voucher_discount_amount
+
+
+def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
+    order_with_lines, voucher_specific_product_type, plugins_manager
+):
+    # given
+    order = order_with_lines
+    voucher = voucher_specific_product_type
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    unit_discount_amount = Decimal("2")
+    voucher_listing.discount_value = unit_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    voucher.variants.add(discounted_line.variant)
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order line discount
+    manual_line_discount_amount = Decimal("3")
+    manual_line_discount = discounted_line.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=manual_line_discount_amount,
+        name="Manual line discount",
+        type=DiscountType.MANUAL,
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line.refresh_from_db()
+    line_1.refresh_from_db()
+    voucher_discount_amount = unit_discount_amount * discounted_line.quantity
+    manual_discount_amount = manual_line_discount_amount * discounted_line.quantity
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - manual_discount_amount
+    )
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - manual_discount_amount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.base_shipping_price == shipping_price
+
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        - unit_discount_amount
+        - manual_line_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert (
+        discounted_line.unit_discount_amount
+        == unit_discount_amount + manual_line_discount_amount
+    )
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 2
+    voucher_line_discount = discounted_line.discounts.get(type=DiscountType.VOUCHER)
+    assert voucher_line_discount.amount_value == voucher_discount_amount
+    assert voucher_line_discount.value_type == DiscountValueType.FIXED
+    assert voucher_line_discount.type == DiscountType.VOUCHER
+    assert voucher_line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert voucher_line_discount.value == voucher_discount_amount
+
+    manual_line_discount.refresh_from_db()
+    assert manual_line_discount.amount_value == manual_discount_amount
+    assert manual_line_discount.type == DiscountType.MANUAL
+
+
+def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_order(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = Decimal("3")
+    voucher_listing.discount_value = discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.apply_once_per_order = True
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type", "apply_once_per_order"])
+
+    lines = order.lines.all()
+    discounted_line, line_1 = lines
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+
+    # create manual order line discount
+    manual_line_discount_amount = Decimal("3")
+    manual_line_discount = discounted_line.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=manual_line_discount_amount,
+        name="Manual line discount",
+        type=DiscountType.MANUAL,
+        reason="Manual line discount",
+    )
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    discounted_line.refresh_from_db()
+    line_1.refresh_from_db()
+    voucher_discount_amount = discount_amount
+    manual_discount_amount = manual_line_discount_amount * discounted_line.quantity
+    assert (
+        order.total_gross_amount
+        == subtotal.amount
+        + shipping_price.amount
+        - voucher_discount_amount
+        - manual_discount_amount
+    )
+    shipping_discount = shipping_price - order.shipping_price_gross
+    subtotal_order_discount = manual_discount_amount - shipping_discount.amount
+    assert (
+        order.subtotal_gross_amount
+        == subtotal.amount - subtotal_order_discount - voucher_discount_amount
+    )
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+    assert order.shipping_price_gross == shipping_price - shipping_discount
+    assert order.base_shipping_price == shipping_price
+
+    unit_discount_amount = discount_amount / discounted_line.quantity
+    assert (
+        discounted_line.base_unit_price_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        - unit_discount_amount
+        - manual_line_discount_amount
+    )
+    assert (
+        discounted_line.total_price_gross_amount
+        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+    )
+    assert (
+        discounted_line.undiscounted_total_price_gross_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
+    )
+    assert (
+        discounted_line.unit_discount_amount
+        == manual_line_discount_amount + unit_discount_amount
+    )
+    assert discounted_line.unit_discount_type == DiscountValueType.FIXED
+    assert (
+        discounted_line.unit_discount_reason
+        == f"{manual_line_discount.reason}; Voucher code: {order.voucher_code}"
+    )
+
+    assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
+    assert (
+        line_1.total_price_gross_amount
+        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
+    )
+    assert line_1.unit_discount_amount == 0
+    assert line_1.unit_discount_type is None
+    assert line_1.unit_discount_reason is None
+
+    assert discounted_line.discounts.count() == 2
+    voucher_line_discount = discounted_line.discounts.get(type=DiscountType.VOUCHER)
+    assert voucher_line_discount.amount_value == voucher_discount_amount
+    assert voucher_line_discount.value_type == DiscountValueType.FIXED
+    assert voucher_line_discount.type == DiscountType.VOUCHER
+    assert voucher_line_discount.reason == f"Voucher code: {order.voucher_code}"
+    assert voucher_line_discount.value == voucher_discount_amount
+
+    manual_line_discount.refresh_from_db()
+    assert manual_line_discount.amount_value == manual_discount_amount
+    assert manual_line_discount.type == DiscountType.MANUAL
 
 
 def test_fetch_order_prices_catalogue_discount_race_condition(

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -857,6 +857,7 @@ def update_discount_for_order_line(
     if reason is not None:
         order_line.unit_discount_reason = reason
         fields_to_update.append("unit_discount_reason")
+
     if current_value != value or current_value_type != value_type:
         undiscounted_base_unit_price = order_line.undiscounted_base_unit_price
         currency = undiscounted_base_unit_price.currency
@@ -871,6 +872,7 @@ def update_discount_for_order_line(
 
         order_line.unit_discount_type = value_type
         order_line.unit_discount_value = value
+        # TODO: should we save those values?
         order_line.total_price = order_line.unit_price * order_line.quantity
         order_line.undiscounted_unit_price = (
             order_line.unit_price + order_line.unit_discount
@@ -915,7 +917,7 @@ def _update_manual_order_line_discount_object(
     for discount in discounts:
         if discount.type == DiscountType.MANUAL and not discount_to_update:
             discount_to_update = discount
-        else:
+        elif discount.type != DiscountType.VOUCHER:
             discount_to_delete_ids.append(discount.pk)
 
     if discount_to_delete_ids:
@@ -932,6 +934,7 @@ def _update_manual_order_line_discount_object(
             amount_value=amount_value,
             currency=currency,
             reason=reason,
+            unique_type=DiscountType.MANUAL,
         )
     else:
         update_fields = []

--- a/saleor/warehouse/tests/test_preorder_availability.py
+++ b/saleor/warehouse/tests/test_preorder_availability.py
@@ -164,6 +164,8 @@ def test_check_preorder_reserved_threshold_bulk_channel_threshold(
                 discounts=[],
                 rules_info=[],
                 channel=channel_USD,
+                voucher=None,
+                voucher_code=None,
             )
         ],
         check_reservations=True,
@@ -234,6 +236,8 @@ def test_check_preorder_reserved_threshold_bulk_global_threshold(
                 discounts=[],
                 rules_info=[],
                 channel=channel_USD,
+                voucher=None,
+                voucher_code=None,
             )
         ],
         check_reservations=True,


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/16153

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
