### PR TITLE
Deprecate `EU` from `CountryCode` enum

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     outputs:
       version: ${{ steps.meta.outputs.version }}
 

--- a/saleor/graphql/account/enums.py
+++ b/saleor/graphql/account/enums.py
@@ -15,7 +15,12 @@ CustomerEventsEnum.doc_category = DOC_CATEGORY_USERS
 
 
 CountryCodeEnum = graphene.Enum(
-    "CountryCode", [(str_to_enum(country[0]), country[0]) for country in countries]
+    "CountryCode",
+    [(str_to_enum(country[0]), country[0]) for country in countries],
+    description=(
+        "Represents country codes defined by the ISO 3166-1 alpha-2 standard."
+        "\n\nThe `EU` value is DEPRECATED and will be removed in Saleor 3.21."
+    ),
 )
 
 

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -2,6 +2,7 @@ from itertools import chain
 from typing import Optional
 
 from django.db.models import Q
+from graphql import GraphQLError
 from i18naddress import get_validation_rules
 
 from ...account import models
@@ -149,6 +150,10 @@ def resolve_address_validation_rules(
         "city": city,
         "city_area": city_area,
     }
+    # EU is available as a country code in CountryCode enum but it's not valid for
+    # the address validation
+    if country_code.upper() == "EU":
+        raise GraphQLError("Cannot validate address for EU country code.")
     rules = get_validation_rules(params)
     return AddressValidationData(
         country_code=rules.country_code,

--- a/saleor/graphql/account/tests/queries/test_address_validation_rules.py
+++ b/saleor/graphql/account/tests/queries/test_address_validation_rules.py
@@ -1,6 +1,6 @@
 import re
 
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_graphql_error_with_message, get_graphql_content
 
 GET_ADDRESS_VALIDATION_RULES_QUERY = """
     query getValidator(
@@ -111,6 +111,20 @@ def test_address_validation_rules_with_country_area(user_api_client):
         "countryArea",
     }
     assert set(data["upperFields"]) == {"countryArea"}
+
+
+def test_address_validation_rules_for_EU(user_api_client):
+    # given
+    query = GET_ADDRESS_VALIDATION_RULES_QUERY
+    variables = {"country_code": "EU", "country_area": None, "city_area": None}
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+
+    # then
+    assert_graphql_error_with_message(
+        response, "Cannot validate address for EU country code."
+    )
 
 
 def test_address_validation_rules_fields_in_camel_case(user_api_client):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5264,7 +5264,11 @@ type ShippingMethodsPerCountry @doc(category: "Shipping") {
   shippingMethods: [ShippingMethod!]
 }
 
-"""An enumeration."""
+"""
+Represents country codes defined by the ISO 3166-1 alpha-2 standard.
+
+The `EU` value is DEPRECATED and will be removed in Saleor 3.21.
+"""
 enum CountryCode {
   AF
   AX


### PR DESCRIPTION
We have `EU` available in `CountryCode` enum but it fails with address validation.

This is the only county code missing in the address validation package so I added a special check for that case.

Port of https://github.com/saleor/saleor/pull/16300

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
