### PR TITLE
Fix voucher total usage count.

### DIFF
--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -56,8 +56,10 @@ class VoucherQueryset(models.QuerySet["Voucher"]):
     def active(self, date):
         subquery = (
             VoucherCode.objects.filter(voucher_id=OuterRef("pk"))
+            .order_by()
+            .values("voucher_id")
             .annotate(total_used=Sum("used"))
-            .values("total_used")[:1]
+            .values("total_used")
         )
         return self.filter(
             Q(usage_limit__isnull=True) | Q(usage_limit__gt=Subquery(subquery)),

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -82,8 +82,10 @@ class VoucherQueryset(models.QuerySet["Voucher"]):
     def expired(self, date):
         subquery = (
             VoucherCode.objects.filter(voucher_id=OuterRef("pk"))
+            .order_by()
+            .values("voucher_id")
             .annotate(total_used=Sum("used"))
-            .values("total_used")[:1]
+            .values("total_used")
         )
         return self.filter(
             Q(usage_limit__lte=Subquery(subquery)) | Q(end_date__lt=date),

--- a/saleor/graphql/discount/tests/queries/test_vouchers_filtering.py
+++ b/saleor/graphql/discount/tests/queries/test_vouchers_filtering.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 from django.utils import timezone
+from freezegun import freeze_time
 
 from .....discount import DiscountValueType
 from .....discount.models import Voucher, VoucherCode
@@ -231,5 +232,98 @@ def test_query_vouchers_with_filter_search(
         QUERY_VOUCHERS_WITH_FILTER, variables, permissions=[permission_manage_discounts]
     )
     content = get_graphql_content(response)
+    data = content["data"]["vouchers"]["edges"]
+    assert len(data) == count
+
+
+@freeze_time("2020-03-18 12:00:00")
+@pytest.mark.parametrize(
+    ("start_date", "end_date", "used", "count"),
+    [
+        (
+            timezone.now().replace(year=2018, month=1, day=1),
+            timezone.now().replace(year=2019, month=1, day=1),
+            0,
+            2,
+        ),
+        (
+            timezone.now().replace(year=2023, month=1, day=1),
+            timezone.now().replace(year=2024, month=1, day=1),
+            0,
+            0,
+        ),
+        (
+            timezone.now().replace(year=2023, month=1, day=1),
+            None,
+            0,
+            0,
+        ),
+        (
+            timezone.now().replace(year=2019, month=1, day=1),
+            timezone.now().replace(year=2021, month=1, day=1),
+            0,
+            0,
+        ),
+        (
+            timezone.now().replace(year=2019, month=1, day=1),
+            timezone.now().replace(year=2021, month=1, day=1),
+            2,
+            1,
+        ),
+        (
+            timezone.now().replace(year=2019, month=1, day=1),
+            timezone.now().replace(year=2021, month=1, day=1),
+            110,
+            2,
+        ),
+    ],
+)
+def test_query_vouchers_with_filter_status_expired(
+    start_date,
+    end_date,
+    used,
+    count,
+    staff_api_client,
+    permission_manage_discounts,
+):
+    # given
+    vouchers = Voucher.objects.bulk_create(
+        [
+            Voucher(
+                name="Voucher1",
+                start_date=timezone.now(),
+            ),
+            Voucher(
+                name="Voucher2",
+                start_date=start_date,
+                end_date=end_date,
+                usage_limit=5,
+            ),
+            Voucher(
+                name="Voucher3",
+                start_date=start_date,
+                end_date=end_date,
+                usage_limit=100,
+            ),
+        ]
+    )
+    VoucherCode.objects.bulk_create(
+        [
+            VoucherCode(code="code-A", voucher=vouchers[0]),
+            VoucherCode(code="code-B", voucher=vouchers[0]),
+            VoucherCode(code="code-1", voucher=vouchers[1], used=3),
+            VoucherCode(code="code-2", voucher=vouchers[1], used=used),
+            VoucherCode(code="code-abc", voucher=vouchers[2], used=used),
+        ]
+    )
+    variables = {"filter": {"status": "EXPIRED"}}
+
+    # whne
+    response = staff_api_client.post_graphql(
+        QUERY_VOUCHERS_WITH_FILTER, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+
+    # then
     data = content["data"]["vouchers"]["edges"]
     assert len(data) == count

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -11,7 +11,7 @@ from .....checkout import AddressType
 from .....core.prices import quantize_price
 from .....core.taxes import TaxError, zero_taxed_money
 from .....discount import DiscountType, DiscountValueType, RewardType, RewardValueType
-from .....discount.models import VoucherChannelListing, VoucherCustomer
+from .....discount.models import VoucherChannelListing, VoucherCode, VoucherCustomer
 from .....order import OrderStatus
 from .....order import events as order_events
 from .....order.error_codes import OrderErrorCode
@@ -3396,6 +3396,7 @@ def test_draft_order_create_voucher_exceed_usage_limit(
     shipping_method,
     variant,
     voucher_with_many_codes,
+    voucher_percentage,
     channel_USD,
     graphql_address_data,
 ):
@@ -3406,13 +3407,25 @@ def test_draft_order_create_voucher_exceed_usage_limit(
     channel_USD.include_draft_order_in_voucher_usage = True
     channel_USD.save(update_fields=["include_draft_order_in_voucher_usage"])
 
-    voucher = voucher_with_many_codes
-    voucher.usage_limit = 1
-    voucher.save(update_fields=["usage_limit"])
+    voucher_1 = voucher_with_many_codes
+    voucher_1.usage_limit = 6
+    voucher_1.save(update_fields=["usage_limit"])
 
-    code_1, code_2, _, _, _ = voucher.codes.all()
+    code_1, code_2, code_3, code_4, code_5 = voucher_1.codes.all()
     code_1.used = 1
-    code_1.save(update_fields=["used"])
+    code_2.used = 2
+    code_3.used = 3
+    code_4.used = 0
+    code_5.used = 0
+    VoucherCode.objects.bulk_update([code_1, code_2, code_3, code_4, code_5], ["used"])
+
+    voucher_2 = voucher_percentage
+    voucher_2.usage_limit = 3
+    voucher_2.save(update_fields=["usage_limit"])
+    code_6 = voucher_2.codes.get()
+    code_6.used = 1
+    code_6.save(update_fields=["used"])
+    voucher_2.codes.create(code="new code voucher 2", used=1)
 
     user_id = graphene.Node.to_global_id("User", customer_user.id)
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
@@ -3446,3 +3459,76 @@ def test_draft_order_create_voucher_exceed_usage_limit(
     assert len(errors) == 1
     assert errors[0]["code"] == OrderErrorCode.INVALID_VOUCHER_CODE.name
     assert errors[0]["field"] == "voucherCode"
+
+
+@pytest.mark.parametrize("used", [0, 1, 2])
+def test_draft_order_create_voucher_with_usage_limit(
+    used,
+    staff_api_client,
+    permission_group_manage_orders,
+    customer_user,
+    shipping_method,
+    variant,
+    voucher_with_many_codes,
+    voucher_percentage,
+    channel_USD,
+    graphql_address_data,
+):
+    # given
+    query = DRAFT_ORDER_CREATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    channel_USD.include_draft_order_in_voucher_usage = True
+    channel_USD.save(update_fields=["include_draft_order_in_voucher_usage"])
+
+    voucher_1 = voucher_with_many_codes
+    voucher_1.usage_limit = 10
+    voucher_1.save(update_fields=["usage_limit"])
+
+    code_1, code_2, code_3, code_4, code_5 = voucher_1.codes.all()
+    code_1.used = used
+    code_2.used = 1
+    code_3.used = 2
+    code_4.used = 3
+    code_5.used = 0
+    VoucherCode.objects.bulk_update([code_1, code_2, code_3, code_4, code_5], ["used"])
+
+    voucher_2 = voucher_percentage
+    voucher_2.usage_limit = 3
+    voucher_2.save(update_fields=["usage_limit"])
+    code_6 = voucher_2.codes.get()
+    code_6.used = 1
+    code_6.save(update_fields=["used"])
+    voucher_2.codes.create(code="new code voucher 2", used=1)
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variant_qty = 2
+
+    variant_list = [
+        {"variantId": variant_id, "quantity": variant_qty},
+    ]
+    shipping_address = graphql_address_data
+    shipping_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    redirect_url = "https://www.example.com"
+    variables = {
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucherCode": code_1.code,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
+    }
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["draftOrderCreate"]["errors"]
+    data = content["data"]["draftOrderCreate"]["order"]
+    assert data["voucherCode"] == code_1.code


### PR DESCRIPTION
I want to merge this change because it counts total usage of the voucher (sum of all codes usage) instead of usage of a single code.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
