### PR TITLE
Disallow changing voucher usage limit setting when voucher has been already used.

### DIFF
--- a/saleor/graphql/discount/tests/mutations/test_voucher_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_update.py
@@ -415,3 +415,69 @@ def test_update_voucher_single_use_voucher_already_used_in_checkout(
     assert errors[0]["field"] == "singleUse"
     assert errors[0]["code"] == DiscountErrorCode.VOUCHER_ALREADY_USED.name
     assert not errors[0]["voucherCodes"]
+
+
+def test_update_voucher_usage_limit_voucher_already_used(
+    staff_api_client,
+    voucher,
+    permission_manage_discounts,
+    checkout,
+):
+    # given
+    assert voucher.usage_limit is None
+    code_instance = voucher.codes.first()
+    checkout.voucher_code = code_instance.code
+    checkout.save(update_fields=["voucher_code"])
+
+    variables = {
+        "id": graphene.Node.to_global_id("Voucher", voucher.id),
+        "input": {"usageLimit": 10},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_VOUCHER_MUTATION, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["voucherUpdate"]["voucher"]
+    errors = content["data"]["voucherUpdate"]["errors"]
+    assert len(errors) == 1
+
+    voucher.refresh_from_db()
+    assert voucher.usage_limit is None
+    assert errors[0]["field"] == "usageLimit"
+    assert errors[0]["code"] == DiscountErrorCode.VOUCHER_ALREADY_USED.name
+
+
+def test_update_voucher_with_deprecated_code_field(
+    staff_api_client,
+    voucher,
+    permission_manage_discounts,
+):
+    # given
+    new_code = "new-code"
+    code_instance = voucher.codes.get()
+    assert code_instance.code != new_code
+    variables = {
+        "id": graphene.Node.to_global_id("Voucher", voucher.id),
+        "input": {
+            "code": new_code,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_VOUCHER_MUTATION, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["voucherUpdate"]["errors"]
+    data = content["data"]["voucherUpdate"]["voucher"]
+    assert len(data["codes"]["edges"]) == 1
+    assert data["codes"]["edges"][0]["node"]["code"] == new_code
+
+    code_instance.refresh_from_db()
+    assert code_instance.code == new_code


### PR DESCRIPTION
I want to merge this change because I want to disallow changing voucher usage limit when voucher has been already used

Issue: https://linear.app/saleor/issue/SHOPX-1089/count-current-voucher-usage-when-setting-the-usage-limit-for-voucher

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
