### PR TITLE
Generate sync webhook payloads in the dataloaders in order taxes.

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -373,7 +373,6 @@ def _calculate_and_add_tax(
         # If taxAppId is provided run tax plugin or Tax App. taxAppId can be
         # configured with Avatax plugin identifier.
         if not tax_app_identifier:
-            # TODO Owczar: Cover this flow
             # Call the tax plugins.
             _apply_tax_data_from_plugins(
                 checkout, manager, checkout_info, lines, address

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -188,6 +188,7 @@ def checkout_line_unit_price(
     lines: Iterable["CheckoutLineInfo"],
     checkout_line_info: "CheckoutLineInfo",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    pregenerated_subscription_payloads: Optional[dict] = {},
 ) -> TaxedMoney:
     """Return the unit price of provided line, taxes included.
 
@@ -201,6 +202,7 @@ def checkout_line_unit_price(
         lines=lines,
         address=address,
         database_connection_name=database_connection_name,
+        pregenerated_subscription_payloads=pregenerated_subscription_payloads,
     )
     checkout_line = find_checkout_line_info(lines, checkout_line_info.line.id).line
     unit_price = checkout_line.total_price / checkout_line.quantity

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -269,7 +269,6 @@ def _fetch_checkout_prices_if_expired(
 
     checkout.tax_error = None
     if prices_entered_with_tax:
-        # TODO Owczar: Cover this flow
         # If prices are entered with tax, we need to always calculate it anyway, to
         # display the tax rate to the user.
         try:
@@ -283,6 +282,7 @@ def _fetch_checkout_prices_if_expired(
                 prices_entered_with_tax,
                 address,
                 database_connection_name=database_connection_name,
+                pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             )
         except TaxEmptyData as e:
             _set_checkout_base_prices(checkout, checkout_info, lines)

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -163,6 +163,7 @@ def checkout_line_total(
     lines: Iterable["CheckoutLineInfo"],
     checkout_line_info: "CheckoutLineInfo",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    pregenerated_subscription_payloads: Optional[dict] = {},
 ) -> TaxedMoney:
     """Return the total price of provided line, taxes included.
 
@@ -176,6 +177,7 @@ def checkout_line_total(
         lines=lines,
         address=address,
         database_connection_name=database_connection_name,
+        pregenerated_subscription_payloads=pregenerated_subscription_payloads,
     )
     checkout_line = find_checkout_line_info(lines, checkout_line_info.line.id).line
     return quantize_price(checkout_line.total_price, currency)

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -43,6 +43,7 @@ def checkout_shipping_price(
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    pregenerated_subscription_payloads: Optional[dict] = {},
 ) -> "TaxedMoney":
     """Return checkout shipping price.
 
@@ -55,6 +56,7 @@ def checkout_shipping_price(
         lines=lines,
         address=address,
         database_connection_name=database_connection_name,
+        pregenerated_subscription_payloads=pregenerated_subscription_payloads,
     )
     return quantize_price(checkout_info.checkout.shipping_price, currency)
 

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -88,6 +88,7 @@ def checkout_subtotal(
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    pregenerated_subscription_payloads: Optional[dict] = {},
 ) -> "TaxedMoney":
     """Return the total cost of all the checkout lines, taxes included.
 
@@ -100,6 +101,7 @@ def checkout_subtotal(
         lines=lines,
         address=address,
         database_connection_name=database_connection_name,
+        pregenerated_subscription_payloads=pregenerated_subscription_payloads,
     )
     return quantize_price(checkout_info.checkout.subtotal, currency)
 

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from django.conf import settings
 
+from ..core.db.connection import allow_writer
 from ..core.pricing.interface import LineInfo
 from ..discount import VoucherType
 from ..discount.interface import fetch_variant_rules_info, fetch_voucher_info
@@ -281,7 +282,10 @@ def get_delivery_method_info(
     if isinstance(delivery_method, ShippingMethodData):
         return ShippingMethodInfo(delivery_method, address)
     if isinstance(delivery_method, Warehouse):
-        return CollectionPointInfo(delivery_method, delivery_method.address)
+        # TODO: Workaround for lack of using in tests.
+        # The warehouse address should be loaded when CheckoutInfo is created.
+        with allow_writer():
+            return CollectionPointInfo(delivery_method, delivery_method.address)
 
     raise NotImplementedError()
 

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -417,7 +417,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(71):
+    with django_assert_num_queries(73):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -435,7 +435,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(71):
+    with django_assert_num_queries(73):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -566,7 +566,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(79):
+    with django_assert_num_queries(78):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then
@@ -821,7 +821,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(95):
+    with django_assert_num_queries(94):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -835,7 +835,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(95):
+    with django_assert_num_queries(94):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -1080,7 +1080,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(91):
+    with django_assert_num_queries(93):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -1093,7 +1093,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(91):
+    with django_assert_num_queries(93):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,
@@ -1143,7 +1143,7 @@ def test_add_checkout_lines_catalogue_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(83):
+    with django_assert_num_queries(85):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1228,7 +1228,7 @@ def test_add_checkout_lines_multiple_catalogue_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(83):
+    with django_assert_num_queries(85):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1263,7 +1263,7 @@ def test_add_checkout_lines_order_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(86):
+    with django_assert_num_queries(88):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1297,7 +1297,7 @@ def test_add_checkout_lines_gift_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(112):
+    with django_assert_num_queries(114):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -566,7 +566,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(76):
+    with django_assert_num_queries(79):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then
@@ -821,7 +821,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(92):
+    with django_assert_num_queries(95):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -835,7 +835,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(92):
+    with django_assert_num_queries(95):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -19,10 +19,6 @@ from .....payment.model_helpers import get_subtotal
 from .....plugins import PLUGIN_IDENTIFIER_PREFIX
 from .....plugins.manager import get_plugins_manager
 from .....plugins.tests.sample_plugins import PluginSample
-from .....plugins.webhook.conftest import (  # noqa: F401
-    tax_data_response,
-    tax_line_data_response,
-)
 from .....webhook.event_types import WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -927,7 +927,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     def resolve_subtotal_price(root: models.Checkout, info: ResolveInfo):
         @allow_writer_in_context(info.context)
         def calculate_subtotal_price(data):
-            address, lines, checkout_info, manager = data
+            address, lines, checkout_info, manager, payloads = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.checkout_subtotal(
                 manager=manager,
@@ -935,9 +935,12 @@ class Checkout(ModelObjectType[models.Checkout]):
                 lines=lines,
                 address=address,
                 database_connection_name=database_connection_name,
+                pregenerated_subscription_payloads=payloads,
             )
 
-        dataloaders = list(get_dataloaders_for_fetching_checkout_data(root, info))
+        dataloaders = list(
+            get_dataloaders_for_fetching_checkout_data(root, info, extra_data=True)
+        )
         return Promise.all(dataloaders).then(calculate_subtotal_price)
 
     @staticmethod

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -949,7 +949,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     def resolve_shipping_price(root: models.Checkout, info: ResolveInfo):
         @allow_writer_in_context(info.context)
         def calculate_shipping_price(data):
-            address, lines, checkout_info, manager = data
+            address, lines, checkout_info, manager, payloads = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.checkout_shipping_price(
                 manager=manager,
@@ -957,9 +957,12 @@ class Checkout(ModelObjectType[models.Checkout]):
                 lines=lines,
                 address=address,
                 database_connection_name=database_connection_name,
+                pregenerated_subscription_payloads=payloads,
             )
 
-        dataloaders = list(get_dataloaders_for_fetching_checkout_data(root, info))
+        dataloaders = list(
+            get_dataloaders_for_fetching_checkout_data(root, info, extra_data=True)
+        )
         return Promise.all(dataloaders).then(calculate_shipping_price)
 
     @staticmethod

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -1215,7 +1215,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     @staticmethod
     def resolve_authorize_status(root: models.Checkout, info):
         def _resolve_authorize_status(data):
-            address, lines, checkout_info, manager, transactions = data
+            address, lines, checkout_info, manager, payloads, transactions = data
             database_connection_name = get_database_connection_name(info.context)
             fetch_checkout_data(
                 checkout_info=checkout_info,
@@ -1225,10 +1225,13 @@ class Checkout(ModelObjectType[models.Checkout]):
                 checkout_transactions=transactions,
                 force_status_update=True,
                 database_connection_name=database_connection_name,
+                pregenerated_subscription_payloads=payloads,
             )
             return checkout_info.checkout.authorize_status
 
-        dataloaders = list(get_dataloaders_for_fetching_checkout_data(root, info))
+        dataloaders = list(
+            get_dataloaders_for_fetching_checkout_data(root, info, extra_data=True)
+        )
         dataloaders.append(
             TransactionItemsByCheckoutIDLoader(info.context).load(root.pk)
         )

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -293,10 +293,13 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
             lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
                 checkout.token
             )
+            payloads = PregeneratedSubscriptionPayloadsByCheckoutTokenLoader(
+                info.context
+            ).load(checkout.token)
 
             @allow_writer_in_context(info.context)
             def calculate_line_unit_price(data):
-                checkout_info, lines = data
+                checkout_info, lines, payloads = data
                 database_connection_name = get_database_connection_name(info.context)
                 for line_info in lines:
                     if line_info.line.pk == root.pk:
@@ -306,6 +309,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                             lines=lines,
                             checkout_line_info=line_info,
                             database_connection_name=database_connection_name,
+                            pregenerated_subscription_payloads=payloads,
                         )
                 return None
 
@@ -313,6 +317,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                 [
                     checkout_info,
                     lines,
+                    payloads,
                 ]
             ).then(calculate_line_unit_price)
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -897,6 +897,11 @@ class Checkout(ModelObjectType[models.Checkout]):
         @allow_writer_in_context(info.context)
         def calculate_total_price(data):
             address, lines, checkout_info, manager = data
