### PR TITLE
Narrow down invalid address logs.

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -14,7 +14,7 @@ from .widgets import DatalistTextWidget
 
 COUNTRY_FORMS = {}
 UNKNOWN_COUNTRIES = set()
-ADDRESS_FIELDS_TO_LOG = ["country_area", "city_area", "city", "postal_code"]
+ADDRESS_FIELDS_TO_LOG = ["country_area", "city_area", "city"]
 
 AREA_TYPE = {
     "area": "Area",
@@ -197,13 +197,15 @@ class CountryAwareAddressForm(AddressForm):
         return self.validate_address(data)
 
     def log_errors(self):
+        if not self.data.get("skip_validation"):
+            return
+
         errors = self.errors
         fields = {}
         for field, _ in errors.items():
             fields[field] = (
                 self.data.get(field) if field in ADDRESS_FIELDS_TO_LOG else "invalid"
             )
-        fields["skip_validation"] = self.data.get("skip_validation")
         fields["country"] = self.data.get("country")
         logger.warning("Invalid address input: %s", fields)
 


### PR DESCRIPTION
I want to merge this change because I want to log invalid address items only when `AddressInput.skip_validation` is set to False. There is also no need to log invalid postal codes.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
