### PR TITLE
Fix `ENTIRE_ORDER` voucher handler in draft orders.

### DIFF
--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -38,7 +38,9 @@ def create_or_update_discount_objects_for_order(
         order, lines_info, database_connection_name
     )
     create_or_update_line_discount_objects_for_manual_discounts(lines_info)
-    create_or_update_discount_objects_from_voucher(order, lines_info)
+    create_or_update_discount_objects_from_voucher(
+        order, lines_info, database_connection_name
+    )
     _copy_unit_discount_data_to_order_line(lines_info)
 
 

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -23,7 +23,7 @@ from .promotion import (
     prepare_line_discount_objects_for_catalogue_promotions,
 )
 from .shared import update_line_info_cached_discounts
-from .voucher import create_or_update_line_discount_objects_from_voucher
+from .voucher import create_or_update_discount_objects_from_voucher
 
 if TYPE_CHECKING:
     from ...order.fetch import EditableOrderLineInfo
@@ -38,7 +38,7 @@ def create_or_update_discount_objects_for_order(
         order, lines_info, database_connection_name
     )
     create_or_update_line_discount_objects_for_manual_discounts(lines_info)
-    create_or_update_line_discount_objects_from_voucher(order, lines_info)
+    create_or_update_discount_objects_from_voucher(order, lines_info)
     _copy_unit_discount_data_to_order_line(lines_info)
 
 

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -44,7 +44,7 @@ from ..models import (
     Promotion,
     PromotionRule,
 )
-from .shared import update_line_discount
+from .shared import update_discount
 
 if TYPE_CHECKING:
     from ...checkout.fetch import CheckoutLineInfo