+            import inspect
+
+            print(len(inspect.stack(0)))
+            # sample_payload = {} #Sample Payload from Dataloader
+            sample_payload = None
             database_connection_name = get_database_connection_name(info.context)
             taxed_total = calculations.calculate_checkout_total_with_gift_cards(
                 manager=manager,
@@ -904,6 +909,7 @@ class Checkout(ModelObjectType[models.Checkout]):
                 lines=lines,
                 address=address,
                 database_connection_name=database_connection_name,
+                subscription_payload=sample_payload,
             )
             return max(taxed_total, zero_taxed_money(root.currency))
 
@@ -1100,11 +1106,11 @@ class Checkout(ModelObjectType[models.Checkout]):
             CheckoutMetadataByCheckoutIdLoader(info.context)
             .load(root.pk)
             .then(
-                lambda metadata_storage: MetaResolvers.resolve_metadata(
-                    metadata_storage.metadata
+                lambda metadata_storage: (
+                    MetaResolvers.resolve_metadata(metadata_storage.metadata)
+                    if metadata_storage
+                    else {}
                 )
-                if metadata_storage
-                else {}
             )
         )
 
@@ -1114,9 +1120,9 @@ class Checkout(ModelObjectType[models.Checkout]):
             CheckoutMetadataByCheckoutIdLoader(info.context)
             .load(root.pk)
             .then(
-                lambda metadata_storage: metadata_storage.metadata.get(key)
-                if metadata_storage
-                else None
+                lambda metadata_storage: (
+                    metadata_storage.metadata.get(key) if metadata_storage else None
+                )
             )
         )
 
@@ -1126,11 +1132,11 @@ class Checkout(ModelObjectType[models.Checkout]):
             CheckoutMetadataByCheckoutIdLoader(info.context)
             .load(root.pk)
             .then(
-                lambda metadata_storage: _filter_metadata(
-                    metadata_storage.metadata, keys
+                lambda metadata_storage: (
+                    _filter_metadata(metadata_storage.metadata, keys)
+                    if metadata_storage
+                    else {}
                 )
-                if metadata_storage
-                else {}
             )
         )
 
@@ -1140,11 +1146,11 @@ class Checkout(ModelObjectType[models.Checkout]):
             CheckoutMetadataByCheckoutIdLoader(info.context)
             .load(root.pk)
             .then(
-                lambda metadata_storage: MetaResolvers.resolve_private_metadata(
-                    metadata_storage, info
+                lambda metadata_storage: (
+                    MetaResolvers.resolve_private_metadata(metadata_storage, info)
+                    if metadata_storage
+                    else {}
                 )
-                if metadata_storage
-                else {}
             )
         )
 
@@ -1158,11 +1164,11 @@ class Checkout(ModelObjectType[models.Checkout]):
             CheckoutMetadataByCheckoutIdLoader(info.context)
             .load(root.pk)
             .then(
-                lambda metadata_storage: resolve_private_metafield_with_privilege_check(
-                    metadata_storage
+                lambda metadata_storage: (
+                    resolve_private_metafield_with_privilege_check(metadata_storage)
+                    if metadata_storage
+                    else None
                 )
-                if metadata_storage
-                else None
             )
         )
 
@@ -1176,11 +1182,11 @@ class Checkout(ModelObjectType[models.Checkout]):
             CheckoutMetadataByCheckoutIdLoader(info.context)
             .load(root.pk)
             .then(
-                lambda metadata_storage: resolve_private_metafields_with_privilege(
-                    metadata_storage
+                lambda metadata_storage: (
+                    resolve_private_metafields_with_privilege(metadata_storage)
+                    if metadata_storage
+                    else {}
                 )
-                if metadata_storage
-                else {}
             )
         )
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -1240,7 +1240,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     @staticmethod
     def resolve_charge_status(root: models.Checkout, info):
         def _resolve_charge_status(data):
-            address, lines, checkout_info, manager, transactions = data
+            address, lines, checkout_info, manager, payloads, transactions = data
             database_connection_name = get_database_connection_name(info.context)
             fetch_checkout_data(
                 checkout_info=checkout_info,
@@ -1250,10 +1250,13 @@ class Checkout(ModelObjectType[models.Checkout]):
                 checkout_transactions=transactions,
                 force_status_update=True,
                 database_connection_name=database_connection_name,
+                pregenerated_subscription_payloads=payloads,
             )
             return checkout_info.checkout.charge_status
 
