### PR TITLE
Ensure that the draft order is not finalize when it is fully paid

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -1688,6 +1688,72 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_fully_paid(
     mock_order_paid.assert_called_once_with(order)
 
 
+@pytest.mark.parametrize(
+    ("auto_order_confirmation"),
+    [True, False],
+)
+@patch("saleor.plugins.manager.PluginsManager.order_paid")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
+def test_transaction_event_report_for_draft_order_triggers_webhooks_when_fully_paid(
+    mock_order_fully_paid,
+    mock_order_updated,
+    mock_order_paid,
+    auto_order_confirmation,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    draft_order,
+):
+    # given
+    order = draft_order
+    order.channel.automatically_confirm_all_new_orders = auto_order_confirmation
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    psp_reference = "111-abc"
+    transaction = transaction_item_generator(app=app_api_client.app, order_id=order.pk)
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": order.total.gross.amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    order.refresh_from_db()
+
+    assert order.status == OrderStatus.DRAFT
+    assert order.charge_status == OrderChargeStatusEnum.FULL.value
+    mock_order_fully_paid.assert_called_once_with(order)
+    mock_order_updated.assert_called_once_with(order)
+    mock_order_paid.assert_called_once_with(order)
+
+
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_transaction_event_report_for_order_triggers_webhooks_when_partially_paid(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -1056,6 +1056,68 @@ def test_order_status_with_order_confirmation(
     assert order.charge_status == OrderChargeStatus.FULL
 
 
+@pytest.mark.parametrize(
+    ("auto_order_confirmation"),
+    [True, False],
+)
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_draft_order_status_with_order_confirmation(
+    mocked_initialize,
+    auto_order_confirmation,
+    user_api_client,
+    draft_order,
+    webhook_app,
+    transaction_session_response,
+):
+    # given
+    order = draft_order
+    order.channel.automatically_confirm_all_new_orders = auto_order_confirmation
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["amount"] = str(order.total_gross_amount)
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = PaymentGatewayData(
+        app_identifier=expected_app_identifier, data=expected_response
+    )
+
+    variables = {
+        "amount": order.total_gross_amount,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    _assert_fields(
+        content=content,
+        source_object=order,
+        expected_amount=order.total_gross_amount,
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_initialize=mocked_initialize,
+        charged_value=order.total_gross_amount,
+        returned_data=expected_response["data"],
+    )
+
+    assert not order.is_fully_paid()
+    order.refresh_from_db()
+    assert order.is_fully_paid()
+    assert order.total_authorized_amount == Decimal(0)
+    assert order.total_charged_amount == order.total_gross_amount
+    assert order.status == OrderStatus.DRAFT
+    assert order.charge_status == OrderChargeStatus.FULL
+
+
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
 def test_order_with_transaction_when_amount_is_not_provided(
     mocked_initialize,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -2916,6 +2916,63 @@ def test_transaction_update_for_order_triggers_webhooks_when_fully_paid(
     mock_order_paid.assert_called_once_with(order)
 
 
+@pytest.mark.parametrize(
+    ("auto_order_confirmation"),
+    [True, False],
+)
+@patch("saleor.plugins.manager.PluginsManager.order_paid")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
+def test_transaction_update_for_draft_order_triggers_webhooks_when_fully_paid(
+    mock_order_fully_paid,
+    mock_order_updated,
+    mock_order_paid,
+    auto_order_confirmation,
+    draft_order,
+    permission_manage_payments,
+    app_api_client,
+    app,
+    transaction_item_generator,
+):
+    # given
+    order = draft_order
+    order.channel.automatically_confirm_all_new_orders = auto_order_confirmation
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    current_authorized_value = Decimal("1")
+    current_charged_value = Decimal("2")
+    transaction = transaction_item_generator(
+        order_id=order.pk,
+        app=app,
+        authorized_value=current_authorized_value,
+        charged_value=current_charged_value,
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            "amountCharged": {
+                "amount": order.total.gross.amount,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    order.refresh_from_db()
+    get_graphql_content(response)
+
+    assert order.status == OrderStatus.DRAFT
+    assert order.charge_status == OrderChargeStatus.FULL
+    mock_order_fully_paid.assert_called_once_with(order)
+    mock_order_updated.assert_called_once_with(order)
+    mock_order_paid.assert_called_once_with(order)
+
+
 @patch("saleor.plugins.manager.PluginsManager.order_paid")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -174,7 +174,7 @@ def handle_fully_paid_order(
         )
 
     call_event(manager.order_fully_paid, order)
-    if order.channel.automatically_confirm_all_new_orders:
+    if not order.is_draft() and order.channel.automatically_confirm_all_new_orders:
         update_order_status(order)
 
     call_event(manager.order_updated, order)

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -298,6 +298,32 @@ def test_handle_fully_paid_order_gift_cards_not_created(
     send_notification_mock.assert_not_called
 
 
+@pytest.mark.parametrize("automatically_confirm_all_new_orders", [True, False])
+@patch("saleor.order.actions.send_payment_confirmation")
+def test_handle_fully_paid_order_for_draft_order(
+    mock_send_payment_confirmation, automatically_confirm_all_new_orders, draft_order
+):
+    # given
+    manager = get_plugins_manager(allow_replica=False)
+
+    channel = draft_order.channel
+    channel.automatically_confirm_all_new_orders = automatically_confirm_all_new_orders
+    channel.save(update_fields=["automatically_confirm_all_new_orders"])
+
+    draft_order.payments.add(Payment.objects.create())
+    order_info = fetch_order_info(draft_order)
+
+    # when
+    handle_fully_paid_order(manager, order_info)
+
+    # then
+    event_order_paid = draft_order.events.get()
+    assert event_order_paid.type == OrderEvents.ORDER_FULLY_PAID
+    assert draft_order.status == OrderStatus.DRAFT
+
+    mock_send_payment_confirmation.assert_called_once_with(order_info, manager)
+
+
 def test_mark_as_paid_with_payment(admin_user, draft_order):
     manager = get_plugins_manager(allow_replica=False)
     mark_order_as_paid_with_payment(draft_order, admin_user, None, manager)


### PR DESCRIPTION
The `draft_order` shouldn't be finalized when the order is fully paid and `automatically_confirm_all_new_orders` is set to `True`.

Internal issue: https://linear.app/saleor/issue/SHOPX-1072/ir-202-draft-orders-are-automatically-being-confirmed

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
