### PR TITLE
Add custom datetime scalar

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -48,7 +48,7 @@ from ..core.doc_category import DOC_CATEGORY_USERS
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import ConnectionField, PermissionsField
-from ..core.scalars import UUID
+from ..core.scalars import UUID, DateTime
 from ..core.tracing import traced_resolver
 from ..core.types import (
     BaseInputObjectType,
@@ -225,9 +225,7 @@ class Address(ModelObjectType[models.Address]):
 
 class CustomerEvent(ModelObjectType[models.CustomerEvent]):
     id = graphene.GlobalID(required=True, description="The ID of the customer event.")
-    date = graphene.types.datetime.DateTime(
-        description="Date when event happened at in ISO 8601 format."
-    )
+    date = DateTime(description="Date when event happened at in ISO 8601 format.")
     type = CustomerEventsEnum(description="Customer event type.")
     user = graphene.Field(lambda: User, description="User who performed the action.")
     app = graphene.Field(App, description="App that performed the action.")
@@ -443,13 +441,13 @@ class User(ModelObjectType[models.User]):
         description=f"External ID of this user. {ADDED_IN_310}", required=False
     )
 
-    last_login = graphene.DateTime(
+    last_login = DateTime(
         description="The date when the user last time log in to the system."
     )
-    date_joined = graphene.DateTime(
+    date_joined = DateTime(
         required=True, description="The data when the user create account."
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True,
         description="The data when the user last update the account information.",
     )

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -35,6 +35,7 @@ from ..core.descriptions import (
 )
 from ..core.doc_category import DOC_CATEGORY_APPS
 from ..core.federation import federated_entity, resolve_federation_references
+from ..core.scalars import DateTime
 from ..core.types import (
     BaseObjectType,
     IconThumbnailField,
@@ -497,9 +498,7 @@ class App(ModelObjectType[models.App]):
         required=False, description="Canonical app ID from the manifest" + ADDED_IN_319
     )
     permissions = NonNullList(Permission, description="List of the app's permissions.")
-    created = graphene.DateTime(
-        description="The date and time when the app was created."
-    )
+    created = DateTime(description="The date and time when the app was created.")
     is_active = graphene.Boolean(
         description="Determine if app will be set active or not."
     )

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -27,7 +27,7 @@ from ..core.descriptions import (
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.enums import MeasurementUnitsEnum
 from ..core.fields import ConnectionField, FilterConnectionField, JSONString
-from ..core.scalars import Date
+from ..core.scalars import Date, DateTime
 from ..core.types import (
     BaseInputObjectType,
     BaseObjectType,
@@ -73,7 +73,7 @@ class AttributeValue(ModelObjectType[models.AttributeValue]):
         description=AttributeValueDescriptions.BOOLEAN, required=False
     )
     date = Date(description=AttributeValueDescriptions.DATE, required=False)
-    date_time = graphene.DateTime(
+    date_time = DateTime(
         description=AttributeValueDescriptions.DATE_TIME, required=False
     )
     external_reference = graphene.String(
@@ -487,7 +487,7 @@ class AttributeValueInput(BaseInputObjectType):
         required=False, description=AttributeValueDescriptions.BOOLEAN
     )
     date = Date(required=False, description=AttributeValueDescriptions.DATE)
-    date_time = graphene.DateTime(
+    date_time = DateTime(
         required=False, description=AttributeValueDescriptions.DATE_TIME
     )
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -54,7 +54,7 @@ from ..core.descriptions import (
 from ..core.doc_category import DOC_CATEGORY_CHECKOUT
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import BaseField, PermissionsField
-from ..core.scalars import UUID, PositiveDecimal
+from ..core.scalars import UUID, DateTime, PositiveDecimal
 from ..core.tracing import traced_resolver
 from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList, TaxedMoney
 from ..core.utils import CHECKOUT_CALCULATE_TAXES_MESSAGE, WebhookEventInfo, str_to_enum
@@ -472,14 +472,14 @@ class DeliveryMethod(graphene.Union):
 
 class Checkout(ModelObjectType[models.Checkout]):
     id = graphene.ID(required=True, description="The ID of the checkout.")
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="The date and time when the checkout was created."
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True,
         description=("Time of last modification of the given checkout." + ADDED_IN_313),
     )
-    last_change = graphene.DateTime(
+    last_change = DateTime(
         required=True,
         deprecation_reason=(f"{DEPRECATED_IN_3X_FIELD} Use `updatedAt` instead."),
     )
@@ -604,7 +604,7 @@ class Checkout(ModelObjectType[models.Checkout]):
         description="Returns True, if checkout requires shipping.", required=True
     )
     quantity = graphene.Int(description="The number of items purchased.", required=True)
-    stock_reservation_expires = graphene.DateTime(
+    stock_reservation_expires = DateTime(
         description=(
             "Date when oldest stock reservation for this checkout "
             "expires or null if no stock is reserved." + ADDED_IN_31

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -1,6 +1,8 @@
 import decimal
+from datetime import MAXYEAR, MINYEAR, datetime
 
 import graphene
+import pytz
 from graphene.types.generic import GenericScalar
 from graphql.language import ast
 from measurement.measures import Weight
@@ -138,6 +140,27 @@ class UUID(graphene.UUID):
             return super(UUID, UUID).parse_value(value)
         except ValueError:
             return None
+
+
+# The custom DateTime scalar is needed as graphene.DateTime allows to save the date-time
+# value in format that is not supported by datetime module.
+# The custom validation makes additional check to confirm that the value is correct
+# Value like this `0001-01-01T00:00:01+07:00` will generate the BC date, which without
+# additional check will be saved in the database as UTC BC time:
+# `0001-12-31 17:00:01+00 BC`.
+class DateTime(graphene.DateTime):
+    __doc__ = graphene.DateTime.__doc__
+
+    @staticmethod
+    def parse_value(value):
+        parsed_value = super(DateTime, DateTime).parse_value(value)
+        if parsed_value is not None and isinstance(parsed_value, datetime):
+            if parsed_value.year in [MINYEAR, MAXYEAR]:
+                try:
+                    parsed_value.astimezone(tz=pytz.UTC)
+                except OverflowError:
+                    return None
+        return parsed_value
 
 
 # The custom Date scalar is needed as the currently used graphene 2 version is not

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -272,3 +272,150 @@ def test_json_scalar_as_correct_value(
 
     # then
     get_graphql_content(response)
+
+
+DATE_TIME_QUERY_WITH_VARIABLE = """
+mutation vv($startDate: DateTime){
+	voucherCreate(input:{
+		type:SHIPPING, code:"test12", startDate: $startDate
+	}){
+		errors{
+			code
+		}
+		voucher{
+			id
+			startDate
+		}
+	}
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "start_date",
+    [
+        "0000-01-01T00:00:00+00:00",
+        "0001-01-01T00:00:01+07:00",
+        "0001-01-01T00:00:01+01:00",
+        "0001-01-01T00:00:00+00:01",
+        "0001-12-31 17:00:01+00 BC",
+        "9999-12-31T23:59:59-07:00",
+    ],
+)
+def test_incorrect_date_time_as_variable(
+    start_date, staff_api_client, permission_manage_discounts
+):
+    # given
+    variables = {"startDate": start_date}
+    staff_api_client.user.user_permissions.add(permission_manage_discounts)
+
+    # when
+    response = staff_api_client.post_graphql(DATE_TIME_QUERY_WITH_VARIABLE, variables)
+
+    # then
+    content = get_graphql_content_from_response(response)
+    assert "errors" in content
+
+
+@pytest.mark.parametrize(
+    "start_date",
+    [
+        "0001-01-01T00:00:01+00:00",
+        "0001-01-01T01:00:02+01:00",
+        "0001-01-10T00:00:01+07:00",
+        "0001-01-01T07:05:01+07:00",
+        "2024-06-10T11:00:00+07:00",
+        "9999-12-31T23:59:59+00:00",
+    ],
+)
+def test_correct_date_time_as_variable(
+    start_date, staff_api_client, permission_manage_discounts
+):
+    # given
+    variables = {"startDate": start_date}
+    staff_api_client.user.user_permissions.add(permission_manage_discounts)
+
+    # when
+    response = staff_api_client.post_graphql(DATE_TIME_QUERY_WITH_VARIABLE, variables)
+
+    # then
+    get_graphql_content(response)
+
+
+@pytest.mark.parametrize(
+    "start_date",
+    [
+        "0000-01-01T00:00:00+00:00",
+        "0001-01-01T00:00:01+07:00",
+        "0001-01-01T00:00:01+01:00",
+        "0001-01-01T00:00:00+00:01",
+        "0001-12-31 17:00:01+00 BC",
+        "9999-12-31T23:59:59-07:00",
+    ],
+)
+def test_incorrect_date_time_as_input(
+    start_date, staff_api_client, permission_manage_discounts
+):
+    # given
+    query = f"""
+    mutation{{
+        voucherCreate(input:{{
+            type:SHIPPING, code:"test12", startDate: "{start_date}"
+        }}){{
+            errors{{
+                code
+            }}
+            voucher{{
+                id
+                startDate
+            }}
+        }}
+    }}
+    """
+    staff_api_client.user.user_permissions.add(permission_manage_discounts)
+
+    # when
+    response = staff_api_client.post_graphql(query)
+
+    # then
+    content = get_graphql_content_from_response(response)
+    assert "errors" in content
+
+
+@pytest.mark.parametrize(
+    "start_date",
+    [
+        "0001-01-01T00:00:01+00:00",
+        "0001-01-01T01:00:02+01:00",
+        "0001-01-10T00:00:01+07:00",
+        "0001-01-01T07:05:01+07:00",
+        "2024-06-10T11:00:00+07:00",
+        "9999-12-31T23:59:59+00:00",
+    ],
+)
+def test_correct_date_time_as_input(
+    start_date, staff_api_client, permission_manage_discounts
+):
+    # given
+    query = f"""
+        mutation {{
+            voucherCreate(input:{{
+                type:SHIPPING, code:"test12", startDate: "{start_date}"
+            }}){{
+                errors{{
+                    code
+                }}
+                voucher{{
+                    id
+                    startDate
+                }}
+            }}
+        }}
+    """
+    staff_api_client.user.user_permissions.add(permission_manage_discounts)
+
+    # when
+    response = staff_api_client.post_graphql(query)
+
+    # then
+    get_graphql_content(response)

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -25,7 +25,7 @@ from ...core.doc_category import (
     DOC_CATEGORY_USERS,
     DOC_CATEGORY_WEBHOOKS,
 )
-from ...core.scalars import Decimal
+from ...core.scalars import DateTime, Decimal
 from ..descriptions import (
     ADDED_IN_36,
     ADDED_IN_312,
@@ -907,8 +907,8 @@ class DateRangeInput(graphene.InputObjectType):
 
 
 class DateTimeRangeInput(graphene.InputObjectType):
-    gte = graphene.DateTime(description="Start date.", required=False)
-    lte = graphene.DateTime(description="End date.", required=False)
+    gte = DateTime(description="Start date.", required=False)
+    lte = DateTime(description="End date.", required=False)
 
 
 class IntRangeInput(graphene.InputObjectType):
@@ -935,10 +935,10 @@ class TaxType(BaseObjectType):
 
 class Job(graphene.Interface):
     status = JobStatusEnum(description="Job status.", required=True)
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         description="Created date time of job in ISO 8601 format.", required=True
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         description="Date time of job last update in ISO 8601 format.", required=True
     )
     message = graphene.String(description="Job message.")

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -7,7 +7,7 @@ from graphene import Argument, InputField, String
 from graphene.types.inputobjecttype import InputObjectTypeOptions
 from graphene.types.utils import yank_fields_from_attrs
 
-from ...core.scalars import Decimal
+from ...core.scalars import DateTime, Decimal
 from ..descriptions import (
     ADDED_IN_311,
     ADDED_IN_314,
@@ -220,9 +220,9 @@ class DateFilterInput(graphene.InputObjectType):
 
 
 class DateTimeFilterInput(graphene.InputObjectType):
-    eq = graphene.DateTime(description=FilterInputDescriptions.EQ, required=False)
+    eq = DateTime(description=FilterInputDescriptions.EQ, required=False)
     one_of = NonNullList(
-        graphene.DateTime,
+        DateTime,
         description=FilterInputDescriptions.ONE_OF,
         required=False,
     )

--- a/saleor/graphql/csv/types.py
+++ b/saleor/graphql/csv/types.py
@@ -10,6 +10,7 @@ from ..app.dataloaders import AppByIdLoader
 from ..app.types import App
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
+from ..core.scalars import DateTime
 from ..core.types import Job, ModelObjectType, NonNullList
 from ..utils import get_user_or_app_from_context
 from .dataloaders import EventsByExportFileIdLoader
@@ -17,7 +18,7 @@ from .enums import ExportEventEnum
 
 
 class ExportEvent(ModelObjectType[models.ExportEvent]):
-    date = graphene.types.datetime.DateTime(
+    date = DateTime(
         description="Date when event happened at in ISO 8601 format.",
         required=True,
     )

--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -20,7 +20,7 @@ from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_317, ADDED_IN_319, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
-from ....core.scalars import JSON
+from ....core.scalars import JSON, DateTime
 from ....core.types import BaseInputObjectType, Error, NonNullList
 from ....core.utils import WebhookEventInfo
 from ....core.validators import validate_end_is_after_start
@@ -70,12 +70,10 @@ class PromotionRuleInput(PromotionRuleBaseInput):
 
 class PromotionInput(BaseInputObjectType):
     description = JSON(description="Promotion description.")
-    start_date = graphene.types.datetime.DateTime(
+    start_date = DateTime(
         description="The start date of the promotion in ISO 8601 format."
     )
-    end_date = graphene.types.datetime.DateTime(
-        description="The end date of the promotion in ISO 8601 format."
-    )
+    end_date = DateTime(description="The end date of the promotion in ISO 8601 format.")
 
 
 class PromotionCreateInput(PromotionInput):

--- a/saleor/graphql/discount/mutations/sale/sale_create.py
+++ b/saleor/graphql/discount/mutations/sale/sale_create.py
@@ -16,7 +16,7 @@ from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_MUTATION
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
-from ....core.scalars import PositiveDecimal
+from ....core.scalars import DateTime, PositiveDecimal
 from ....core.types import BaseInputObjectType, DiscountError, NonNullList
 from ....core.utils import WebhookEventInfo
 from ....core.validators import validate_end_is_after_start
@@ -51,12 +51,8 @@ class SaleInput(BaseInputObjectType):
         description="Collections related to the discount.",
         name="collections",
     )
-    start_date = graphene.types.datetime.DateTime(
-        description="Start date of the voucher in ISO 8601 format."
-    )
-    end_date = graphene.types.datetime.DateTime(
-        description="End date of the voucher in ISO 8601 format."
-    )
+    start_date = DateTime(description="Start date of the voucher in ISO 8601 format.")
+    end_date = DateTime(description="End date of the voucher in ISO 8601 format.")
 
     class Meta:
         doc_category = DOC_CATEGORY_DISCOUNTS

--- a/saleor/graphql/discount/mutations/voucher/voucher_create.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_create.py
@@ -17,6 +17,7 @@ from ....core.descriptions import (
 )
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
+from ....core.scalars import DateTime
 from ....core.types import BaseInputObjectType, DiscountError, NonNullList
 from ....core.utils import WebhookEventInfo, get_duplicated_values
 from ....core.validators import (
@@ -44,12 +45,8 @@ class VoucherInput(BaseInputObjectType):
         required=False,
         description="List of codes to add." + ADDED_IN_318 + PREVIEW_FEATURE,
     )
-    start_date = graphene.types.datetime.DateTime(
-        description="Start date of the voucher in ISO 8601 format."
-    )
-    end_date = graphene.types.datetime.DateTime(
-        description="End date of the voucher in ISO 8601 format."
-    )
+    start_date = DateTime(description="Start date of the voucher in ISO 8601 format.")
+    end_date = DateTime(description="End date of the voucher in ISO 8601 format.")
     discount_value_type = DiscountValueTypeEnum(
         description="Choices: fixed or percentage."
     )

--- a/saleor/graphql/discount/types/promotion_events.py
+++ b/saleor/graphql/discount/types/promotion_events.py
@@ -11,6 +11,7 @@ from ...app.dataloaders import AppByIdLoader
 from ...core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
+from ...core.scalars import DateTime
 from ...core.types import ModelObjectType
 from ...core.types.user_or_app import UserOrApp
 from ...utils import get_user_or_app_from_context
@@ -23,7 +24,7 @@ def resolve_event_type(root: models.PromotionEvent, _info):
 
 class PromotionEventInterface(graphene.Interface):
     id = graphene.GlobalID()
-    date = graphene.DateTime(description="Date when event happened.", required=True)
+    date = DateTime(description="Date when event happened.", required=True)
     type = PromotionEventsEnum(
         description="Promotion event type.", resolver=resolve_event_type, required=True
     )

--- a/saleor/graphql/discount/types/promotions.py
+++ b/saleor/graphql/discount/types/promotions.py
@@ -9,7 +9,7 @@ from ...core.connection import CountableConnection
 from ...core.descriptions import ADDED_IN_317, ADDED_IN_319, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
-from ...core.scalars import JSON, PositiveDecimal
+from ...core.scalars import JSON, DateTime, PositiveDecimal
 from ...core.types import ModelObjectType, NonNullList
 from ...meta.types import ObjectWithMetadata
 from ...translations.fields import TranslationField
@@ -35,14 +35,10 @@ class Promotion(ModelObjectType[models.Promotion]):
         )
     )
     description = JSON(description="Description of the promotion.")
-    start_date = graphene.DateTime(
-        required=True, description="Start date of the promotion."
-    )
-    end_date = graphene.DateTime(description="End date of the promotion.")
-    created_at = graphene.DateTime(
-        required=True, description="Date time of promotion creation."
-    )
-    updated_at = graphene.DateTime(
+    start_date = DateTime(required=True, description="Start date of the promotion.")
+    end_date = DateTime(description="End date of the promotion.")
+    created_at = DateTime(required=True, description="Date time of promotion creation.")
+    updated_at = DateTime(
         required=True, description="Date time of last update of promotion."
     )
     rules = NonNullList(

--- a/saleor/graphql/discount/types/sales.py
+++ b/saleor/graphql/discount/types/sales.py
@@ -18,6 +18,7 @@ from ...core.context import get_database_connection_name
 from ...core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_TYPE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import ConnectionField, PermissionsField
+from ...core.scalars import DateTime
 from ...core.types import BaseObjectType, ModelObjectType, NonNullList
 from ...meta.types import ObjectWithMetadata
 from ...product.types import (
@@ -67,14 +68,14 @@ class Sale(ChannelContextTypeWithMetadata, ModelObjectType[models.Promotion]):
     id = graphene.GlobalID(required=True, description="The ID of the sale.")
     name = graphene.String(required=True, description="The name of the sale.")
     type = SaleType(required=True, description="Type of the sale, fixed or percentage.")
-    start_date = graphene.DateTime(
+    start_date = DateTime(
         required=True, description="The start date and time of the sale."
     )
-    end_date = graphene.DateTime(description="The end date and time of the sale.")
-    created = graphene.DateTime(
+    end_date = DateTime(description="The end date and time of the sale.")
+    created = DateTime(
         required=True, description="The date and time when the sale was created."
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True, description="The date and time when the sale was updated."
     )
     categories = ConnectionField(

--- a/saleor/graphql/discount/types/vouchers.py
+++ b/saleor/graphql/discount/types/vouchers.py
@@ -22,6 +22,7 @@ from ...core.descriptions import (
 )
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import ConnectionField, PermissionsField
+from ...core.scalars import DateTime
 from ...core.types import ModelObjectType, Money, NonNullList
 from ...meta.types import ObjectWithMetadata
 from ...product.types import (
@@ -73,9 +74,7 @@ class VoucherCode(ModelObjectType[models.VoucherCode]):
     code = graphene.String(description="Code to use the voucher.")
     used = graphene.Int(description="Number of times a code has been used.")
     is_active = graphene.Boolean(description="Whether a code is active or not.")
-    created_at = graphene.DateTime(
-        required=True, description="Date time of code creation."
-    )
+    created_at = DateTime(required=True, description="Date time of code creation.")
 
     class Meta:
         description = "Represents voucher code." + ADDED_IN_318 + PREVIEW_FEATURE
@@ -103,10 +102,10 @@ class Voucher(ChannelContextTypeWithMetadata[models.Voucher]):
         required=True,
         description="Usage count of the voucher.",
     )
-    start_date = graphene.DateTime(
+    start_date = DateTime(
         required=True, description="The start date and time of voucher."
     )
-    end_date = graphene.DateTime(description="The end date and time of voucher.")
+    end_date = DateTime(description="The end date and time of voucher.")
     apply_once_per_order = graphene.Boolean(
         required=True,
         description="Determine if the voucher should be applied once per order. If set "

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -22,7 +22,7 @@ from ..core.connection import CountableConnection
 from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.fields import PermissionsField
-from ..core.scalars import Date
+from ..core.scalars import Date, DateTime
 from ..core.tracing import traced_resolver
 from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList
 from ..meta.types import ObjectWithMetadata
@@ -68,9 +68,7 @@ class GiftCardEvent(ModelObjectType[models.GiftCardEvent]):
     id = graphene.GlobalID(
         required=True, description="ID of the event associated with a gift card."
     )
-    date = graphene.types.datetime.DateTime(
-        description="Date when event happened at in ISO 8601 format."
-    )
+    date = DateTime(description="Date when event happened at in ISO 8601 format.")
     type = GiftCardEventsEnum(description="Gift card event type.")
     user = graphene.Field(
         "saleor.graphql.account.types.User",
@@ -251,7 +249,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
         ),
         required=True,
     )
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="Date and time when gift card was created."
     )
     created_by = graphene.Field(
@@ -280,9 +278,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
         ),
         deprecation_reason=DEPRECATED_IN_3X_FIELD,
     )
-    last_used_on = graphene.DateTime(
-        description="Date and time when gift card was last used."
-    )
+    last_used_on = DateTime(description="Date and time when gift card was last used.")
     expiry_date = Date(description="Expiry date of the gift card.")
     app = graphene.Field(
         App,
@@ -332,11 +328,11 @@ class GiftCard(ModelObjectType[models.GiftCard]):
         description="The customer who bought a gift card.",
         deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `createdBy` field instead.",
     )
-    end_date = graphene.types.datetime.DateTime(
+    end_date = DateTime(
         description="End date of gift card.",
         deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `expiryDate` field instead.",
     )
-    start_date = graphene.types.datetime.DateTime(
+    start_date = DateTime(
         description="Start date of gift card.",
         deprecation_reason=f"{DEPRECATED_IN_3X_FIELD}",
     )

--- a/saleor/graphql/invoice/types.py
+++ b/saleor/graphql/invoice/types.py
@@ -2,6 +2,7 @@ import graphene
 
 from ...invoice import models
 from ..core.descriptions import ADDED_IN_310, DEPRECATED_IN_3X_FIELD
+from ..core.scalars import DateTime
 from ..core.types import Job, ModelObjectType
 from ..meta.types import ObjectWithMetadata
 from ..order.dataloaders import OrderByIdLoader
@@ -17,10 +18,10 @@ class Invoice(ModelObjectType[models.Invoice]):
             "This field will be removed in 4.0"
         ),
     )
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         required=True, description="Date and time at which invoice was created."
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True, description="Date and time at which invoice was updated."
     )
     message = graphene.String(description="Message associated with an invoice.")

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -52,7 +52,7 @@ from ...core.descriptions import ADDED_IN_314, ADDED_IN_318, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.enums import ErrorPolicy, ErrorPolicyEnum, LanguageCodeEnum
 from ...core.mutations import BaseMutation
-from ...core.scalars import PositiveDecimal, WeightScalar
+from ...core.scalars import DateTime, PositiveDecimal, WeightScalar
 from ...core.types import BaseInputObjectType, BaseObjectType, NonNullList
 from ...core.types.common import OrderBulkCreateError
 from ...core.utils import from_global_id_or_error
@@ -327,7 +327,7 @@ class OrderBulkCreateUserInput(BaseInputObjectType):
 
 
 class OrderBulkCreateInvoiceInput(BaseInputObjectType):
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         required=True, description="The date, when the invoice was created."
     )
     number = graphene.String(description="Invoice number.")
@@ -369,7 +369,7 @@ class OrderBulkCreateNoteInput(BaseInputObjectType):
     message = graphene.String(
         required=True, description=f"Note message. Max characters: {MAX_NOTE_LENGTH}."
     )
-    date = graphene.DateTime(description="The date associated with the message.")
+    date = DateTime(description="The date associated with the message.")
     user_id = graphene.ID(description="The user ID associated with the message.")
     user_email = graphene.ID(description="The user email associated with the message.")
     user_external_reference = graphene.ID(
@@ -431,7 +431,7 @@ class OrderBulkCreateOrderLineInput(BaseInputObjectType):
     translated_product_name = graphene.String(
         description="Translation of the product name."
     )
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         required=True, description="The date, when the order line was created."
     )
     is_shipping_required = graphene.Boolean(
@@ -477,7 +477,7 @@ class OrderBulkCreateInput(BaseInputObjectType):
     channel = graphene.String(
         required=True, description="Slug of the channel associated with the order."
     )
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         required=True,
         description="The date, when the order was inserted to Saleor database.",
     )

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -85,7 +85,7 @@ from ..core.doc_category import DOC_CATEGORY_ORDERS
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import PermissionsField
 from ..core.mutations import validation_error_to_error_type
-from ..core.scalars import PositiveDecimal
+from ..core.scalars import DateTime, PositiveDecimal
 from ..core.tracing import traced_resolver
 from ..core.types import (
     BaseObjectType,
@@ -233,8 +233,8 @@ class OrderGrantedRefundLine(ModelObjectType[models.OrderGrantedRefundLine]):
 
 class OrderGrantedRefund(ModelObjectType[models.OrderGrantedRefund]):
     id = graphene.GlobalID(required=True)
-    created_at = graphene.DateTime(required=True, description="Time of creation.")
-    updated_at = graphene.DateTime(required=True, description="Time of last update.")
+    created_at = DateTime(required=True, description="Time of creation.")
+    updated_at = DateTime(required=True, description="Time of last update.")
     amount = graphene.Field(Money, required=True, description="Refund amount.")
     reason = graphene.String(description="Reason of the refund.")
     user = graphene.Field(
@@ -352,9 +352,7 @@ class OrderEvent(ModelObjectType[models.OrderEvent]):
     id = graphene.GlobalID(
         required=True, description="ID of the event associated with an order."
     )
-    date = graphene.types.datetime.DateTime(
-        description="Date when event happened at in ISO 8601 format."
-    )
+    date = DateTime(description="Date when event happened at in ISO 8601 format.")
     type = OrderEventsEnum(description="Order event type.")
     user = graphene.Field(User, description="User who performed the action.")
     app = graphene.Field(
@@ -637,7 +635,7 @@ class Fulfillment(ModelObjectType[models.Fulfillment]):
     tracking_number = graphene.String(
         required=True, description="Fulfillment tracking number."
     )
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="Date and time when fulfillment was created."
     )
     lines = NonNullList(
@@ -1092,10 +1090,10 @@ class OrderLine(ModelObjectType[models.OrderLine]):
 @federated_entity("id")
 class Order(ModelObjectType[models.Order]):
     id = graphene.GlobalID(required=True, description="ID of the order.")
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="Date and time when the order was created."
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True, description="Date and time when the order was created."
     )
     status = OrderStatusEnum(required=True, description="Status of the order.")

--- a/saleor/graphql/page/mutations/page_create.py
+++ b/saleor/graphql/page/mutations/page_create.py
@@ -15,6 +15,7 @@ from ...core.descriptions import ADDED_IN_33, DEPRECATED_IN_3X_INPUT, RICH_CONTE
 from ...core.doc_category import DOC_CATEGORY_PAGES
 from ...core.fields import JSONString
 from ...core.mutations import ModelMutation
+from ...core.scalars import DateTime
 from ...core.types import BaseInputObjectType, NonNullList, PageError, SeoInput
 from ...core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -35,7 +36,7 @@ class PageInput(BaseInputObjectType):
             "Use `publishedAt` field instead."
         )
     )
-    published_at = graphene.DateTime(
+    published_at = DateTime(
         description="Publication date time. ISO 8601 standard." + ADDED_IN_33
     )
     seo = SeoInput(description="Search engine optimization fields.")

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -16,7 +16,7 @@ from ..core.descriptions import ADDED_IN_33, DEPRECATED_IN_3X_FIELD, RICH_CONTEN
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import FilterConnectionField, JSONString, PermissionsField
-from ..core.scalars import Date
+from ..core.scalars import Date, DateTime
 from ..core.types import ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
 from ..translations.fields import TranslationField
@@ -126,9 +126,7 @@ class Page(ModelObjectType[models.Page]):
             "Use the `publishedAt` field to fetch the publication date."
         ),
     )
-    published_at = graphene.DateTime(
-        description="The page publication date." + ADDED_IN_33
-    )
+    published_at = DateTime(description="The page publication date." + ADDED_IN_33)
     is_published = graphene.Boolean(
         required=True, description="Determines if the page is published."
     )
@@ -136,7 +134,7 @@ class Page(ModelObjectType[models.Page]):
     page_type = graphene.Field(
         PageType, required=True, description="Determines the type of page"
     )
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="Date and time at which page was created."
     )
     content_json = JSONString(

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -29,7 +29,7 @@ from ....core.descriptions import ADDED_IN_313, ADDED_IN_314, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.enums import TransactionEventReportErrorCode
 from ....core.mutations import ModelMutation
-from ....core.scalars import UUID, PositiveDecimal
+from ....core.scalars import UUID, DateTime, PositiveDecimal
 from ....core.types import common as common_types
 from ....core.validators import validate_one_of_args_is_in_mutation
 from ....plugins.dataloaders import get_plugin_manager_promise
@@ -79,7 +79,7 @@ class TransactionEventReport(ModelMutation):
         amount = PositiveDecimal(
             description="The amount of the event to report.", required=True
         )
-        time = graphene.DateTime(
+        time = DateTime(
             description=(
                 "The time of the event to report. If not provide, "
                 "the current time will be used."

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -25,7 +25,7 @@ from ..core.descriptions import (
 )
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import JSONString, PermissionsField
-from ..core.scalars import JSON
+from ..core.scalars import JSON, DateTime
 from ..core.scalars import UUID as UUIDScalar
 from ..core.tracing import traced_resolver
 from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList
@@ -50,7 +50,7 @@ from .enums import (
 
 class Transaction(ModelObjectType[models.Transaction]):
     id = graphene.GlobalID(required=True, description="ID of the transaction.")
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="Date and time at which transaction was created."
     )
     payment = graphene.Field(
@@ -140,10 +140,10 @@ class Payment(ModelObjectType[models.Payment]):
     is_active = graphene.Boolean(
         required=True, description="Determines if the payment is active or not."
     )
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="Date and time at which payment was created."
     )
-    modified = graphene.DateTime(
+    modified = DateTime(
         required=True, description="Date and time at which payment was modified."
     )
     token = graphene.String(
@@ -311,7 +311,7 @@ class PaymentInitialized(BaseObjectType):
 
 
 class TransactionEvent(ModelObjectType[models.TransactionEvent]):
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         required=True,
         description="Date and time at which a transaction event was created.",
     )
@@ -412,11 +412,11 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     token = graphene.Field(
         UUIDScalar, description="The transaction token." + ADDED_IN_314, required=True
     )
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         required=True,
         description="Date and time at which payment transaction was created.",
     )
-    modified_at = graphene.DateTime(
+    modified_at = DateTime(
         required=True,
         description="Date and time at which payment transaction was modified.",
     )

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -32,7 +32,7 @@ from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.enums import ErrorPolicyEnum
 from ...core.fields import JSONString
 from ...core.mutations import BaseMutation, ModelMutation
-from ...core.scalars import WeightScalar
+from ...core.scalars import DateTime, WeightScalar
 from ...core.types import (
     BaseInputObjectType,
     BaseObjectType,
@@ -77,9 +77,7 @@ class ProductChannelListingCreateInput(BaseInputObjectType):
     is_published = graphene.Boolean(
         description="Determines if object is visible to customers."
     )
-    published_at = graphene.types.datetime.DateTime(
-        description="Publication date time. ISO 8601 standard."
-    )
+    published_at = DateTime(description="Publication date time. ISO 8601 standard.")
     visible_in_listings = graphene.Boolean(
         description=(
             "Determines if product is visible in product listings "
@@ -93,7 +91,7 @@ class ProductChannelListingCreateInput(BaseInputObjectType):
             "this product is still visible to customers, but it cannot be purchased."
         ),
     )
-    available_for_purchase_at = graphene.DateTime(
+    available_for_purchase_at = DateTime(
         description=(
             "A start date time from which a product will be available "
             "for purchase. When not set and `isAvailable` is set to True, "

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -37,7 +37,7 @@ from ...core.mutations import (
     ModelMutation,
     validation_error_to_error_type,
 )
-from ...core.scalars import Date
+from ...core.scalars import Date, DateTime
 from ...core.types import (
     BaseInputObjectType,
     BaseObjectType,
@@ -190,7 +190,7 @@ class BulkAttributeValueInput(BaseInputObjectType):
     date = Date(
         required=False, description=AttributeValueDescriptions.DATE + ADDED_IN_312
     )
-    date_time = graphene.DateTime(
+    date_time = DateTime(
         required=False, description=AttributeValueDescriptions.DATE_TIME + ADDED_IN_312
     )
 

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -52,6 +52,7 @@ from ..core.filters import (
     OperationObjectTypeWhereFilter,
     filter_slug_list,
 )
+from ..core.scalars import DateTime
 from ..core.types import (
     BaseInputObjectType,
     ChannelFilterInputObjectType,
@@ -684,7 +685,7 @@ class ProductStockFilterInput(BaseInputObjectType):
 class ProductFilter(MetadataFilterBase):
     is_published = django_filters.BooleanFilter(method="filter_is_published")
     published_from = ObjectTypeFilter(
-        input_class=graphene.DateTime,
+        input_class=DateTime,
         method="filter_published_from",
         help_text=f"Filter by the publication date. {ADDED_IN_38}",
     )
@@ -693,7 +694,7 @@ class ProductFilter(MetadataFilterBase):
         help_text=f"Filter by availability for purchase. {ADDED_IN_38}",
     )
     available_from = ObjectTypeFilter(
-        input_class=graphene.DateTime,
+        input_class=DateTime,
         method="filter_available_from",
         help_text=f"Filter by the date of availability for purchase. {ADDED_IN_38}",
     )
@@ -1028,12 +1029,12 @@ class ProductWhere(MetadataWhereFilterBase):
         method="filter_is_listed", help_text="Filter by visibility on the channel."
     )
     published_from = ObjectTypeWhereFilter(
-        input_class=graphene.DateTime,
+        input_class=DateTime,
         method="filter_published_from",
         help_text="Filter by the publication date.",
     )
     available_from = ObjectTypeWhereFilter(
-        input_class=graphene.DateTime,
+        input_class=DateTime,
         method="filter_available_from",
         help_text="Filter by the date of availability for purchase.",
     )

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -32,7 +32,7 @@ from ...core.descriptions import (
 )
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.mutations import BaseMutation
-from ...core.scalars import Date, PositiveDecimal
+from ...core.scalars import Date, DateTime, PositiveDecimal
 from ...core.types import (
     BaseInputObjectType,
     CollectionChannelListingError,
@@ -67,7 +67,7 @@ class PublishableChannelListingInput(BaseInputObjectType):
             "Use `publishedAt` field instead."
         )
     )
-    published_at = graphene.types.datetime.DateTime(
+    published_at = DateTime(
         description="Publication date time. ISO 8601 standard." + ADDED_IN_33
     )
 
@@ -97,7 +97,7 @@ class ProductChannelListingAddInput(PublishableChannelListingInput):
             "Use `availableForPurchaseAt` field instead."
         )
     )
-    available_for_purchase_at = graphene.DateTime(
+    available_for_purchase_at = DateTime(
         description=(
             "A start date time from which a product will be available "
             "for purchase. When not set and `isAvailable` is set to True, "

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -19,7 +19,7 @@ from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_31, ADDED_IN_38, ADDED_IN_310
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
 from ....core.mutations import ModelMutation
-from ....core.scalars import WeightScalar
+from ....core.scalars import DateTime, WeightScalar
 from ....core.types import BaseInputObjectType, NonNullList, ProductError
 from ....core.utils import get_duplicated_values
 from ....meta.inputs import MetadataInput
@@ -41,7 +41,7 @@ class PreorderSettingsInput(BaseInputObjectType):
     global_threshold = graphene.Int(
         description="The global threshold for preorder variant."
     )
-    end_date = graphene.DateTime(description="The end date for preorder.")
+    end_date = DateTime(description="The end date for preorder.")
 
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -31,6 +31,7 @@ from ...core.descriptions import (
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.federation import federated_entity, resolve_federation_references
 from ...core.fields import ConnectionField, FilterConnectionField, JSONString
+from ...core.scalars import DateTime
 from ...core.types import Image, ModelObjectType, ThumbnailField
 from ...meta.types import ObjectWithMetadata
 from ...translations.fields import TranslationField
@@ -62,7 +63,7 @@ class Category(ModelObjectType[models.Category]):
             f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
         ),
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True,
         description="The date and time when the category was last updated."
         + ADDED_IN_317,

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -25,7 +25,7 @@ from ...channel.types import Channel
 from ...core.descriptions import ADDED_IN_31, ADDED_IN_33, DEPRECATED_IN_3X_FIELD
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.fields import PermissionsField
-from ...core.scalars import Date
+from ...core.scalars import Date, DateTime
 from ...core.tracing import traced_resolver
 from ...core.types import BaseObjectType, ModelObjectType
 from ...tax.dataloaders import (
@@ -62,7 +62,7 @@ class ProductChannelListing(ModelObjectType[models.ProductChannelListing]):
             "Use the `publishedAt` field to fetch the publication date."
         ),
     )
-    published_at = graphene.DateTime(
+    published_at = DateTime(
         description="The product publication date time." + ADDED_IN_33
     )
     is_published = graphene.Boolean(
@@ -85,7 +85,7 @@ class ProductChannelListing(ModelObjectType[models.ProductChannelListing]):
             "the available for purchase date."
         ),
     )
-    available_for_purchase_at = graphene.DateTime(
+    available_for_purchase_at = DateTime(
         description="The product available for purchase date time." + ADDED_IN_33
     )
     discounted_price = graphene.Field(
@@ -397,7 +397,7 @@ class CollectionChannelListing(ModelObjectType[models.CollectionChannelListing])
             "Use the `publishedAt` field to fetch the publication date."
         ),
     )
-    published_at = graphene.DateTime(
+    published_at = DateTime(
         description="The collection publication date." + ADDED_IN_33
     )
     is_published = graphene.Boolean(

--- a/saleor/graphql/product/types/digital_contents.py
+++ b/saleor/graphql/product/types/digital_contents.py
@@ -6,7 +6,7 @@ from ...channel import ChannelContext
 from ...core import ResolveInfo
 from ...core.connection import CountableConnection
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
-from ...core.scalars import UUID
+from ...core.scalars import UUID, DateTime
 from ...core.types import ModelObjectType, NonNullList
 from ...meta.types import ObjectWithMetadata
 from ..dataloaders import ProductVariantByIdLoader
@@ -21,7 +21,7 @@ class DigitalContentUrl(ModelObjectType[models.DigitalContentUrl]):
         required=True,
         description="Digital content associated with the URL.",
     )
-    created = graphene.DateTime(
+    created = DateTime(
         required=True,
         description="Date and time when the digital content URL was created.",
     )

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -73,7 +73,7 @@ from ...core.fields import (
     JSONString,
     PermissionsField,
 )
-from ...core.scalars import Date
+from ...core.scalars import Date, DateTime
 from ...core.tracing import traced_resolver
 from ...core.types import (
     BaseObjectType,
@@ -251,7 +251,7 @@ class PreorderData(BaseObjectType):
         description="Total number of sold product variant during preorder.",
         permissions=[ProductPermissions.MANAGE_PRODUCTS],
     )
-    end_date = graphene.DateTime(required=False, description="Preorder end date.")
+    end_date = DateTime(required=False, description="Preorder end date.")
 
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
@@ -399,11 +399,11 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
         required=False,
         description=("Preorder data for product variant." + ADDED_IN_31),
     )
-    created = graphene.DateTime(
+    created = DateTime(
         required=True,
         description="The date and time when the product variant was created.",
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True,
         description="The date and time when the product variant was last updated.",
     )
@@ -852,10 +852,10 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
     )
     slug = graphene.String(required=True, description="Slug of the product.")
     category = graphene.Field("saleor.graphql.product.types.categories.Category")
-    created = graphene.DateTime(
+    created = DateTime(
         required=True, description="The date and time when the product was created."
     )
-    updated_at = graphene.DateTime(
+    updated_at = DateTime(
         required=True,
         description="The date and time when the product was last updated.",
     )
@@ -987,7 +987,7 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
             "the available for purchase date."
         ),
     )
-    available_for_purchase_at = graphene.DateTime(
+    available_for_purchase_at = DateTime(
         description="Date when product is available for purchase."
     )
     is_available_for_purchase = graphene.Boolean(

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -73,7 +73,7 @@ from ..core.doc_category import (
     DOC_CATEGORY_TAXES,
     DOC_CATEGORY_USERS,
 )
-from ..core.scalars import JSON, PositiveDecimal
+from ..core.scalars import JSON, DateTime, PositiveDecimal
 from ..core.types import NonNullList, SubscriptionObjectType
 from ..core.types.order_or_checkout import OrderOrCheckout
 from ..order.dataloaders import OrderByIdLoader
@@ -116,7 +116,7 @@ class IssuingPrincipal(Union):
 
 
 class Event(graphene.Interface):
-    issued_at = graphene.DateTime(description="Time of the event.")
+    issued_at = DateTime(description="Time of the event.")
     version = graphene.String(description="Saleor version that triggered the event.")
     issuing_principal = graphene.Field(
         IssuingPrincipal,

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -13,6 +13,7 @@ from ..core.connection import (
 from ..core.context import get_database_connection_name
 from ..core.descriptions import ADDED_IN_312, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
 from ..core.fields import FilterConnectionField, JSONString
+from ..core.scalars import DateTime
 from ..core.types import ModelObjectType, NonNullList
 from ..webhook.enums import EventDeliveryStatusEnum, WebhookEventTypeEnum
 from ..webhook.filters import EventDeliveryFilterInput
@@ -77,7 +78,7 @@ class EventDeliveryAttempt(ModelObjectType[core_models.EventDeliveryAttempt]):
     id = graphene.GlobalID(
         required=True, description="The ID of Event Delivery Attempt."
     )
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         description="Event delivery creation date and time.", required=True
     )
     task_id = graphene.String(description="Task id for delivery attempt.")
@@ -109,7 +110,7 @@ class EventDeliveryAttemptCountableConnection(CountableConnection):
 
 class EventDelivery(ModelObjectType[core_models.EventDelivery]):
     id = graphene.GlobalID(required=True, description="The ID of an event delivery.")
-    created_at = graphene.DateTime(
+    created_at = DateTime(
         required=True, description="Creation time of an event delivery."
     )
     status = EventDeliveryStatusEnum(


### PR DESCRIPTION
I want to merge this change because it adds our own DateTime scalar. The graphene scalar doesn't validate if provided datetime, after converting to UTC time doesn't exceed the datetime's min, max values.
For example when using input like this one:
"0001-01-01T00:00:01+07:00", it will be saved on DB as -> 0001-12-31 17:00:01+00 BC. When fetching the details from DB and casting it to datetime instance, datetime module will raise an exception, as the value is lower than the datetime.min.

Port of changes from: #16202 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
