### PR TITLE
Fix Vulnerability: User enumeration via login response time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 - Remove the `anonymize` plugin. Use `saleor/core/utils/anonymization` code instead. - by @aniav
+- Change error codes related to user enumeration bad habbit. Included mutations will now not reveal information in error codes if email was already registered:
+  - `AccountRegister`,
+    `AccountRegister` mutation will additionaly not return `ID` of the user.
+  - `ConfirmAccount`,
+  - `RequestPasswordReset`,
+  - `SetPassword`, #16243 by @kadewu
 
 ### GraphQL API
 - Add `translatableContent` to all translation types; add translated object id to all translatable content types - #15617 by @zedzior

--- a/saleor/account/utils.py
+++ b/saleor/account/utils.py
@@ -1,3 +1,5 @@
+import random
+
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -133,6 +135,13 @@ def retrieve_user_by_email(email):
     if users:
         return users[0]
     return None
+
+
+def get_random_user():
+    users = list(User.objects.all())
+    random_number = random.randint(0, (len(users)-1))
+
+    return users[random_number]
 
 
 def get_user_groups_permissions(user: User):

--- a/saleor/graphql/account/mutations/account/confirm_account.py
+++ b/saleor/graphql/account/mutations/account/confirm_account.py
@@ -47,19 +47,15 @@ class ConfirmAccount(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        error = False
         try:
             user = models.User.objects.get(email=data["email"])
         except ObjectDoesNotExist:
-            raise ValidationError(
-                {
-                    "email": ValidationError(
-                        "User with this email doesn't exist",
-                        code=AccountErrorCode.NOT_FOUND.value,
-                    )
-                }
-            )
+            error = True
+            user = models.User()
 
-        if not default_token_generator.check_token(user, data["token"]):
+        valid_token = default_token_generator.check_token(user, data["token"])
+        if not valid_token or error:
             raise ValidationError(
                 {
                     "token": ValidationError(

--- a/saleor/graphql/account/mutations/authentication/set_password.py
+++ b/saleor/graphql/account/mutations/authentication/set_password.py
@@ -60,17 +60,15 @@ class SetPassword(CreateToken):
 
     @classmethod
     def _set_password_for_user(cls, email, password, token):
+        error = False
         try:
             user = models.User.objects.get(email=email)
         except ObjectDoesNotExist:
-            raise ValidationError(
-                {
-                    "email": ValidationError(
-                        "User doesn't exist", code=AccountErrorCode.NOT_FOUND.value
-                    )
-                }
-            )
-        if not default_token_generator.check_token(user, token):
+            error = True
+            user = models.User()
+
+        valid_token = default_token_generator.check_token(user, token)
+        if not valid_token or error:
             raise ValidationError(
                 {
                     "token": ValidationError(

--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -5,7 +5,6 @@ from django.contrib.auth.tokens import default_token_generator
 from django.test import override_settings
 
 from ......account import events as account_events
-from ......account.error_codes import AccountErrorCode
 from ......account.models import User
 from ......account.notifications import get_default_user_payload
 from ......account.search import generate_user_fields_search_document_value
@@ -99,9 +98,7 @@ def test_customer_register(
     response = api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content["data"][mutation_name]
-    assert data["errors"]
-    assert data["errors"][0]["field"] == "email"
-    assert data["errors"][0]["code"] == AccountErrorCode.UNIQUE.name
+    assert not data["errors"]
 
     customer_creation_event = account_events.CustomerEvent.objects.get()
     assert customer_creation_event.type == account_events.CustomerEvents.ACCOUNT_CREATED

--- a/saleor/graphql/account/tests/mutations/account/test_confirm_account.py
+++ b/saleor/graphql/account/tests/mutations/account/test_confirm_account.py
@@ -78,10 +78,10 @@ def test_account_confirmation_invalid_user(
     }
     response = user_api_client.post_graphql(CONFIRM_ACCOUNT_MUTATION, variables)
     content = get_graphql_content(response)
-    assert content["data"]["confirmAccount"]["errors"][0]["field"] == "email"
+    assert content["data"]["confirmAccount"]["errors"][0]["field"] == "token"
     assert (
         content["data"]["confirmAccount"]["errors"][0]["code"]
-        == AccountErrorCode.NOT_FOUND.name
+        == AccountErrorCode.INVALID.name
     )
     match_orders_with_new_user_mock.assert_not_called()
     assign_gift_cards_mock.assert_not_called()

--- a/saleor/graphql/account/tests/mutations/authentication/test_set_password.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_set_password.py
@@ -104,12 +104,12 @@ def test_set_password_invalid_email(user_api_client):
     content = get_graphql_content(response)
     errors = content["data"]["setPassword"]["errors"]
     assert len(errors) == 1
-    assert errors[0]["field"] == "email"
+    assert errors[0]["field"] == "token"
 
     account_errors = content["data"]["setPassword"]["errors"]
     assert len(account_errors) == 1
-    assert account_errors[0]["field"] == "email"
-    assert account_errors[0]["code"] == AccountErrorCode.NOT_FOUND.name
+    assert account_errors[0]["field"] == "token"
+    assert account_errors[0]["code"] == AccountErrorCode.INVALID.name
 
 
 @freeze_time("2018-05-31 12:00:01")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -31548,9 +31548,9 @@ Triggers the following webhook events:
 type AccountRegister @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, NOTIFY_USER, ACCOUNT_CONFIRMATION_REQUESTED], syncEvents: []) {
   """Informs whether users need to confirm their email address."""
   requiresConfirmation: Boolean
+  user: User @deprecated(reason: "This field will be removed in Saleor 4.0.")
   accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
-  user: User
 }
 
 """Fields required to create a user."""

--- a/saleor/tests/e2e/account/test_login_throttling.py
+++ b/saleor/tests/e2e/account/test_login_throttling.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-import graphene
 import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
 from ....account.error_codes import AccountErrorCode
+from ....account.models import User
 from ....account.throttling import (
     get_cache_key_blocked_ip,
     get_cache_key_failed_ip,
@@ -74,9 +74,9 @@ def test_customer_should_not_be_able_to_perform_credential_guessing_attacks_core
         user_password,
         channel_slug,
     )
-    user_id = user_account["user"]["id"]
-    assert user_id is not None
-    _, user_db_id = graphene.Node.from_global_id(user_id)
+    user_object = User.objects.last()
+    assert user_object
+    user_db_id = user_object.pk
     assert user_account["user"]["isActive"] is True
 
     # Step 2 - First attempt of logging with an invalid password

--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ....account.models import User
+from ....graphql.core.utils import to_global_id_or_none
 from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import account_register, token_create
@@ -51,7 +53,9 @@ def test_should_create_account_without_email_confirmation_core_1502(
         channel_slug,
         redirect_url,
     )
-    user_id = user_account["user"]["id"]
+    user = User.objects.last()
+    assert user
+    user_id = to_global_id_or_none(user)
     assert user_account["user"]["isActive"] is True
 
     # Step 2 - Authenticate as new created user

--- a/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ....account.models import User
+from ....graphql.core.utils import to_global_id_or_none
 from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import account_register, token_create
@@ -53,7 +55,9 @@ def test_should_login_before_email_confirmation_core_1510(
         redirect_url,
     )
 
-    user_id = user_account["user"]["id"]
+    user = User.objects.last()
+    assert user
+    user_id = to_global_id_or_none(user)
     assert user_account["user"]["isActive"] is True
     assert user_account["requiresConfirmation"] is True
 

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ....account.models import User
 from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import account_register, raw_account_register
@@ -48,8 +49,6 @@ def test_should_not_be_able_to_create_account_with_existing_email_core_1503(
         user_password,
         channel_slug,
     )
-    user_id = user_account["user"]["id"]
-    assert user_id is not None
     assert user_account["user"]["isActive"] is True
 
     # Step 2 - Create a new account with the same email address
@@ -60,7 +59,6 @@ def test_should_not_be_able_to_create_account_with_existing_email_core_1503(
         new_password,
         channel_slug,
     )
-    error = new_user_account["data"]["accountRegister"]["errors"][0]
-    assert error["field"] == "email"
-    assert error["message"] == "User with this Email already exists."
-    assert error["code"] == "UNIQUE"
+    # we do not return errors in case email exists
+    assert not new_user_account["data"]["accountRegister"]["errors"]
+    assert User.objects.filter(email__iexact=user_email).count() == 1

--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ....account.models import User
+from ....graphql.core.utils import to_global_id_or_none
 from ..account.utils import account_register
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_shop
@@ -136,7 +138,9 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
         channel_slug,
         redirect_url,
     )
-    user_id = user_account["user"]["id"]
+    user = User.objects.last()
+    assert user
+    user_id = to_global_id_or_none(user)
     assert user_account["user"]["isActive"] is True
 
     # Step 6 - Confirm new account


### PR DESCRIPTION
I want to merge this change because...

I have identified and fixed an user enumeration vulnerability in the authentication process. This vulnerability allowed attackers to determine if an email was registered in the system via response time.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://docs.google.com/document/d/137G3aHZ-aMdV7JFDzgkWsygjUHoL2NTy/edit?usp=sharing&ouid=101128278685376508073&rtpof=true&sd=true

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
