### PR TITLE
Add filterable webhook events for draft orders

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -32362,6 +32362,48 @@ type Subscription @doc(category: "Miscellaneous") {
   event: Event
 
   """
+  Event sent when new draft order is created.
+  
+  Added in Saleor 3.20.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  draftOrderCreated(
+    """
+    List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): DraftOrderCreated
+
+  """
+  Event sent when draft order is updated.
+  
+  Added in Saleor 3.20.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  draftOrderUpdated(
+    """
+    List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): DraftOrderUpdated
+
+  """
+  Event sent when draft order is deleted.
+  
+  Added in Saleor 3.20.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  draftOrderDeleted(
+    """
+    List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): DraftOrderDeleted
+
+  """
   Event sent when new order is created.
   
   Added in Saleor 3.20.
@@ -32545,6 +32587,72 @@ interface Event {
 }
 
 union IssuingPrincipal = App | User
+
+"""
+Event sent when new draft order is created.
+
+Added in Saleor 3.2.
+"""
+type DraftOrderCreated implements Event @doc(category: "Orders") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The order the event relates to."""
+  order: Order
+}
+
+"""
+Event sent when draft order is updated.
+
+Added in Saleor 3.2.
+"""
+type DraftOrderUpdated implements Event @doc(category: "Orders") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The order the event relates to."""
+  order: Order
+}
+
+"""
+Event sent when draft order is deleted.
+
+Added in Saleor 3.2.
+"""
+type DraftOrderDeleted implements Event @doc(category: "Orders") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The order the event relates to."""
+  order: Order
+}
 
 """
 Event sent when new order is created.
@@ -33877,72 +33985,6 @@ type MenuItemDeleted implements Event @doc(category: "Menu") {
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): MenuItem
-}
-
-"""
-Event sent when new draft order is created.
-
-Added in Saleor 3.2.
-"""
-type DraftOrderCreated implements Event @doc(category: "Orders") {
-  """Time of the event."""
-  issuedAt: DateTime
-
-  """Saleor version that triggered the event."""
-  version: String
-
-  """The user or application that triggered the event."""
-  issuingPrincipal: IssuingPrincipal
-
-  """The application receiving the webhook."""
-  recipient: App
-
-  """The order the event relates to."""
-  order: Order
-}
-
-"""
-Event sent when draft order is updated.
-
-Added in Saleor 3.2.
-"""
-type DraftOrderUpdated implements Event @doc(category: "Orders") {
-  """Time of the event."""
-  issuedAt: DateTime
-
-  """Saleor version that triggered the event."""
-  version: String
-
-  """The user or application that triggered the event."""
-  issuingPrincipal: IssuingPrincipal
-
-  """The application receiving the webhook."""
-  recipient: App
-
-  """The order the event relates to."""
-  order: Order
-}
-
-"""
-Event sent when draft order is deleted.
-
-Added in Saleor 3.2.
-"""
-type DraftOrderDeleted implements Event @doc(category: "Orders") {
-  """Time of the event."""
-  issuedAt: DateTime
-
-  """Saleor version that triggered the event."""
-  version: String
-
-  """The user or application that triggered the event."""
-  issuingPrincipal: IssuingPrincipal
-
-  """The application receiving the webhook."""
-  recipient: App
-
-  """The order the event relates to."""
-  order: Order
 }
 
 """

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -2722,6 +2722,32 @@ class Subscription(SubscriptionObjectType):
         Event,
         description="Look up subscription event." + ADDED_IN_32,
     )
