### PR TITLE
Do not update `VoucherCode.used` field with negative value

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -2,6 +2,7 @@ import logging
 from datetime import timedelta
 
 from django.db.models import Exists, F, Func, OuterRef, Subquery, Value
+from django.db.models.functions import Greatest
 from django.utils import timezone
 
 from ..celeryconf import app
@@ -53,12 +54,21 @@ def _bulk_release_voucher_usage(order_ids):
     ).values("count")
 
     vouchers = Voucher.objects.filter(usage_limit__isnull=False)
-    VoucherCode.objects.filter(
+    codes = VoucherCode.objects.filter(
         Exists(voucher_orders),
         Exists(vouchers.filter(id=OuterRef("voucher_id"))),
-    ).annotate(order_count=Subquery(count_orders)).update(
-        used=F("used") - F("order_count")
-    )
+    ).annotate(order_count=Subquery(count_orders))
+
+    # We observed mismatch between code.used and number of orders which utilize the code
+    # In some cases it is expected, but we want to further investigate the issue
+    suspected_codes = [code.code for code in codes if code.used < code.order_count]
+    if suspected_codes:
+        logger.error(
+            f"Voucher codes: [{','.join(suspected_codes)}] have been used more times "
+            f"than indicated by `code.used` field."
+        )
+
+    codes.update(used=Greatest(F("used") - F("order_count"), 0))
 
     orders = Order.objects.filter(id__in=order_ids)
     voucher_codes = VoucherCode.objects.filter(


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/16291

I want to merge this change because it protects against updating the VoucherCode.used field with a negative value.

I identified two cases when it can happen. IMO in both cases, setting used=0 is a proper behavior.

I also added logging when it happens to investigate the issue further.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
