### PR TITLE
Use replica in resolve_ancestors resolver

### DIFF
--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -78,6 +78,28 @@ def test_category_query_by_id(user_api_client, product, channel_USD):
     assert len(category_data["children"]["edges"]) == category.get_children().count()
 
 
+def test_category_query_with_ancestors(user_api_client, product, channel_USD):
+    # given
+    category = Category.objects.first()
+    child = Category.objects.create(
+        name="Child Category", slug="child-category", parent=category
+    )
+
+    # when
+    variables = {
+        "id": graphene.Node.to_global_id("Category", child.pk),
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(QUERY_CATEGORY, variables=variables)
+    content = get_graphql_content(response)
+    category_data = content["data"]["category"]
+
+    # then
+    assert category_data is not None
+    assert len(category_data["ancestors"]["edges"]) == child.get_ancestors().count()
+    assert len(category_data["children"]["edges"]) == child.get_children().count()
+
+
 def test_category_query_invalid_id(user_api_client, product, channel_USD):
     category_id = "'"
     variables = {

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -110,8 +110,12 @@ class Category(ModelObjectType[models.Category]):
 
     @staticmethod
     def resolve_ancestors(root: models.Category, info, **kwargs):
+        database_connection_name = get_database_connection_name(info.context)
         return create_connection_slice(
-            root.get_ancestors(), info, kwargs, CategoryCountableConnection
+            root.get_ancestors().using(database_connection_name),
+            info,
+            kwargs,
+            CategoryCountableConnection,
         )
 
     @staticmethod


### PR DESCRIPTION
The `resolve_ancestors` was lacking the replica DB usage.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
