### PR TITLE
Remove sync webhook calls from transactions in `TransactionInitialize` and `TransactionProcess`

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -49,6 +49,7 @@ from ..giftcard.utils import (
     add_gift_card_code_to_checkout,
     remove_gift_card_code_from_checkout_or_error,
 )
+from ..payment.models import Payment
 from ..plugins.manager import PluginsManager
 from ..product import models as product_models
 from ..shipping.interface import ShippingMethodData
@@ -954,8 +955,15 @@ def is_fully_paid(
     return total_paid >= checkout_total.amount
 
 
-def cancel_active_payments(checkout: Checkout) -> None:
-    checkout.payments.filter(is_active=True).update(is_active=False)
+def cancel_active_payments(checkout: Checkout) -> list[int]:
+    payments = checkout.payments.filter(is_active=True)
+    payment_ids = list(payments.values_list("id", flat=True))
+    payments.update(is_active=False)
+    return payment_ids
+
+
+def activate_payments(payment_ids: list[int]) -> None:
+    Payment.objects.filter(id__in=payment_ids).update(is_active=True)
 
 
 def is_shipping_required(lines: Iterable["CheckoutLineInfo"]):

--- a/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
@@ -8,9 +8,8 @@ from django.core.exceptions import ValidationError
 from .....app.models import App
 from .....channel.models import Channel
 from .....checkout import models as checkout_models
-from .....checkout.utils import cancel_active_payments
+from .....checkout.utils import activate_payments, cancel_active_payments
 from .....core.exceptions import PermissionDenied
-from .....core.tracing import traced_atomic_transaction
 from .....payment import TransactionItemIdempotencyUniqueError
 from .....payment.interface import PaymentGatewayData
 from .....payment.utils import handle_transaction_initialize_session
@@ -184,34 +183,36 @@ class TransactionInitialize(TransactionSessionBase):
             amount,
         )
         app = cls.clean_app_from_payment_gateway(payment_gateway_data)
-        with traced_atomic_transaction():
-            if isinstance(source_object, checkout_models.Checkout):
-                # Deactivate active payment objects to avoid processing checkout
-                # with use of two different flows.
-                cancel_active_payments(source_object)
-            try:
-                transaction, event, data = handle_transaction_initialize_session(
-                    source_object=source_object,
-                    payment_gateway_data=payment_gateway_data,
-                    amount=amount,
-                    action=action,
-                    customer_ip_address=customer_ip_address,
-                    app=app,
-                    manager=manager,
-                    idempotency_key=idempotency_key,
-                )
-            except TransactionItemIdempotencyUniqueError:
-                raise ValidationError(
-                    {
-                        "idempotency_key": ValidationError(
-                            message=(
-                                "Different transaction with provided idempotency key "
-                                "already exists."
-                            ),
-                            code=TransactionInitializeErrorCode.UNIQUE.value,
-                        )
-                    }
-                )
+        payment_ids = []
+        if isinstance(source_object, checkout_models.Checkout):
+            # Deactivate active payment objects to avoid processing checkout
+            # with use of two different flows.
+            payment_ids = cancel_active_payments(source_object)
+        try:
+            transaction, event, data = handle_transaction_initialize_session(
+                source_object=source_object,
+                payment_gateway_data=payment_gateway_data,
+                amount=amount,
+                action=action,
+                customer_ip_address=customer_ip_address,
+                app=app,
+                manager=manager,
+                idempotency_key=idempotency_key,
+            )
+        except TransactionItemIdempotencyUniqueError:
+            if payment_ids:
+                activate_payments(payment_ids)
+            raise ValidationError(
+                {
+                    "idempotency_key": ValidationError(
+                        message=(
+                            "Different transaction with provided idempotency key "
+                            "already exists."
+                        ),
+                        code=TransactionInitializeErrorCode.UNIQUE.value,
+                    )
+                }
+            )
         return cls(transaction=transaction, transaction_event=event, data=data)
 
     @staticmethod

--- a/saleor/graphql/payment/mutations/transaction/transaction_process.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_process.py
@@ -9,10 +9,9 @@ from .....app.models import App
 from .....channel import TransactionFlowStrategy
 from .....channel.models import Channel
 from .....checkout import models as checkout_models
-from .....checkout.utils import cancel_active_payments
-from .....core.tracing import traced_atomic_transaction
+from .....checkout.utils import activate_payments, cancel_active_payments
 from .....order import models as order_models
-from .....payment import TransactionEventType
+from .....payment import FAILED_TRANSACTION_EVENTS, TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionProcessErrorCode
 from .....payment.interface import PaymentGatewayData
