### PR TITLE
Fix not saving is_confirmed in bulk update mutation

### DIFF
--- a/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
@@ -520,6 +520,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                 "last_name",
                 "email",
                 "is_active",
+                "is_confirmed",
                 "note",
                 "language_code",
                 "external_reference",

--- a/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
@@ -351,6 +351,7 @@ def test_customers_bulk_update_match_orders_and_gift_card_when_confirmed(
     assert gift_card.created_by == customer_user
     assert gift_card.created_by_email == customer_user.email
     assert order.user == customer_user
+    assert customer_user.is_confirmed
 
 
 def test_customers_bulk_update_using_external_refs(


### PR DESCRIPTION
I want to merge this change because because saving state of `is_confirmed` wasn't actually done in `bulkUpdate`

https://linear.app/saleor/issue/MERX-768/bug-customerbulkupdate-dont-update-isconfirmed-field

Port of #16421

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
