### PR TITLE
Fix catalogue discount application on custom price in checkout and draft orders

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -548,7 +548,9 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
             continue
 
         # check if the line price is discounted by catalogue promotion
-        discounted_line = _is_discounted_line(line_info.channel_listing)
+        discounted_line = _is_discounted_line_by_catalogue_promotion(
+            line_info.channel_listing
+        )
 
         # delete all existing discounts if the line is not discounted or it is a gift
         if not discounted_line or line.is_gift:
@@ -600,7 +602,7 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
     )
 
 
-def _is_discounted_line(
+def _is_discounted_line_by_catalogue_promotion(
     variant_channel_listing: "ProductVariantChannelListing",
 ) -> bool:
     """Return True when the price is discounted by catalogue promotion."""

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -19,7 +19,7 @@ from ..checkout.base_calculations import (
     base_checkout_delivery_price,
     base_checkout_subtotal,
 )
-from ..checkout.models import Checkout
+from ..checkout.models import Checkout, CheckoutLine
 from ..core.db.connection import allow_writer
 from ..core.exceptions import InsufficientStock
 from ..core.taxes import zero_money
@@ -58,10 +58,11 @@ if TYPE_CHECKING:
     from ..account.models import User
     from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ..core.pricing.interface import LineInfo
+    from ..discount.models import Voucher
     from ..order.fetch import DraftOrderLineInfo
+    from ..order.models import OrderLine
     from ..plugins.manager import PluginsManager
     from ..product.managers import ProductVariantQueryset
-    from ..product.models import VariantChannelListingPromotionRule
     from .interface import VoucherInfo
 
 CatalogueInfo = defaultdict[str, set[Union[int, str]]]
@@ -546,11 +547,11 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
             line_discounts_to_remove.extend(discounts_to_update)
             continue
 
-        # discount_amount based on the difference between discounted_price and price
-        discount_amount = _get_discount_amount(line_info.channel_listing, line.quantity)
+        # check if the line price is discounted by catalogue promotion
+        discounted_line = _is_discounted_line(line_info.channel_listing)
 
         # delete all existing discounts if the line is not discounted or it is a gift
-        if not discount_amount or line.is_gift:
+        if not discounted_line or line.is_gift:
             line_discounts_to_remove.extend(discounts_to_update)
             continue
 
@@ -558,7 +559,7 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
             rule_info = line_info.rules_info[0]
             rule = rule_info.rule
             rule_discount_amount = _get_rule_discount_amount(
-                rule_info.variant_listing_promotion_rule, line.quantity
+                line, rule_info, line_info.channel
             )
             discount_name = get_discount_name(rule, rule_info.promotion)
             translated_name = get_discount_translated_name(rule_info)
@@ -599,9 +600,10 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
     )
 
 
-def _get_discount_amount(
-    variant_channel_listing: "ProductVariantChannelListing", line_quantity: int
-) -> Decimal:
+def _is_discounted_line(
+    variant_channel_listing: "ProductVariantChannelListing",
+) -> bool:
+    """Return True when the price is discounted by catalogue promotion."""
     price_amount = variant_channel_listing.price_amount
     discounted_price_amount = variant_channel_listing.discounted_price_amount
 
@@ -610,20 +612,44 @@ def _get_discount_amount(
         or discounted_price_amount is None
         or price_amount == discounted_price_amount
     ):
-        return Decimal("0.0")
+        return False
 
-    unit_discount = price_amount - discounted_price_amount
-    return unit_discount * line_quantity
+    return True
 
 
 def _get_rule_discount_amount(
-    variant_listing_promotion_rule: Optional["VariantChannelListingPromotionRule"],
-    line_quantity: int,
+    line: Union["CheckoutLine", "OrderLine"],
+    rule_info: "VariantPromotionRuleInfo",
+    channel: "Channel",
 ) -> Decimal:
+    """Calculate the discount amount for catalogue promotion rule.
+
+    When the line has overridden price, the discount is applied on the
+    new overridden base price.
+    """
+    variant_listing_promotion_rule = rule_info.variant_listing_promotion_rule
     if not variant_listing_promotion_rule:
         return Decimal("0.0")
