### PR TITLE
Optimize SQL queries for fetching product variants

### DIFF
--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -566,7 +566,6 @@ class ProductQueries(graphene.ObjectType):
                 ids=ids,
                 channel=channel_obj,
                 limited_channel_access=limited_channel_access,
-                requestor_has_access_to_all=has_required_permissions,
                 requestor=requestor,
             )
             kwargs["channel"] = qs.channel_slug

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -803,9 +803,6 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
     @staticmethod
     def __resolve_references(roots: list["ProductVariant"], info):
         requestor = get_user_or_app_from_context(info.context)
-        requestor_has_access_to_all = has_one_of_permissions(
-            requestor, ALL_PRODUCTS_PERMISSIONS
-        )
 
         channels = defaultdict(set)
         roots_ids = []
@@ -819,7 +816,6 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
             limited_channel_access = False if channel_slug is None else True
             qs = resolve_product_variants(
                 info,
-                requestor_has_access_to_all,
                 requestor,
                 ids=ids,
                 channel=channels_map.get(channel_slug),

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -327,7 +327,7 @@ class ProductVariantQueryset(models.QuerySet):
         # - have a variant channel listing for this channel and the price is not null
         # - have a product channel listing for this channel and the product is published
         #  and visible in listings
-        variants = ProductVariant.objects.filter(
+        variants = ProductVariant.objects.using(self.db).filter(
             channel_listings__channel_id=channel.id,
             channel_listings__price_amount__isnull=False,
         )

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -306,7 +306,7 @@ class ProductVariantQueryset(models.QuerySet):
         channel: Optional[Channel],
         limited_channel_access: bool,
     ):
-        from .models import ALL_PRODUCTS_PERMISSIONS, ProductVariant
+        from .models import ALL_PRODUCTS_PERMISSIONS
 
         # User with product permissions can see all variants. If channel is given,
         # filter variants with product channel listings for this channel.
@@ -327,7 +327,7 @@ class ProductVariantQueryset(models.QuerySet):
         # - have a variant channel listing for this channel and the price is not null
         # - have a product channel listing for this channel and the product is published
         #  and visible in listings
-        variants = ProductVariant.objects.using(self.db).filter(
+        variants = self.filter(
             channel_listings__channel_id=channel.id,
             channel_listings__price_amount__isnull=False,
         )


### PR DESCRIPTION
Optimize SQL queries made by the `productVariants` GraphQL field to use JOINs instead of subqueries.

Port #16154 to 3.19.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
