### PR TITLE
Fix CollectionsByProductIdLoader if collection is missing

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -248,7 +248,7 @@ def get_discounted_lines(
                 continue
             line_category = line_product.category
             line_collections = set(
-                [collection.pk for collection in line_info.collections]
+                [collection.pk for collection in line_info.collections if collection]
             )
             if line_info.variant and (
                 line_variant.pk in voucher_info.variant_pks

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -135,7 +135,11 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineIn
                                 product_type=product_types_map[line.variant_id],
                                 collections=sorted(
                                     collections_map[line.variant_id],
-                                    key=lambda collection: collection.slug,
+                                    key=(
+                                        lambda collection: collection.slug
+                                        if collection
+                                        else ""
+                                    ),
                                 ),
                                 discounts=checkout_lines_discounts[line.id],
                                 tax_class=tax_class_map[line.variant_id],

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -523,10 +523,8 @@ class CollectionByIdLoader(DataLoader):
     context_key = "collection_by_id"
 
     def batch_load(self, keys):
-        collections = (
-            Collection.objects.using(self.database_connection_name)
-            .using(self.database_connection_name)
-            .in_bulk(keys)
+        collections = Collection.objects.using(self.database_connection_name).in_bulk(
+            keys
         )
         return [collections.get(collection_id) for collection_id in keys]
 
@@ -537,7 +535,6 @@ class CollectionsByProductIdLoader(DataLoader):
     def batch_load(self, keys):
         product_collection_pairs = list(
             CollectionProduct.objects.using(self.database_connection_name)
-            .using(self.database_connection_name)
             .filter(product_id__in=keys)
             .order_by("id")
             .values_list("product_id", "collection_id")
@@ -548,9 +545,10 @@ class CollectionsByProductIdLoader(DataLoader):
             product_collection_map[pid].append(cid)
 
         def map_collections(collections):
-            collection_map = {c.id: c for c in collections}
+            collection_map = {c.id: c for c in collections if c is not None}
+
             return [
-                [collection_map[cid] for cid in product_collection_map[pid]]
+                [collection_map.get(cid) for cid in product_collection_map[pid]]
                 for pid in keys
             ]
 


### PR DESCRIPTION
In some cases, the collections list may contain `None` instance. Fixes `AttributeError` when that happens.

Fixes: https://linear.app/saleor/issue/SHOPX-683/attributeerror-nonetype-object-has-no-attribute-id

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
