### PR TITLE
Optimize SQL queries for fetching product variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extend valid address values - #15877 by @zedzior
 - Fixed a rare crash in the introspection query detection code - #15966 by @patrys
 - Added HTTP compression telemetry - #16125 by @patrys
+- Rewrite `productVariants` resolvers to use JOINs instead of subqueries - #16262 by @maarcingebala
 
 # 3.19.0
 

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -165,35 +165,24 @@ def resolve_variant(
 @traced_resolver
 def resolve_product_variants(
     info: ResolveInfo,
-    requestor_has_access_to_all,
     requestor,
     ids=None,
     channel: Optional[Channel] = None,
     limited_channel_access: bool = False,
 ) -> ChannelQsContext:
     connection_name = get_database_connection_name(info.context)
-    visible_products = models.Product.objects.using(connection_name).visible_to_user(
+
+    qs = models.ProductVariant.objects.using(connection_name).visible_to_user(
         requestor, channel, limited_channel_access
     )
-    qs = models.ProductVariant.objects.using(connection_name).filter(
-        product__id__in=visible_products
-    )
 
-    channel_slug = channel.slug if channel else None
-    if not requestor_has_access_to_all:
-        visible_products = visible_products.annotate_visible_in_listings(
-            channel
-        ).exclude(visible_in_listings=False)
-        qs = (
-            qs.using(connection_name)
-            .filter(product__in=visible_products)
-            .available_in_channel(channel)
-        )
     if ids:
         db_ids = [
             from_global_id_or_error(node_id, "ProductVariant")[1] for node_id in ids
         ]
         qs = qs.filter(pk__in=db_ids)
+
+    channel_slug = channel.slug if channel else None
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
 
 

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -586,7 +586,6 @@ class ProductQueries(graphene.ObjectType):
                 ids=ids,
                 channel=channel_obj,
                 limited_channel_access=limited_channel_access,
-                requestor_has_access_to_all=has_required_permissions,
                 requestor=requestor,
             )
             kwargs["channel"] = qs.channel_slug

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -808,9 +808,6 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
     @staticmethod
     def __resolve_references(roots: list["ProductVariant"], info):
         requestor = get_user_or_app_from_context(info.context)
-        requestor_has_access_to_all = has_one_of_permissions(
-            requestor, ALL_PRODUCTS_PERMISSIONS
-        )
 
         channels = defaultdict(set)
         roots_ids = []
@@ -827,7 +824,6 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
             limited_channel_access = False if channel_slug is None else True
             qs = resolve_product_variants(
                 info,
-                requestor_has_access_to_all,
                 requestor,
                 ids=ids,
                 channel=channels_map.get(channel_slug),

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -343,7 +343,7 @@ class ProductVariantQueryset(models.QuerySet):
         # - have a variant channel listing for this channel and the price is not null
         # - have a product channel listing for this channel and the product is published
         #  and visible in listings
-        variants = ProductVariant.objects.filter(
+        variants = ProductVariant.objects.using(self.db).filter(
             channel_listings__channel_id=channel.id,
             channel_listings__price_amount__isnull=False,
         )

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -316,6 +316,48 @@ class ProductVariantQueryset(models.QuerySet):
             "variant_media__media",
         )
 
+    def visible_to_user(
+        self,
+        requestor: Union["User", "App", None],
+        channel: Optional[Channel],
+        limited_channel_access: bool,
+    ):
+        from .models import ALL_PRODUCTS_PERMISSIONS, ProductVariant
+
+        # User with product permissions can see all variants. If channel is given,
+        # filter variants with product channel listings for this channel.
+        if has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
+            if limited_channel_access:
+                if channel:
+                    return self.filter(product__channel_listings__channel_id=channel.id)
+                return self.none()
+            return self.all()
+
+        # If user has no permissions (customer) and channel is not given or is inactive,
+        # return no variants.
+        if not channel or not channel.is_active:
+            return self.none()
+
+        # If user has no permissions (customer) and channel is given, return variants
+        # that:
+        # - have a variant channel listing for this channel and the price is not null
+        # - have a product channel listing for this channel and the product is published
+        #  and visible in listings
+        variants = ProductVariant.objects.filter(
+            channel_listings__channel_id=channel.id,
+            channel_listings__price_amount__isnull=False,
+        )
+
+        today = datetime.datetime.now(pytz.UTC)
+        variants = variants.filter(
+            Q(product__channel_listings__published_at__lte=today)
+            | Q(product__channel_listings__published_at__isnull=True),
+            product__channel_listings__is_published=True,
+            product__channel_listings__channel_id=channel.id,
+            product__channel_listings__visible_in_listings=True,
+        )
+        return variants
+
 
 ProductVariantManager = models.Manager.from_queryset(ProductVariantQueryset)
 

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -322,7 +322,7 @@ class ProductVariantQueryset(models.QuerySet):
         channel: Optional[Channel],
         limited_channel_access: bool,
     ):
-        from .models import ALL_PRODUCTS_PERMISSIONS, ProductVariant
+        from .models import ALL_PRODUCTS_PERMISSIONS
 
         # User with product permissions can see all variants. If channel is given,
         # filter variants with product channel listings for this channel.
@@ -343,7 +343,7 @@ class ProductVariantQueryset(models.QuerySet):
         # - have a variant channel listing for this channel and the price is not null
         # - have a product channel listing for this channel and the product is published
         #  and visible in listings
-        variants = ProductVariant.objects.using(self.db).filter(
+        variants = self.filter(
             channel_listings__channel_id=channel.id,
             channel_listings__price_amount__isnull=False,
         )


### PR DESCRIPTION
Optimize SQL queries made by the productVariants GraphQL field to use JOINs instead of subqueries.

Port https://github.com/saleor/saleor/pull/16154 to main.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
