### PR TITLE
Add logs when checkout is paid by gift cards.

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1188,6 +1188,7 @@ def test_checkout_complete(
     shipping_method,
     transaction_events_generator,
     transaction_item_generator,
+    caplog,
 ):
     # given
     checkout = prepare_checkout_for_test(
@@ -1288,6 +1289,14 @@ def test_checkout_complete(
     recalculate_with_plugins_mock.assert_not_called()
 
     assert not len(Reservation.objects.all())
+
+    assert str(checkout_info.checkout.pk) == caplog.records[0].checkout_id
+    assert gift_card.initial_balance_amount == Decimal(
+        caplog.records[0].gift_card_compensation
+    )
+    assert total.gross.amount == Decimal(
+        caplog.records[0].total_after_gift_card_compensation
+    )
 
 
 @pytest.mark.integration

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from decimal import Decimal
 from typing import TYPE_CHECKING, Optional, cast
@@ -63,6 +64,8 @@ if TYPE_CHECKING:
     from ..discount.interface import VariantPromotionRuleInfo
     from ..payment.models import Payment, TransactionItem
     from ..plugins.manager import PluginsManager
+
+logger = logging.getLogger(__name__)
 
 
 def get_order_country(order: Order) -> str:
@@ -442,6 +445,7 @@ def add_gift_cards_to_order(
     user: Optional[User],
     app: Optional["App"],
 ):
+    total_before_gift_card_compensation = total_price_left
     order_gift_cards = []
     gift_cards_to_update = []
     balance_data: list[tuple[GiftCard, float]] = []
@@ -469,6 +473,15 @@ def add_gift_cards_to_order(
     ]
     GiftCard.objects.bulk_update(gift_cards_to_update, update_fields)
     gift_card_events.gift_cards_used_in_order_event(balance_data, order, user, app)
+
+    gift_card_compensation = total_before_gift_card_compensation - total_price_left
+    if gift_card_compensation.amount > 0:
+        details = {
+            "checkout_id": str(checkout_info.checkout.pk),
+            "gift_card_compensation": str(gift_card_compensation.amount),
+            "total_after_gift_card_compensation": str(total_price_left.amount),
+        }
+        logger.info("Gift card payment.", extra=details)
 
 
 def update_gift_card_balance(


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/16325
I want to merge this change because it adds logs when a gift card was used to pay for the checkout.

Issue: https://linear.app/saleor/issue/SHOPX-1000/add-logs-when-gift-card-was-used-to-pay-for-the-checkout

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
