### PR TITLE
settings: add support for numeric & lower-case boolean env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Webhooks
 
 ### Other changes
+
+- Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 import os
 import os.path
@@ -39,13 +38,14 @@ def get_list(text):
 
 
 def get_bool_from_env(name, default_value):
-    if name in os.environ:
-        value = os.environ[name]
-        try:
-            return ast.literal_eval(value)
-        except ValueError as e:
-            raise ValueError(f"{value} is an invalid value for {name}") from e
-    return default_value
+    """Retrieve and convert an environment variable to a boolean object.
+
+    Accepted values are `true` (case-insensitive) and `1`, any other value resolves to `False`.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default_value
+    return value.lower() in ("true", "1")
 
 
 def get_url_from_env(name, *, schemes=None) -> Optional[str]:


### PR DESCRIPTION
This adds supports for `true|True|1` boolean environment variables as only accepting `True` sometimes makes it difficult to work with other libraries that do not support `True`.



<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
