### PR TITLE
Preload as much of the app as possible

### DIFF
--- a/saleor/asgi/__init__.py
+++ b/saleor/asgi/__init__.py
@@ -14,9 +14,23 @@ from .cors_handler import cors_handler
 from .gzip_compression import gzip_compression
 from .health_check import health_check
 
+
+def preload_app() -> None:
+    """Import the app code to make sure that Django application is loaded.
+
+    By default, Django does not import the application until the first request is processed.
+    """
+    from django.conf import settings
+    from django.urls import get_resolver
+
+    get_resolver(settings.ROOT_URLCONF).url_patterns
+
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")
 
 application = get_asgi_application()
 application = health_check(application, "/health/")  # type: ignore[arg-type] # Django's ASGI app is less strict than the spec # noqa: E501
 application = gzip_compression(application)
 application = cors_handler(application)
+
+preload_app()


### PR DESCRIPTION
While the app is starting up, loading as much of the code as possible is generally beneficial, especially in multi-process and multi-threaded environments that can share memory, but only if that data was already there before forking.

This change ensures Django imports the URL configuration (and thus also views and their dependencies) before the first request arrives.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
