### PR TITLE
Include Saleor version and query name in error logs

### DIFF
--- a/saleor/core/logging.py
+++ b/saleor/core/logging.py
@@ -4,6 +4,8 @@ import time
 from celery._state import get_current_task as get_current_celery_task
 from pythonjsonlogger.jsonlogger import JsonFormatter as BaseFormatter
 
+from .. import __version__ as saleor_version
+
 
 class JsonFormatter(BaseFormatter):
     converter = time.gmtime
@@ -11,6 +13,11 @@ class JsonFormatter(BaseFormatter):
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
         log_record["hostname"] = platform.node()
+        try:
+            log_record["query"] = record.exc_info[1]._exc_query
+            log_record["version"] = saleor_version
+        except (TypeError, IndexError, AttributeError):
+            pass
 
 
 class JsonCeleryFormatter(JsonFormatter):

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -270,7 +270,7 @@ def query_fingerprint(document: GraphQLDocument) -> str:
     return f"{label}:{query_hash}"
 
 
-def format_error(error, handled_exceptions):
+def format_error(error, handled_exceptions, query=None):
     result: dict[str, Any]
     if isinstance(error, GraphQLError):
         result = format_graphql_error(error)
@@ -285,6 +285,8 @@ def format_error(error, handled_exceptions):
         exc = exc.original_error
     if isinstance(exc, AssertionError):
         exc = GraphQLError(str(exc))
+    if query:
+        exc._exc_query = query
     if isinstance(exc, handled_exceptions):
         handled_errors_logger.info("A query had an error", exc_info=exc)
     else:

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -59,6 +59,7 @@ class GraphQLView(View):
     executor = None
     middleware = None
     root_value = None
+    _query: Optional[str] = None
 
     HANDLED_EXCEPTIONS = (
         GraphQLError,
@@ -280,7 +281,6 @@ class GraphQLView(View):
             )
 
             query, variables, operation_name = self.get_graphql_params(request, data)
-
             document, error = self.parse_query(query)
             with observability.report_gql_operation() as operation:
                 operation.query = document
@@ -289,9 +289,11 @@ class GraphQLView(View):
             if error or document is None:
                 return error
 
+            _query_identifier = query_identifier(document)
+            self._query = _query_identifier
             raw_query_string = document.document_string
             span.set_tag("graphql.query", raw_query_string)
-            span.set_tag("graphql.query_identifier", query_identifier(document))
+            span.set_tag("graphql.query_identifier", _query_identifier)
             span.set_tag("graphql.query_fingerprint", query_fingerprint(document))
             try:
                 query_contains_schema = self.check_if_query_contains_only_schema(
@@ -391,9 +393,8 @@ class GraphQLView(View):
             variables = operations.get("variables")
         return query, variables, operation_name
 
-    @classmethod
-    def format_error(cls, error):
-        return format_error(error, cls.HANDLED_EXCEPTIONS)
+    def format_error(self, error):
+        return format_error(error, self.HANDLED_EXCEPTIONS, self._query)
 
 
 def get_key(key):


### PR DESCRIPTION
I want to merge this change because it adds Saleor version and query information to the error logs.
It's a port of https://github.com/saleor/saleor/pull/16320

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
