### PR TITLE
Fix clean_manifest validation.

### DIFF
--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -153,8 +153,11 @@ def clean_manifest_data(manifest_data, raise_for_saleor_version=False):
         app_permissions = []
 
     manifest_data["permissions"] = app_permissions
-
-    if app := App.objects.filter(identifier=manifest_data.get("id")).first():
+    if (
+        app := App.objects.not_removed()
+        .filter(identifier=manifest_data.get("id"))
+        .first()
+    ):
         errors["identifier"].append(
             ValidationError(
                 f"App with the same identifier is already installed: {app.name}"

--- a/saleor/app/models.py
+++ b/saleor/app/models.py
@@ -31,6 +31,12 @@ class AppQueryset(models.QuerySet["App"]):
             **permissions,
         )
 
+    def not_removed(self):
+        return self.filter(removed_at__isnull=True)
+
+    def marked_to_be_removed(self):
+        return self.filter(removed_at__isnull=False)
+
 
 AppManager = models.Manager.from_queryset(AppQueryset)
 

--- a/saleor/graphql/app/tests/mutations/cassettes/test_app_fetch_manifest/test_fetch_manifest_app_with_same_identifier_installed_but_marked_to_be_removed.yaml
+++ b/saleor/graphql/app/tests/mutations/cassettes/test_app_fetch_manifest/test_fetch_manifest_app_with_same_identifier_installed_but_marked_to_be_removed.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      Saleor-Schema-Version:
+      - '3.19'
+      User-Agent:
+      - Saleor/3.19
+    method: GET
+    uri: http://localhost:3000/api/manifest
+  response:
+    body:
+      string: '{"about":"App connects with Avatax to dynamically calculate taxes","appUrl":"http://localhost:3000","author":"Saleor
+        Commerce","brand":{"logo":{"default":"http://localhost:3000/logo.png"}},"dataPrivacyUrl":"https://saleor.io/legal/privacy/","extensions":[],"homepageUrl":"https://github.com/saleor/apps","id":"saleor.app.avatax","name":"Avatax","permissions":["HANDLE_TAXES","MANAGE_ORDERS"],"requiredSaleorVersion":">=3.18
+        <4","supportUrl":"https://github.com/saleor/apps/discussions","tokenTargetUrl":"http://localhost:3000/api/register","version":"1.5.2","webhooks":[{"query":"subscription
+        CalculateTaxes { event { ...CalculateTaxesEvent }}fragment CalculateTaxesEvent
+        on Event { __typename ...WebhookMetadata ... on CalculateTaxes { taxBase {
+        ...TaxBase } recipient { privateMetadata { key value } } }}fragment WebhookMetadata
+        on Event { issuedAt version}fragment TaxBase on TaxableObject { pricesEnteredWithTax
+        currency channel { slug } address { ...Address } shippingPrice { amount }
+        lines { ...TaxBaseLine } sourceObject { __typename ... on Checkout { id avataxEntityCode:
+        metafield(key: \"avataxEntityCode\") avataxCustomerCode: metafield(key: \"avataxCustomerCode\")
+        user { ...User } } ... on Order { id avataxEntityCode: metafield(key: \"avataxEntityCode\")
+        avataxCustomerCode: metafield(key: \"avataxCustomerCode\") user { ...User
+        } } }}fragment Address on Address { streetAddress1 streetAddress2 city countryArea
+        postalCode country { code }}fragment TaxBaseLine on TaxableObjectLine { sourceLine
+        { __typename ... on CheckoutLine { id checkoutProductVariant: variant { id
+        product { taxClass { id name } } } } ... on OrderLine { id orderProductVariant:
+        variant { id product { taxClass { id name } } } } } quantity unitPrice { amount
+        } totalPrice { amount }}fragment User on User { id email avataxCustomerCode:
+        metafield(key: \"avataxCustomerCode\")}","name":"CheckoutCalculateTaxes","targetUrl":"http://localhost:3000/api/webhooks/checkout-calculate-taxes","isActive":true,"syncEvents":["CHECKOUT_CALCULATE_TAXES"]},{"query":"subscription
+        CalculateTaxes { event { ...CalculateTaxesEvent }}fragment CalculateTaxesEvent
+        on Event { __typename ...WebhookMetadata ... on CalculateTaxes { taxBase {
+        ...TaxBase } recipient { privateMetadata { key value } } }}fragment WebhookMetadata
+        on Event { issuedAt version}fragment TaxBase on TaxableObject { pricesEnteredWithTax
+        currency channel { slug } address { ...Address } shippingPrice { amount }
+        lines { ...TaxBaseLine } sourceObject { __typename ... on Checkout { id avataxEntityCode:
+        metafield(key: \"avataxEntityCode\") avataxCustomerCode: metafield(key: \"avataxCustomerCode\")
+        user { ...User } } ... on Order { id avataxEntityCode: metafield(key: \"avataxEntityCode\")
+        avataxCustomerCode: metafield(key: \"avataxCustomerCode\") user { ...User
+        } } }}fragment Address on Address { streetAddress1 streetAddress2 city countryArea
+        postalCode country { code }}fragment TaxBaseLine on TaxableObjectLine { sourceLine
+        { __typename ... on CheckoutLine { id checkoutProductVariant: variant { id
+        product { taxClass { id name } } } } ... on OrderLine { id orderProductVariant:
+        variant { id product { taxClass { id name } } } } } quantity unitPrice { amount
+        } totalPrice { amount }}fragment User on User { id email avataxCustomerCode:
+        metafield(key: \"avataxCustomerCode\")}","name":"OrderCalculateTaxes","targetUrl":"http://localhost:3000/api/webhooks/order-calculate-taxes","isActive":true,"syncEvents":["ORDER_CALCULATE_TAXES"]},{"query":"subscription
+        OrderCancelledSubscription { event { ...OrderCancelledEventSubscription }}fragment
+        OrderCancelledEventSubscription on Event { __typename ...WebhookMetadata ...
+        on OrderCancelled { order { ...OrderCancelledSubscription } recipient { privateMetadata
+        { key value } } }}fragment WebhookMetadata on Event { issuedAt version}fragment
+        OrderCancelledSubscription on Order { id avataxId: metafield(key: \"avataxId\")
+        channel { id slug }}","name":"OrderCancelled","targetUrl":"http://localhost:3000/api/webhooks/order-cancelled","isActive":true,"asyncEvents":["ORDER_CANCELLED"]},{"query":"subscription
+        OrderConfirmedSubscription { event { ...OrderConfirmedEventSubscription }}fragment
+        OrderConfirmedEventSubscription on Event { __typename ...WebhookMetadata ...
+        on OrderConfirmed { order { ...OrderConfirmedSubscription } } recipient {
+        privateMetadata { key value } }}fragment WebhookMetadata on Event { issuedAt
+        version}fragment OrderConfirmedSubscription on Order { id number userEmail
+        user { ...User } avataxCustomerCode: metafield(key: \"avataxCustomerCode\")
+        created status channel { id slug taxConfiguration { pricesEnteredWithTax taxCalculationStrategy
+        } } shippingAddress { ...Address } billingAddress { ...Address } total { currency
+        net { amount } tax { amount } } shippingPrice { gross { amount } net { amount
+        } } lines { ...OrderLine } avataxEntityCode: metafield(key: \"avataxEntityCode\")
+        avataxTaxCalculationDate: metafield(key: \"avataxTaxCalculationDate\") avataxDocumentCode:
+        metafield(key: \"avataxDocumentCode\")}fragment User on User { id email avataxCustomerCode:
+        metafield(key: \"avataxCustomerCode\")}fragment Address on Address { streetAddress1
+        streetAddress2 city countryArea postalCode country { code }}fragment OrderLine
+        on OrderLine { productSku productVariantId productName quantity taxClass {
+        id } unitPrice { net { amount } } totalPrice { net { amount } tax { amount
+        } gross { amount } }}","name":"OrderConfirmed","targetUrl":"http://localhost:3000/api/webhooks/order-confirmed","isActive":true,"asyncEvents":["ORDER_CONFIRMED"]}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5549'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Jul 2024 08:06:12 GMT
+      ETag:
+      - '"16l6t5qo2d34a5"'
+      Keep-Alive:
+      - timeout=5
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
+++ b/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
@@ -1,6 +1,6 @@
 import base64
 from io import BytesIO
-from unittest.mock import ANY, Mock
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 import requests
@@ -9,6 +9,7 @@ from requests_hardened import HTTPSession
 
 from ..... import schema_version
 from .....app.error_codes import AppErrorCode
+from .....app.models import App
 from .....thumbnail import IconThumbnailFormat
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ...enums import AppExtensionMountEnum, AppExtensionTargetEnum
@@ -885,3 +886,42 @@ def test_fetch_manifest_fail_when_app_with_same_identifier_already_installed(
     assert errors[0]["message"] == (
         f"App with the same identifier is already installed: {app.name}"
     )
+
+
+@pytest.mark.vcr
+def test_fetch_manifest_app_with_same_identifier_installed_but_marked_to_be_removed(
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    app_marked_to_be_removed,
+):
+    # given
+    app_marked_to_be_removed.identifier = "saleor.app.avatax"
+    app_marked_to_be_removed.save()
+    manifest_url = "http://localhost:3000/api/manifest"
+
+    query = APP_FETCH_MANIFEST_MUTATION
+    variables = {
+        "manifest_url": manifest_url,
+    }
+    staff_user.user_permissions.set([permission_manage_apps])
+
+    # when
+    with patch(
+        "saleor.graphql.app.mutations.app_fetch_manifest.fetch_brand_data"
+    ) as mocked_fetch_brand:
+        mocked_fetch_brand.return_value = None
+        response = staff_api_client.post_graphql(
+            query,
+            variables=variables,
+        )
+    content = get_graphql_content(response)
+    errors = content["data"]["appFetchManifest"]["errors"]
+    manifest = content["data"]["appFetchManifest"]["manifest"]
+
+    # then
+    all_apps = App.objects.all()
+    assert not errors
+    assert manifest["identifier"] == "saleor.app.avatax"
+    assert all_apps.not_removed().count() == 0
+    assert all_apps.marked_to_be_removed().count() == 1

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -7451,6 +7451,18 @@ def app(db):
 
 
 @pytest.fixture
+def app_marked_to_be_removed(db):
+    app = App.objects.create(
+        name="Sample app objects",
+        is_active=True,
+        identifier="saleor.app.test",
+        manifest_url="http://localhost:3000/manifest",
+        removed_at=timezone.now(),
+    )
+    return app
+
+
+@pytest.fixture
 def webhook_app(
     db,
     permission_manage_shipping,


### PR DESCRIPTION
I want to merge this change because it fixes checks when two apps with the same identifier are being installed. Now, if an app has removed_at, it is not considered an installed app. The mechanism for installing apps needs to be adjusted in the future.

Fixes: https://linear.app/saleor/issue/SHOPX-1074/fix-check-for-appinstall

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