+    draft_order_created = graphene.Field(
+        DraftOrderCreated,
+        description=(
+            "Event sent when new draft order is created."
+            + ADDED_IN_320
+            + PREVIEW_FEATURE
+        ),
+        resolver=default_order_resolver,
+        channels=channels_argument,
+    )
+    draft_order_updated = graphene.Field(
+        DraftOrderUpdated,
+        description=(
+            "Event sent when draft order is updated." + ADDED_IN_320 + PREVIEW_FEATURE
+        ),
+        resolver=default_order_resolver,
+        channels=channels_argument,
+    )
+    draft_order_deleted = graphene.Field(
+        DraftOrderDeleted,
+        description=(
+            "Event sent when draft order is deleted." + ADDED_IN_320 + PREVIEW_FEATURE
+        ),
+        resolver=default_order_resolver,
+        channels=channels_argument,
+    )
     order_created = graphene.Field(
         OrderCreated,
         description=(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1369,7 +1369,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
-        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
+        if webhooks := self._get_webhooks_for_order_events(event_type, order, webhooks):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
@@ -1389,7 +1389,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
-        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
+        if webhooks := self._get_webhooks_for_order_events(event_type, order, webhooks):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
@@ -1409,7 +1409,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
-        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
+        if webhooks := self._get_webhooks_for_order_events(event_type, order, webhooks):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_created.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_created.py
@@ -1,0 +1,233 @@
+import json
+from unittest.mock import patch
+
+import graphene
+from django.test import override_settings
+
+from ......core.models import EventDelivery
+from ......graphql.webhook.subscription_query import SubscriptionQuery
+from ......webhook.event_types import WebhookEventAsyncType
+from .....manager import get_plugins_manager
+
+DRAFT_ORDER_CREATED_SUBSCRIPTION = """
+subscription {
+  draftOrderCreated(channels: ["default-channel"]) {
+    order {
+      id
+      number
+      lines {
+        id
+        variant {
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_created(mocked_async, order_line, subscription_webhook):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "default-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
+
+    webhook = subscription_webhook(DRAFT_ORDER_CREATED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_CREATED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    # when
+    manager.draft_order_created(order)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "draftOrderCreated": {
+                    "order": {
+                        "id": order_id,
+                        "number": str(order.number),
+                        "lines": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "OrderLine", order_line.id
+                                ),
+                                "variant": {
+                                    "id": graphene.Node.to_global_id(
+                                        "ProductVariant", order_line.variant_id
+                                    )
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    )
+
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_created_without_channels_input(
+    mocked_async, order_line, subscription_webhook
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
+
+    query = """subscription {
+      draftOrderCreated {
+        order {
+          id
+          number
+          lines {
+            id
+            variant {
+              id
+            }
+          }
+        }
+      }
+    }"""
+    webhook = subscription_webhook(query, event_type)
+    subscription_query = SubscriptionQuery(query)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    # when
+    manager.draft_order_created(order)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "draftOrderCreated": {
+                    "order": {
+                        "id": order_id,
+                        "number": str(order.number),
+                        "lines": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "OrderLine", order_line.id
+                                ),
+                                "variant": {
+                                    "id": graphene.Node.to_global_id(
+                                        "ProductVariant", order_line.variant_id
+                                    )
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    )
+
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_created_with_different_channel(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    order_line,
+    subscription_webhook,
+):
+    # given
+
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "different-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.ORDER_CREATED
+
+    webhook = subscription_webhook(DRAFT_ORDER_CREATED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_CREATED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.draft_order_created(order)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_different_event_doesnt_trigger_webhook(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    order_line,
+    subscription_webhook,
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "default-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.ORDER_UPDATED
+
+    webhook = subscription_webhook(DRAFT_ORDER_CREATED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_CREATED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.draft_order_created(order)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_deleted.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_deleted.py
@@ -1,0 +1,192 @@
+import json
+from unittest.mock import patch
+
+import graphene
+from django.test import override_settings
+
+from ......core.models import EventDelivery
+from ......graphql.webhook.subscription_query import SubscriptionQuery
+from ......webhook.event_types import WebhookEventAsyncType
+from .....manager import get_plugins_manager
+
+DRAFT_ORDER_DELETED_SUBSCRIPTION = """
+subscription {
+  draftOrderDeleted(channels: ["default-channel"]) {
+    order {
+      id
+    }
+  }
+}
+"""
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_deleted(mocked_async, order_line, subscription_webhook):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "default-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
+
+    webhook = subscription_webhook(DRAFT_ORDER_DELETED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_DELETED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    # when
+    manager.draft_order_deleted(order)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "draftOrderDeleted": {
+                    "order": {
+                        "id": order_id,
+                    }
+                }
+            }
+        }
+    )
+
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_deleted_without_channels_input(
+    mocked_async, order_line, subscription_webhook
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
+
+    query = """subscription {
+      draftOrderDeleted {
+        order {
+          id
+        }
+      }
+    }"""
+    webhook = subscription_webhook(query, event_type)
+    subscription_query = SubscriptionQuery(query)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    # when
+    manager.draft_order_deleted(order)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "draftOrderDeleted": {
+                    "order": {
+                        "id": order_id,
+                    }
+                }
+            }
+        }
+    )
+
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_updated_with_different_channel(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    order_line,
+    subscription_webhook,
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "different-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
+
+    webhook = subscription_webhook(DRAFT_ORDER_DELETED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_DELETED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.draft_order_deleted(order)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_different_event_doesnt_trigger_webhook(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    order_line,
+    subscription_webhook,
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "default-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.ORDER_UPDATED
+
+    webhook = subscription_webhook(DRAFT_ORDER_DELETED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_DELETED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.draft_order_deleted(order)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_updated.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_updated.py
@@ -1,0 +1,231 @@
+import json
+from unittest.mock import patch
+
+import graphene
+from django.test import override_settings
+
+from ......core.models import EventDelivery
+from ......graphql.webhook.subscription_query import SubscriptionQuery
+from ......webhook.event_types import WebhookEventAsyncType
+from .....manager import get_plugins_manager
+
+DRAFT_ORDER_UPDATED_SUBSCRIPTION = """
+subscription {
+  draftOrderUpdated(channels: ["default-channel"]) {
+    order {
+      id
+      number
+      lines {
+        id
+        variant {
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_updated(mocked_async, order_line, subscription_webhook):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "default-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
+
+    webhook = subscription_webhook(DRAFT_ORDER_UPDATED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_UPDATED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    # when
+    manager.draft_order_updated(order)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "draftOrderUpdated": {
+                    "order": {
+                        "id": order_id,
+                        "number": str(order.number),
+                        "lines": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "OrderLine", order_line.id
+                                ),
+                                "variant": {
+                                    "id": graphene.Node.to_global_id(
+                                        "ProductVariant", order_line.variant_id
+                                    )
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    )
+
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_updated_without_channels_input(
+    mocked_async, order_line, subscription_webhook
+):
+    # given
+    manager = get_plugins_manager(False)
+    order = order_line.order
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
+
+    query = """subscription {
+      draftOrderUpdated {
+        order {
+          id
+          number
+          lines {
+            id
+            variant {
+              id
+            }
+          }
+        }
+      }
+    }"""
+    webhook = subscription_webhook(query, event_type)
+    subscription_query = SubscriptionQuery(query)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    # when
+    manager.draft_order_updated(order)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "draftOrderUpdated": {
+                    "order": {
+                        "id": order_id,
+                        "number": str(order.number),
+                        "lines": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "OrderLine", order_line.id
+                                ),
+                                "variant": {
+                                    "id": graphene.Node.to_global_id(
+                                        "ProductVariant", order_line.variant_id
+                                    )
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    )
+
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_updated_with_different_channel(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    order_line,
+    subscription_webhook,
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "different-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
+
+    webhook = subscription_webhook(DRAFT_ORDER_UPDATED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_UPDATED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.draft_order_updated(order)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_different_event_doesnt_trigger_webhook(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    order_line,
+    subscription_webhook,
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    order = order_line.order
+    channel = order.channel
+    channel.slug = "default-channel"
+    channel.save()
+
+    event_type = WebhookEventAsyncType.ORDER_UPDATED
+
+    webhook = subscription_webhook(DRAFT_ORDER_UPDATED_SUBSCRIPTION, event_type)
+    subscription_query = SubscriptionQuery(DRAFT_ORDER_UPDATED_SUBSCRIPTION)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.draft_order_updated(order)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0


### PR DESCRIPTION
I want to merge this change because it introduces the possibility of filtering out order webhooks via channel slug. 
So providing the subscription query like this:
```graphql
subscription {
  draftOrderCreated(channels: ["default-channel"]) {
    order {
      id
      number
      lines {
        id
        variant {
          id
        }
      }
    }
  }
}
```
Will send `draft-order-created` event only for orders that belong to the channel (slug:default-channel).

> [!NOTE]  
> Only one top field can be requested as a subscription query. This means that in a single subscription, you cannot define more than one filterable event or mix it with the `event` field. In that case, a new webhook with a new subscription should be created.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1228

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
