### PR TITLE
Fix customer filter on orders and draft orders

### DIFF
--- a/saleor/graphql/order/tests/test_filters.py
+++ b/saleor/graphql/order/tests/test_filters.py
@@ -1,0 +1,94 @@
+import pytest
+
+from ....order.models import Order
+from ..filters import filter_customer
+
+
+@pytest.fixture
+def similar_customers_with_orders(order, customer_user, customer_user2, channel_USD):
+    customer_user.first_name = "Test"
+    customer_user.last_name = "User"
+    customer_user.save()
+    customer_user2.first_name = "tester"
+    customer_user2.last_name = "users"
+    customer_user2.save()
+    order2 = Order.objects.create(
+        billing_address=customer_user2.default_billing_address,
+        channel=channel_USD,
+        user_email=customer_user2.email,
+        user=customer_user2,
+    )
+    return order, order2, customer_user, customer_user2
+
+
+def test_filter_customer_by_email(similar_customers_with_orders):
+    # given
+    order, order2, customer_user, customer_user2 = similar_customers_with_orders
+    qs = Order.objects.all()
+    value = customer_user.email
+
+    # when
+    qs = filter_customer(qs, None, value)
+
+    # then
+    assert qs.count() == 1
+    assert qs.first() == order
+
+
+def test_filter_customer_by_first_name(similar_customers_with_orders):
+    # given
+    order, order2, customer_user, customer_user2 = similar_customers_with_orders
+    qs = Order.objects.all()
+    value = customer_user.first_name
+
+    # when
+    qs = filter_customer(qs, None, value)
+
+    # then
+    assert qs.count() == 2
+    assert order in qs
+    assert order2 in qs
+
+
+def test_filter_customer_by_last_name(similar_customers_with_orders):
+    # given
+    order, order2, customer_user, customer_user2 = similar_customers_with_orders
+    qs = Order.objects.all()
+    value = customer_user.last_name
+
+    # when
+    qs = filter_customer(qs, None, value)
+
+    # then
+    assert qs.count() == 2
+    assert order in qs
+    assert order2 in qs
+
+
+def test_filter_customer_by_full_name(similar_customers_with_orders):
+    # given
+    order, order2, customer_user, customer_user2 = similar_customers_with_orders
+    qs = Order.objects.all()
+    value = f"{customer_user.first_name} {customer_user.last_name}"
+
+    # when
+    qs = filter_customer(qs, None, value)
+
+    # then
+    assert qs.count() == 1
+    assert qs.first() == order
+
+
+def test_filter_customer_by_email_domain(similar_customers_with_orders):
+    # given
+    order, order2, customer_user, customer_user2 = similar_customers_with_orders
+    qs = Order.objects.all()
+    value = customer_user.email.split("@")[1]
+
+    # when
+    qs = filter_customer(qs, None, value)
+
+    # then
+    assert qs.count() == 2
+    assert order in qs
+    assert order2 in qs


### PR DESCRIPTION
I want to merge this change because it will improve filtering by customer when querying orders or draft orders

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
