### PR TITLE
Fix warning in test

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -329,11 +329,12 @@ def test_generate_cache_key_use_saleor_version():
     assert saleor_version in cache_key
 
 
-def test_graphql_view_clears_context(rf, staff_user, product):
+def test_graphql_view_clears_context(rf, staff_user, product, channel_USD):
     # given
     product_id = graphene.Node.to_global_id("Product", product.pk)
+    channel_slug = channel_USD.slug
     data = {
-        "query": f'{{ product(id: "{product_id}") {{ name category {{ name }} }} }}'
+        "query": f'{{ product(id: "{product_id}" channel: "{channel_slug}") {{ name category {{ name }} }} }}'
     }
     request = rf.post(path="/", data=data, content_type="application/json")
     request.app = None


### PR DESCRIPTION
Pass channel to query to fix the warning about using a default channel.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
