### PR TITLE
Fix create deliveries for subscription when  circular error is raised

### DIFF
--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -123,7 +123,7 @@ def generate_payload_from_subscription(
         return None
 
     payload_instance = payload[0]
-    event_payload = get_event_payload(payload_instance.data.get("event"))
+    event_payload = get_event_payload(payload_instance.data.get("event")) or {}
 
     if payload_instance.errors:
         event_payload["errors"] = [

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -3025,6 +3025,52 @@ def test_generate_payload_from_subscription_return_permission_errors_in_payload(
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_generate_payload_from_subscription_circular_subscription_sync_event_error(
+    checkout, subscription_webhook, permission_handle_taxes
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    invalid_subscription_webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        checkout,
+        [invalid_subscription_webhook],
+    )
+
+    # then
+    payload = json.loads(deliveries[0].payload.payload)
+    error_code = "CircularSubscriptionSyncEvent"
+
+    assert "event" not in payload
+    assert payload["errors"][0]["extensions"]["exception"]["code"] == error_code
+    assert len(deliveries) == 1
+    assert deliveries[0].webhook == invalid_subscription_webhook
+
+
 def test_thumbnail_created_product_media(
     thumbnail_product_media, subscription_thumbnail_created_webhook
 ):


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/16314

Fix create deliveries for a subscription when a circular error is raised.

The problem is that in such case `payload_instance.data` is `{event: None}` so the `event_payload` is `None` as well and `event_payload["errors"]` is raising an error. I ensure that `event_payload` will always be a `dict` instance.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
