### PR TITLE
Require the `type` field on `PromotionCreateInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Breaking changes
 
 - Remove the `anonymize` plugin. Use `saleor/core/utils/anonymization` code instead. - by @aniav
+- Require the `type` field on `PromotionCreateInput` - #16296 by @IKarbowiak
 
 ### GraphQL API
 

--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -82,11 +82,9 @@ class PromotionCreateInput(PromotionInput):
         description=(
             "Defines the promotion type. Implicate the required promotion rules "
             "predicate type and whether the promotion rules will give the catalogue "
-            "or order discount. "
-            "\n\nThe default value is `Catalogue`."
-            "\n\nThis field will be required from Saleor 3.20." + ADDED_IN_319
+            "or order discount. " + ADDED_IN_319
         ),
-        required=False,
+        required=True,
     )
     rules = NonNullList(PromotionRuleInput, description="List of promotion rules.")
 
@@ -133,7 +131,7 @@ class PromotionCreate(ModelMutation):
             error.code = PromotionCreateErrorCode.INVALID.value
             errors["end_date"].append(error)
 
-        promotion_type = cleaned_input.get("type", PromotionType.CATALOGUE)
+        promotion_type = cleaned_input.get("type")
         if rules := cleaned_input.get("rules"):
             cleaned_rules, errors = cls.clean_rules(info, rules, promotion_type, errors)
             cleaned_input["rules"] = cleaned_rules

--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -215,6 +215,7 @@ def test_promotion_create_by_app(
     variables = {
         "input": {
             "name": promotion_name,
+            "type": PromotionTypeEnum.CATALOGUE.name,
             "description": description_json,
             "startDate": start_date.isoformat(),
             "endDate": end_date.isoformat(),
@@ -604,6 +605,7 @@ def test_promotion_create_only_name_and_end_date(
     variables = {
         "input": {
             "name": promotion_name,
+            "type": PromotionTypeEnum.CATALOGUE.name,
             "endDate": end_date.isoformat(),
         }
     }
@@ -1580,6 +1582,7 @@ def test_promotion_create_rules_without_channels_and_percentage_reward(
     variables = {
         "input": {
             "name": "test promotion",
+            "type": PromotionTypeEnum.CATALOGUE.name,
             "startDate": start_date.isoformat(),
             "endDate": end_date.isoformat(),
             "rules": [
@@ -2073,6 +2076,7 @@ def test_promotion_create_without_catalogue_predicate(
     variables = {
         "input": {
             "name": promotion_name,
+            "type": PromotionTypeEnum.CATALOGUE.name,
             "description": description_json,
             "startDate": start_date.isoformat(),
             "endDate": end_date.isoformat(),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27937,13 +27937,9 @@ input PromotionCreateInput @doc(category: "Discounts") {
   """
   Defines the promotion type. Implicate the required promotion rules predicate type and whether the promotion rules will give the catalogue or order discount. 
   
-  The default value is `Catalogue`.
-  
-  This field will be required from Saleor 3.20.
-  
   Added in Saleor 3.19.
   """
-  type: PromotionTypeEnum
+  type: PromotionTypeEnum!
 
   """List of promotion rules."""
   rules: [PromotionRuleInput!]


### PR DESCRIPTION
Update `type` field on `PromotionCreateInput` - make it required.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