-    discount_amount = variant_listing_promotion_rule.discount_amount
-    return discount_amount * line_quantity
+
+    if isinstance(line, CheckoutLine):
+        price_override = (
+            Money(line.price_override, channel.currency_code)
+            if line.price_override is not None
+            else None
+        )
+    else:
+        price_override = (
+            line.undiscounted_base_unit_price if line.is_price_overridden else None
+        )
+
+    if price_override:
+        # calculate discount amount on overridden price
+        discount = rule_info.rule.get_discount(channel.currency_code)
+        discounted_price = discount(price_override)
+        discount_amount = (price_override - discounted_price).amount
+    else:
+        discount_amount = variant_listing_promotion_rule.discount_amount
+    return discount_amount * line.quantity
 
 
 def get_discount_name(rule: "PromotionRule", promotion: "Promotion"):

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -642,7 +642,7 @@ def _get_rule_discount_amount(
             line.undiscounted_base_unit_price if line.is_price_overridden else None
         )
 
-    if price_override:
+    if price_override is not None:
         # calculate discount amount on overridden price
         discount = rule_info.rule.get_discount(channel.currency_code)
         discounted_price = discount(price_override)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -51,11 +51,6 @@ DRAFT_ORDER_CREATE_MUTATION = """
                         reason
                     }
                     redirectUrl
-                    lines {
-                        productName
-                        productSku
-                        quantity
-                    }
                     billingAddress{
                         city
                         streetAddress1
@@ -127,6 +122,7 @@ DRAFT_ORDER_CREATE_MUTATION = """
                         unitDiscountType
                         unitDiscountValue
                         isGift
+                        isPriceOverridden
                     }
                 }
             }
@@ -2714,6 +2710,121 @@ def test_draft_order_create_with_custom_price_in_order_line(
     assert order_line_1.base_unit_price_amount == expected_price_variant_1
     assert order_line_1.undiscounted_base_unit_price_amount == expected_price_variant_1
     assert order_line_1.is_price_overridden is True
+
+
+def test_draft_order_create_with_custom_price_and_catalogue_promotion(
+    staff_api_client,
+    permission_group_manage_orders,
+    customer_user,
+    variant_on_promotion,
+    channel_USD,
+):
+    # given
+    query = DRAFT_ORDER_CREATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variant = variant_on_promotion
+
+    variant_listing = variant.channel_listings.get(channel=channel_USD)
+    variant_price = variant_listing.price_amount
+    promotion_rule = variant_listing.promotion_rules.first()
+    reward_value = promotion_rule.reward_value
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+
+    custom_price = 18
+    quantity = 2
+    variant_list = [
+        {
+            "variantId": variant_id,
+            "quantity": quantity,
+            "price": custom_price,
+            "forceNewLine": False,
+        },
+        {
+            "variantId": variant_id,
+            "quantity": quantity,
+            "forceNewLine": True,
+        },
+    ]
+    variables = {
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "channelId": channel_id,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["draftOrderCreate"]["errors"]
+    data = content["data"]["draftOrderCreate"]["order"]
+    assert data["status"] == OrderStatus.DRAFT.upper()
+    assert len(data["lines"]) == 2
+
+    line_1_unit_discount = custom_price * reward_value / 100
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion_rule.promotion_id)
+    line_data_1 = {
+        "productVariantId": variant_id,
+        "quantity": quantity,
+        "unitDiscount": {
+            "amount": float(line_1_unit_discount),
+        },
+        "unitPrice": {
+            "gross": {
+                "amount": float(custom_price - line_1_unit_discount),
+            },
+        },
+        "undiscountedUnitPrice": {
+            "gross": {
+                "amount": float(custom_price),
+            },
+        },
+        "totalPrice": {
+            "gross": {
+                "amount": float((custom_price - line_1_unit_discount) * quantity),
+            },
+        },
+        "unitDiscountReason": f"Promotion: {promotion_id}",
+        "unitDiscountType": RewardValueType.PERCENTAGE.upper(),
+        "unitDiscountValue": reward_value,
+        "isPriceOverridden": True,
+        "isGift": False,
+    }
+    assert line_data_1 in data["lines"]
+    line_2_unit_discount = variant_price * reward_value / 100
+    line_data_2 = {
+        "productVariantId": variant_id,
+        "quantity": quantity,
+        "unitDiscount": {
+            "amount": float(line_2_unit_discount),
+        },
+        "unitPrice": {
+            "gross": {
+                "amount": float(variant_price - line_2_unit_discount),
+            },
+        },
+        "undiscountedUnitPrice": {
+            "gross": {
+                "amount": float(variant_price),
+            },
+        },
+        "totalPrice": {
+            "gross": {
+                "amount": float((variant_price - line_2_unit_discount) * quantity),
+            },
+        },
+        "unitDiscountReason": f"Promotion: {promotion_id}",
+        "unitDiscountType": RewardValueType.PERCENTAGE.upper(),
+        "unitDiscountValue": reward_value,
+        "isPriceOverridden": False,
+        "isGift": False,
+    }
+    assert line_data_2 in data["lines"]
 
 
 def test_draft_order_create_product_catalogue_promotion(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1028,16 +1028,41 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         )
 
     @staticmethod
-    def resolve_unit_discount_type(root: models.OrderLine, _info):
-        return root.unit_discount_type
+    def resolve_unit_discount_type(root: models.OrderLine, info):
+        def _resolve_unit_discount_type(data):
+            order, lines, manager = data
+            return calculations.order_line_unit_discount_type(
+                order, root, manager, lines
+            )
+
+        order = OrderByIdLoader(info.context).load(root.order_id)
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_discount_type)
 
     @staticmethod
