### PR TITLE
Add checkoutTokens filter to orders query

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -20,6 +20,7 @@ from ..core.filters import (
     MetadataFilterBase,
     ObjectTypeFilter,
 )
+from ..core.scalars import UUID as UUIDScalar
 from ..core.types import DateRangeInput, DateTimeRangeInput
 from ..core.utils import from_global_id_or_error
 from ..discount.filters import DiscountedObjectWhere
@@ -176,6 +177,12 @@ def filter_by_order_number(qs, _, values):
     return qs.filter(number__in=values)
 
 
+def filter_by_checkout_tokens(qs, _, values):
+    if not values:
+        return qs
+    return qs.filter(checkout_token__in=values)
+
+
 class DraftOrderFilter(MetadataFilterBase):
     customer = django_filters.CharFilter(method=filter_customer)
     created = ObjectTypeFilter(input_class=DateRangeInput, method=filter_created_range)
@@ -210,6 +217,9 @@ class OrderFilter(DraftOrderFilter):
     )
     is_preorder = django_filters.BooleanFilter(method=filter_is_preorder)
     ids = GlobalIDMultipleChoiceFilter(method=filter_order_by_id)
+    checkout_tokens = ListObjectTypeFilter(
+        input_class=UUIDScalar, method=filter_by_checkout_tokens
+    )
     gift_card_used = django_filters.BooleanFilter(method=filter_gift_card_used)
     gift_card_bought = django_filters.BooleanFilter(method=filter_gift_card_bought)
     numbers = ListObjectTypeFilter(

--- a/saleor/graphql/order/tests/queries/test_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_filter.py
@@ -28,7 +28,7 @@ from ....tests.utils import get_graphql_content, get_graphql_content_from_respon
 def orders_query_with_filter():
     query = """
       query ($filter: OrderFilterInput!, ) {
-        orders(first: 5, filter:$filter) {
+        orders(first: 10, filter:$filter) {
           totalCount
           edges {
             node {
@@ -1360,3 +1360,66 @@ def test_order_query_with_filter_by_empty_list(
     # then
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == len(orders_from_checkout)
+
+
+def test_order_query_with_filter_checkout_tokens(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_group_manage_orders,
+    order,
+    orders_from_checkout,
+    channel_USD,
+):
+    assert not order.checkout_token
+    assert all([order.checkout_token for order in orders_from_checkout])
+    # given
+    variables = {
+        "filter": {
+            "checkoutTokens": [order.checkout_token for order in orders_from_checkout],
+        },
+    }
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
+
+    # then
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"]
+    assert len(order_data) == len(orders_from_checkout)
+    for order in orders_from_checkout:
+        assert {
+            "node": {"id": graphene.Node.to_global_id("Order", order.pk)}
+        } in order_data
+
+
+def test_order_query_with_filter_checkout_tokens_empty_list(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_group_manage_orders,
+    order,
+    orders_from_checkout,
+    channel_USD,
+):
+    assert not order.checkout_token
+    assert all([order.checkout_token for order in orders_from_checkout])
+    # given
+    variables = {
+        "filter": {
+            "checkoutTokens": [],
+        },
+    }
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
+
+    # then
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"]
+
+    assert len(order_data) == len(orders_from_checkout + [order])
+    for order in orders_from_checkout + [order]:
+        assert {
+            "node": {"id": graphene.Node.to_global_id("Order", order.pk)}
+        } in order_data

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13994,6 +13994,7 @@ input OrderFilterInput @doc(category: "Orders") {
   isClickAndCollect: Boolean
   isPreorder: Boolean
   ids: [ID!]
+  checkoutTokens: [UUID!]
   giftCardUsed: Boolean
   giftCardBought: Boolean
   numbers: [String!]


### PR DESCRIPTION
I want to merge this change because it adds filtering needed for apps to avoid using a hack (use checkoutComplete mutation to get checkout information). Now apps can filter orders by UUID of checkout.

Fixes: https://linear.app/saleor/issue/SHOPX-567/ir-170-add-api-for-fetching-order-based-on-checkouts-token

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