@@ -350,18 +350,19 @@ def _update_promotion_discount(
     value_type = rule.reward_value_type or RewardValueType.FIXED
     # gift rule has empty reward_value
     value = rule.reward_value or rule_discount_amount
-    update_line_discount(
-        rule,
-        None,
-        discount_name,
-        translated_name,
-        reason,
-        rule_discount_amount,
-        value,
-        value_type,
-        DiscountType.PROMOTION,
-        discount_to_update,
-        updated_fields,
+    update_discount(
+        rule=rule,
+        voucher=None,
+        discount_name=discount_name,
+        translated_name=translated_name,
+        discount_reason=reason,
+        discount_amount=rule_discount_amount,
+        value=value,
+        value_type=value_type,
+        unique_type=DiscountType.PROMOTION,
+        discount_to_update=discount_to_update,
+        updated_fields=updated_fields,
+        voucher_code=None,
     )
 
 

--- a/saleor/discount/utils/shared.py
+++ b/saleor/discount/utils/shared.py
@@ -8,14 +8,13 @@ from ..models import (
     OrderDiscount,
     OrderLineDiscount,
     PromotionRule,
-    Voucher,
 )
 
 if TYPE_CHECKING:
     from ..models import Voucher
 
 
-def update_line_discount(
+def update_discount(
     rule: Optional["PromotionRule"],
     voucher: Optional["Voucher"],
     discount_name: str,
@@ -29,6 +28,7 @@ def update_line_discount(
         "CheckoutLineDiscount", "CheckoutDiscount", "OrderLineDiscount", "OrderDiscount"
     ],
     updated_fields: list[str],
+    voucher_code: Optional[str],
 ):
     if voucher and discount_to_update.voucher_id != voucher.id:
         discount_to_update.voucher_id = voucher.id
@@ -59,6 +59,9 @@ def update_line_discount(
         if discount_to_update.unique_type is None:
             discount_to_update.unique_type = unique_type
             updated_fields.append("unique_type")
+    if voucher_code and discount_to_update.voucher_code != voucher_code:
+        discount_to_update.voucher_code = voucher_code
+        updated_fields.append("voucher_code")
 
 
 def update_line_info_cached_discounts(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -821,8 +821,7 @@ def test_draft_order_create_with_voucher_specific_product(
     assert line_1_data["unitDiscountType"] is None
     assert line_1_data["unitDiscountReason"] is None
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
+    assert order.discounts.count() == 0
 
     discounted_line = order.lines.get(variant=discounted_variant)
     assert discounted_line.discounts.count() == 1
@@ -963,8 +962,7 @@ def test_draft_order_create_with_voucher_apply_once_per_order(
     assert line_1_data["unitDiscountType"] is None
     assert line_1_data["unitDiscountReason"] is None
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
+    assert order.discounts.count() == 0
 
     discounted_line = order.lines.get(variant=discounted_variant)
     assert discounted_line.discounts.count() == 1

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -1,10 +1,13 @@
+from decimal import Decimal
+
 import graphene
 import pytest
 from prices import TaxedMoney
 
 from .....core.prices import quantize_price
 from .....core.taxes import zero_money
-from .....discount import DiscountType, DiscountValueType, RewardValueType
+from .....discount import DiscountType, DiscountValueType, RewardValueType, VoucherType
+from .....discount.models import OrderDiscount, Voucher
 from .....order import OrderStatus
 from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent
@@ -119,6 +122,14 @@ DRAFT_ORDER_UPDATE_MUTATION = """
                         unitDiscountType
                         unitDiscountValue
                         isGift
+                    }
+                    shippingPrice {
+                        gross {
+                            amount
+                        }
+                        net {
+                            amount
+                        }
                     }
                 }
             }
@@ -342,9 +353,7 @@ def test_draft_order_update_with_voucher_specific_product(
     assert order.voucher_code == voucher.code
     assert order.search_vector
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
-
+    assert order.discounts.count() == 0
     assert discounted_line.discounts.count() == 1
     order_line_discount = discounted_line.discounts.first()
     assert order_line_discount.voucher == voucher
@@ -436,9 +445,7 @@ def test_draft_order_update_with_voucher_apply_once_per_order(
     assert order.voucher_code == voucher.code
     assert order.search_vector
 
-    # TODO (SHOPX-874): Order discount object shouldn't be created
-    assert order.discounts.count() == 1
-
+    assert order.discounts.count() == 0
     assert discounted_line.discounts.count() == 1
     order_line_discount = discounted_line.discounts.first()
     assert order_line_discount.voucher == voucher
@@ -1840,3 +1847,222 @@ def test_draft_order_update_undiscounted_base_shipping_price_set(
         order.undiscounted_base_shipping_price_amount
         == order.base_shipping_price_amount
     )
+
+
+def test_draft_order_update_ensure_entire_order_voucher_discount_is_overridden(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    voucher,
+    graphql_address_data,
+    channel_USD,
+):
+    # given
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    order = draft_order
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    assert voucher.discount_value_type == DiscountValueType.FIXED
+
+    # apply voucher to order
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    order.save(update_fields=["voucher_id", "voucher_code"])
+
+    currency = order.currency
+    undiscounted_subtotal = zero_money(currency)
+    for line in order.lines.all():
+        undiscounted_subtotal += line.base_unit_price * line.quantity
+
+    voucher_listing = voucher.channel_listings.get(channel=channel_USD)
+    discount_value = voucher_listing.discount_value
+
+    order_discount = order.discounts.create(
+        voucher=voucher,
+        value=discount_value,
+        value_type=DiscountValueType.FIXED,
+        type=DiscountType.VOUCHER,
+    )
+
+    # create new voucher
+    new_discount_value = Decimal(50)
+    new_code = "new_code"
+    new_voucher = Voucher.objects.create(
+        type=VoucherType.ENTIRE_ORDER,
+        name="new voucher",
+        discount_value_type=DiscountValueType.PERCENTAGE,
+    )
+    new_voucher.codes.create(code=new_code)
+    new_voucher.channel_listings.create(
+        channel=channel_USD,
+        discount_value=new_discount_value,
+    )
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id, "input": {"voucherCode": new_code}}
+
+    # when apply new voucher to order
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+    assert data["order"]["voucher"]["code"] == new_code
+    assert data["order"]["voucherCode"] == new_code
+    assert data["order"]["subtotal"]["gross"]["amount"] == Decimal(
+        undiscounted_subtotal.amount / 2
+    )
+
+    order.refresh_from_db()
+    assert order.voucher_code == new_code
+
+    order_discount.refresh_from_db()
+    assert order.discounts.count() == 1
+    assert order.discounts.first() == order_discount
+    assert order_discount.voucher == new_voucher
+    assert order_discount.voucher_code == new_code
+    assert order_discount.type == DiscountType.VOUCHER
+    assert order_discount.value_type == DiscountValueType.PERCENTAGE
+    assert order_discount.value == new_discount_value
+    assert order_discount.amount_value == Decimal(undiscounted_subtotal.amount / 2)
+
+
+def test_draft_order_update_remove_entire_order_voucher(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    voucher,
+    graphql_address_data,
+    channel_USD,
+):
+    # given
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    order = draft_order
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    assert voucher.discount_value_type == DiscountValueType.FIXED
+
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    order.save(update_fields=["voucher_id", "voucher_code"])
+
+    currency = order.currency
+    undiscounted_subtotal = zero_money(currency)
+    for line in order.lines.all():
+        undiscounted_subtotal += line.base_unit_price * line.quantity
+
+    voucher_listing = voucher.channel_listings.get(channel=channel_USD)
+    discount_value = voucher_listing.discount_value
+
+    order_discount = order.discounts.create(
+        voucher=voucher,
+        value=discount_value,
+        value_type=DiscountValueType.FIXED,
+        type=DiscountType.VOUCHER,
+    )
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id, "input": {"voucherCode": None}}
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+    assert not data["order"]["voucher"]
+    assert not data["order"]["voucherCode"]
+    assert data["order"]["subtotal"]["gross"]["amount"] == undiscounted_subtotal.amount
+
+    order.refresh_from_db()
+    assert order.voucher_code is None
+    assert order.voucher is None
+
+    with pytest.raises(OrderDiscount.DoesNotExist):
+        order_discount.refresh_from_db()
+
+
+def test_draft_order_update_replace_entire_order_voucher_with_shipping_voucher(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    voucher_percentage,
+    voucher_shipping_type,
+    graphql_address_data,
+    channel_USD,
+):
+    # given
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    order = draft_order
+    voucher = voucher_percentage
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+
+    order.voucher = voucher
+    entire_order_code = voucher.codes.first().code
+    order.voucher_code = entire_order_code
+    order.save(update_fields=["voucher_id", "voucher_code"])
+
+    currency = order.currency
+    undiscounted_subtotal = zero_money(currency)
+    for line in order.lines.all():
+        undiscounted_subtotal += line.base_unit_price * line.quantity
+
+    voucher_listing = voucher.channel_listings.get(channel=channel_USD)
+    discount_value = voucher_listing.discount_value
+
+    order_discount = order.discounts.create(
+        voucher=voucher,
+        value=discount_value,
+        value_type=DiscountValueType.FIXED,
+        type=DiscountType.VOUCHER,
+    )
+
+    undiscounted_shipping_price = order.base_shipping_price
+    shipping_code = voucher_shipping_type.codes.first().code
+    assert shipping_code != entire_order_code
+    shipping_discount = voucher_shipping_type.channel_listings.get(
+        channel=channel_USD
+    ).discount_value
+    expected_shipping_price = undiscounted_shipping_price.amount - shipping_discount
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id, "input": {"voucherCode": shipping_code}}
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+    assert data["order"]["voucher"]["code"] == shipping_code
+    assert data["order"]["voucherCode"] == shipping_code
+    assert data["order"]["subtotal"]["gross"]["amount"] == undiscounted_subtotal.amount
+    assert data["order"]["shippingPrice"]["gross"]["amount"] == expected_shipping_price
+    assert (
+        data["order"]["total"]["gross"]["amount"]
+        == undiscounted_subtotal.amount + expected_shipping_price
+    )
+
+    order.refresh_from_db()
+    assert order.voucher_code == shipping_code
+    assert order.voucher == voucher_shipping_type
+
+    order_discount.refresh_from_db()
+    discounts = order.discounts.all()
+    assert len(discounts) == 1
+    assert discounts[0] == order_discount
+    assert order_discount.voucher == voucher_shipping_type
+    assert order_discount.value_type == voucher_shipping_type.discount_value_type
+    assert order_discount.value == discount_value
+    assert order_discount.amount_value == shipping_discount
+    assert order_discount.reason == f"Voucher code: {shipping_code}"
+    assert voucher_shipping_type.name is None
+    assert order_discount.name == ""
+    assert order_discount.type == DiscountType.VOUCHER
+    assert order_discount.voucher_code == shipping_code

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -11,7 +11,6 @@ from prices import Money, TaxedMoney
 from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
 from ..core.taxes import TaxData, TaxEmptyData, TaxError, zero_taxed_money
-from ..discount import DiscountType
 from ..discount.utils.order import create_or_update_discount_objects_for_order
 from ..payment.model_helpers import get_subtotal
 from ..plugins import PLUGIN_IDENTIFIER_PREFIX
@@ -61,7 +60,6 @@ def fetch_order_prices_if_expired(
         order, lines_info, database_connection_name
     )
     lines = [line_info.line for line_info in lines_info]
-    _update_order_discount_for_voucher(order)
 
     _clear_prefetched_discounts(order, lines)
     with allow_writer():
@@ -116,31 +114,6 @@ def fetch_order_prices_if_expired(
             )
 
         return order, lines
-
-
-@allow_writer()
-def _update_order_discount_for_voucher(order: Order):
-    """Create or delete OrderDiscount instances."""
-    if not order.voucher_id:
-        order.discounts.filter(type=DiscountType.VOUCHER).delete()
-
-    elif (
-        order.voucher_id
-        and not order.discounts.filter(voucher_code=order.voucher_code).exists()
-    ):
-        voucher = order.voucher
-        voucher_channel_listing = voucher.channel_listings.filter(  # type: ignore
-            channel=order.channel
-        ).first()
-        if voucher_channel_listing:
-            order.discounts.create(
-                value_type=voucher.discount_value_type,  # type: ignore
-                value=voucher_channel_listing.discount_value,
-                reason=f"Voucher: {voucher.name}",  # type: ignore
-                voucher=voucher,
-                type=DiscountType.VOUCHER,
-                voucher_code=order.voucher_code,
-            )
 
 
 def _clear_prefetched_discounts(order, lines):

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -2563,7 +2563,8 @@ def test_fetch_order_prices_voucher_shipping_fixed(
     # TODO (SHOPX-914): set translated voucher name
     assert discount.translated_name == ""
 
-    assert order.base_shipping_price.amount == undiscounted_shipping_price
+    assert order.undiscounted_base_shipping_price_amount == undiscounted_shipping_price
+    assert order.base_shipping_price_amount == expected_shipping_price
     assert order.shipping_price_net_amount == expected_shipping_price
     assert order.shipping_price_gross.amount == expected_shipping_price
     assert order.subtotal_net_amount == subtotal.amount
@@ -2633,7 +2634,8 @@ def test_fetch_order_prices_voucher_shipping_percentage(
     # TODO (SHOPX-914): set translated voucher name
     assert discount.translated_name == ""
 
-    assert order.base_shipping_price.amount == undiscounted_shipping_price
+    assert order.undiscounted_base_shipping_price.amount == undiscounted_shipping_price
+    assert order.base_shipping_price.amount == expected_shipping_price
     assert order.shipping_price_net_amount == expected_shipping_price
     assert order.shipping_price_gross.amount == expected_shipping_price
     assert order.subtotal_net_amount == subtotal.amount

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -6,7 +6,7 @@ import pytest
 
 from ...core.prices import quantize_price
 from ...core.taxes import zero_money
-from ...discount import DiscountType, DiscountValueType
+from ...discount import DiscountType, DiscountValueType, VoucherType
 from ...discount.models import (
     OrderDiscount,
     OrderLineDiscount,
@@ -2295,3 +2295,358 @@ def test_fetch_order_prices_catalogue_discount_race_condition(
 
     # then
     assert OrderLineDiscount.objects.count() == 1
+
+
+def test_fetch_order_prices_voucher_entire_order_fixed(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    assert voucher.discount_value_type == DiscountValueType.FIXED
+
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = Decimal("35")
+    voucher_listing.discount_value = discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.name = "Voucher name"
+    voucher.save(update_fields=["name"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    lines = order.lines.all()
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    assert OrderDiscount.objects.count() == 1
+    discount = order.discounts.first()
+    assert discount.voucher == voucher
+    assert discount.value_type == voucher.discount_value_type
+    assert discount.value == discount_amount
+    assert discount.amount_value == discount_amount
+    assert discount.reason == f"Voucher code: {code}"
+    assert discount.name == voucher.name
+    assert discount.type == DiscountType.VOUCHER
+    assert discount.voucher_code == code
+    # TODO (SHOPX-914): set translated voucher name
+    assert discount.translated_name == ""
+
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == subtotal.amount - discount_amount
+    assert order.subtotal_gross_amount == subtotal.amount - discount_amount
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    lines = order.lines.all()
+    line_1 = [line for line in lines if line.quantity == 3][0]
+    line_2 = [line for line in lines if line.quantity == 2][0]
+
+    line_1_base_total = line_1.quantity * line_1.base_unit_price_amount
+    line_2_base_total = line_2.quantity * line_2.base_unit_price_amount
+    base_total = line_1_base_total + line_2_base_total
+    line_1_order_discount_portion = discount_amount * line_1_base_total / base_total
+    line_2_order_discount_portion = discount_amount - line_1_order_discount_portion
+
+    variant_1 = line_1.variant
+    variant_1_listing = variant_1.channel_listings.get(channel=order.channel)
+    variant_1_undiscounted_unit_price = variant_1_listing.price_amount
+    line_1_total_net_amount = quantize_price(
+        line_1.undiscounted_total_price_net_amount - line_1_order_discount_portion,
+        currency,
+    )
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == variant_1_undiscounted_unit_price * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == variant_1_undiscounted_unit_price
+    )
+    assert line_1.total_price_net_amount == line_1_total_net_amount
+    assert line_1.base_unit_price_amount == variant_1_undiscounted_unit_price
+    assert line_1.unit_price_net_amount == line_1_total_net_amount / line_1.quantity
+
+    variant_2 = line_2.variant
+    variant_2_listing = variant_2.channel_listings.get(channel=order.channel)
+    variant_2_undiscounted_unit_price = variant_2_listing.price_amount
+    line_2_total_net_amount = quantize_price(
+        line_2.undiscounted_total_price_net_amount - line_2_order_discount_portion,
+        currency,
+    )
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == variant_2_undiscounted_unit_price * line_2.quantity
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == variant_2_undiscounted_unit_price
+    )
+    assert line_2.total_price_net_amount == line_2_total_net_amount
+    assert line_2.base_unit_price_amount == variant_2_undiscounted_unit_price
+    assert line_2.unit_price_net_amount == line_2_total_net_amount / line_2.quantity
+
+
+def test_fetch_order_prices_voucher_entire_order_percentage(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_value = Decimal("50")
+    voucher_listing.discount_value = discount_value
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.name = "Voucher name"
+    voucher.save(update_fields=["name"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    shipping_price = order.shipping_price.net
+    currency = order.currency
+    subtotal = zero_money(currency)
+    lines = order.lines.all()
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    assert OrderDiscount.objects.count() == 1
+    discount = order.discounts.first()
+    assert discount.voucher == voucher
+    assert discount.value_type == voucher.discount_value_type
+    assert discount.value == discount_value
+    assert discount.amount_value == Decimal(subtotal.amount / 2)
+    assert discount.reason == f"Voucher code: {code}"
+    assert discount.name == voucher.name
+    assert discount.type == DiscountType.VOUCHER
+    assert discount.voucher_code == code
+    # TODO (SHOPX-914): set translated voucher name
+    assert discount.translated_name == ""
+
+    assert order.base_shipping_price == shipping_price
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price
+    assert order.subtotal_net_amount == Decimal(subtotal.amount / 2)
+    assert order.subtotal_gross_amount == Decimal(subtotal.amount / 2)
+    assert (
+        order.total_net_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert (
+        order.total_gross_amount
+        == order.subtotal_net_amount + order.base_shipping_price_amount
+    )
+    assert order.undiscounted_total_net == subtotal + shipping_price
+    assert order.undiscounted_total_gross == subtotal + shipping_price
+
+    lines = order.lines.all()
+    line_1 = [line for line in lines if line.quantity == 3][0]
+    line_2 = [line for line in lines if line.quantity == 2][0]
+
+    variant_1 = line_1.variant
+    variant_1_listing = variant_1.channel_listings.get(channel=order.channel)
+    variant_1_undiscounted_unit_price = variant_1_listing.price_amount
+    line_1_total_net_amount = quantize_price(
+        line_1.undiscounted_total_price_net_amount / 2,
+        currency,
+    )
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == variant_1_undiscounted_unit_price * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == variant_1_undiscounted_unit_price
+    )
+    assert line_1.total_price_net_amount == line_1_total_net_amount
+    assert line_1.base_unit_price_amount == variant_1_undiscounted_unit_price
+    assert line_1.unit_price_net_amount == line_1_total_net_amount / line_1.quantity
+
+    variant_2 = line_2.variant
+    variant_2_listing = variant_2.channel_listings.get(channel=order.channel)
+    variant_2_undiscounted_unit_price = variant_2_listing.price_amount
+    line_2_total_net_amount = quantize_price(
+        line_2.undiscounted_total_price_net_amount / 2,
+        currency,
+    )
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == variant_2_undiscounted_unit_price * line_2.quantity
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == variant_2_undiscounted_unit_price
+    )
+    assert line_2.total_price_net_amount == line_2_total_net_amount
+    assert line_2.base_unit_price_amount == variant_2_undiscounted_unit_price
+    assert line_2.unit_price_net_amount == line_2_total_net_amount / line_2.quantity
+
+
+def test_fetch_order_prices_voucher_shipping_fixed(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    voucher.type = VoucherType.SHIPPING
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["type", "discount_value_type"])
+
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_value = Decimal("5")
+    voucher_listing.discount_value = discount_value
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.name = "Voucher shipping"
+    voucher.save(update_fields=["name"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    undiscounted_shipping_price = order.shipping_price.net.amount
+    expected_shipping_price = Decimal(undiscounted_shipping_price - discount_value)
+    currency = order.currency
+    subtotal = zero_money(currency)
+    lines = order.lines.all()
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    assert OrderDiscount.objects.count() == 1
+    discount = order.discounts.first()
+    assert discount.voucher == voucher
+    assert discount.value_type == voucher.discount_value_type
+    assert discount.value == discount_value
+    assert (
+        discount.amount_value == undiscounted_shipping_price - expected_shipping_price
+    )
+    assert discount.reason == f"Voucher code: {code}"
+    assert discount.name == voucher.name
+    assert discount.type == DiscountType.VOUCHER
+    assert discount.voucher_code == code
+    # TODO (SHOPX-914): set translated voucher name
+    assert discount.translated_name == ""
+
+    assert order.base_shipping_price.amount == undiscounted_shipping_price
+    assert order.shipping_price_net_amount == expected_shipping_price
+    assert order.shipping_price_gross.amount == expected_shipping_price
+    assert order.subtotal_net_amount == subtotal.amount
+    assert order.subtotal_gross_amount == subtotal.amount
+    assert order.total_net_amount == order.subtotal_net_amount + expected_shipping_price
+    assert (
+        order.total_gross_amount == order.subtotal_net_amount + expected_shipping_price
+    )
+    assert (
+        order.undiscounted_total_net_amount
+        == subtotal.amount + undiscounted_shipping_price
+    )
+    assert (
+        order.undiscounted_total_gross_amount
+        == subtotal.amount + undiscounted_shipping_price
+    )
+
+
+def test_fetch_order_prices_voucher_shipping_percentage(
+    order_with_lines, voucher, plugins_manager
+):
+    # given
+    voucher.type = VoucherType.SHIPPING
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["type", "discount_value_type"])
+
+    order = order_with_lines
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_value = Decimal("50")
+    voucher_listing.discount_value = discount_value
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.name = "Voucher shipping"
+    voucher.save(update_fields=["name"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    undiscounted_shipping_price = order.shipping_price.net.amount
+    expected_shipping_price = Decimal(undiscounted_shipping_price / 2)
+    currency = order.currency
+    subtotal = zero_money(currency)
+    lines = order.lines.all()
+    for line in lines:
+        subtotal += line.base_unit_price * line.quantity
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    assert OrderDiscount.objects.count() == 1
+    discount = order.discounts.first()
+    assert discount.voucher == voucher
+    assert discount.value_type == voucher.discount_value_type
+    assert discount.value == discount_value
+    assert (
+        discount.amount_value == undiscounted_shipping_price - expected_shipping_price
+    )
+    assert discount.reason == f"Voucher code: {code}"
+    assert discount.name == voucher.name
+    assert discount.type == DiscountType.VOUCHER
+    assert discount.voucher_code == code
+    # TODO (SHOPX-914): set translated voucher name
+    assert discount.translated_name == ""
+
+    assert order.base_shipping_price.amount == undiscounted_shipping_price
+    assert order.shipping_price_net_amount == expected_shipping_price
+    assert order.shipping_price_gross.amount == expected_shipping_price
+    assert order.subtotal_net_amount == subtotal.amount
+    assert order.subtotal_gross_amount == subtotal.amount
+    assert order.total_net_amount == order.subtotal_net_amount + expected_shipping_price
+    assert (
+        order.total_gross_amount == order.subtotal_net_amount + expected_shipping_price
+    )
+    assert (
+        order.undiscounted_total_net_amount
+        == subtotal.amount + undiscounted_shipping_price
+    )
+    assert (
+        order.undiscounted_total_gross_amount
+        == subtotal.amount + undiscounted_shipping_price
+    )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -586,6 +586,10 @@ def test_draft_order_calculate_taxes_entire_order_voucher(
     voucher.save(update_fields=["type"])
 
     discount_amount = Decimal("10")
+    channel_listing = voucher.channel_listings.get()
+    channel_listing.discount_value = discount_amount
+    channel_listing.save(update_fields=["discount_value"])
+
     order_discount = order.discounts.first()
     order_discount.value = discount_amount
     order_discount.save(update_fields=["value"])


### PR DESCRIPTION
This PR:
- makes sure a proper order level discount object is created when utilizing `ENTIRE_ORDER` and `SHIPPING` vouchers in draft orders
- fixes the issue when updating the draft order with a new voucher resulting in two discount objects
- fixes the issue when order level discount is created when any voucher is assigned to draft order
- fixes order discount reason
- makes sure to always update `BaseDiscount.voucher_code` field

Internal issues: 
- https://linear.app/saleor/issue/SHOPX-874/clean-up-orderdiscount-for-draft-orders
- https://linear.app/saleor/issue/SHOPX-1083/bug-inconsistency-with-vouchers-on-checkout-and-draftorder-order

Port: https://github.com/saleor/saleor/pull/16336

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
