### PR TITLE
Revert "Downgrade the dependecies which uses setuptools in the newest version"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1134,19 +1134,18 @@ files = [
 
 [[package]]
 name = "django-celery-beat"
-version = "2.5.0"
+version = "2.6.0"
 description = "Database-backed Periodic Tasks."
 optional = false
 python-versions = "*"
 files = [
-    {file = "django-celery-beat-2.5.0.tar.gz", hash = "sha256:cd0a47f5958402f51ac0c715bc942ae33d7b50b4e48cba91bc3f2712be505df1"},
-    {file = "django_celery_beat-2.5.0-py3-none-any.whl", hash = "sha256:ae460faa5ea142fba0875409095d22f6bd7bcc7377889b85e8cab5c0dfb781fe"},
+    {file = "django-celery-beat-2.6.0.tar.gz", hash = "sha256:f75b2d129731f1214be8383e18fae6bfeacdb55dffb2116ce849222c0106f9ad"},
 ]
 
 [package.dependencies]
 celery = ">=5.2.3,<6.0"
 cron-descriptor = ">=1.2.32"
-Django = ">=2.2,<5.0"
+Django = ">=2.2,<5.1"
 django-timezone-field = ">=5.0"
 python-crontab = ">=2.3.4"
 tzdata = "*"
@@ -4870,20 +4869,22 @@ test = ["Cython (>=0.29.36,<0.30.0)", "aiohttp (==3.9.0b0)", "aiohttp (>=3.8.1)"
 
 [[package]]
 name = "vcrpy"
-version = "5.1.0"
+version = "6.0.1"
 description = "Automatically mock your HTTP interactions to simplify and speed up testing"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "vcrpy-5.1.0-py2.py3-none-any.whl", hash = "sha256:605e7b7a63dcd940db1df3ab2697ca7faf0e835c0852882142bafb19649d599e"},
-    {file = "vcrpy-5.1.0.tar.gz", hash = "sha256:bbf1532f2618a04f11bce2a99af3a9647a32c880957293ff91e0a5f187b6b3d2"},
+    {file = "vcrpy-6.0.1.tar.gz", hash = "sha256:9e023fee7f892baa0bbda2f7da7c8ac51165c1c6e38ff8688683a12a4bde9278"},
 ]
 
 [package.dependencies]
 PyYAML = "*"
-urllib3 = {version = "<2", markers = "python_version < \"3.10\""}
+urllib3 = {version = "<2", markers = "platform_python_implementation == \"PyPy\" or python_version < \"3.10\""}
 wrapt = "*"
 yarl = "*"
+
+[package.extras]
+tests = ["Werkzeug (==2.0.3)", "aiohttp", "boto3", "httplib2", "httpx", "pytest", "pytest-aiohttp", "pytest-asyncio", "pytest-cov", "pytest-httpbin", "requests (>=2.22.0)", "tornado", "urllib3"]
 
 [[package]]
 name = "vine"
@@ -5418,4 +5419,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "c44f62504286dcc5ffab58d63b28ef6853a6ec7bfdb6d2305c7c3a3623975a80"
+content-hash = "9ca9e17c4180a6dd042c19ec6ff07419396b86c46d62d1efa3895fca3379da84"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,7 @@ documentation = "https://docs.saleor.io/"
   dj-email-url = "^1"
   django = {version = "^3.2.24", extras = ["bcrypt"]}
   django-cache-url = "^3.1.2"
-  # This is related to the issue with setuptools:
-  # https://github.com/pypa/setuptools/issues/4519. It can be removed when 2.7.0 is
-  # released.
-  django-celery-beat = "<2.6.0"
+  django-celery-beat = "^2.2.1"
   django-countries = "^7.2"
   django-filter = "^23.1"
   django-measurement = "^3.0"
@@ -146,7 +143,7 @@ documentation = "https://docs.saleor.io/"
   types-redis = "^4.6.0"
   types-requests = "^2.31.0"
   types-six = "^1.16.17"
-  vcrpy = ">=4.0,<=5.1.0"
+  vcrpy = ">=4.0,<7.0"
 
 [tool.deptry]
 extend_exclude = ["conftest\\.py", ".*/conftest\\.py", ".*/tests/.*"]


### PR DESCRIPTION
Reverts saleor/saleor#16453

No needed anymore. setuptools 72 was marked as yank.