### PR TITLE
Do not update `VoucherCode.used` field with negative value

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.db.models import Exists, F, Func, OuterRef, Subquery, Value
+from django.db.models.functions import Greatest
 from django.utils import timezone
 
 from ..celeryconf import app
@@ -60,7 +61,7 @@ def _bulk_release_voucher_usage(order_ids):
         Exists(voucher_orders),
         Exists(vouchers.filter(id=OuterRef("voucher_id"))),
     ).annotate(order_count=Subquery(count_orders)).update(
-        used=F("used") - F("order_count")
+        used=Greatest(F("used") - F("order_count"), 0)
     )
 
     orders = Order.objects.filter(id__in=order_ids)

--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -63,6 +63,7 @@ def _bulk_release_voucher_usage(order_ids):
     ).annotate(order_count=Subquery(count_orders))
 
     # We observed mismatch between code.used and number of orders which utilize the code
+    # In some cases it is expected, but we want to further investigate the issue
     suspected_codes = [code.code for code in codes if code.used < code.order_count]
     if suspected_codes:
         logger.error(

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from unittest import mock
 from unittest.mock import patch
@@ -618,13 +619,14 @@ def test_delete_expired_orders_task_schedule_itself(
 
 
 def test_bulk_release_voucher_usage_no_negative_value(
-    order_list, allocations, channel_USD, voucher_customer
+    order_list, allocations, channel_USD, voucher_customer, caplog
 ):
     # given
     channel_USD.expire_orders_after = 1
     channel_USD.save()
 
     now = timezone.now()
+    caplog.set_level(logging.ERROR)
     code = voucher_customer.voucher_code
     voucher = code.voucher
     code.used = 1
@@ -650,3 +652,4 @@ def test_bulk_release_voucher_usage_no_negative_value(
     # then
     code.refresh_from_db()
     assert code.used == 0
+    assert code.code in caplog.text


### PR DESCRIPTION
I want to merge this change because it protects against updating the `VoucherCode.used` field with a negative value. 

I identified two cases when it can happen. IMO in both cases, setting `used=0` is a proper behavior.

I also added logging when it happens to investigate the issue further. 

### Steps to reproduce 1:
1. use `channelUpdate` mutation to set:
  a. `include_draft_order_in_voucher_usage=True`
  b. `automatically_confirm_all_new_orders=False`
  c. `expire_orders_after=1`
2. create voucher with `usageLimit=5`
3. create voucher code (let me name it `code-123` for reference)
4. create draft order and associate it with the `code-123`
State 1: Now we have draft order where `order.voucher_code=code-123` and `voucher_code.used=1`
5. use `channelUpdate` mutation to set `include_draft_order_in_voucher_usage=False`. It will decrease the `voucher_code.used`, but **won't disconnect voucher from the orders**
State 2: Now we have draft order where `order.voucher_code=code-123` and `voucher_code.used=0`
6. run `draftOrderCompletet` to change status to `unconfirmed` (only unconfirmed orders can be expired)

With such a state, run `expire_order_task`. It will try to save -1 value to `used` positive integer field

### Steps to reproduce 2:
1. use `channelUpdate` mutation to set:
  a. `include_draft_order_in_voucher_usage=True`
  b. `automatically_confirm_all_new_orders=False`
  c. `expire_orders_after=1`
2. create voucher **without setting usage_limit**
3. create new code for the voucher (ie. code-123)
4. create draft order and associate it with the "code-123"
5. set `usageLimit` for the voucher
6. run `draftOrderComplete`
Now we have unconfirmed order where `order.voucher_code=code-123` and `voucher_code.used=0`

With such a state, run `expire_order_task`. It will try to save -1 value to `used` positive integer field

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
