### PR TITLE
Add threshold when updating user.last_login field

### DIFF
--- a/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import graphene
+import pytz
 from django.urls import reverse
 from freezegun import freeze_time
 
@@ -284,3 +285,58 @@ def test_create_token_email_case_insensitive(api_client, customer_user, settings
     assert customer_user.email == data["user"]["email"]
     assert not data["errors"]
     assert data["token"]
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_create_token_do_not_update_last_login_when_in_threshold(
+    api_client, customer_user, settings
+):
+    # given
+    customer_password = customer_user._password
+    customer_user.last_login = datetime.now(tz=pytz.UTC)
+    customer_user.save()
+    expected_last_login = customer_user.last_login
+    expected_updated_at = customer_user.updated_at
+    variables = {"email": customer_user.email, "password": customer_password}
+    time_in_threshold = datetime.now(tz=pytz.UTC) + timedelta(
+        seconds=settings.TOKEN_UPDATE_LAST_LOGIN_THRESHOLD - 1
+    )
+
+    # when
+    with freeze_time(time_in_threshold):
+        response = api_client.post_graphql(MUTATION_CREATE_TOKEN, variables)
+
+    # then
+    get_graphql_content(response)
+    customer_user.refresh_from_db()
+    assert customer_user.updated_at == expected_updated_at
+    assert customer_user.last_login == expected_last_login
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_create_token_do_not_update_last_login_when_out_of_threshold(
+    api_client, customer_user, settings
+):
+    # given
+    customer_password = customer_user._password
+    customer_user.last_login = datetime.now(tz=pytz.UTC)
+    customer_user.save()
+    previous_last_login = customer_user.last_login
+    previous_updated_at = customer_user.updated_at
+
+    variables = {"email": customer_user.email, "password": customer_password}
+    time_in_threshold = datetime.now(tz=pytz.UTC) + timedelta(
+        seconds=settings.TOKEN_UPDATE_LAST_LOGIN_THRESHOLD + 1
+    )
+
+    # when
+    with freeze_time(time_in_threshold):
+        response = api_client.post_graphql(MUTATION_CREATE_TOKEN, variables)
+
+    # then
+    get_graphql_content(response)
+    customer_user.refresh_from_db()
+    assert customer_user.updated_at != previous_updated_at
+    assert customer_user.last_login != previous_last_login
+    assert customer_user.updated_at == time_in_threshold
+    assert customer_user.last_login == time_in_threshold

--- a/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
@@ -314,7 +314,7 @@ def test_create_token_do_not_update_last_login_when_in_threshold(
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_create_token_do_not_update_last_login_when_out_of_threshold(
+def test_create_token_do_update_last_login_when_out_of_threshold(
     api_client, customer_user, settings
 ):
     # given

--- a/saleor/graphql/account/tests/mutations/authentication/test_token_refresh.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_token_refresh.py
@@ -332,7 +332,7 @@ def test_refresh_token_do_not_update_last_login_when_in_threshold(
 
 
 @freeze_time("2020-03-18 12:00:00")
-def test_refresh_token_do_not_update_last_login_when_out_of_threshold(
+def test_refresh_token_do_update_last_login_when_out_of_threshold(
     api_client, customer_user, settings
 ):
     # given

--- a/saleor/graphql/account/tests/mutations/authentication/test_token_refresh.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_token_refresh.py
@@ -1,6 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
+import pytz
 from django.urls import reverse
 from freezegun import freeze_time
 
@@ -292,3 +293,77 @@ def test_refresh_token_incorrect_token_provided(api_client, customer_user, token
     assert not data.get("token")
     assert len(errors) == 1
     assert errors[0]["code"] == AccountErrorCode.JWT_DECODE_ERROR.name
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_refresh_token_do_not_update_last_login_when_in_threshold(
+    api_client, customer_user, settings
+):
+    # given
+    csrf_token = _get_new_csrf_token()
+    token_audience = "custom:dashboard"
+    refresh_token = create_refresh_token(
+        customer_user, {"csrfToken": csrf_token, "aud": token_audience}
+    )
+    api_client.cookies[JWT_REFRESH_TOKEN_COOKIE_NAME] = refresh_token
+    api_client.cookies[JWT_REFRESH_TOKEN_COOKIE_NAME]["httponly"] = True
+
+    customer_user.last_login = datetime.now(tz=pytz.UTC)
+    customer_user.save()
+
+    expected_last_login = customer_user.last_login
+    expected_updated_at = customer_user.updated_at
+
+    variables = {"token": None, "csrf_token": csrf_token}
+
+    time_in_threshold = datetime.now(tz=pytz.UTC) + timedelta(
+        seconds=settings.TOKEN_UPDATE_LAST_LOGIN_THRESHOLD - 1
+    )
+
+    # when
+    with freeze_time(time_in_threshold):
+        response = api_client.post_graphql(MUTATION_TOKEN_REFRESH, variables)
+
+    # then
+    get_graphql_content(response)
+    customer_user.refresh_from_db()
+    assert customer_user.updated_at == expected_updated_at
+    assert customer_user.last_login == expected_last_login
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_refresh_token_do_not_update_last_login_when_out_of_threshold(
+    api_client, customer_user, settings
+):
+    # given
+    csrf_token = _get_new_csrf_token()
+    token_audience = "custom:dashboard"
+    refresh_token = create_refresh_token(
+        customer_user, {"csrfToken": csrf_token, "aud": token_audience}
+    )
+    api_client.cookies[JWT_REFRESH_TOKEN_COOKIE_NAME] = refresh_token
+    api_client.cookies[JWT_REFRESH_TOKEN_COOKIE_NAME]["httponly"] = True
+
+    customer_user.last_login = datetime.now(tz=pytz.UTC)
+    customer_user.save()
+
+    previous_last_login = customer_user.last_login
+    previous_updated_at = customer_user.updated_at
+
+    variables = {"token": None, "csrf_token": csrf_token}
+
+    time_in_threshold = datetime.now(tz=pytz.UTC) + timedelta(
+        seconds=settings.TOKEN_UPDATE_LAST_LOGIN_THRESHOLD + 1
+    )
+
+    # when
+    with freeze_time(time_in_threshold):
+        response = api_client.post_graphql(MUTATION_TOKEN_REFRESH, variables)
+
+    # then
+    get_graphql_content(response)
+    customer_user.refresh_from_db()
+    assert customer_user.updated_at != previous_updated_at
+    assert customer_user.last_login != previous_last_login
+    assert customer_user.updated_at == time_in_threshold
+    assert customer_user.last_login == time_in_threshold

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -914,6 +914,12 @@ OAUTH_UPDATE_LAST_LOGIN_THRESHOLD = parse(
     os.environ.get("OAUTH_UPDATE_LAST_LOGIN_THRESHOLD", "15 minutes")
 )
 
+# Time threshold to update user last_login when using tokenCreate/tokenRefresh
+# mutations.
+TOKEN_UPDATE_LAST_LOGIN_THRESHOLD = parse(
+    os.environ.get("TOKEN_UPDATE_LAST_LOGIN_THRESHOLD", "5 seconds")
+)
+
 # Max lock time for checkout processing.
 # It prevents locking checkout when unhandled issue appears.
 CHECKOUT_COMPLETION_LOCK_TIME = parse(


### PR DESCRIPTION
I want to merge this change because it adds 5 seconds of threshold (settings variable) when calling tokenCreate/tokenRefresh mutation. In case of calling multiple times this mutation for the same user, this will not make an additional updates on DB side.
Port of changes from: #16245

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