@@ -214,24 +213,26 @@ class TransactionProcess(BaseMutation):
 
         manager = get_plugin_manager_promise(info.context).get()
 
-        with traced_atomic_transaction():
-            if isinstance(source_object, checkout_models.Checkout):
-                # Deactivate active payment objects to avoid processing checkout
-                # with use of two different flows.
-                cancel_active_payments(source_object)
+        payment_ids = []
+        if isinstance(source_object, checkout_models.Checkout):
+            # Deactivate active payment objects to avoid processing checkout
+            # with use of two different flows.
+            payment_ids = cancel_active_payments(source_object)
 
-            event, data = handle_transaction_process_session(
-                transaction_item=transaction_item,
-                source_object=source_object,
-                payment_gateway_data=PaymentGatewayData(
-                    app_identifier=app_identifier, data=data
-                ),
-                app=app,
-                action=action,
-                customer_ip_address=customer_ip_address,
-                manager=manager,
-                request_event=request_event,
-            )
+        event, data = handle_transaction_process_session(
+            transaction_item=transaction_item,
+            source_object=source_object,
+            payment_gateway_data=PaymentGatewayData(
+                app_identifier=app_identifier, data=data
+            ),
+            app=app,
+            action=action,
+            customer_ip_address=customer_ip_address,
+            manager=manager,
+            request_event=request_event,
+        )
+        if event.type in FAILED_TRANSACTION_EVENTS and payment_ids:
+            activate_payments(payment_ids)
 
         transaction_item.refresh_from_db()
         return cls(transaction=transaction_item, transaction_event=event, data=data)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -14,7 +14,7 @@ from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....core.prices import quantize_price
 from .....order import OrderChargeStatus, OrderStatus
-from .....payment import TransactionEventType
+from .....payment import FAILED_TRANSACTION_EVENTS, TransactionEventType
 from .....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
@@ -217,7 +217,10 @@ def _assert_fields(
     response_event = transaction.events.filter(type=response_event_type).first()
     assert response_event
     assert response_event.amount_value == expected_amount
-    assert response_event.include_in_calculations
+    include_in_calculations = (
+        True if response_event_type not in FAILED_TRANSACTION_EVENTS else False
+    )
+    assert response_event.include_in_calculations is include_in_calculations
     assert response_event.psp_reference == expected_psp_reference
 
     mocked_process.assert_called_with(
@@ -1736,3 +1739,77 @@ def test_for_checkout_with_payments(
     for payment in payments:
         payment.refresh_from_db()
         assert payment.is_active is False
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_for_checkout_with_payments_transaction_process_failure(
+    mocked_process,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    transaction_item_generator,
+):
+    # given
+    expected_amount = Decimal("10.00")
+
+    checkout = checkout_with_prices
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    # create payments
+    payments = Payment.objects.bulk_create(
+        [
+            Payment(
+                gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+            ),
+            Payment(
+                gateway="mirumee.payments.dummy", is_active=False, checkout=checkout
+            ),
+        ]
+    )
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout_with_prices.pk, app=webhook_app
+    )
+    TransactionEvent.objects.create(
+        transaction=transaction_item,
+        amount_value=expected_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    data = None
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=data
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "data": None,
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    checkout.refresh_from_db()
+    _assert_fields(
+        content=content,
+        source_object=checkout,
+        expected_amount=expected_amount,
+        expected_psp_reference=None,
+        response_event_type=TransactionEventType.CHARGE_FAILURE,
+        app_identifier=webhook_app.identifier,
+        mocked_process=mocked_process,
+        charged_value=Decimal("0"),
+        data=None,
+        returned_data=None,
+    )
+    assert checkout.charge_status == CheckoutChargeStatus.NONE
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.NONE
+    for payment in payments:
+        payment.refresh_from_db()
+    assert payments[0].is_active is True
+    assert payments[1].is_active is False

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -245,6 +245,14 @@ class TransactionEventType:
     ]
 
 
+FAILED_TRANSACTION_EVENTS = [
+    TransactionEventType.AUTHORIZATION_FAILURE,
+    TransactionEventType.CHARGE_FAILURE,
+    TransactionEventType.REFUND_FAILURE,
+    TransactionEventType.CANCEL_FAILURE,
+]
+
+
 class TokenizedPaymentFlow:
     """Represents possible tokenized payment flows that can be used to process payment.
 


### PR DESCRIPTION
Sync webhooks cannot be called in the transaction. It can potentially block the source object's update that might be performed by the app that received the webhook.

Port of https://github.com/saleor/saleor/pull/16337

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
