### PR TITLE
Include Saleor version and query name in error logs

### DIFF
--- a/saleor/core/logging.py
+++ b/saleor/core/logging.py
@@ -1,6 +1,7 @@
 import platform
 import time
 
+from .. import __version__ as saleor_version
 from celery._state import get_current_task as get_current_celery_task
 from pythonjsonlogger.jsonlogger import JsonFormatter as BaseFormatter
 
@@ -11,6 +12,11 @@ class JsonFormatter(BaseFormatter):
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
         log_record["hostname"] = platform.node()
+        try:
+            log_record["query"] = record.exc_info[1]._exc_query
+            log_record["version"] = saleor_version
+        except (KeyError, TypeError):
+            pass
 
 
 class JsonCeleryFormatter(JsonFormatter):

--- a/saleor/core/logging.py
+++ b/saleor/core/logging.py
@@ -1,9 +1,10 @@
 import platform
 import time
 
-from .. import __version__ as saleor_version
 from celery._state import get_current_task as get_current_celery_task
 from pythonjsonlogger.jsonlogger import JsonFormatter as BaseFormatter
+
+from .. import __version__ as saleor_version
 
 
 class JsonFormatter(BaseFormatter):
@@ -15,7 +16,7 @@ class JsonFormatter(BaseFormatter):
         try:
             log_record["query"] = record.exc_info[1]._exc_query
             log_record["version"] = saleor_version
-        except (KeyError, TypeError):
+        except (TypeError, IndexError, AttributeError):
             pass
 
 

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -268,7 +268,7 @@ def query_fingerprint(document: GraphQLDocument) -> str:
     return f"{label}:{query_hash}"
 
 
-def format_error(error, handled_exceptions):
+def format_error(error, handled_exceptions, query=None):
     result: dict[str, Any]
     if isinstance(error, GraphQLError):
         result = format_graphql_error(error)
@@ -283,6 +283,8 @@ def format_error(error, handled_exceptions):
         exc = exc.original_error
     if isinstance(exc, AssertionError):
         exc = GraphQLError(str(exc))
+    if query:
+        exc._exc_query = query
     if isinstance(exc, handled_exceptions):
         handled_errors_logger.info("A query had an error", exc_info=exc)
     else:

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -60,6 +60,7 @@ class GraphQLView(View):
     middleware = None
     root_value = None
     backend: GraphQLBackend = None  # type: ignore[assignment]
+    _query: str = None
 
     HANDLED_EXCEPTIONS = (
         GraphQLError,
@@ -278,6 +279,7 @@ class GraphQLView(View):
             )
 
             query, variables, operation_name = self.get_graphql_params(request, data)
+            self._query = operation_name
 
             document, error = self.parse_query(query)
             with observability.report_gql_operation() as operation:
@@ -389,9 +391,8 @@ class GraphQLView(View):
             variables = operations.get("variables")
         return query, variables, operation_name
 
-    @classmethod
-    def format_error(cls, error):
-        return format_error(error, cls.HANDLED_EXCEPTIONS)
+    def format_error(self, error):
+        return format_error(error, self.HANDLED_EXCEPTIONS, self._query)
 
 
 def get_key(key):


### PR DESCRIPTION
I want to merge this change because it adds Saleor version and query information to the error logs.
Can be easily tested locally with overriding logging in settings.py - use "json" formatter.

Internal issue: https://linear.app/saleor/issue/SHOPX-697/add-attributes-query-name-and-saleor-version-to-core-error-log-a-query

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