-    def resolve_unit_discount_value(root: models.OrderLine, _info):
-        return root.unit_discount_value
+    def resolve_unit_discount_value(root: models.OrderLine, info):
+        def _resolve_unit_discount_value(data):
+            order, lines, manager = data
+            return calculations.order_line_unit_discount_value(
+                order, root, manager, lines
+            )
+
+        order = OrderByIdLoader(info.context).load(root.order_id)
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_discount_value)
 
     @staticmethod
-    def resolve_unit_discount(root: models.OrderLine, _info):
-        return root.unit_discount
+    def resolve_unit_discount(root: models.OrderLine, info):
+        def _resolve_unit_discount(data):
+            order, lines, manager = data
+            return calculations.order_line_unit_discount(order, root, manager, lines)
+
+        order = OrderByIdLoader(info.context).load(root.order_id)
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_discount)
 
     @staticmethod
     @traced_resolver

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -534,9 +534,14 @@ def order_line_unit_discount(
 ) -> Decimal:
     """Return the line unit discount.
 
-    It takes into account all plugins.
-    If the prices are expired, call all order price calculation methods
-    and save them in the model directly.
+        It takes into account all plugins.
+        If the prices are expired, call all order price calculation methods
+        and save them in the model directly.
+    g
+        Line unit discount include discounts from:
+        - catalogue promotion
+        - voucher applied on the line (`SPECIFIC_PRODUCT`, `apply_once_per_order` )
+        - manual line discounts
     """
     _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
     order_line = _find_order_line(lines, order_line)

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -525,6 +525,60 @@ def order_line_tax_rate(
     return order_line.tax_rate
 
 
+def order_line_unit_discount(
+    order: Order,
+    order_line: OrderLine,
+    manager: PluginsManager,
+    lines: Optional[Iterable[OrderLine]] = None,
+    force_update: bool = False,
+) -> Decimal:
+    """Return the line unit discount.
+
+    It takes into account all plugins.
+    If the prices are expired, call all order price calculation methods
+    and save them in the model directly.
+    """
+    _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order_line = _find_order_line(lines, order_line)
+    return order_line.unit_discount
+
+
+def order_line_unit_discount_value(
+    order: Order,
+    order_line: OrderLine,
+    manager: PluginsManager,
+    lines: Optional[Iterable[OrderLine]] = None,
+    force_update: bool = False,
+) -> Decimal:
+    """Return the line unit discount value.
+
+    It takes into account all plugins.
+    If the prices are expired, call all order price calculation methods
+    and save them in the model directly.
+    """
+    _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order_line = _find_order_line(lines, order_line)
+    return order_line.unit_discount_value
+
+
+def order_line_unit_discount_type(
+    order: Order,
+    order_line: OrderLine,
+    manager: PluginsManager,
+    lines: Optional[Iterable[OrderLine]] = None,
+    force_update: bool = False,
+) -> Optional[str]:
+    """Return the line unit discount type.
+
+    It takes into account all plugins.
+    If the prices are expired, call all order price calculation methods
+    and save them in the model directly.
+    """
+    _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order_line = _find_order_line(lines, order_line)
+    return order_line.unit_discount_type
+
+
 def order_shipping(
     order: Order,
     manager: PluginsManager,

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -534,14 +534,14 @@ def order_line_unit_discount(
 ) -> Decimal:
     """Return the line unit discount.
 
-        It takes into account all plugins.
-        If the prices are expired, call all order price calculation methods
-        and save them in the model directly.
-    g
-        Line unit discount include discounts from:
-        - catalogue promotion
-        - voucher applied on the line (`SPECIFIC_PRODUCT`, `apply_once_per_order` )
-        - manual line discounts
+    It takes into account all plugins.
+    If the prices are expired, call all order price calculation methods
+    and save them in the model directly.
+
+    Line unit discount includes discounts from:
+    - catalogue promotion
+    - voucher applied on the line (`SPECIFIC_PRODUCT`, `apply_once_per_order` )
+    - manual line discounts
     """
     _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
     order_line = _find_order_line(lines, order_line)

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_fixed_promotion.py
@@ -1,0 +1,149 @@
+import pytest
+
+from ......product.tasks import recalculate_discounted_price_for_products_task
+from ....checkout.utils import checkout_lines_update
+from ....product.utils.preparing_product import prepare_product
+from ....promotions.utils import create_promotion, create_promotion_rule
+from ....shop.utils import prepare_default_shop
+from ....utils import assign_permissions
+from ...utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_custom_price_and_fixed_promotion_core_2138(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    shop_permissions,
+    permission_handle_checkouts,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    app_permissions = [permission_handle_checkouts]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
+    )
+
+    promotion_name = "Promotion Fixed"
+    discount_value = 5
+    discount_type = "FIXED"
+    promotion_rule_name = "rule for product"
+    promotion_type = "CATALOGUE"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": "FIXED",
+    }
+    promotion_rule = create_promotion_rule(
+        e2e_staff_api_client,
+        input,
+    )
+    product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
+    assert promotion_rule["channels"][0]["id"] == channel_id
+    assert product_predicate[0] == product_id
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    # Step 1 - checkoutCreate for product on promotion
+    lines = [
+        {"variantId": product_variant_id, "quantity": 2},
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    checkout_line = checkout_data["lines"][0]
+    unit_price = float(product_variant_price) - discount_value
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_line["unitPrice"]["gross"]["amount"] == unit_price
+    assert checkout_line["undiscountedUnitPrice"]["amount"] == float(
+        product_variant_price
+    )
+
+    # Step 2 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+
+    # Step 3 - Set the custom price for the checkout line
+    custom_price = 10
+    line_qty = 1
+    lines = [
+        {"lineId": checkout_line["id"], "quantity": line_qty, "price": custom_price}
+    ]
+    lines_data = checkout_lines_update(e2e_app_api_client, checkout_id, lines)
+    assert len(lines_data["checkout"]["lines"]) == 1
+    line_data = lines_data["checkout"]["lines"][0]
+    assert line_data["undiscountedUnitPrice"]["amount"] == custom_price
+    assert line_data["unitPrice"]["gross"]["amount"] == custom_price - discount_value
+    subtotal_gross_amount = lines_data["checkout"]["subtotalPrice"]["gross"]["amount"]
+    assert subtotal_gross_amount == (custom_price - discount_value) * line_qty
+    total_gross_amount = lines_data["checkout"]["totalPrice"]["gross"]["amount"]
+
+    # Step 4 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client, checkout_id, total_gross_amount
+    )
+
+    # Step 5 - Complete checkout.
+    order_data = checkout_complete(e2e_not_logged_api_client, checkout_id)
+
+    order_line = order_data["lines"][0]
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_data["subtotal"]["gross"]["amount"] == subtotal_gross_amount
+    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(custom_price)
+    assert order_line["unitDiscountType"] == discount_type
+    assert order_line["unitPrice"]["gross"]["amount"] == custom_price - discount_value
+    assert order_line["unitDiscount"]["amount"] == float(discount_value)
+    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_custom_price_and_percentage_promotion.py
@@ -1,0 +1,147 @@
+import pytest
+
+from ......product.tasks import recalculate_discounted_price_for_products_task
+from ....checkout.utils import checkout_lines_update
+from ....product.utils.preparing_product import prepare_product
+from ....promotions.utils import create_promotion, create_promotion_rule
+from ....shop.utils import prepare_default_shop
+from ....utils import assign_permissions
+from ...utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_custom_price_and_percentage_promotion_core_2139(
+    e2e_logged_api_client,
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    shop_permissions,
+    permission_handle_checkouts,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    app_permissions = [permission_handle_checkouts]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=19.89
+    )
+
+    promotion_name = "Promotion PERCENTAGE"
+    discount_value = 10
+    discount_type = "PERCENTAGE"
+    promotion_rule_name = "rule for product"
+    promotion_type = "CATALOGUE"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
+
+    promotion_rule = create_promotion_rule(e2e_staff_api_client, input)
+    product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
+    assert promotion_rule["channels"][0]["id"] == channel_id
+    assert product_predicate[0] == product_id
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    # Step 1 - checkoutCreate for product on promotion
+    lines = [
+        {"variantId": product_variant_id, "quantity": 2},
+    ]
+    checkout_data = checkout_create(
+        e2e_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    checkout_line = checkout_data["lines"][0]
+    line_discount = round(float(product_variant_price) * discount_value / 100, 2)
+    unit_price = round(float(product_variant_price) - line_discount, 2)
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_line["unitPrice"]["gross"]["amount"] == unit_price
+    assert checkout_line["undiscountedUnitPrice"]["amount"] == float(
+        product_variant_price
+    )
+
+    # Step 2 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+
+    # Step 3 - Set the custom price for the checkout line
+    custom_price = 10
+    line_qty = 2
+    lines = [
+        {"lineId": checkout_line["id"], "quantity": line_qty, "price": custom_price}
+    ]
+    lines_data = checkout_lines_update(e2e_app_api_client, checkout_id, lines)
+    discount_amount = custom_price * discount_value / 100
+    assert len(lines_data["checkout"]["lines"]) == 1
+    line_data = lines_data["checkout"]["lines"][0]
+    assert line_data["undiscountedUnitPrice"]["amount"] == custom_price
+    assert line_data["unitPrice"]["gross"]["amount"] == custom_price - discount_amount
+    subtotal_gross_amount = lines_data["checkout"]["subtotalPrice"]["gross"]["amount"]
+    assert subtotal_gross_amount == (custom_price - discount_amount) * line_qty
+    total_gross_amount = lines_data["checkout"]["totalPrice"]["gross"]["amount"]
+
+    # Step 4 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_logged_api_client, checkout_id, total_gross_amount
+    )
+
+    # Step 5 - Complete checkout.
+    order_data = checkout_complete(e2e_logged_api_client, checkout_id)
+
+    order_line = order_data["lines"][0]
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(custom_price)
+    assert order_line["unitDiscountType"] == "FIXED"
+    assert order_line["unitPrice"]["gross"]["amount"] == custom_price - discount_amount
+    assert order_line["unitDiscount"]["amount"] == discount_amount
+    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"


### PR DESCRIPTION
- Fix applying catalogue discounts on checkout instances. The `priceOverride` is treated as overridden base price, so it should be the base price on which the catalogue discounts are applied
- Fix applying catalogue discount on draft order instances.

Port of https://github.com/saleor/saleor/pull/16191

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