-        dataloaders = list(get_dataloaders_for_fetching_checkout_data(root, info))
+        dataloaders = list(
+            get_dataloaders_for_fetching_checkout_data(root, info, extra_data=True)
+        )
         dataloaders.append(
             TransactionItemsByCheckoutIDLoader(info.context).load(root.pk)
         )

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -85,7 +85,7 @@ from ..tax.dataloaders import (
 from ..utils import get_user_or_app_from_context
 from ..warehouse.dataloaders import StocksReservationsByCheckoutTokenLoader
 from ..warehouse.types import Warehouse
-from ..webhook.dataloaders import PregeneratedSubscriptionPayloadsByCheckoutTokenLoader
+from ..webhook.dataloaders import PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader
 from .dataloaders import (
     CheckoutByTokenLoader,
     CheckoutInfoByCheckoutTokenLoader,
@@ -117,7 +117,7 @@ def get_dataloaders_for_fetching_checkout_data(
     lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(root.token)
     checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(root.token)
     manager = get_plugin_manager_promise(info.context)
-    payloads = PregeneratedSubscriptionPayloadsByCheckoutTokenLoader(info.context).load(
+    payloads = PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(info.context).load(
         root.token
     )
     return address, lines, checkout_info, manager, payloads
@@ -293,7 +293,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
             lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
                 checkout.token
             )
-            payloads = PregeneratedSubscriptionPayloadsByCheckoutTokenLoader(
+            payloads = PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(
                 info.context
             ).load(checkout.token)
 
@@ -376,7 +376,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
             lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
                 checkout.token
             )
-            payloads = PregeneratedSubscriptionPayloadsByCheckoutTokenLoader(
+            payloads = PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(
                 info.context
             ).load(checkout.token)
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -900,8 +900,7 @@ class Checkout(ModelObjectType[models.Checkout]):
             import inspect
 
             print(len(inspect.stack(0)))
-            # sample_payload = {} #Sample Payload from Dataloader
-            sample_payload = None
+            sample_payloads = {} #Sample Payload from Dataloader
             database_connection_name = get_database_connection_name(info.context)
             taxed_total = calculations.calculate_checkout_total_with_gift_cards(
                 manager=manager,
@@ -909,7 +908,7 @@ class Checkout(ModelObjectType[models.Checkout]):
                 lines=lines,
                 address=address,
                 database_connection_name=database_connection_name,
-                subscription_payload=sample_payload,
+                pregenerated_subscription_payloads=sample_payloads,
             )
             return max(taxed_total, zero_taxed_money(root.currency))
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -376,10 +376,13 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
             lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
                 checkout.token
             )
+            payloads = PregeneratedSubscriptionPayloadsByCheckoutTokenLoader(
+                info.context
+            ).load(checkout.token)
 
             @allow_writer_in_context(info.context)
             def calculate_line_total_price(data):
-                (checkout_info, lines) = data
+                checkout_info, lines, payloads = data
                 database_connection_name = get_database_connection_name(info.context)
                 for line_info in lines:
                     if line_info.line.pk == root.pk:
@@ -389,10 +392,17 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                             lines=lines,
                             checkout_line_info=line_info,
                             database_connection_name=database_connection_name,
+                            pregenerated_subscription_payloads=payloads,
                         )
                 return None
 
-            return Promise.all([checkout_info, lines]).then(calculate_line_total_price)
+            return Promise.all(
+                [
+                    checkout_info,
+                    lines,
+                    payloads,
+                ]
+            ).then(calculate_line_total_price)
 
         return Promise.all(
             [

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -103,6 +103,7 @@ if TYPE_CHECKING:
     from ...plugins.manager import PluginsManager
 
 
+# TODO: Owczar: Fix typing.
 def get_dataloaders_for_fetching_checkout_data(
     root: models.Checkout, info: ResolveInfo, extra_data: bool = False
 ) -> tuple[
@@ -119,8 +120,9 @@ def get_dataloaders_for_fetching_checkout_data(
     payloads = PregeneratedSubscriptionPayloadsByCheckoutTokenLoader(info.context).load(
         root.token
     )
+    # TODO: Owczar: Remove it when we remove the old checkout calculations
     if extra_data:
-        return address, lines, checkout_info, manager, payloads
+        return address, lines, checkout_info, manager, payloads  # type: ignore
     return address, lines, checkout_info, manager
 
 
@@ -903,10 +905,6 @@ class Checkout(ModelObjectType[models.Checkout]):
         @allow_writer_in_context(info.context)
         def calculate_total_price(data):
             address, lines, checkout_info, manager, payloads = data
-            # address, lines, checkout_info, manager = data
-            import inspect
-
-            print(len(inspect.stack(0)))
             database_connection_name = get_database_connection_name(info.context)
             taxed_total = calculations.calculate_checkout_total_with_gift_cards(
                 manager=manager,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -25,10 +25,6 @@ from .....payment.model_helpers import get_subtotal
 from .....plugins import PLUGIN_IDENTIFIER_PREFIX
 from .....plugins.base_plugin import ExcludedShippingMethod
 from .....plugins.tests.sample_plugins import PluginSample
-from .....plugins.webhook.conftest import (  # noqa: F401
-    tax_data_response,
-    tax_line_data_response,
-)
 from .....product.models import ProductVariant
 from .....warehouse.models import Allocation, PreorderAllocation, Stock
 from .....warehouse.tests.utils import get_available_quantity_for_stock

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1797,9 +1797,54 @@ class Order(ModelObjectType[models.Order]):
     def resolve_total(root: models.Order, info, manager):
         @allow_writer_in_context(info.context)
         def _resolve_total(lines):
+            pregenerated_subscription_payloads = {
+                2: {
+                    "29b68cac6e4afbb662108dd4e6f9a385": {
+                        "taxBase": {
+                            "pricesEnteredWithTax": True,
+                            "currency": "USD",
+                            "channel": {"slug": "default-channel3"},
+                            "shippingPrice": {"amount": 0.0},
+                            "lines": [
+                                {
+                                    "sourceLine": {
+                                        "__typename": "OrderLine",
+                                        "id": "Order:ID",
+                                        "orderVariant": {
+                                            "id": "UHJvZHVjdFZhcmlhbnQ6Mzg0",
+                                            "product": {
+                                                "taxClass": {
+                                                    "id": "VGF4Q2xhc3M6Mg==",
+                                                    "name": "Books",
+                                                }
+                                            },
+                                        },
+                                    },
+                                    "quantity": 1,
+                                    "unitPrice": {"amount": 1.99},
+                                    "totalPrice": {"amount": 1.99},
+                                    "chargeTaxes": True,
+                                }
+                            ],
+                            "discounts": [],
+                            "sourceObject": {
+                                "__typename": "Order",
+                                "id": "Order:ID",
+                            },
+                        }
+                    }
+                }
+            }
+
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_total(
-                root, manager, lines, database_connection_name=database_connection_name
+                root,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+                # TODO Owczar: Remove it before merge!
+                # force_update=True,
             )
 
         return (
@@ -2456,9 +2501,9 @@ class Order(ModelObjectType[models.Order]):
     def resolve_shipping_tax_class(cls, root: models.Order, info):
         if root.shipping_method_id:
             return cls.resolve_shipping_method(root, info).then(
-                lambda shipping_method_data: shipping_method_data.tax_class
-                if shipping_method_data
-                else None
+                lambda shipping_method_data: (
+                    shipping_method_data.tax_class if shipping_method_data else None
+                )
             )
         return None
 

--- a/saleor/graphql/webhook/dataloaders.py
+++ b/saleor/graphql/webhook/dataloaders.py
@@ -109,10 +109,10 @@ class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
 
         @allow_writer_in_context(self.context)
         def generate_payloads(data):
-            checkouts_info, checkout_liens_info, apps = data
+            checkouts_info, checkout_lines_info, apps = data
             apps_map = {app.id: app for app in apps}
             promises = []
-            for checkout_info, lines_info in zip(checkouts_info, checkout_liens_info):
+            for checkout_info, lines_info in zip(checkouts_info, checkout_lines_info):
                 tax_configuration, country_tax_configuration = (
                     get_tax_configuration_for_checkout(
                         checkout_info, lines_info, self.database_connection_name

--- a/saleor/graphql/webhook/dataloaders.py
+++ b/saleor/graphql/webhook/dataloaders.py
@@ -70,11 +70,28 @@ class WebhooksByAppIdLoader(DataLoader):
         return [webhooks_by_app_map.get(app_id, []) for app_id in keys]
 
 
-class PregeneratedSubscriptionPayloadsByCheckoutTokenLoader(DataLoader):
-    context_key = "pregenerated_subscription_payloads_by_checkout_token"
+class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
+    context_key = "pregenerated_checkout_tax_payloads_by_checkout_token"
 
     def batch_load(self, keys):
-        # TODO Owczar: Add dict explanation here.
+        """Fetch pregenerated tax payloads for checkouts.
+
+        This loader is used to fetch pregenerated tax payloads for checkouts.
+
+        return: A dict of tax payloads for checkouts.
+
+        Example:
+        {
+            "checkout_token": {
+                "app_id": {
+                    "query_hash": {
+                        <payload>
+                    }
+                }
+            }
+        }
+
+        """
         results: dict[str, dict[int, dict[str, dict[str, Any]]]] = defaultdict(
             lambda: defaultdict(dict)
         )

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -81,7 +81,7 @@ def generate_payload_promise_from_subscription(
     subscribable_object: is an object which have a dedicated own type in Subscription
     definition.
     subscription_query: query used to prepare a payload via graphql engine.
-    context: A dummy request used to share context between apps in order to use
+    request: A dummy request used to share context between apps in order to use
     dataloaders benefits.
     app: the owner of the given payload. Required in case when webhook contains
     protected fields.
@@ -165,7 +165,7 @@ def generate_payload_from_subscription(
     subscribable_object: is an object which have a dedicated own type in Subscription
     definition.
     subscription_query: query used to prepare a payload via graphql engine.
-    context: A dummy request used to share context between apps in order to use
+    request: A dummy request used to share context between apps in order to use
     dataloaders benefits.
     app: the owner of the given payload. Required in case when webhook contains
     protected fields.

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -113,7 +113,7 @@ def generate_payload_promise_from_subscription(
         if hasattr(results, "errors"):
             logger.warning(
                 "Unable to build a payload for subscription. \n"
-                "error: %s" % str(results.errors),
+                f"error: {str(results.errors)}",
                 extra={"query": subscription_query, "app": app_id},
             )
             return None

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -129,7 +129,7 @@ def generate_payload_promise_from_subscription(
             return None
 
         payload_instance = payload[0]
-        event_payload = payload_instance.data.get("event")
+        event_payload = payload_instance.data.get("event") or {}
 
         def check_errors(
             event_payload, payload_instance=payload_instance

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -105,7 +105,7 @@ def test_checkout_subtotal_price_use_pregenerated_payload(
 @mock.patch(
     "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
 )
-def test_checkout_total_total_balance_use_pregenerated_payload(
+def test_checkout_total_balance_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
     checkout,
@@ -146,7 +146,7 @@ def test_checkout_total_total_balance_use_pregenerated_payload(
 @mock.patch(
     "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
 )
-def test_checkout_total_shipping_price_use_pregenerated_payload(
+def test_checkout_shipping_price_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
     checkout,
@@ -173,6 +173,45 @@ def test_checkout_total_shipping_price_use_pregenerated_payload(
                         amount
                     }
                 }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_authorize_status_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                authorizeStatus
             }
         }
     """

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -317,3 +317,54 @@ def test_checkout_line_unit_price_use_pregenerated_payload(
     assert content["data"]["checkout"]["id"] == checkout_global_id
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_line_total_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout_with_item,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout_with_item.price_expiration = timezone.now() - timedelta(days=1)
+    checkout_with_item.save()
+    checkout_global_id = to_global_id_or_none(checkout_with_item)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                lines {
+                    totalPrice {
+                        net {
+                            amount
+                        }
+                        gross {
+                            amount
+                        }
+                        tax {
+                            amount
+                        }
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -227,3 +227,42 @@ def test_checkout_authorize_status_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_charge_status_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                chargeStatus
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -1,0 +1,54 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.test import override_settings
+from django.utils import timezone
+
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_total_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -98,3 +98,44 @@ def test_checkout_subtotal_price_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_total_total_balance_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalBalance {
+                    amount
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -52,3 +52,49 @@ def test_checkout_total_price_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_subtotal_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                subtotalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -162,14 +162,14 @@ def test_checkout_shipping_price_use_pregenerated_payload(
         query getCheckout($id: ID!) {
             checkout(id: $id) {
                 id
-                shippingPrice{
-                    net{
+                shippingPrice {
+                    net {
                         amount
                     }
-                    gross{
+                    gross {
                         amount
                     }
-                    tax{
+                    tax {
                         amount
                     }
                 }
@@ -266,3 +266,54 @@ def test_checkout_charge_status_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_line_unit_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout_with_item,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout_with_item.price_expiration = timezone.now() - timedelta(days=1)
+    checkout_with_item.save()
+    checkout_global_id = to_global_id_or_none(checkout_with_item)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                lines {
+                    unitPrice {
+                        net {
+                            amount
+                        }
+                        gross {
+                            amount
+                        }
+                        tax {
+                            amount
+                        }
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_tax_configurations_with_pregenerated_payloads.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_tax_configurations_with_pregenerated_payloads.py
@@ -1,0 +1,320 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.test import override_settings
+from django.utils import timezone
+
+from .....tax import TaxCalculationStrategy
+from .....tax.models import TaxConfiguration
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_selected_tax_app_price_entered_with_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    tax_app_global_id = to_global_id_or_none(tax_app)
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.tax_app_id = tax_app_global_id
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_selected_tax_app_price_entered_without_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    tax_app_global_id = to_global_id_or_none(tax_app)
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = False
+    tax_configuration.tax_app_id = tax_app_global_id
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_selected_external_tax_app_price_entered_without_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = False
+    tax_configuration.tax_app_id = external_tax_app.identifier
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_selected_external_tax_app_price_entered_with_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.tax_app_id = external_tax_app.identifier
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_all_apps_price_entered_with_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    # Set response for tax calculation to None to ensure that all apps are called
+    mock_request.return_value = None
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    assert mock_request.call_count == 2
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_all_apps_price_entered_without_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = False
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    # Set response for tax calculation to None to ensure that all apps are called
+    mock_request.return_value = None
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    assert mock_request.call_count == 2
+    assert content["data"]["checkout"]["id"] == checkout_global_id

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_utils.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_utils.py
@@ -1,0 +1,104 @@
+from .....webhook.models import Webhook
+from ...utils import get_pregenerated_subscription_payload, get_subscription_query_hash
+
+
+def test_get_subscription_query_hash():
+    # given
+    subscription_query = "subscription { orderCreated { id } }"
+
+    # when
+    query_hash = get_subscription_query_hash(subscription_query)
+
+    # then
+    assert query_hash == "6553179c22234d0b8e07d8db49ac9bd2"
+
+
+def test_get_pregenerated_subscription_payload(webhook_app):
+    # given
+    example_payload = {"payload": "example"}
+    subscription_query = "subscription { orderCreated { id } }"
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=subscription_query,
+    )
+
+    pregenerated_subscription_payloads = {
+        webhook_app.pk: {"6553179c22234d0b8e07d8db49ac9bd2": example_payload}
+    }
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload == example_payload
+
+
+def test_get_pregenerated_subscription_payload_payload_for_other_app(webhook_app):
+    # given
+    example_payload = {"payload": "example"}
+    subscription_query = "subscription { orderCreated { id } }"
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=subscription_query,
+    )
+    invalid_app_id = webhook_app.pk + 1
+
+    pregenerated_subscription_payloads = {
+        invalid_app_id: {"6553179c22234d0b8e07d8db49ac9bd2": example_payload}
+    }
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload is None
+
+
+def test_get_pregenerated_subscription_payload_empty_pregenerated_dict(webhook_app):
+    # given
+    subscription_query = "subscription { orderCreated { id } }"
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=subscription_query,
+    )
+
+    pregenerated_subscription_payloads = {}
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload is None
+
+
+def test_get_pregenerated_subscription_payload_webhook_without_subscription(
+    webhook_app,
+):
+    # given
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+    )
+
+    pregenerated_subscription_payloads = {}
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload is None

--- a/saleor/graphql/webhook/tests/test_subscription_payload.py
+++ b/saleor/graphql/webhook/tests/test_subscription_payload.py
@@ -1,9 +1,11 @@
+import graphene
 from django.test import override_settings
 from django.utils import timezone
 
-from ....webhook.event_types import WebhookEventAsyncType
+from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....webhook.models import Webhook
 from ..subscription_payload import (
+    generate_payload_from_subscription,
     generate_pre_save_payloads,
     get_pre_save_payload_key,
     initialize_request,
@@ -117,3 +119,163 @@ def test_generate_pre_save_payloads(webhook_app, variant):
     key = get_pre_save_payload_key(webhook, variant)
     assert key in pre_save_payloads
     assert pre_save_payloads[key]
+
+
+def test_generate_payload_from_subscription(
+    checkout,
+    subscription_webhook,
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ... on Checkout {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request()
+    checkout_global_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    assert payload["taxBase"]["sourceObject"]["id"] == checkout_global_id
+
+
+def test_generate_payload_from_subscription_missing_permissions(
+    gift_card, subscription_gift_card_created_webhook, permission_manage_gift_card
+):
+    # given
+
+    webhook = subscription_gift_card_created_webhook
+    app = webhook.app
+    app.permissions.remove(permission_manage_gift_card)
+    request = initialize_request(requestor=app, sync_event=False)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventAsyncType.GIFT_CARD_CREATED,
+        subscribable_object=gift_card,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    error_code = "PermissionDenied"
+    assert "errors" in payload.keys()
+    assert not payload["giftCard"]
+    error = payload["errors"][0]
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_from_subscription_circular_call(
+    checkout, subscription_webhook, permission_handle_taxes
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    error_code = "CircularSubscriptionSyncEvent"
+    assert list(payload.keys()) == ["errors"]
+    error = payload["errors"][0]
+    assert (
+        error["message"] == "Resolving this field is not allowed in synchronous events."
+    )
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_from_subscription_unable_to_build_payload(
+    checkout, subscription_webhook
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on OrderCalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    assert payload is None

--- a/saleor/graphql/webhook/tests/test_subscription_payload.py
+++ b/saleor/graphql/webhook/tests/test_subscription_payload.py
@@ -6,6 +6,7 @@ from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....webhook.models import Webhook
 from ..subscription_payload import (
     generate_payload_from_subscription,
+    generate_payload_promise_from_subscription,
     generate_pre_save_payloads,
     get_pre_save_payload_key,
     initialize_request,
@@ -278,4 +279,168 @@ def test_generate_payload_from_subscription_unable_to_build_payload(
         app=app,
     )
     # then
+    assert payload is None
+
+
+def test_generate_payload_promise_from_subscription(
+    checkout,
+    subscription_webhook,
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ... on Checkout {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request()
+    checkout_global_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    payload = payload.get()
+    assert payload["taxBase"]["sourceObject"]["id"] == checkout_global_id
+
+
+def test_generate_payload_promise_from_subscription_missing_permissions(
+    gift_card, subscription_gift_card_created_webhook, permission_manage_gift_card
+):
+    # given
+
+    webhook = subscription_gift_card_created_webhook
+    app = webhook.app
+    app.permissions.remove(permission_manage_gift_card)
+    request = initialize_request(requestor=app, sync_event=False)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventAsyncType.GIFT_CARD_CREATED,
+        subscribable_object=gift_card,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    payload = payload.get()
+    error_code = "PermissionDenied"
+    assert "errors" in payload.keys()
+    assert not payload["giftCard"]
+    error = payload["errors"][0]
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_promise_from_subscription_circular_call(
+    checkout, subscription_webhook, permission_handle_taxes
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    payload = payload.get()
+    error_code = "CircularSubscriptionSyncEvent"
+    assert list(payload.keys()) == ["errors"]
+    error = payload["errors"][0]
+    assert (
+        error["message"] == "Resolving this field is not allowed in synchronous events."
+    )
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_promise_from_subscription_unable_to_build_payload(
+    checkout, subscription_webhook
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on OrderCalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    payload = payload.get()
     assert payload is None

--- a/saleor/graphql/webhook/utils.py
+++ b/saleor/graphql/webhook/utils.py
@@ -26,8 +26,6 @@ def get_pregenerated_subscription_payload(
         return None
 
     query_hash = get_subscription_query_hash(webhook.subscription_query)
-    return (
-        pregenerated_subscription_payloads.get(webhook.app_id, {})
-        .get(query_hash, {})
-        .get(str(subscriptable_object.pk), None)
+    return pregenerated_subscription_payloads.get(webhook.app_id, {}).get(
+        query_hash, None
     )

--- a/saleor/graphql/webhook/utils.py
+++ b/saleor/graphql/webhook/utils.py
@@ -13,16 +13,9 @@ def get_subscription_query_hash(subscription_query: str) -> str:
 
 def get_pregenerated_subscription_payload(
     webhook: Webhook,
-    subscriptable_object,
     pregenerated_subscription_payloads: Optional[dict] = {},
 ) -> Optional[dict]:
     if webhook.subscription_query is None or pregenerated_subscription_payloads is None:
-        return None
-
-    if not hasattr(subscriptable_object, "pk"):
-        logger.warning(
-            "Subscriptable object doesn't have a primary key. Skipping usage of pregenerated subscription payload."
-        )
         return None
 
     query_hash = get_subscription_query_hash(webhook.subscription_query)

--- a/saleor/graphql/webhook/utils.py
+++ b/saleor/graphql/webhook/utils.py
@@ -1,0 +1,33 @@
+import hashlib
+import logging
+from typing import Optional
+
+from ...webhook.models import Webhook
+
+logger = logging.getLogger(__name__)
+
+
+def get_subscription_query_hash(subscription_query: str) -> str:
+    return hashlib.md5(subscription_query.encode("utf-8")).hexdigest()
+
+
+def get_pregenerated_subscription_payload(
+    webhook: Webhook,
+    subscriptable_object,
+    pregenerated_subscription_payloads: Optional[dict] = {},
+) -> Optional[dict]:
+    if webhook.subscription_query is None or pregenerated_subscription_payloads is None:
+        return None
+
+    if not hasattr(subscriptable_object, "pk"):
+        logger.warning(
+            "Subscriptable object doesn't have a primary key. Skipping usage of pregenerated subscription payload."
+        )
+        return None
+
+    query_hash = get_subscription_query_hash(webhook.subscription_query)
+    return (
+        pregenerated_subscription_payloads.get(webhook.app_id, {})
+        .get(query_hash, {})
+        .get(str(subscriptable_object.pk), None)
+    )

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -608,7 +608,9 @@ class BasePlugin:
         Optional["TaxData"],
     ]
 
-    get_taxes_for_order: Callable[["Order", str, Any], Optional["TaxData"]]
+    get_taxes_for_order: Callable[
+        ["Order", str, Any, Optional[dict]], Optional["TaxData"]
+    ]
 
     get_client_token: Callable[[Any, Any], Any]
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -604,7 +604,7 @@ class BasePlugin:
     ]
 
     get_taxes_for_checkout: Callable[
-        ["CheckoutInfo", Iterable["CheckoutLineInfo"], str, Any],
+        ["CheckoutInfo", Iterable["CheckoutLineInfo"], str, Any, Optional[dict]],
         Optional["TaxData"],
     ]
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -251,9 +251,7 @@ class PluginsManager(PaymentInterface):
         plugin_method = getattr(plugin, method_name, NotImplemented)
         if plugin_method == NotImplemented:
             return previous_value
-        returned_value = plugin_method(
-            *args, **kwargs, previous_value=previous_value
-        )  # type:ignore
+        returned_value = plugin_method(*args, **kwargs, previous_value=previous_value)  # type:ignore
         if returned_value == NotImplemented:
             return previous_value
         return returned_value

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -251,7 +251,9 @@ class PluginsManager(PaymentInterface):
         plugin_method = getattr(plugin, method_name, NotImplemented)
         if plugin_method == NotImplemented:
             return previous_value
-        returned_value = plugin_method(*args, **kwargs, previous_value=previous_value)  # type:ignore
+        returned_value = plugin_method(
+            *args, **kwargs, previous_value=previous_value
+        )  # type:ignore
         if returned_value == NotImplemented:
             return previous_value
         return returned_value
@@ -652,14 +654,18 @@ class PluginsManager(PaymentInterface):
         )
 
     def get_taxes_for_checkout(
-        self, checkout_info, lines, app_identifier, subscription_payload=None
+        self,
+        checkout_info,
+        lines,
+        app_identifier,
+        pregenerated_subscription_payloads: Optional[dict] = {},
     ) -> Optional[TaxData]:
         return self.__run_plugin_method_until_first_success(
             "get_taxes_for_checkout",
             checkout_info,
             lines,
             app_identifier,
-            subscription_payload=subscription_payload,
+            pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             channel_slug=checkout_info.channel.slug,
         )
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -652,13 +652,14 @@ class PluginsManager(PaymentInterface):
         )
 
     def get_taxes_for_checkout(
-        self, checkout_info, lines, app_identifier
+        self, checkout_info, lines, app_identifier, subscription_payload=None
     ) -> Optional[TaxData]:
         return self.__run_plugin_method_until_first_success(
             "get_taxes_for_checkout",
             checkout_info,
             lines,
             app_identifier,
+            subscription_payload=subscription_payload,
             channel_slug=checkout_info.channel.slug,
         )
 
@@ -2291,13 +2292,14 @@ class PluginsManager(PaymentInterface):
         *args,
         channel_slug: Optional[str],
         plugins: Optional[list["BasePlugin"]] = None,
+        **kwargs,
     ):
         if plugins is None:
             plugins = self.get_plugins(channel_slug=channel_slug, active_only=True)
         if plugins:
             for plugin in plugins:
                 result = self.__run_method_on_single_plugin(
-                    plugin, method_name, None, *args
+                    plugin, method_name, None, *args, **kwargs
                 )
                 if result is not None:
                     return result

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -667,12 +667,18 @@ class PluginsManager(PaymentInterface):
             channel_slug=checkout_info.channel.slug,
         )
 
-    def get_taxes_for_order(self, order: "Order", app_identifier) -> Optional[TaxData]:
+    def get_taxes_for_order(
+        self,
+        order: "Order",
+        app_identifier,
+        pregenerated_subscription_payloads: Optional[dict] = {},
+    ) -> Optional[TaxData]:
         return self.__run_plugin_method_until_first_success(
             "get_taxes_for_order",
             order,
             app_identifier,
             channel_slug=order.channel.slug,
+            pregenerated_subscription_payloads=pregenerated_subscription_payloads,
         )
 
     def preprocess_order_creation(

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -303,7 +303,11 @@ class PluginSample(BasePlugin):
         return sample_tax_data(checkout_info.checkout)
 
     def get_taxes_for_order(
-        self, order: "Order", app_identifier, previous_value
+        self,
+        order: "Order",
+        app_identifier,
+        previous_value,
+        pregenerated_subscription_payloads: Optional[dict] = {},
     ) -> Optional["TaxData"]:
         return sample_tax_data(order)
 

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -293,7 +293,12 @@ class PluginSample(BasePlugin):
         return Decimal("0.080").quantize(Decimal(".01"))
 
     def get_taxes_for_checkout(
-        self, checkout_info: "CheckoutInfo", lines, app_identifier, previous_value
+        self,
+        checkout_info: "CheckoutInfo",
+        lines,
+        app_identifier,
+        previous_value,
+        pregenerated_subscription_payloads={},
     ) -> Optional["TaxData"]:
         return sample_tax_data(checkout_info.checkout)
 

--- a/saleor/plugins/webhook/conftest.py
+++ b/saleor/plugins/webhook/conftest.py
@@ -6,34 +6,6 @@ from ..manager import get_plugins_manager
 
 
 @pytest.fixture
-def tax_line_data_response():
-    return {
-        "id": "1234",
-        "currency": "PLN",
-        "unit_net_amount": 12.34,
-        "unit_gross_amount": 12.34,
-        "total_gross_amount": 12.34,
-        "total_net_amount": 12.34,
-        "tax_rate": 23,
-    }
-
-
-@pytest.fixture
-def tax_data_response(tax_line_data_response):
-    return {
-        "currency": "PLN",
-        "total_net_amount": 12.34,
-        "total_gross_amount": 12.34,
-        "subtotal_net_amount": 12.34,
-        "subtotal_gross_amount": 12.34,
-        "shipping_price_gross_amount": 12.34,
-        "shipping_price_net_amount": 12.34,
-        "shipping_tax_rate": 23,
-        "lines": [tax_line_data_response] * 5,
-    }
-
-
-@pytest.fixture
 def tax_app(app, permission_handle_taxes, webhook):
     app.permissions.add(permission_handle_taxes)
     return app

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3043,7 +3043,8 @@ class WebhookPlugin(BasePlugin):
         pregenerated_subscription_payloads: Optional[dict] = {},
     ):
         app = (
-            App.objects.filter(
+            App.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+            .filter(
                 identifier=app_identifier,
                 is_active=True,
             )
@@ -3068,7 +3069,7 @@ class WebhookPlugin(BasePlugin):
         )
 
         pregenerated_subscription_payload = get_pregenerated_subscription_payload(
-            webhook, subscriptable_object, pregenerated_subscription_payloads
+            webhook, pregenerated_subscription_payloads
         )
         response = trigger_webhook_sync(
             event_type=event_type,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3116,7 +3116,11 @@ class WebhookPlugin(BasePlugin):
             )
 
     def get_taxes_for_order(
-        self, order: "Order", app_identifier, previous_value
+        self,
+        order: "Order",
+        app_identifier,
+        previous_value,
+        pregenerated_subscription_payloads: Optional[dict] = {},
     ) -> Optional["TaxData"]:
         event_type = WebhookEventSyncType.ORDER_CALCULATE_TAXES
         if app_identifier:
@@ -3125,6 +3129,7 @@ class WebhookPlugin(BasePlugin):
                 app_identifier,
                 lambda: generate_order_payload_for_tax_calculation(order),
                 order,
+                pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             )
         else:
             return trigger_all_webhooks_sync(
@@ -3133,6 +3138,7 @@ class WebhookPlugin(BasePlugin):
                 parse_tax_data,
                 order,
                 self.requestor,
+                pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             )
 
     def get_shipping_methods_for_checkout(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3090,18 +3090,8 @@ class WebhookPlugin(BasePlugin):
         previous_value,
         pregenerated_subscription_payloads={},
     ) -> Optional["TaxData"]:
-        print("checkout_info", checkout_info)
-        print("lines", lines)
-        print("app_identifier", app_identifier)
-        print("previous_value", previous_value)
-        from pprint import pprint
-
-        print("pregenerated_subscription_payloads", "!" * 50)
-        pprint(pregenerated_subscription_payloads)
-        print("\n\n")
         event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
         if app_identifier:
-
             return self.__run_tax_webhook(
                 event_type,
                 app_identifier,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3039,6 +3039,7 @@ class WebhookPlugin(BasePlugin):
         app_identifier: str,
         payload_gen: Callable,
         subscriptable_object=None,
+        subscription_payload=None,
     ):
         app = (
             App.objects.filter(
@@ -3072,12 +3073,23 @@ class WebhookPlugin(BasePlugin):
             subscribable_object=subscriptable_object,
             request=request_context,
             requestor=self.requestor,
+            subscription_payload=subscription_payload,
         )
         return parse_tax_data(response)
 
     def get_taxes_for_checkout(
-        self, checkout_info, lines, app_identifier, previous_value
+        self,
+        checkout_info,
+        lines,
+        app_identifier,
+        previous_value,
+        subscription_payload=None,
     ) -> Optional["TaxData"]:
+        print("checkout_info", checkout_info)
+        print("lines", lines)
+        print("app_identifier", app_identifier)
+        print("previous_value", previous_value)
+        print("subscription_payload", subscription_payload)
         event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
         if app_identifier:
             return self.__run_tax_webhook(
@@ -3087,6 +3099,7 @@ class WebhookPlugin(BasePlugin):
                     checkout_info, lines
                 ),
                 checkout_info.checkout,
+                subscription_payload=subscription_payload,
             )
         else:
             return trigger_all_webhooks_sync(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -196,6 +196,37 @@ def test_checkout_calculate_taxes_with_free_shipping_voucher(
 
 
 @freeze_time("2020-03-18 12:00:00")
+def test_checkout_calculate_taxes_with_pregenerated_payload(
+    checkout_with_voucher_free_shipping,
+    webhook_app,
+    permission_handle_taxes,
+):
+    # given
+    checkout = checkout_with_voucher_free_shipping
+    webhook_app.permissions.add(permission_handle_taxes)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+    expected_payload = {"payload": "test"}
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(
+        event_type,
+        checkout,
+        webhook,
+        pregenerated_payload=expected_payload,
+    )
+
+    # then
+    assert json.loads(deliveries.payload.payload) == expected_payload
+
+
+@freeze_time("2020-03-18 12:00:00")
 def test_checkout_calculate_taxes_with_entire_order_voucher(
     checkout_with_voucher,
     webhook_app,

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -1,6 +1,6 @@
 import json
 from unittest import mock
-from unittest.mock import sentinel
+from unittest.mock import ANY, sentinel
 
 import pytest
 from freezegun import freeze_time
@@ -9,6 +9,7 @@ from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....core import EventDeliveryStatus
 from ....core.models import EventDelivery, EventPayload
 from ....core.taxes import TaxType
+from ....graphql.webhook.utils import get_subscription_query_hash
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
 from ....webhook.payloads import generate_order_payload_for_tax_calculation
@@ -199,7 +200,11 @@ def test_get_taxes_for_order_with_sync_subscription(
 @freeze_time()
 @mock.patch("saleor.checkout.calculations.fetch_checkout_data")
 @mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
 def test_get_taxes_for_checkout_with_sync_subscription(
+    mock_generate_payload,
     mock_request,
     mock_fetch,
     webhook_plugin,
@@ -208,6 +213,65 @@ def test_get_taxes_for_checkout_with_sync_subscription(
     tax_app,
 ):
     # given
+    subscription_query = "subscription{event{... on CalculateTaxes{taxBase{currency}}}}"
+    expected_payload = {"taxBase": {"currency": "USD"}}
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
+    mock_request.return_value = tax_data_response
+    mock_generate_payload.return_value = expected_payload
+    plugin = webhook_plugin()
+    webhook = Webhook.objects.create(
+        name="Tax checkout webhook",
+        app=tax_app,
+        target_url="https://localhost:8888/tax-order",
+        subscription_query=subscription_query,
+    )
+    webhook.events.create(event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES)
+    app_identifier = None
+
+    # when
+    tax_data = plugin.get_taxes_for_checkout(checkout_info, [], app_identifier, None)
+
+    # then
+    mock_generate_payload.assert_called_once_with(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=subscription_query,
+        request=ANY,  # SaleorContext,
+        app=tax_app,
+    )
+    payload = EventPayload.objects.get()
+    assert payload.payload == json.dumps(expected_payload)
+    delivery = EventDelivery.objects.get()
+    assert delivery.status == EventDeliveryStatus.PENDING
+    assert delivery.event_type == WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    assert delivery.payload == payload
+    assert delivery.webhook == webhook
+    mock_request.assert_called_once_with(delivery)
+    mock_fetch.assert_not_called()
+    assert tax_data == parse_tax_data(tax_data_response)
+
+
+@freeze_time()
+@mock.patch("saleor.checkout.calculations.fetch_checkout_data")
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_get_taxes_for_checkout_with_sync_subscription_with_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    mock_fetch,
+    webhook_plugin,
+    tax_data_response,
+    checkout,
+    tax_app,
+):
+    # given
+    subscription_query = "subscription{event{... on CalculateTaxes{taxBase{currency}}}}"
+    subscription_query_hash = get_subscription_query_hash(subscription_query)
+    expected_payload = {"taxBase": {"currency": "USD"}}
     checkout_info = fetch_checkout_info(
         checkout, [], get_plugins_manager(allow_replica=False)
     )
@@ -217,19 +281,27 @@ def test_get_taxes_for_checkout_with_sync_subscription(
         name="Tax checkout webhook",
         app=tax_app,
         target_url="https://localhost:8888/tax-order",
-        subscription_query=(
-            "subscription{event{... on CalculateTaxes{taxBase{currency}}}}"
-        ),
+        subscription_query=subscription_query,
     )
     webhook.events.create(event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES)
     app_identifier = None
+    pregenerated_subscription_payloads = {
+        tax_app.id: {subscription_query_hash: expected_payload}
+    }
 
     # when
-    tax_data = plugin.get_taxes_for_checkout(checkout_info, [], app_identifier, None)
+    tax_data = plugin.get_taxes_for_checkout(
+        checkout_info,
+        [],
+        app_identifier,
+        None,
+        pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+    )
 
     # then
+    mock_generate_payload.assert_not_called()
     payload = EventPayload.objects.get()
-    assert payload.payload == json.dumps({"taxBase": {"currency": "USD"}})
+    assert payload.payload == json.dumps(expected_payload)
     delivery = EventDelivery.objects.get()
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -128,7 +128,7 @@ def get_tax_app_identifier_for_order(order: "Order"):
     return get_tax_app_id(tax_configuration, country_tax_configuration)
 
 
-def _get_tax_configuration_for_checkout(
+def get_tax_configuration_for_checkout(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
@@ -158,7 +158,7 @@ def get_charge_taxes_for_checkout(
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ):
     """Get charge_taxes value for checkout."""
-    tax_configuration, country_tax_configuration = _get_tax_configuration_for_checkout(
+    tax_configuration, country_tax_configuration = get_tax_configuration_for_checkout(
         checkout_info, lines, database_connection_name=database_connection_name
     )
     return get_charge_taxes(tax_configuration, country_tax_configuration)
@@ -170,7 +170,7 @@ def get_tax_calculation_strategy_for_checkout(
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ):
     """Get tax_calculation_strategy value for checkout."""
-    tax_configuration, country_tax_configuration = _get_tax_configuration_for_checkout(
+    tax_configuration, country_tax_configuration = get_tax_configuration_for_checkout(
         checkout_info, lines, database_connection_name=database_connection_name
     )
     return get_tax_calculation_strategy(tax_configuration, country_tax_configuration)
@@ -182,7 +182,7 @@ def get_tax_app_identifier_for_checkout(
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ):
     """Get tax_app_id value for checkout."""
-    tax_configuration, country_tax_configuration = _get_tax_configuration_for_checkout(
+    tax_configuration, country_tax_configuration = get_tax_configuration_for_checkout(
         checkout_info, lines, database_connection_name=database_connection_name
     )
     return get_tax_app_id(tax_configuration, country_tax_configuration)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -86,6 +86,7 @@ from ..discount.utils.voucher import (
 )
 from ..giftcard import GiftCardEvents
 from ..giftcard.models import GiftCard, GiftCardEvent, GiftCardTag
+from ..graphql.core.utils import to_global_id_or_none
 from ..menu.models import Menu, MenuItem, MenuItemTranslation
 from ..order import OrderOrigin, OrderStatus
 from ..order.actions import cancel_fulfillment, fulfill_order_lines
@@ -7745,6 +7746,8 @@ def payment_method_process_tokenization_app(db, permission_manage_payments):
 @pytest.fixture
 def tax_app(db, permission_handle_taxes):
     app = App.objects.create(name="Tax App", is_active=True)
+    app.identifier = to_global_id_or_none(app)
+    app.save()
     app.permissions.add(permission_handle_taxes)
 
     webhook = Webhook.objects.create(
@@ -7763,6 +7766,70 @@ def tax_app(db, permission_handle_taxes):
         ]
     )
     return app
+
+
+@pytest.fixture
+def external_tax_app(db, permission_handle_taxes):
+    app = App.objects.create(
+        name="External App",
+        is_active=True,
+        type=AppType.THIRDPARTY,
+        identifier="mirumee.app.simple.tax",
+        about_app="About app text.",
+        data_privacy="Data privacy text.",
+        data_privacy_url="http://www.example.com/privacy/",
+        homepage_url="http://www.example.com/homepage/",
+        support_url="http://www.example.com/support/contact/",
+        configuration_url="http://www.example.com/app-configuration/",
+        app_url="http://www.example.com/app/",
+    )
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_handle_taxes)
+
+    webhook = Webhook.objects.create(
+        name="external-tax-webhook-1",
+        app=app,
+        target_url="https://tax-app.example.com/api/",
+        subscription_query=CALCULATE_TAXES_SUBSCRIPTION_QUERY,
+    )
+    webhook.events.bulk_create(
+        [
+            WebhookEvent(event_type=event_type, webhook=webhook)
+            for event_type in [
+                WebhookEventSyncType.ORDER_CALCULATE_TAXES,
+                WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+            ]
+        ]
+    )
+    return app
+
+
+@pytest.fixture
+def tax_line_data_response():
+    return {
+        "id": "1234",
+        "currency": "PLN",
+        "unit_net_amount": 12.34,
+        "unit_gross_amount": 12.34,
+        "total_gross_amount": 12.34,
+        "total_net_amount": 12.34,
+        "tax_rate": 23,
+    }
+
+
+@pytest.fixture
+def tax_data_response(tax_line_data_response):
+    return {
+        "currency": "PLN",
+        "total_net_amount": 12.34,
+        "total_gross_amount": 12.34,
+        "subtotal_net_amount": 12.34,
+        "subtotal_gross_amount": 12.34,
+        "shipping_price_gross_amount": 12.34,
+        "shipping_price_net_amount": 12.34,
+        "shipping_tax_rate": 23,
+        "lines": [tax_line_data_response] * 5,
+    }
 
 
 @pytest.fixture

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -182,7 +182,6 @@ def trigger_webhook_sync_if_not_cached(
     - Fetch response from cache if it is still valid.
     """
 
-    # TODO Owczar: Task for issue with 2 webhooks for same url, same event and different query.
     cache_key = generate_cache_key_for_webhook(
         cache_data, webhook.target_url, event_type, webhook.app_id
     )
@@ -251,15 +250,7 @@ def create_delivery_for_subscription_sync_event(
             request=request,
             app=webhook.app,
         )
-        print("Payload generated from subscription!!!!!!!")
-        print("webhook", webhook.pk)
-        print("app", webhook.app_id)
-        print("subscribable_object", subscribable_object)
-        print("subscribable_object_id", subscribable_object.pk)
-        print("data", data)
     else:
-        print("Using pregenerated payload")
-        print("For checkout", subscribable_object.token)
         data = pregenerated_payload
 
     if not data:
@@ -339,7 +330,6 @@ def trigger_all_webhooks_sync(
     If no webhook responds with expected response,
     this function returns None.
     """
-    # TODO Owczar: Adjust flow to handle pre-generated payloads
     webhooks = get_webhooks_for_event(event_type)
     request_context = None
     event_payload = None

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -212,6 +212,7 @@ def create_delivery_for_subscription_sync_event(
     requestor=None,
     request=None,
     allow_replica=False,
+    payload=None,
 ) -> Optional[EventDelivery]:
     """Generate webhook payload based on subscription query and create delivery object.
 
@@ -239,13 +240,17 @@ def create_delivery_for_subscription_sync_event(
             event_type=event_type,
             allow_replica=allow_replica,
         )
-    data = generate_payload_from_subscription(
-        event_type=event_type,
-        subscribable_object=subscribable_object,
-        subscription_query=webhook.subscription_query,
-        request=request,
-        app=webhook.app,
-    )
+    if not payload:
+        data = generate_payload_from_subscription(
+            event_type=event_type,
+            subscribable_object=subscribable_object,
+            subscription_query=webhook.subscription_query,
+            request=request,
+            app=webhook.app,
+        )
+    else:
+        data = payload
+
     if not data:
         logger.info(
             "No payload was generated with subscription for event: %s", event_type
@@ -274,6 +279,7 @@ def trigger_webhook_sync(
     timeout=None,
     request=None,
     requestor=None,
+    subscription_payload=None,
 ) -> Optional[dict[Any, Any]]:
     """Send a synchronous webhook request."""
     if webhook.subscription_query:
@@ -284,6 +290,7 @@ def trigger_webhook_sync(
             requestor=requestor,
             request=request,
             allow_replica=allow_replica,
+            payload=subscription_payload,
         )
         if not delivery:
             return None
@@ -320,6 +327,7 @@ def trigger_all_webhooks_sync(
     If no webhook responds with expected response,
     this function returns None.
     """
+    # TODO Owczar: Adjust flow to handle pre-generated payloads
     webhooks = get_webhooks_for_event(event_type)
     request_context = None
     event_payload = None

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -344,7 +344,7 @@ def trigger_all_webhooks_sync(
                 )
 
             pregenerated_payload = get_pregenerated_subscription_payload(
-                webhook, subscribable_object, pregenerated_subscription_payloads
+                webhook, pregenerated_subscription_payloads
             )
 
             delivery = create_delivery_for_subscription_sync_event(

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -225,10 +225,10 @@ def create_delivery_for_subscription_sync_event(
     :param webhook: webhook object for which delivery will be created.
     :param requestor: used in subscription webhooks to generate meta data for payload.
     :param request: used to share context between sync event calls
-    :return: List of event deliveries to send via webhook tasks.
     :param allow_replica: use replica database.
+    :param pregenerated_payload: Pregenerated payload to use instead of generating one when creating delivery.
+    :return: List of event deliveries to send via webhook tasks.
     """
-    # TODO Owczar: Adjust docstring to new solution
     if event_type not in WEBHOOK_TYPES_MAP:
         logger.info(
             "Skipping subscription webhook. Event %s is not subscribable.", event_type

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -251,7 +251,15 @@ def create_delivery_for_subscription_sync_event(
             request=request,
             app=webhook.app,
         )
+        print("Payload generated from subscription!!!!!!!")
+        print("webhook", webhook.pk)
+        print("app", webhook.app_id)
+        print("subscribable_object", subscribable_object)
+        print("subscribable_object_id", subscribable_object.pk)
+        print("data", data)
     else:
+        print("Using pregenerated payload")
+        print("For checkout", subscribable_object.token)
         data = pregenerated_payload
 
     if not data:


### PR DESCRIPTION
I want to merge this change because generating sync webhook payloads in the dataloaders for order tax calculation.
 
 ⚠️ ⚠️ ⚠️ 
 This PR should be merged after PR#16086.
 ⚠️ ⚠️ ⚠️ 
 
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
