### PR TITLE
Fix Order and click-and-collect address data migration

### DIFF
--- a/saleor/order/migrations/0172_update_order_cc_addresses.py
+++ b/saleor/order/migrations/0172_update_order_cc_addresses.py
@@ -38,7 +38,11 @@ def update_order_addresses(apps, schema_editor):
                 order_address = Address(**model_to_dict(cc_address, exclude=["id"]))
                 order.shipping_address = order_address
                 addresses.append(order_address)
-        Address.objects.bulk_create(addresses, ignore_conflicts=True)
+        Address.objects.bulk_create(addresses, ignore_conflicts=False)
+        # Due to a bug in Django, addresses need to be reassigned for bulk_update of Orders to work correctly.
+        # For more information about the bug, see: https://code.djangoproject.com/ticket/33322
+        for order in orders:
+            order.shipping_address = order.shipping_address
         Order.objects.bulk_update(orders, ["shipping_address"])
 
 


### PR DESCRIPTION
This change addresses a bug in the data migration, which involves two separate issues:

1. Addresses are created using the `bulk_create` method with the `ignore_conflicts=True` argument. However, this prevents primary keys from being assigned to Address objects, making it impossible to assign them to Orders properly. We discussed that `ignore_conflicts=True` is unnecessary here and can be turned off, which fixes this issue.
2. Due to a bug in Django (fixed in version 4.1+), addresses need to be reassigned for the `bulk_update` of Orders to work correctly. More details can be found here: [https://code.djangoproject.com/ticket/33322](https://code.djangoproject.com/ticket/33322)

Related task [SHOPX-1002](https://linear.app/saleor/issue/SHOPX-1002)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
