### PR TITLE
Fix amount precision in transaction API

### DIFF
--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -1461,7 +1461,9 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             new_transaction = TransactionCreate.create_transaction(
                 transaction_data, None, None, save=False
             )
-            money_data = TransactionCreate.get_money_data_from_input(transaction_data)
+            money_data = TransactionCreate.get_money_data_from_input(
+                transaction_data, order.currency
+            )
             events: List[TransactionEvent] = []
             if money_data:
                 amountfield_eventtype_map = {

--- a/saleor/graphql/payment/mutations/base.py
+++ b/saleor/graphql/payment/mutations/base.py
@@ -8,6 +8,7 @@ from graphql import GraphQLError
 from ....checkout import models as checkout_models
 from ....checkout.calculations import fetch_checkout_data
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from ....core.prices import quantize_price
 from ....order import models as order_models
 from ...core.enums import TransactionInitializeErrorCode
 from ...core.mutations import BaseMutation
@@ -98,8 +99,9 @@ class TransactionSessionBase(BaseMutation):
         source_object: Union[checkout_models.Checkout, order_models.Order],
         input_amount: Optional[Decimal],
     ) -> Decimal:
+        currency = source_object.currency
         if input_amount is not None:
-            return input_amount
+            return quantize_price(input_amount, currency)
         amount: Decimal = source_object.total_gross_amount
         transactions = source_object.payment_transactions.all()
         for transaction_item in transactions:
@@ -110,4 +112,4 @@ class TransactionSessionBase(BaseMutation):
             amount -= transaction_item.authorize_pending_value
             amount -= transaction_item.charge_pending_value
 
-        return amount if amount >= Decimal(0) else Decimal(0)
+        return quantize_price(amount, currency) if amount >= Decimal(0) else Decimal(0)

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -9,6 +9,7 @@ from django.db.models import Model
 
 from .....checkout import models as checkout_models
 from .....checkout.actions import transaction_amounts_for_checkout_updated
+from .....core.prices import quantize_price
 from .....order import OrderStatus
 from .....order import models as order_models
 from .....order.actions import order_transaction_updated
@@ -151,17 +152,27 @@ class TransactionCreate(BaseMutation):
             )
 
     @classmethod
-    def get_money_data_from_input(cls, cleaned_data: dict) -> Dict[str, Decimal]:
+    def get_money_data_from_input(
+        cls, cleaned_data: dict, currency: str
+    ) -> Dict[str, Decimal]:
         money_data = {}
         if amount_authorized := cleaned_data.pop("amount_authorized", None):
-            money_data["authorized_value"] = amount_authorized["amount"]
+            money_data["authorized_value"] = quantize_price(
+                amount_authorized["amount"], currency
+            )
         if amount_charged := cleaned_data.pop("amount_charged", None):
-            money_data["charged_value"] = amount_charged["amount"]
+            money_data["charged_value"] = quantize_price(
+                amount_charged["amount"], currency
+            )
         if amount_refunded := cleaned_data.pop("amount_refunded", None):
-            money_data["refunded_value"] = amount_refunded["amount"]
+            money_data["refunded_value"] = quantize_price(
+                amount_refunded["amount"], currency
+            )
 
         if amount_canceled := cleaned_data.pop("amount_canceled", None):
-            money_data["canceled_value"] = amount_canceled["amount"]
+            money_data["canceled_value"] = quantize_price(
+                amount_canceled["amount"], currency
+            )
         return money_data
 
     @classmethod
@@ -340,7 +351,8 @@ class TransactionCreate(BaseMutation):
             order_or_checkout_instance, transaction=transaction
         )
         transaction_data = {**transaction}
-        transaction_data["currency"] = order_or_checkout_instance.currency
+        currency = order_or_checkout_instance.currency
+        transaction_data["currency"] = currency
         app = get_app_promise(info.context).get()
         user = info.context.user
         manager = get_plugin_manager_promise(info.context).get()
@@ -357,7 +369,7 @@ class TransactionCreate(BaseMutation):
                     reference=transaction_event.get("psp_reference"),
                     message=transaction_event.get("message", ""),
                 )
-        money_data = cls.get_money_data_from_input(transaction_data)
+        money_data = cls.get_money_data_from_input(transaction_data, currency)
         new_transaction = cls.create_transaction(transaction_data, user=user, app=app)
         if money_data:
             create_manual_adjustment_events(

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from .....app.models import App
 from .....checkout.actions import transaction_amounts_for_checkout_updated
 from .....core.exceptions import PermissionDenied
+from .....core.prices import quantize_price
 from .....core.tracing import traced_atomic_transaction
 from .....order import models as order_models
 from .....order.actions import order_transaction_updated
@@ -198,6 +199,7 @@ class TransactionEventReport(ModelMutation):
                 ]
             )
 
+        amount = quantize_price(amount, transaction.currency)
         app_identifier = None
         if app and app.identifier:
             app_identifier = app.identifier

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -217,7 +217,7 @@ class TransactionUpdate(TransactionCreate):
             cls.validate_transaction_input(instance, transaction)
             cls.assign_app_to_transaction_data_if_missing(instance, transaction, app)
             cls.cleanup_metadata_data(transaction)
