### PR TITLE
Fix `ENTIRE_ORDER` voucher handler in draft orders.

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -1709,13 +1709,13 @@ def create_or_update_discount_objects_from_voucher(order, lines_info):
 
 
 def create_or_update_discount_object_from_order_level_voucher(order):
-    """Create or update discount object for ENTIRE_ORDER voucher."""
+    """Create or update discount object for ENTIRE_ORDER and SHIPPING voucher."""
     if not order.voucher_id:
         order.discounts.filter(type=DiscountType.VOUCHER).delete()
         return
 
     voucher = order.voucher
-    if not (is_order_level_voucher(voucher) or is_shipping_voucher(voucher)):
+    if not is_order_level_voucher(voucher) and not is_shipping_voucher(voucher):
         return
 
     voucher_channel_listing = voucher.channel_listings.filter(

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -1710,9 +1710,11 @@ def create_or_update_discount_object_from_order_level_voucher(order):
         if not voucher_channel_listing:
             return
 
-        discount_amount = voucher.get_discount_amount_for(order.subtotal, order.channel)
+        discount_amount = voucher.get_discount_amount_for(
+            order.subtotal.net, order.channel
+        )
         discount_reason = f"Voucher code: {order.voucher_code}"
-        discount_name = f"{voucher.name}"
+        discount_name = voucher.name or ""
         discount_to_update = order.discounts.filter(type=DiscountType.VOUCHER).first()
         if discount_to_update:
             updated_fields: list[str] = []
@@ -1723,7 +1725,7 @@ def create_or_update_discount_object_from_order_level_voucher(order):
                 # TODO (SHOPX-914): set translated voucher name
                 translated_name="",
                 discount_reason=discount_reason,
-                discount_amount=discount_amount,
+                discount_amount=discount_amount.amount,
                 value=voucher_channel_listing.discount_value,
                 value_type=voucher.discount_value_type,
                 unique_type=DiscountType.VOUCHER,
@@ -1735,11 +1737,13 @@ def create_or_update_discount_object_from_order_level_voucher(order):
                 voucher=voucher,
                 value_type=voucher.discount_value_type,
                 value=voucher_channel_listing.discount_value,
-                amount_value=discount_amount,
+                amount_value=discount_amount.amount,
                 reason=f"Voucher: {voucher.name}",
                 name=discount_name,
                 type=DiscountType.VOUCHER,
                 voucher_code=order.voucher_code,
+                # TODO (SHOPX-914): set translated voucher name
+                translated_name="",
             )
 
 

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -748,8 +748,7 @@ def test_draft_order_create_with_voucher_specific_product(
     assert line_1_data["unitDiscountType"] is None
     assert line_1_data["unitDiscountReason"] is None
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
+    assert order.discounts.count() == 0
 
     discounted_line = order.lines.get(variant=discounted_variant)
     assert discounted_line.discounts.count() == 1
@@ -890,8 +889,7 @@ def test_draft_order_create_with_voucher_apply_once_per_order(
     assert line_1_data["unitDiscountType"] is None
     assert line_1_data["unitDiscountReason"] is None
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
+    assert order.discounts.count() == 0
 
     discounted_line = order.lines.get(variant=discounted_variant)
     assert discounted_line.discounts.count() == 1

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -342,9 +342,7 @@ def test_draft_order_update_with_voucher_specific_product(
     assert order.voucher_code == voucher.code
     assert order.search_vector
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
-
+    assert order.discounts.count() == 0
     assert discounted_line.discounts.count() == 1
     order_line_discount = discounted_line.discounts.first()
     assert order_line_discount.voucher == voucher
@@ -436,9 +434,7 @@ def test_draft_order_update_with_voucher_apply_once_per_order(
     assert order.voucher_code == voucher.code
     assert order.search_vector
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
-
+    assert order.discounts.count() == 0
     assert discounted_line.discounts.count() == 1
     order_line_discount = discounted_line.discounts.first()
     assert order_line_discount.voucher == voucher

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -1937,7 +1937,6 @@ def test_draft_order_update_remove_entire_order_voucher(
     assert voucher.type == VoucherType.ENTIRE_ORDER
     assert voucher.discount_value_type == DiscountValueType.FIXED
 
-    # apply voucher to order
     order.voucher = voucher
     order.voucher_code = voucher.codes.first().code
     order.save(update_fields=["voucher_id", "voucher_code"])
@@ -1960,7 +1959,7 @@ def test_draft_order_update_remove_entire_order_voucher(
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id, "input": {"voucherCode": None}}
 
-    # when apply new voucher to order
+    # when
     response = staff_api_client.post_graphql(query, variables)
 
     # then

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -6,7 +6,7 @@ import pytest
 
 from ...core.prices import quantize_price
 from ...core.taxes import zero_money
-from ...discount import DiscountType, DiscountValueType
+from ...discount import DiscountType, DiscountValueType, VoucherType
 from ...discount.models import (
     OrderDiscount,
     OrderLineDiscount,
@@ -2294,3 +2294,218 @@ def test_fetch_order_prices_catalogue_discount_race_condition(
 
     # then
     assert OrderLineDiscount.objects.count() == 1
+
+
+def test_fetch_order_prices_voucher_entire_order_fixed(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    assert voucher.discount_value_type == DiscountValueType.FIXED
+
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = Decimal("35")
+    voucher_listing.discount_value = discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.name = "Voucher name"
+    voucher.save(update_fields=["name"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    lines = order.lines.all()
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    assert OrderDiscount.objects.count() == 1
+    discount = order.discounts.first()
+    assert discount.voucher == voucher
+    assert discount.value_type == voucher.discount_value_type
+    assert discount.value == discount_amount
+    assert discount.amount_value == discount_amount
+    assert discount.reason == f"Voucher: {voucher.name}"
+    assert discount.name == voucher.name
+    assert discount.type == DiscountType.VOUCHER
+    assert discount.voucher_code == code
+    # TODO (SHOPX-914): set translated voucher name
+    assert discount.translated_name == ""
+
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    lines = order.lines.all()
+    line_1 = [line for line in lines if line.quantity == 3][0]
+    line_2 = [line for line in lines if line.quantity == 2][0]
+
+    line_1_base_total = line_1.quantity * line_1.base_unit_price_amount
+    line_2_base_total = line_2.quantity * line_2.base_unit_price_amount
+    base_total = line_1_base_total + line_2_base_total
+    line_1_order_discount_portion = discount_amount * line_1_base_total / base_total
+    line_2_order_discount_portion = discount_amount - line_1_order_discount_portion
+
+    variant_1 = line_1.variant
+    variant_1_listing = variant_1.channel_listings.get(channel=order.channel)
+    variant_1_undiscounted_unit_price = variant_1_listing.price_amount
+    line_1_total_net_amount = quantize_price(
+        line_1.undiscounted_total_price_net_amount - line_1_order_discount_portion,
+        currency,
+    )
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == variant_1_undiscounted_unit_price * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == variant_1_undiscounted_unit_price
+    )
+    assert line_1.total_price_net_amount == line_1_total_net_amount
+    assert line_1.base_unit_price_amount == variant_1_undiscounted_unit_price
+    assert line_1.unit_price_net_amount == line_1_total_net_amount / line_1.quantity
+
+    variant_2 = line_2.variant
+    variant_2_listing = variant_2.channel_listings.get(channel=order.channel)
+    variant_2_undiscounted_unit_price = variant_2_listing.price_amount
+    line_2_total_net_amount = quantize_price(
+        line_2.undiscounted_total_price_net_amount - line_2_order_discount_portion,
+        currency,
+    )
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == variant_2_undiscounted_unit_price * line_2.quantity
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == variant_2_undiscounted_unit_price
+    )
+    assert line_2.total_price_net_amount == line_2_total_net_amount
+    assert line_2.base_unit_price_amount == variant_2_undiscounted_unit_price
+    assert line_2.unit_price_net_amount == line_2_total_net_amount / line_2.quantity
+
+
+def test_fetch_order_prices_voucher_entire_order_percentage(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_value = Decimal("50")
+    voucher_listing.discount_value = discount_value
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.name = "Voucher name"
+    voucher.save(update_fields=["name"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    lines = order.lines.all()
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    assert OrderDiscount.objects.count() == 1
+    discount = order.discounts.first()
+    assert discount.voucher == voucher
+    assert discount.value_type == voucher.discount_value_type
+    assert discount.value == discount_value
+    assert discount.amount_value == Decimal(subtotal.amount / 2)
+    assert discount.reason == f"Voucher: {voucher.name}"
+    assert discount.name == voucher.name
+    assert discount.type == DiscountType.VOUCHER
+    assert discount.voucher_code == code
+    # TODO (SHOPX-914): set translated voucher name
+    assert discount.translated_name == ""
+
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == Decimal(subtotal.amount / 2)
+    assert order.subtotal_gross_amount == Decimal(subtotal.amount / 2)
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    lines = order.lines.all()
+    line_1 = [line for line in lines if line.quantity == 3][0]
+    line_2 = [line for line in lines if line.quantity == 2][0]
+
+    variant_1 = line_1.variant
+    variant_1_listing = variant_1.channel_listings.get(channel=order.channel)
+    variant_1_undiscounted_unit_price = variant_1_listing.price_amount
+    line_1_total_net_amount = quantize_price(
+        line_1.undiscounted_total_price_net_amount / 2,
+        currency,
+    )
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == variant_1_undiscounted_unit_price * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == variant_1_undiscounted_unit_price
+    )
+    assert line_1.total_price_net_amount == line_1_total_net_amount
+    assert line_1.base_unit_price_amount == variant_1_undiscounted_unit_price
+    assert line_1.unit_price_net_amount == line_1_total_net_amount / line_1.quantity
+
+    variant_2 = line_2.variant
+    variant_2_listing = variant_2.channel_listings.get(channel=order.channel)
+    variant_2_undiscounted_unit_price = variant_2_listing.price_amount
+    line_2_total_net_amount = quantize_price(
+        line_2.undiscounted_total_price_net_amount / 2,
+        currency,
+    )
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == variant_2_undiscounted_unit_price * line_2.quantity
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == variant_2_undiscounted_unit_price
+    )
+    assert line_2.total_price_net_amount == line_2_total_net_amount
+    assert line_2.base_unit_price_amount == variant_2_undiscounted_unit_price
+    assert line_2.unit_price_net_amount == line_2_total_net_amount / line_2.quantity

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -2562,6 +2562,7 @@ def test_fetch_order_prices_voucher_shipping_fixed(
     # TODO (SHOPX-914): set translated voucher name
     assert discount.translated_name == ""
 
+    assert order.undiscounted_base_shipping_price.amount == undiscounted_shipping_price
     assert order.base_shipping_price.amount == undiscounted_shipping_price
     assert order.shipping_price_net_amount == expected_shipping_price
     assert order.shipping_price_gross.amount == expected_shipping_price
@@ -2632,6 +2633,7 @@ def test_fetch_order_prices_voucher_shipping_percentage(
     # TODO (SHOPX-914): set translated voucher name
     assert discount.translated_name == ""
 
+    assert order.undiscounted_base_shipping_price.amount == undiscounted_shipping_price
     assert order.base_shipping_price.amount == undiscounted_shipping_price
     assert order.shipping_price_net_amount == expected_shipping_price
     assert order.shipping_price_gross.amount == expected_shipping_price

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -586,6 +586,10 @@ def test_draft_order_calculate_taxes_entire_order_voucher(
     voucher.save(update_fields=["type"])
 
     discount_amount = Decimal("10")
+    channel_listing = voucher.channel_listings.get()
+    channel_listing.discount_value = discount_amount
+    channel_listing.save(update_fields=["discount_value"])
+
     order_discount = order.discounts.first()
     order_discount.value = discount_amount
     order_discount.save(update_fields=["value"])


### PR DESCRIPTION
This PR:
- makes sure a proper order level discount object is created when utilizing `ENTIRE_ORDER` and `SHIPPING` vouchers in draft orders
- fixes the issue when updating the draft order with a new voucher resulting in two discount objects
- fixes the issue when order level discount is created when any voucher is assigned to draft order
- fixes order discount reason
- makes sure to always update `BaseDiscount.voucher_code` field

Internal issues: 
- https://linear.app/saleor/issue/SHOPX-874/clean-up-orderdiscount-for-draft-orders
- https://linear.app/saleor/issue/SHOPX-1083/bug-inconsistency-with-vouchers-on-checkout-and-draftorder-order

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
