### PR TITLE
Ensure that the draft order is not finalized when it is fully paid 

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -369,8 +369,7 @@ def test_transaction_create_for_draft_order(
     variables = {
         "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
         "transaction": {
-            "status": "Charged 10$",
-            "type": "Credit Card",
+            "name": "Credit card",
             "pspReference": "PSP reference - 123",
             "availableActions": [],
             "amountCharged": {

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -343,6 +343,64 @@ def test_transaction_create_for_order_updates_order_total_charged_by_app(
     assert charged_value == transaction.charged_value
 
 
+@pytest.mark.parametrize("automatically_confirm_all_new_orders", [True, False])
+def test_transaction_create_for_draft_order(
+    automatically_confirm_all_new_orders,
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.save(update_fields=["status"])
+
+    channel = order_with_lines.channel
+    channel.automatically_confirm_all_new_orders = automatically_confirm_all_new_orders
+    channel.save(update_fields=["automatically_confirm_all_new_orders"])
+
+    previously_charged_value = Decimal("90")
+    old_transaction = order_with_lines.payment_transactions.create(
+        charged_value=previously_charged_value, currency=order_with_lines.currency
+    )
+    update_order_charge_data(order_with_lines)
+
+    charged_value = Decimal("10")
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "status": "Charged 10$",
+            "type": "Credit Card",
+            "pspReference": "PSP reference - 123",
+            "availableActions": [],
+            "amountCharged": {
+                "amount": charged_value,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    order_with_lines.refresh_from_db()
+    transaction = order_with_lines.payment_transactions.exclude(
+        id=old_transaction.id
+    ).last()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]["transaction"]
+    assert data["chargedAmount"]["amount"] == charged_value
+    assert (
+        order_with_lines.total_charged_amount
+        == previously_charged_value + charged_value
+    )
+    assert charged_value == transaction.charged_value
+    assert order_with_lines.status == OrderStatus.DRAFT
+
+
 def test_transaction_create_for_checkout_by_app(
     checkout_with_items, permission_manage_payments, app_api_client
 ):

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -1689,6 +1689,72 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_fully_paid(
     mock_order_paid.assert_called_once_with(order)
 
 
+@pytest.mark.parametrize(
+    ("auto_order_confirmation"),
+    [True, False],
+)
+@patch("saleor.plugins.manager.PluginsManager.order_paid")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
+def test_transaction_event_report_for_draft_order_triggers_webhooks_when_fully_paid(
+    mock_order_fully_paid,
+    mock_order_updated,
+    mock_order_paid,
+    auto_order_confirmation,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    draft_order,
+):
+    # given
+    order = draft_order
+    order.channel.automatically_confirm_all_new_orders = auto_order_confirmation
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    psp_reference = "111-abc"
+    transaction = transaction_item_generator(app=app_api_client.app, order_id=order.pk)
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": order.total.gross.amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    order.refresh_from_db()
+
+    assert order.status == OrderStatus.DRAFT
+    assert order.charge_status == OrderChargeStatusEnum.FULL.value
+    mock_order_fully_paid.assert_called_once_with(order)
+    mock_order_updated.assert_called_once_with(order)
+    mock_order_paid.assert_called_once_with(order)
+
+
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_transaction_event_report_for_order_triggers_webhooks_when_partially_paid(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -1026,6 +1026,68 @@ def test_order_status_with_order_confirmation(
     assert order.charge_status == OrderChargeStatus.FULL
 
 
+@pytest.mark.parametrize(
+    ("auto_order_confirmation"),
+    [True, False],
+)
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_draft_order_status_with_order_confirmation(
+    mocked_initialize,
+    auto_order_confirmation,
+    user_api_client,
+    draft_order,
+    webhook_app,
+    transaction_session_response,
+):
+    # given
+    order = draft_order
+    order.channel.automatically_confirm_all_new_orders = auto_order_confirmation
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["amount"] = str(order.total_gross_amount)
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = PaymentGatewayData(
+        app_identifier=expected_app_identifier, data=expected_response
+    )
+
+    variables = {
+        "amount": order.total_gross_amount,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    _assert_fields(
+        content=content,
+        source_object=order,
+        expected_amount=order.total_gross_amount,
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_initialize=mocked_initialize,
+        charged_value=order.total_gross_amount,
+        returned_data=expected_response["data"],
+    )
+
+    assert not order.is_fully_paid()
+    order.refresh_from_db()
+    assert order.is_fully_paid()
+    assert order.total_authorized_amount == Decimal(0)
+    assert order.total_charged_amount == order.total_gross_amount
+    assert order.status == OrderStatus.DRAFT
+    assert order.charge_status == OrderChargeStatus.FULL
+
+
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
 def test_order_with_transaction_when_amount_is_not_provided(
     mocked_initialize,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -1052,8 +1052,8 @@ def test_draft_order_status_with_order_confirmation(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["amount"] = str(order.total_gross_amount)
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -468,8 +468,8 @@ def test_draft_order_status_with_order_confirmation(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
     del expected_response["data"]
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -432,6 +432,73 @@ def test_order_status_with_order_confirmation(
     assert order.charge_status == OrderChargeStatus.FULL
 
 
+@pytest.mark.parametrize(
+    ("auto_order_confirmation"),
+    [True, False],
+)
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_draft_order_status_with_order_confirmation(
+    mocked_process,
+    auto_order_confirmation,
+    user_api_client,
+    draft_order,
+    webhook_app,
+    transaction_session_response,
+    transaction_item_generator,
+):
+    # given
+    order = draft_order
+    order.channel.automatically_confirm_all_new_orders = auto_order_confirmation
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    transaction_item = transaction_item_generator(order_id=order.pk, app=webhook_app)
+    TransactionEvent.objects.create(
+        transaction=transaction_item,
+        amount_value=order.total.gross.amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = order.total.gross.amount
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    del expected_response["data"]
+    mocked_process.return_value = PaymentGatewayData(
+        app_identifier=expected_app_identifier, data=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "data": None,
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    _assert_fields(
+        content=content,
+        source_object=order,
+        expected_amount=order.total.gross.amount,
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_process=mocked_process,
+        charged_value=order.total.gross.amount,
+        returned_data=None,
+    )
+
+    order.refresh_from_db()
+    assert order.status == OrderStatus.DRAFT
+    assert order.charge_status == OrderChargeStatus.FULL
+
+
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
 def test_for_checkout_with_data(
     mocked_process,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -2749,6 +2749,63 @@ def test_transaction_update_for_order_triggers_webhooks_when_fully_paid(
     mock_order_paid.assert_called_once_with(order)
 
 
+@pytest.mark.parametrize(
+    ("auto_order_confirmation"),
+    [True, False],
+)
+@patch("saleor.plugins.manager.PluginsManager.order_paid")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
+def test_transaction_update_for_draft_order_triggers_webhooks_when_fully_paid(
+    mock_order_fully_paid,
+    mock_order_updated,
+    mock_order_paid,
+    auto_order_confirmation,
+    draft_order,
+    permission_manage_payments,
+    app_api_client,
+    app,
+    transaction_item_generator,
+):
+    # given
+    order = draft_order
+    order.channel.automatically_confirm_all_new_orders = auto_order_confirmation
+    order.channel.save(update_fields=["automatically_confirm_all_new_orders"])
+    current_authorized_value = Decimal("1")
+    current_charged_value = Decimal("2")
+    transaction = transaction_item_generator(
+        order_id=order.pk,
+        app=app,
+        authorized_value=current_authorized_value,
+        charged_value=current_charged_value,
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            "amountCharged": {
+                "amount": order.total.gross.amount,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    order.refresh_from_db()
+    get_graphql_content(response)
+
+    assert order.status == OrderStatus.DRAFT
+    assert order.charge_status == OrderChargeStatus.FULL
+    mock_order_fully_paid.assert_called_once_with(order)
+    mock_order_updated.assert_called_once_with(order)
+    mock_order_paid.assert_called_once_with(order)
+
+
 @patch("saleor.plugins.manager.PluginsManager.order_paid")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -169,7 +169,7 @@ def handle_fully_paid_order(
         )
 
     call_event(manager.order_fully_paid, order)
-    if order.channel.automatically_confirm_all_new_orders:
+    if not order.is_draft() and order.channel.automatically_confirm_all_new_orders:
         update_order_status(order)
 
     call_event(manager.order_updated, order)

--- a/saleor/tests/e2e/orders/test_draft_order_complete_with_transaction.py
+++ b/saleor/tests/e2e/orders/test_draft_order_complete_with_transaction.py
@@ -1,0 +1,116 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..transactions.utils import create_transaction
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+    order_query,
+)
+
+
+@pytest.mark.e2e
+def test_draft_order_complete_with_transaction_CORE_0221(
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_payments,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+    app_permissions = [permission_manage_payments, permission_manage_orders]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    price = 10
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    # Step 1 - Create draft order
+    draft_order_input = {
+        "channelId": channel_id,
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+    assert order_id is not None
+
+    # Step 2 - Add lines to the order
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        }
+    ]
+    order_lines = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id == product_variant_id
+
+    # Step 3 - Update order's shipping method
+    input = {"shippingMethod": shipping_method_id}
+    draft_order = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id is not None
+    order_total = draft_order["order"]["total"]["gross"]["amount"]
+
+    # Step 4 - Create a full payment for the order
+    create_transaction(
+        e2e_app_api_client,
+        order_id,
+        transaction_name="CreditCard",
+        message="Charged",
+        psp_reference="PSP-ref123",
+        available_actions=["REFUND", "CANCEL"],
+        amount=order_total,
+    )
+
+    order = order_query(e2e_staff_api_client, order_id)
+    assert order["paymentStatus"] == "FULLY_CHARGED"
+    assert order["status"] == "DRAFT"
+
+    # Step 5 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"


### PR DESCRIPTION
The `draft_order` shouldn't be finalized when the order is fully paid and `automatically_confirm_all_new_orders` is set to `True`.

Port of https://github.com/saleor/saleor/pull/16375

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