-            money_data = cls.get_money_data_from_input(transaction)
+            money_data = cls.get_money_data_from_input(transaction, instance.currency)
             cls.update_transaction(instance, transaction, money_data, user, app)
 
         event = None

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2086,3 +2086,70 @@ def test_transaction_create_for_checkout_updates_last_transaction_modified_at(
     transaction = checkout_with_items.payment_transactions.first()
 
     assert checkout_with_items.last_transaction_modified_at == transaction.modified_at
+
+
+@pytest.mark.parametrize(
+    "amount_field_name, transaction_field_name, amount_db_field",
+    [
+        ("amountAuthorized", "authorizedAmount", "authorized_value"),
+        ("amountCharged", "chargedAmount", "charged_value"),
+        ("amountCanceled", "canceledAmount", "canceled_value"),
+        ("amountRefunded", "refundedAmount", "refunded_value"),
+    ],
+)
+def test_transaction_create_amount_with_lot_of_decimal_places(
+    amount_field_name,
+    transaction_field_name,
+    amount_db_field,
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+        TransactionActionEnum.CANCEL.name,
+        TransactionActionEnum.CHARGE.name,
+    ]
+    value = Decimal("9.88789999")
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": "Credit Card",
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            amount_field_name: {
+                "amount": value,
+                "currency": "USD",
+            },
+            "externalUrl": external_url,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    available_actions = set(available_actions)
+
+    transaction = order_with_lines.payment_transactions.first()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]["transaction"]
+    assert set(data["actions"]) == available_actions
+    assert data["pspReference"] == psp_reference
+    assert str(data[transaction_field_name]["amount"]) == str(round(value, 2))
+    assert data["externalUrl"] == external_url
+    assert data["createdBy"]["id"] == to_global_id_or_none(app_api_client.app)
+
+    assert available_actions == set(map(str.upper, transaction.available_actions))
+    assert psp_reference == transaction.psp_reference
+    assert round(value, 2) == getattr(transaction, amount_db_field)
+    assert transaction.app_identifier == app_api_client.app.identifier
+    assert transaction.app == app_api_client.app
+    assert transaction.user is None
+    assert transaction.external_url == external_url

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -329,6 +329,71 @@ def test_for_checkout_with_idempotency_key(
 
 
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_for_checkout_amount_with_lot_of_decimal_places(
+    mocked_initialize,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+):
+    # given
+    checkout = checkout_with_prices
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    expected_amount = Decimal("9.8888888889")
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["result"] = "CHARGE_SUCCESS"
+    expected_response["pspReference"] = expected_psp_reference
+    expected_response["amount"] = round(expected_amount, 2)
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "action": None,
+        "amount": expected_amount,
+        "id": to_global_id_or_none(checkout),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    transaction_item = checkout.payment_transactions.last()
+    mocked_initialize.assert_called_once_with(
+        TransactionSessionData(
+            transaction=transaction_item,
+            source_object=checkout,
+            payment_gateway_data=mock.ANY,
+            action=TransactionProcessActionData(
+                action_type=TransactionFlowStrategy.CHARGE,
+                currency=checkout.currency,
+                amount=round(expected_amount, 2),
+            ),
+            idempotency_key=mock.ANY,
+            customer_ip_address=mock.ANY,
+        )
+    )
+    checkout.refresh_from_db()
+    _assert_fields(
+        content=content,
+        source_object=checkout,
+        expected_amount=round(expected_amount, 2),
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_initialize=mocked_initialize,
+        charged_value=round(expected_amount, 2),
+        returned_data=expected_response["data"],
+    )
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
 def test_for_checkout_with_multiple_calls_and_idempotency_key(
     mocked_initialize,
     user_api_client,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3075,3 +3075,56 @@ def test_transaction_update_for_checkout_updates_last_transaction_modified_at(
 
     assert checkout_with_items.last_transaction_modified_at != previous_modified_at
     assert checkout_with_items.last_transaction_modified_at == transaction.modified_at
+
+
+@pytest.mark.parametrize(
+    "field_name, response_field, db_field_name",
+    [
+        ("amountAuthorized", "authorizedAmount", "authorized_value"),
+        ("amountCharged", "chargedAmount", "charged_value"),
+        ("amountCanceled", "canceledAmount", "canceled_value"),
+        ("amountRefunded", "refundedAmount", "refunded_value"),
+    ],
+)
+def test_transaction_update_amounts_with_lot_of_decimal_places(
+    field_name,
+    response_field,
+    db_field_name,
+    permission_manage_payments,
+    app_api_client,
+    transaction_item_generator,
+    order,
+    app,
+):
+    # given
+    current_authorized_value = Decimal("1")
+    current_charged_value = Decimal("2")
+    current_refunded_value = Decimal("3")
+    current_canceled_value = Decimal("4")
+
+    transaction = transaction_item_generator(
+        order_id=order.pk,
+        app=app,
+        authorized_value=current_authorized_value,
+        charged_value=current_charged_value,
+        canceled_value=current_canceled_value,
+        refunded_value=current_refunded_value,
+    )
+    value = Decimal("9.88888888889")
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {field_name: {"amount": value, "currency": "USD"}},
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    transaction.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionUpdate"]["transaction"]
+    assert str(data[response_field]["amount"]) == str(round(value, 2))
+    assert getattr(transaction, db_field_name) == round(value, 2)


### PR DESCRIPTION
Fix amount precision in transaction API.
The amount should be quantized as invalid precision might break the calls for payment providers.

Affected mutations:
- paymentGatewayInitialize
- transactionInitialize
- transactionCreate
- transactionUpdate
- transactionEventReport
- transactionRequestAction


Port of https://github.com/saleor/saleor/pull/16410
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
