### PR TITLE
Fix empty sync webhooks for Order type

### DIFF
--- a/saleor/core/utils/events.py
+++ b/saleor/core/utils/events.py
@@ -2,6 +2,41 @@ from django.db import transaction
 
 from ...checkout.fetch import CheckoutInfo
 from ...checkout.models import Checkout
+from ...order.fetch import OrderInfo
+from ...order.models import Order
+from ...webhook.event_types import WebhookEventAsyncType
+from ...webhook.models import Webhook
+
+
+def webhook_async_event_requires_sync_webhooks_to_trigger(
+    event_name: str,
+    webhook_event_map: dict[str, set["Webhook"]],
+    possible_sync_events: list[str],
+) -> bool:
+    """Check if calling the event requires additional actions.
+
+    In case of having active webhook with the `event_name`, the function will return
+    True, when any sync from `possible_sync_events`'s webhooks are active. `True`
+    means that sync webhook should be triggered first, before calling async webhook.
+    """
+    is_async_event = event_name in WebhookEventAsyncType.ALL
+    if not is_async_event:
+        raise ValueError(f"Event {event_name} is not an async event.")
+
+    if event_name not in webhook_event_map:
+        raise ValueError(f"Event {event_name} not found in webhook_event_map.")
+
+    if not webhook_event_map[event_name] and not webhook_event_map.get(
+        WebhookEventAsyncType.ANY
+    ):
+        return False
+
+    active_webhook_events = set(
+        [event for event, webhooks in webhook_event_map.items() if webhooks]
+    )
+    if not active_webhook_events.intersection(possible_sync_events):
+        return False
+    return True
 
 
 def call_event_including_protected_events(func_obj, *func_args, **func_kwargs):
@@ -23,10 +58,16 @@ def call_event(func_obj, *func_args, **func_kwargs):
 
     Ensures that in atomic transaction event is called on_commit.
     """
-    is_checkout_instance = any(
-        [isinstance(arg, (Checkout, CheckoutInfo)) for arg in func_args]
+    is_protected_instance = any(
+        [
+            isinstance(arg, (Checkout, CheckoutInfo, Order, OrderInfo))
+            for arg in func_args
+        ]
     )
-
-    if is_checkout_instance:
+    func_obj_self = getattr(func_obj, "__self__", None)
+    is_plugin_manager_method = "PluginsManager" in str(
+        getattr(func_obj_self, "__class__", "")
+    )
+    if is_protected_instance and is_plugin_manager_method:
         raise NotImplementedError("`call_event` doesn't support checkout/order events.")
     call_event_including_protected_events(func_obj, *func_args, **func_kwargs)

--- a/saleor/core/utils/events.py
+++ b/saleor/core/utils/events.py
@@ -26,6 +26,14 @@ def webhook_async_event_requires_sync_webhooks_to_trigger(
     if event_name not in webhook_event_map:
         raise ValueError(f"Event {event_name} not found in webhook_event_map.")
 
+    missing_possible_sync_events_in_map = set(possible_sync_events).difference(
+        webhook_event_map.keys()
+    )
+    if missing_possible_sync_events_in_map:
+        raise ValueError(
+            f"Event {missing_possible_sync_events_in_map} not found in webhook_event_map."
+        )
+
     if not webhook_event_map[event_name] and not webhook_event_map.get(
         WebhookEventAsyncType.ANY
     ):

--- a/saleor/core/utils/tests/test_events.py
+++ b/saleor/core/utils/tests/test_events.py
@@ -1,6 +1,8 @@
 import pytest
 
-from ..events import call_event
+from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ....webhook.utils import get_webhooks_for_multiple_events
+from ..events import call_event, webhook_async_event_requires_sync_webhooks_to_trigger
 
 
 def test_call_event_cannot_be_used_with_checkout_info_object(
@@ -13,3 +15,68 @@ def test_call_event_cannot_be_used_with_checkout_info_object(
 def test_call_event_cannot_be_used_with_checkout_object(checkout, plugins_manager):
     with pytest.raises(NotImplementedError):
         call_event(plugins_manager.checkout_updated, checkout)
+
+
+def test_webhook_async_event_requires_sync_webhooks_to_trigger_requires_event_in_map():
+    # given
+    event_name = WebhookEventAsyncType.ORDER_CREATED
+    webhook_event_map = {}
+
+    # when & then
+    with pytest.raises(
+        ValueError, match=f"Event {event_name} not found in webhook_event_map."
+    ):
+        webhook_async_event_requires_sync_webhooks_to_trigger(
+            event_name, webhook_event_map, []
+        )
+
+
+def test_webhook_async_event_requires_sync_webhooks_to_trigger_not_async_event():
+    # given
+    event_name = WebhookEventSyncType.ORDER_CALCULATE_TAXES
+    webhook_event_map = {}
+
+    # when & then
+    with pytest.raises(ValueError, match=f"Event {event_name} is not an async event."):
+        webhook_async_event_requires_sync_webhooks_to_trigger(
+            event_name, webhook_event_map, []
+        )
+
+
+def test_webhook_async_event_requires_sync_webhooks_to_trigger():
+    # given
+    event_name = WebhookEventAsyncType.ORDER_CREATED
+    webhook_event_map = get_webhooks_for_multiple_events(
+        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
+    )
+
+    # when
+
+    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
+        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
+    )
+
+    # then
+    assert not should_trigger
+
+
+def test_webhook_async_event_requires_sync_webhooks_to_trigger_missing_event_in_map():
+    # given
+    event_name = WebhookEventAsyncType.ORDER_CREATED
+    webhook_event_map = get_webhooks_for_multiple_events(
+        [
+            WebhookEventAsyncType.ORDER_CREATED,
+        ]
+    )
+
+    # when & then
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"Event {set(WebhookEventSyncType.ORDER_EVENTS)} not found in "
+            "webhook_event_map."
+        ),
+    ):
+        webhook_async_event_requires_sync_webhooks_to_trigger(
+            event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
+        )

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1551,7 +1551,7 @@ def test_with_active_problems_flow(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_add_voucher_triggers_sync_webhooks(
+def test_checkout_add_voucher_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -654,7 +654,7 @@ def test_checkout_billing_address_skip_validation_by_app(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_billing_address_triggers_sync_webhooks(
+def test_checkout_billing_address_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -68,7 +68,7 @@ MUTATION_CHECKOUT_CREATE = """
 
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_checkout_create_triggers_webhooks(
+def test_checkout_create_triggers_async_webhooks(
     mocked_webhook_trigger,
     mocked_get_webhooks_for_event,
     any_webhook,
@@ -2656,7 +2656,7 @@ def test_checkout_create_skip_validation_billing_address_by_app(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_create_triggers_sync_webhooks(
+def test_checkout_create_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -244,7 +244,7 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_customer_triggers_sync_webhooks(
+def test_checkout_customer_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -123,7 +123,7 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_customer_detach_triggers_sync_webhooks(
+def test_checkout_customer_detach_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -1017,7 +1017,7 @@ def test_checkout_delivery_method_update_from_cc_to_all_warehouses_disabled_cc(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_delivery_method_update_triggers_sync_webhooks(
+def test_checkout_delivery_method_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,
@@ -1093,7 +1093,7 @@ def test_checkout_delivery_method_update_triggers_sync_webhooks(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_delivery_method_update_cc_triggers_sync_webhooks(
+def test_checkout_delivery_method_update_cc_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,
@@ -1180,7 +1180,7 @@ def test_checkout_delivery_method_update_cc_triggers_sync_webhooks(
     "saleor.graphql.checkout.mutations.checkout_delivery_method_update."
     "clean_delivery_method"
 )
-def test_checkout_delivery_method_update_external_shipping_triggers_sync_webhooks(
+def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
     mock_clean_delivery,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -96,7 +96,7 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_email_update_triggers_sync_webhooks(
+def test_checkout_email_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -79,7 +79,7 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_update_language_code_triggers_sync_webhooks(
+def test_checkout_update_language_code_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -214,7 +214,7 @@ def test_checkout_line_delete_non_removable_gift(user_api_client, checkout_line)
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_line_delete_triggers_sync_webhooks(
+def test_checkout_line_delete_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1764,7 +1764,7 @@ def test_with_active_problems_flow(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_lines_add_triggers_sync_webhooks(
+def test_checkout_lines_add_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -211,7 +211,7 @@ def test_checkout_lines_delete_not_associated_with_checkout(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_lines_delete_triggers_sync_webhooks(
+def test_checkout_lines_delete_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1371,7 +1371,7 @@ def test_checkout_lines_update_quantity_gift(user_api_client, checkout_with_item
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_lines_update_triggers_sync_webhooks(
+def test_checkout_lines_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -716,7 +716,7 @@ def test_with_active_problems_flow(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_remove_triggers_sync_webhooks(
+def test_checkout_remove_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -1086,7 +1086,7 @@ def test_checkout_shipping_address_skip_validation_by_app(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_shipping_address_update_triggers_sync_webhooks(
+def test_checkout_shipping_address_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -487,7 +487,7 @@ def test_with_active_problems_flow(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_shipping_method_update_triggers_sync_webhooks(
+def test_checkout_shipping_method_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,
@@ -564,7 +564,7 @@ def test_checkout_shipping_method_update_triggers_sync_webhooks(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_shipping_method_update_external_shipping_triggers_sync_webhooks(
+def test_checkout_shipping_method_update_external_shipping_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,
@@ -655,7 +655,7 @@ def test_checkout_shipping_method_update_external_shipping_triggers_sync_webhook
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_checkout_shipping_method_update_to_none_triggers_sync_webhooks(
+def test_checkout_shipping_method_update_to_none_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -372,7 +372,7 @@ def test_update_public_metadata_for_checkout_line(api_client, checkout_line):
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_add_metadata_for_checkout_triggers_sync_webhooks_with_checkout_updated(
+def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,
@@ -442,7 +442,7 @@ def test_add_metadata_for_checkout_triggers_sync_webhooks_with_checkout_updated(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_add_metadata_for_checkout_triggers_sync_webhooks_with_updated_metadata(
+def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event_for_checkout,

--- a/saleor/graphql/meta/tests/mutations/test_order.py
+++ b/saleor/graphql/meta/tests/mutations/test_order.py
@@ -1,6 +1,13 @@
-import graphene
+from unittest.mock import call, patch
 
+import graphene
+from django.test import override_settings
+
+from .....core.models import EventDelivery
+from .....order import OrderStatus
+from .....order.actions import call_order_event
 from .....payment.models import TransactionItem
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from . import PRIVATE_KEY, PRIVATE_VALUE, PUBLIC_KEY, PUBLIC_VALUE
 from .test_delete_metadata import (
     execute_clear_public_metadata_for_item,
@@ -578,3 +585,142 @@ def test_add_private_metadata_for_fulfillment(
     assert item_contains_proper_private_metadata(
         response["data"]["updatePrivateMetadata"]["item"], fulfillment, fulfillment_id
     )
+
+
+@patch(
+    "saleor.graphql.meta.extra_methods.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_change_in_public_metadata_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    api_client,
+    order_with_lines,
+    django_capture_on_commit_callbacks,
+    settings,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        additional_order_webhook,
+    ) = setup_order_webhooks([WebhookEventAsyncType.ORDER_METADATA_UPDATED])
+
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        execute_update_public_metadata_for_item(
+            api_client, None, order_id, "Order", key="new-key"
+        )
+
+    # then
+    order_metadata_updated_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+    )
+
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_metadata_updated_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called
+
+
+@patch(
+    "saleor.graphql.meta.extra_methods.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_change_in_private_metadata_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    django_capture_on_commit_callbacks,
+    settings,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        additional_order_webhook,
+    ) = setup_order_webhooks([WebhookEventAsyncType.ORDER_METADATA_UPDATED])
+
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        execute_update_private_metadata_for_item(
+            staff_api_client, permission_manage_orders, order_id, "Order", key="new-key"
+        )
+
+    # then
+    order_metadata_updated_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+    )
+
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_metadata_updated_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -16,6 +16,7 @@ from ....discount.utils.voucher import (
     increase_voucher_usage,
 )
 from ....order import OrderOrigin, OrderStatus, events, models
+from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
 from ....order.search import update_order_search_vector
 from ....order.utils import (
@@ -26,6 +27,7 @@ from ....order.utils import (
 )
 from ....permission.enums import OrderPermissions
 from ....shipping.utils import convert_to_shipping_method_data
+from ....webhook.event_types import WebhookEventAsyncType
 from ...account.i18n import I18nMixin
 from ...account.mixins import AddressMetadataMixin
 from ...account.types import AddressInput
@@ -574,12 +576,6 @@ class DraftOrderCreate(
 
             update_order_display_gross_prices(instance)
 
-            if is_new_instance:
-                cls.call_event(manager.draft_order_created, instance)
-
-            else:
-                cls.call_event(manager.draft_order_updated, instance)
-
             # Post-process the results
             updated_fields.extend(
                 [
@@ -596,6 +592,20 @@ class DraftOrderCreate(
             update_order_search_vector(instance, save=False)
 
             instance.save(update_fields=updated_fields)
+            if is_new_instance:
+                call_order_event(
+                    manager,
+                    manager.draft_order_created,
+                    WebhookEventAsyncType.DRAFT_ORDER_CREATED,
+                    instance,
+                )
+            else:
+                call_order_event(
+                    manager,
+                    manager.draft_order_updated,
+                    WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
+                    instance,
+                )
 
     @classmethod
     def handle_order_voucher(cls, cleaned_input, instance, voucher):

--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -5,8 +5,10 @@ from ....core.tracing import traced_atomic_transaction
 from ....discount.models import VoucherCode
 from ....discount.utils.voucher import release_voucher_code_usage
 from ....order import OrderStatus, models
+from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_310
 from ...core.mutations import (
@@ -54,7 +56,12 @@ class DraftOrderDelete(
         manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             response = super().perform_mutation(_root, info, **data)
-            cls.call_event(manager.draft_order_deleted, order)
+            call_order_event(
+                manager,
+                manager.draft_order_deleted,
+                WebhookEventAsyncType.DRAFT_ORDER_DELETED,
+                order,
+            )
         return response
 
     @classmethod

--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -20,7 +20,7 @@ from ...core.types import OrderError
 from ...core.utils import raise_validation_error
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderLine
-from .utils import EditableOrderValidationMixin, get_webhook_handler_by_order_status
+from .utils import EditableOrderValidationMixin, call_event_by_order_status
 
 
 class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
@@ -98,8 +98,7 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
                 ["should_refresh_prices", "weight", "search_vector", "updated_at"]
             )
             order.save(update_fields=updated_fields)
-            func = get_webhook_handler_by_order_status(order.status, manager)
-            cls.call_event(func, order)
+            call_event_by_order_status(order, manager)
         return OrderLineDelete(order=order, order_line=line)
 
     @classmethod

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -19,7 +19,7 @@ from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderLine
 from .draft_order_create import OrderLineInput
-from .utils import EditableOrderValidationMixin, get_webhook_handler_by_order_status
+from .utils import EditableOrderValidationMixin, call_event_by_order_status
 
 
 class OrderLineUpdate(
@@ -106,8 +106,7 @@ class OrderLineUpdate(
             recalculate_order_weight(instance.order)
             instance.order.save(update_fields=["should_refresh_prices", "weight"])
 
-            func = get_webhook_handler_by_order_status(instance.order.status, manager)
-            cls.call_event(func, instance.order)
+            call_event_by_order_status(instance.order, manager)
 
     @classmethod
     def success_response(cls, instance):

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -31,8 +31,8 @@ from ..utils import (
 from .draft_order_create import OrderLineCreateInput
 from .utils import (
     EditableOrderValidationMixin,
+    call_event_by_order_status,
     get_variant_rule_info_map,
-    get_webhook_handler_by_order_status,
 )
 
 VariantData = namedtuple("VariantData", ["variant", "rules_info"])
@@ -204,8 +204,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
                     "updated_at",
                 ]
             )
-            func = get_webhook_handler_by_order_status(order.status, manager)
-            cls.call_event(func, order)
+            call_event_by_order_status(order, manager)
 
         return OrderLinesCreate(order=order, order_lines=added_lines)
 

--- a/saleor/graphql/order/mutations/order_note_add.py
+++ b/saleor/graphql/order/mutations/order_note_add.py
@@ -16,7 +16,7 @@ from ...core.types import BaseInputObjectType, Error, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderEvent
 from .order_note_common import OrderNoteCommon
-from .utils import get_webhook_handler_by_order_status
+from .utils import call_event_by_order_status
 
 OrderNoteAddErrorCode = graphene.Enum.from_enum(error_codes.OrderNoteAddErrorCode)
 OrderNoteAddErrorCode.doc_category = DOC_CATEGORY_ORDERS
@@ -62,8 +62,7 @@ class OrderNoteAdd(OrderNoteCommon):
                 app=app,
                 message=cleaned_input["message"],
             )
-            func = get_webhook_handler_by_order_status(order.status, manager)
-            cls.call_event(func, order)
+            call_event_by_order_status(order, manager)
         return OrderNoteAdd(order=order, event=event)
 
 

--- a/saleor/graphql/order/mutations/order_note_update.py
+++ b/saleor/graphql/order/mutations/order_note_update.py
@@ -11,7 +11,7 @@ from ...core.types import Error
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderEvent
 from .order_note_common import OrderNoteCommon
-from .utils import get_webhook_handler_by_order_status
+from .utils import call_event_by_order_status
 
 OrderNoteUpdateErrorCode = graphene.Enum.from_enum(error_codes.OrderNoteUpdateErrorCode)
 OrderNoteUpdateErrorCode.doc_category = DOC_CATEGORY_ORDERS
@@ -63,6 +63,5 @@ class OrderNoteUpdate(OrderNoteCommon):
                 message=cleaned_input["message"],
                 related_event=order_event_to_update,
             )
-            func = get_webhook_handler_by_order_status(order.status, manager)
-            cls.call_event(func, order)
+            call_event_by_order_status(order, manager)
         return OrderNoteUpdate(order=order, event=event)

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -5,10 +5,12 @@ from ....account.models import User
 from ....core.postgres import FlatConcatSearchVector
 from ....core.tracing import traced_atomic_transaction
 from ....order import OrderStatus, models
+from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
 from ....order.search import prepare_order_search_vector_value
 from ....order.utils import invalidate_order_prices
 from ....permission.enums import OrderPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import AddressInput
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_310
@@ -105,4 +107,9 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
                 invalidate_order_prices(instance)
 
             instance.save()
-            cls.call_event(manager.order_updated, instance)
+            call_order_event(
+                manager,
+                manager.order_updated,
+                WebhookEventAsyncType.ORDER_UPDATED,
+                instance,
+            )

--- a/saleor/graphql/order/mutations/order_update_shipping.py
+++ b/saleor/graphql/order/mutations/order_update_shipping.py
@@ -2,10 +2,12 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from ....order import OrderStatus, models
+from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ....shipping import models as shipping_models
 from ....shipping.utils import convert_to_shipping_method_data
+from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
@@ -134,5 +136,7 @@ class OrderUpdateShipping(
 
         order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
         # Post-process the results
-        cls.call_event(manager.order_updated, order)
+        call_order_event(
+            manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
+        )
         return OrderUpdateShipping(order=order)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -1,25 +1,29 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import graphene
 import pytest
 import pytz
+from django.test import override_settings
 from prices import Money
 
 from .....checkout import AddressType
+from .....core.models import EventDelivery
 from .....core.prices import quantize_price
 from .....core.taxes import TaxError, zero_taxed_money
 from .....discount import DiscountType, DiscountValueType, RewardType, RewardValueType
 from .....discount.models import VoucherChannelListing, VoucherCode, VoucherCustomer
 from .....order import OrderStatus
 from .....order import events as order_events
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....order.models import Order, OrderEvent
 from .....payment.model_helpers import get_subtotal
 from .....product.models import ProductVariant
 from .....tax import TaxCalculationStrategy
 from .....tests.utils import round_up
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 DRAFT_ORDER_CREATE_MUTATION = """
@@ -3603,3 +3607,99 @@ def test_draft_order_create_voucher_with_usage_limit(
     assert not content["data"]["draftOrderCreate"]["errors"]
     data = content["data"]["draftOrderCreate"]["order"]
     assert data["voucherCode"] == code_1.code
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_create.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_create_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    app_api_client,
+    permission_manage_orders,
+    customer_user,
+    shipping_method_channel_PLN,
+    product_available_in_many_channels,
+    channel_PLN,
+    graphql_address_data,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        draft_order_created_webhook,
+    ) = setup_order_webhooks(WebhookEventAsyncType.DRAFT_ORDER_CREATED)
+
+    variant = product_available_in_many_channels.variants.first()
+    query = DRAFT_ORDER_CREATE_MUTATION
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variant_list = [
+        {"variantId": variant_id, "quantity": 2},
+    ]
+    shipping_address = graphql_address_data
+    shipping_id = graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method_channel_PLN.id
+    )
+    channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
+    redirect_url = "https://www.example.com"
+
+    variables = {
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
+    }
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = app_api_client.post_graphql(
+            query, variables, permissions=(permission_manage_orders,)
+        )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["draftOrderCreate"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    draft_order_created_delivery = EventDelivery.objects.get(
+        webhook_id=draft_order_created_webhook.id
+    )
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": draft_order_created_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -1,17 +1,22 @@
 from decimal import Decimal
+from unittest.mock import call, patch
 
 import graphene
 import pytest
+from django.test import override_settings
 from prices import TaxedMoney
 
+from .....core.models import EventDelivery
 from .....core.prices import quantize_price
 from .....core.taxes import zero_money
 from .....discount import DiscountType, DiscountValueType, RewardValueType, VoucherType
 from .....discount.models import OrderDiscount, Voucher
 from .....order import OrderStatus
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent
 from .....payment.model_helpers import get_subtotal
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 DRAFT_ORDER_UPDATE_MUTATION = """
@@ -2067,3 +2072,168 @@ def test_draft_order_update_replace_entire_order_voucher_with_shipping_voucher(
     assert order_discount.name == ""
     assert order_discount.type == DiscountType.VOUCHER
     assert order_discount.voucher_code == shipping_code
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_create.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_update_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    voucher,
+    app_api_client,
+    permission_manage_orders,
+    draft_order,
+    django_capture_on_commit_callbacks,
+    settings,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        draft_order_updated_webhook,
+    ) = setup_order_webhooks(WebhookEventAsyncType.DRAFT_ORDER_UPDATED)
+
+    order = draft_order
+    order.voucher = voucher
+    order.save(update_fields=["voucher"])
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    discount_amount = voucher_listing.discount_value
+    order.discounts.create(
+        voucher=voucher,
+        value=discount_amount,
+        type=DiscountType.VOUCHER,
+    )
+
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {
+        "id": order_id,
+        "input": {
+            "voucher": None,
+        },
+    }
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = app_api_client.post_graphql(
+            query, variables, permissions=(permission_manage_orders,)
+        )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+    order.refresh_from_db()
+
+    # confirm that event delivery was generated for each webhook.
+    draft_order_updated_delivery = EventDelivery.objects.get(
+        webhook_id=draft_order_updated_webhook.id
+    )
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": draft_order_updated_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_create.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    voucher,
+    app_api_client,
+    permission_manage_orders,
+    draft_order,
+    django_capture_on_commit_callbacks,
+    settings,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        draft_order_updated_webhook,
+    ) = setup_order_webhooks(WebhookEventAsyncType.DRAFT_ORDER_UPDATED)
+
+    order = draft_order
+
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {
+        "id": order_id,
+        "input": {
+            "customerNote": "New note",
+        },
+    }
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = app_api_client.post_graphql(
+            query, variables, permissions=(permission_manage_orders,)
+        )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+    order.refresh_from_db()
+
+    # confirm that event delivery was generated for each webhook.
+    draft_order_updated_delivery = EventDelivery.objects.get(
+        webhook_id=draft_order_updated_webhook.id
+    )
+    tax_delivery = EventDelivery.objects.filter(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    assert not tax_delivery
+    assert not order.should_refresh_prices
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": draft_order_updated_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_called_once_with(
+        filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -1030,7 +1030,7 @@ def test_order_bulk_create_multiple_notes(
     assert event_2["message"] == note_2["message"]
     assert event_2["app"]["id"] == note_2["appId"]
 
-    db_events = OrderEvent.objects.all()
+    db_events = OrderEvent.objects.all().order_by("pk")
     db_event_1 = db_events[0]
     assert db_event_1.parameters["message"] == note_1["message"]
     assert db_event_1.user == customer_user

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -1,13 +1,18 @@
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, call, patch
 
 import graphene
+from django.test import override_settings
 
+from .....core.models import EventDelivery
 from .....core.notify_events import NotifyEventType
 from .....core.tests.utils import get_site_context_payload
+from .....order import OrderStatus
 from .....order import events as order_events
+from .....order.actions import call_order_event, order_charged
 from .....order.notifications import get_default_order_payload
 from .....payment import ChargeStatus
 from .....payment.models import Payment
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....payment.types import PaymentChargeStatusEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -35,11 +40,15 @@ ORDER_CAPTURE_MUTATION = """
 """
 
 
+@patch(
+    "saleor.graphql.order.mutations.order_capture.order_charged", wraps=order_charged
+)
 @patch("saleor.giftcard.utils.fulfill_non_shippable_gift_cards")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_order_capture(
     mocked_notify,
     fulfill_non_shippable_gift_cards_mock,
+    order_charged_mock,
     staff_api_client,
     permission_group_manage_orders,
     payment_txn_preauth,
@@ -104,6 +113,7 @@ def test_order_capture(
     fulfill_non_shippable_gift_cards_mock.assert_called_once_with(
         order, list(order.lines.all()), site_settings, staff_api_client.user, None, ANY
     )
+    assert order_charged_mock.called
 
 
 def test_order_capture_by_user_no_channel_access(
@@ -155,3 +165,107 @@ def test_order_capture_by_app(
     assert data["paymentStatusDisplay"] == payment_status_display
     assert data["isPaid"]
     assert data["totalCaptured"]["amount"] == float(amount)
+
+
+@patch(
+    "saleor.order.actions.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(
+    PLUGINS=[
+        "saleor.plugins.webhook.plugin.WebhookPlugin",
+        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+    ]
+)
+def test_order_capture_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    permission_group_manage_orders,
+    payment_txn_preauth,
+    staff_user,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        additional_order_webhook,
+    ) = setup_order_webhooks(
+        [
+            WebhookEventAsyncType.ORDER_PAID,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            WebhookEventAsyncType.ORDER_FULLY_PAID,
+        ]
+    )
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = payment_txn_preauth.order
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    amount = float(payment_txn_preauth.total)
+    variables = {"id": order_id, "amount": amount}
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(ORDER_CAPTURE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["orderCapture"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_paid_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_PAID,
+    )
+    order_updated_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_UPDATED,
+    )
+    order_fully_paid_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_FULLY_PAID,
+    )
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    order_deliveries = [
+        order_fully_paid_delivery,
+        order_paid_delivery,
+        order_updated_delivery,
+    ]
+
+    mocked_send_webhook_request_async.assert_has_calls(
+        [
+            call(
+                kwargs={"event_delivery_id": delivery.id},
+                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+                bind=True,
+                retry_backoff=10,
+                retry_kwargs={"max_retries": 5},
+            )
+            for delivery in order_deliveries
+        ],
+        any_order=True,
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -1,17 +1,31 @@
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, call, patch
 
 import graphene
+from django.test import override_settings
 
+from .....core.models import EventDelivery
+from .....core.notification.utils import get_site_context
 from .....core.notify_events import NotifyEventType
+from .....core.prices import quantize_price
 from .....core.tests.utils import get_site_context_payload
 from .....order import OrderStatus
 from .....order import events as order_events
+from .....order.actions import (
+    WEBHOOK_EVENTS_FOR_ORDER_CHARGED,
+    WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED,
+    call_order_event,
+    handle_fully_paid_order,
+    order_charged,
+    order_confirmed,
+)
 from .....order.error_codes import OrderErrorCode
 from .....order.fetch import fetch_order_info
 from .....order.models import OrderEvent
 from .....order.notifications import get_default_order_payload
 from .....order.utils import updates_amounts_for_order
 from .....product.models import ProductVariant
+from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.utils import get_webhooks_for_multiple_events
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -30,12 +44,21 @@ ORDER_CONFIRM_MUTATION = """
 """
 
 
-@patch("saleor.order.actions.handle_fully_paid_order")
+@patch("saleor.order.actions.handle_fully_paid_order", wraps=handle_fully_paid_order)
+@patch(
+    "saleor.graphql.order.mutations.order_confirm.order_confirmed",
+    wraps=order_confirmed,
+)
+@patch(
+    "saleor.graphql.order.mutations.order_confirm.order_charged", wraps=order_charged
+)
 @patch("saleor.plugins.manager.PluginsManager.notify")
 @patch("saleor.payment.gateway.capture")
 def test_order_confirm(
     capture_mock,
     mocked_notify,
+    order_charged_mock,
+    order_confirmed_mock,
     handle_fully_paid_order_mock,
     staff_api_client,
     order_unconfirmed,
@@ -44,6 +67,9 @@ def test_order_confirm(
     site_settings,
 ):
     # given
+    webhook_event_map = get_webhooks_for_multiple_events(
+        WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED.union(WEBHOOK_EVENTS_FOR_ORDER_CHARGED)
+    )
     payment_txn_preauth.order = order_unconfirmed
     payment_txn_preauth.captured_amount = order_unconfirmed.total.gross.amount
     payment_txn_preauth.total = order_unconfirmed.total.gross.amount
@@ -68,7 +94,7 @@ def test_order_confirm(
     assert order_data["status"] == OrderStatus.UNFULFILLED.upper()
     order_unconfirmed.refresh_from_db()
     assert order_unconfirmed.status == OrderStatus.UNFULFILLED
-    assert OrderEvent.objects.count() == 2
+    assert OrderEvent.objects.count() == 3
     assert OrderEvent.objects.filter(
         order=order_unconfirmed,
         user=staff_api_client.user,
@@ -78,33 +104,88 @@ def test_order_confirm(
     assert OrderEvent.objects.filter(
         order=order_unconfirmed,
         user=staff_api_client.user,
+        type=order_events.OrderEvents.ORDER_FULLY_PAID,
+    ).exists()
+
+    assert OrderEvent.objects.filter(
+        order=order_unconfirmed,
+        user=staff_api_client.user,
         type=order_events.OrderEvents.PAYMENT_CAPTURED,
         parameters__amount=payment_txn_preauth.get_total().amount,
     ).exists()
 
+    order_info = fetch_order_info(order_unconfirmed)
+
+    order_charged_mock.assert_called_once_with(
+        order_info,
+        staff_api_client.user,
+        None,
+        payment_txn_preauth.total,
+        payment_txn_preauth,
+        ANY,
+        site_settings,
+        payment_txn_preauth.gateway,
+        webhook_event_map=webhook_event_map,
+    )
+    order_confirmed_mock.assert_called_once_with(
+        order_unconfirmed,
+        staff_api_client.user,
+        None,
+        ANY,
+        send_confirmation_email=True,
+        webhook_event_map=webhook_event_map,
+    )
+    handle_fully_paid_order_mock.assert_called_once_with(
+        ANY,
+        order_info,
+        user=staff_api_client.user,
+        app=None,
+        site_settings=site_settings,
+        gateway=payment_txn_preauth.gateway,
+        webhook_event_map=webhook_event_map,
+    )
+
     capture_mock.assert_called_once_with(
         payment_txn_preauth, ANY, channel_slug=order_unconfirmed.channel.slug
     )
-    expected_payload = {
+    expected_confirmed_payload = {
         "order": get_default_order_payload(order_unconfirmed, ""),
         "recipient_email": order_unconfirmed.user.email,
         "requester_user_id": to_global_id_or_none(staff_api_client.user),
         "requester_app_id": None,
         **get_site_context_payload(site_settings.site),
     }
-    mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CONFIRMED,
-        expected_payload,
-        channel_slug=order_unconfirmed.channel.slug,
-    )
-    order_info = fetch_order_info(order_unconfirmed)
-    handle_fully_paid_order_mock.assert_called_once_with(
-        ANY,
-        order_info,
-        staff_api_client.user,
-        None,
-        site_settings,
-        payment_txn_preauth.gateway,
+    expected_payment_payload = {
+        "order": get_default_order_payload(order_unconfirmed),
+        "recipient_email": order_unconfirmed.user.email,
+        "payment": {
+            "created": payment_txn_preauth.created_at,
+            "modified": payment_txn_preauth.modified_at,
+            "charge_status": payment_txn_preauth.charge_status,
+            "total": quantize_price(
+                payment_txn_preauth.total, payment_txn_preauth.currency
+            ),
+            "captured_amount": quantize_price(
+                payment_txn_preauth.captured_amount, payment_txn_preauth.currency
+            ),
+            "currency": payment_txn_preauth.currency,
+        },
+        **get_site_context(),
+    }
+
+    mocked_notify.has_calls(
+        [
+            call(
+                NotifyEventType.ORDER_CONFIRMED,
+                expected_confirmed_payload,
+                channel_slug=order_unconfirmed.channel.slug,
+            ),
+            call(
+                NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+                expected_payment_payload,
+                channel_slug=order_unconfirmed.channel.slug,
+            ),
+        ]
     )
 
 
@@ -300,12 +381,21 @@ def test_order_confirm_by_user_no_channel_access(
     assert_no_permission(response)
 
 
-@patch("saleor.order.actions.handle_fully_paid_order")
+@patch("saleor.order.actions.handle_fully_paid_order", wraps=handle_fully_paid_order)
+@patch(
+    "saleor.graphql.order.mutations.order_confirm.order_confirmed",
+    wraps=order_confirmed,
+)
+@patch(
+    "saleor.graphql.order.mutations.order_confirm.order_charged", wraps=order_charged
+)
 @patch("saleor.plugins.manager.PluginsManager.notify")
 @patch("saleor.payment.gateway.capture")
 def test_order_confirm_by_app(
     capture_mock,
     mocked_notify,
+    order_charged_mock,
+    order_confirmed_mock,
     handle_fully_paid_order_mock,
     app_api_client,
     order_unconfirmed,
@@ -314,6 +404,9 @@ def test_order_confirm_by_app(
     site_settings,
 ):
     # given
+    webhook_event_map = get_webhooks_for_multiple_events(
+        WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED.union(WEBHOOK_EVENTS_FOR_ORDER_CHARGED)
+    )
     payment_txn_preauth.order = order_unconfirmed
     payment_txn_preauth.captured_amount = order_unconfirmed.total.gross.amount
     payment_txn_preauth.total = order_unconfirmed.total.gross.amount
@@ -338,7 +431,7 @@ def test_order_confirm_by_app(
     assert order_data["status"] == OrderStatus.UNFULFILLED.upper()
     order_unconfirmed.refresh_from_db()
     assert order_unconfirmed.status == OrderStatus.UNFULFILLED
-    assert OrderEvent.objects.count() == 2
+    assert OrderEvent.objects.count() == 3
     assert OrderEvent.objects.filter(
         order=order_unconfirmed,
         app=app_api_client.app,
@@ -348,33 +441,88 @@ def test_order_confirm_by_app(
     assert OrderEvent.objects.filter(
         order=order_unconfirmed,
         app=app_api_client.app,
+        type=order_events.OrderEvents.ORDER_FULLY_PAID,
+    ).exists()
+
+    assert OrderEvent.objects.filter(
+        order=order_unconfirmed,
+        app=app_api_client.app,
         type=order_events.OrderEvents.PAYMENT_CAPTURED,
         parameters__amount=payment_txn_preauth.get_total().amount,
     ).exists()
 
+    order_info = fetch_order_info(order_unconfirmed)
+
+    order_charged_mock.assert_called_once_with(
+        order_info,
+        None,
+        app_api_client.app,
+        payment_txn_preauth.total,
+        payment_txn_preauth,
+        ANY,
+        site_settings,
+        payment_txn_preauth.gateway,
+        webhook_event_map=webhook_event_map,
+    )
+    order_confirmed_mock.assert_called_once_with(
+        order_unconfirmed,
+        None,
+        app_api_client.app,
+        ANY,
+        send_confirmation_email=True,
+        webhook_event_map=webhook_event_map,
+    )
+    handle_fully_paid_order_mock.assert_called_once_with(
+        ANY,
+        order_info,
+        user=None,
+        app=app_api_client.app,
+        site_settings=site_settings,
+        gateway=payment_txn_preauth.gateway,
+        webhook_event_map=webhook_event_map,
+    )
+
     capture_mock.assert_called_once_with(
         payment_txn_preauth, ANY, channel_slug=order_unconfirmed.channel.slug
     )
-    expected_payload = {
+    expected_confirmed_payload = {
         "order": get_default_order_payload(order_unconfirmed, ""),
         "recipient_email": order_unconfirmed.user.email,
         "requester_user_id": None,
         "requester_app_id": to_global_id_or_none(app_api_client.app),
         **get_site_context_payload(site_settings.site),
     }
-    mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CONFIRMED,
-        expected_payload,
-        channel_slug=order_unconfirmed.channel.slug,
-    )
-    order_info = fetch_order_info(order_unconfirmed)
-    handle_fully_paid_order_mock.assert_called_once_with(
-        ANY,
-        order_info,
-        None,
-        app_api_client.app,
-        site_settings,
-        payment_txn_preauth.gateway,
+    expected_payment_payload = {
+        "order": get_default_order_payload(order_unconfirmed),
+        "recipient_email": order_unconfirmed.user.email,
+        "payment": {
+            "created": payment_txn_preauth.created_at,
+            "modified": payment_txn_preauth.modified_at,
+            "charge_status": payment_txn_preauth.charge_status,
+            "total": quantize_price(
+                payment_txn_preauth.total, payment_txn_preauth.currency
+            ),
+            "captured_amount": quantize_price(
+                payment_txn_preauth.captured_amount, payment_txn_preauth.currency
+            ),
+            "currency": payment_txn_preauth.currency,
+        },
+        **get_site_context(),
+    }
+
+    mocked_notify.has_calls(
+        [
+            call(
+                NotifyEventType.ORDER_CONFIRMED,
+                expected_confirmed_payload,
+                channel_slug=order_unconfirmed.channel.slug,
+            ),
+            call(
+                NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+                expected_payment_payload,
+                channel_slug=order_unconfirmed.channel.slug,
+            ),
+        ]
     )
 
 
@@ -429,3 +577,104 @@ def test_order_confirm_skip_address_validation(
     assert order.shipping_address.postal_code == invalid_postal_code
     assert order.billing_address.postal_code == invalid_postal_code
     assert order.status == OrderStatus.UNFULFILLED
+
+
+@patch(
+    "saleor.order.actions.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch("saleor.payment.gateway.capture")
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_confirm_triggers_webhooks(
+    capture_mock,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    order_unconfirmed,
+    permission_group_manage_orders,
+    payment_txn_preauth,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        additional_order_webhook,
+    ) = setup_order_webhooks(
+        [
+            WebhookEventAsyncType.ORDER_CONFIRMED,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            WebhookEventAsyncType.ORDER_FULLY_PAID,
+            WebhookEventAsyncType.ORDER_PAID,
+        ]
+    )
+
+    payment_txn_preauth.order = order_unconfirmed
+    payment_txn_preauth.captured_amount = order_unconfirmed.total.gross.amount
+    payment_txn_preauth.total = order_unconfirmed.total.gross.amount
+    payment_txn_preauth.save(update_fields=["order", "captured_amount", "total"])
+
+    order_unconfirmed.total_charged = order_unconfirmed.total.gross
+    order_unconfirmed.save(update_fields=["total_charged_amount"])
+    updates_amounts_for_order(order_unconfirmed)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    assert not OrderEvent.objects.exists()
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            ORDER_CONFIRM_MUTATION,
+            {"id": graphene.Node.to_global_id("Order", order_unconfirmed.id)},
+        )
+
+    # then
+    assert not get_graphql_content(response)["data"]["orderConfirm"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_confirmed_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_CONFIRMED,
+    )
+    order_updated_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_UPDATED,
+    )
+    order_fully_paid_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_FULLY_PAID,
+    )
+    order_paid_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_PAID,
+    )
+    order_deliveries = [
+        order_confirmed_delivery,
+        order_updated_delivery,
+        order_fully_paid_delivery,
+        order_paid_delivery,
+    ]
+
+    mocked_send_webhook_request_async.assert_has_calls(
+        [
+            call(
+                kwargs={"event_delivery_id": delivery.id},
+                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+                bind=True,
+                retry_backoff=10,
+                retry_kwargs={"max_retries": 5},
+            )
+            for delivery in order_deliveries
+        ],
+        any_order=True,
+    )
+    assert not mocked_send_webhook_request_sync.called
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -1,18 +1,21 @@
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, call, patch
 
 import graphene
 import pytest
+from django.test import override_settings
 
 from .....core.exceptions import InsufficientStock, InsufficientStockData
+from .....core.models import EventDelivery
 from .....giftcard import GiftCardEvents
 from .....giftcard.models import GiftCard, GiftCardEvent
 from .....order import FulfillmentStatus, OrderStatus
+from .....order.actions import call_order_event, order_fulfilled
 from .....order.error_codes import OrderErrorCode
 from .....order.models import Fulfillment, FulfillmentLine
 from .....product.models import ProductVariant
 from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.models import Allocation, Stock
-from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ORDER_FULFILL_MUTATION = """
@@ -38,9 +41,11 @@ ORDER_FULFILL_MUTATION = """
 """
 
 
+@patch("saleor.order.actions.order_fulfilled", wraps=order_fulfilled)
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_order_fulfill_with_out_of_stock_webhook(
     product_variant_out_of_stock_webhooks,
+    wrapped_order_fulfilled,
     staff_api_client,
     order_with_lines,
     permission_group_manage_orders,
@@ -70,6 +75,7 @@ def test_order_fulfill_with_out_of_stock_webhook(
 
     stock = order_line2.variant.stocks.filter(warehouse=warehouse).first()
     product_variant_out_of_stock_webhooks.assert_called_once_with(stock)
+    assert wrapped_order_fulfilled.called
 
 
 @pytest.mark.parametrize("fulfillment_auto_approve", [True, False])
@@ -1545,3 +1551,111 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
         == WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED
     )
     assert mocked_fulfillment_created[0][1] == WebhookEventAsyncType.FULFILLMENT_CREATED
+
+
+@patch(
+    "saleor.order.actions.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_fulfill_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    order_with_lines,
+    permission_group_manage_orders,
+    warehouse,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        additional_order_webhook,
+    ) = setup_order_webhooks(
+        [WebhookEventAsyncType.ORDER_UPDATED, WebhookEventAsyncType.ORDER_FULFILLED]
+    )
+    order = order_with_lines
+
+    query = ORDER_FULFILL_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    order_line1, order_line2 = order.lines.all()
+    order_line1_id = graphene.Node.to_global_id("OrderLine", order_line1.id)
+    order_line2_id = graphene.Node.to_global_id("OrderLine", order_line2.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    variables = {
+        "order": order_id,
+        "input": {
+            "notifyCustomer": True,
+            "lines": [
+                {
+                    "orderLineId": order_line2_id,
+                    "stocks": [
+                        {"quantity": order_line2.quantity, "warehouse": warehouse_id}
+                    ],
+                },
+                {
+                    "orderLineId": order_line1_id,
+                    "stocks": [
+                        {"quantity": order_line1.quantity, "warehouse": warehouse_id}
+                    ],
+                },
+            ],
+        },
+    }
+    # when
+    with django_capture_on_commit_callbacks(execute=False) as callbacks:
+        response = staff_api_client.post_graphql(query, variables)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        for callback in callbacks:
+            callback()
+
+    # then
+    assert not get_graphql_content(response)["data"]["orderFulfill"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_updated_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_UPDATED,
+    )
+    order_fulfilled_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_FULFILLED,
+    )
+    order_deliveries = [
+        order_updated_delivery,
+        order_fulfilled_delivery,
+    ]
+
+    tax_delivery = EventDelivery.objects.filter(webhook_id=tax_webhook.id).first()
+    filter_shipping_delivery = EventDelivery.objects.filter(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    ).first()
+    assert not tax_delivery
+    assert not filter_shipping_delivery
+
+    mocked_send_webhook_request_async.assert_has_calls(
+        [
+            call(
+                kwargs={"event_delivery_id": delivery.id},
+                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+                bind=True,
+                retry_backoff=10,
+                retry_kwargs={"max_retries": 5},
+            )
+            for delivery in order_deliveries
+        ],
+        any_order=True,
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -1,14 +1,18 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import graphene
 import pytest
 from django.db.models import Sum
+from django.test import override_settings
 
+from .....core.models import EventDelivery
 from .....order import OrderStatus
 from .....order import events as order_events
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent
 from .....warehouse.models import Stock
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ..utils import assert_proper_webhook_called_once
 
@@ -300,3 +304,84 @@ def test_order_line_delete_non_removable_gift(
     assert len(errors) == 1
     assert errors[0]["field"] == "id"
     assert errors[0]["code"] == OrderErrorCode.NON_REMOVABLE_GIFT_LINE.name
+
+
+@pytest.mark.parametrize(
+    ("status", "webhook_event"),
+    [
+        (OrderStatus.DRAFT, WebhookEventAsyncType.DRAFT_ORDER_UPDATED),
+        (OrderStatus.UNCONFIRMED, WebhookEventAsyncType.ORDER_UPDATED),
+    ],
+)
+@patch(
+    "saleor.graphql.order.mutations.utils.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_line_delete_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    draft_order,
+    permission_group_manage_orders,
+    staff_api_client,
+    settings,
+    django_capture_on_commit_callbacks,
+    status,
+    webhook_event,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    query = ORDER_LINE_DELETE_MUTATION
+    order = draft_order
+    order.status = status
+    order.save(update_fields=["status"])
+
+    line = order.lines.first()
+
+    line_id = graphene.Node.to_global_id("OrderLine", line.id)
+    variables = {"id": line_id}
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["orderLineDelete"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_line_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_update.py
@@ -1,17 +1,21 @@
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import graphene
 import pytest
+from django.test import override_settings
 
+from .....core.models import EventDelivery
 from .....discount import DiscountType, RewardValueType
 from .....order import OrderStatus
 from .....order import events as order_events
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent
 from .....product.models import ProductVariant
 from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.models import Allocation, Stock
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ..utils import assert_proper_webhook_called_once
 
@@ -574,3 +578,86 @@ def test_order_line_update_gift_promotion(
     assert discount.amount_value == gift_price
     assert discount.type == DiscountType.ORDER_PROMOTION
     assert discount.reason == f"Promotion: {promotion_id}"
+
+
+@pytest.mark.parametrize(
+    ("status", "webhook_event"),
+    [
+        (OrderStatus.DRAFT, WebhookEventAsyncType.DRAFT_ORDER_UPDATED),
+        (OrderStatus.UNCONFIRMED, WebhookEventAsyncType.ORDER_UPDATED),
+    ],
+)
+@patch(
+    "saleor.graphql.order.mutations.utils.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_line_update_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    order_with_lines,
+    permission_group_manage_orders,
+    staff_api_client,
+    settings,
+    django_capture_on_commit_callbacks,
+    status,
+    webhook_event,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    query = ORDER_LINE_UPDATE_MUTATION
+    order = order_with_lines
+    order.should_refresh_prices = True
+    order.status = status
+    order.save(update_fields=["status", "should_refresh_prices"])
+    first_line, second_line = order.lines.all()
+    new_quantity = 5
+
+    first_line_id = graphene.Node.to_global_id("OrderLine", first_line.id)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    variables = {"lineId": first_line_id, "quantity": new_quantity}
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["orderLineUpdate"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_note_add.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_add.py
@@ -1,12 +1,16 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import graphene
 import pytest
+from django.test import override_settings
 
 from .....account.models import CustomerEvent
+from .....core.models import EventDelivery
 from .....order import OrderStatus
 from .....order import events as order_events
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderNoteAddErrorCode
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ORDER_NOTE_ADD_MUTATION = """
@@ -170,3 +174,82 @@ def test_order_note_add_fail_on_missing_permission(staff_api_client, order):
 
     # then
     assert_no_permission(response)
+
+
+@pytest.mark.parametrize(
+    ("status", "webhook_event"),
+    [
+        (OrderStatus.DRAFT, WebhookEventAsyncType.DRAFT_ORDER_UPDATED),
+        (OrderStatus.UNCONFIRMED, WebhookEventAsyncType.ORDER_UPDATED),
+    ],
+)
+@patch(
+    "saleor.graphql.order.mutations.utils.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_note_add_user_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+    status,
+    webhook_event,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = order_with_lines
+    order.should_refresh_prices = True
+    order.status = status
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    message = "new note"
+    variables = {"id": order_id, "message": message}
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(ORDER_NOTE_ADD_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["orderNoteAdd"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_note_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_update.py
@@ -1,12 +1,16 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import graphene
 import pytest
+from django.test import override_settings
 
 from .....account.models import CustomerEvent
+from .....core.models import EventDelivery
 from .....order import OrderEvents, OrderStatus
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderNoteUpdateErrorCode
 from .....order.models import OrderEvent
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ORDER_NOTE_UPDATE_MUTATION = """
@@ -202,3 +206,94 @@ def test_order_note_remove_fail_on_missing_permission(staff_api_client, order):
 
     # then
     assert_no_permission(response)
+
+
+@pytest.mark.parametrize(
+    ("status", "webhook_event"),
+    [
+        (OrderStatus.DRAFT, WebhookEventAsyncType.DRAFT_ORDER_UPDATED),
+        (OrderStatus.UNCONFIRMED, WebhookEventAsyncType.ORDER_UPDATED),
+    ],
+)
+@patch(
+    "saleor.graphql.order.mutations.utils.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_note_update_user_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    staff_user,
+    settings,
+    django_capture_on_commit_callbacks,
+    status,
+    webhook_event,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    order = order_with_lines
+    order.should_refresh_prices = True
+    order.status = status
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    parameters = {"message": "a note"}
+    note = OrderEvent.objects.create(
+        order=order,
+        type=OrderEvents.NOTE_ADDED,
+        user=staff_user,
+        parameters=parameters,
+    )
+    note_id = graphene.Node.to_global_id("OrderEvent", note.pk)
+
+    message = "new note"
+    variables = {"id": note_id, "message": message}
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            ORDER_NOTE_UPDATE_MUTATION,
+            variables,
+            permissions=[permission_manage_orders],
+        )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["orderNoteUpdate"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update.py
@@ -1,10 +1,14 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import graphene
+from django.test import override_settings
 
+from .....core.models import EventDelivery
 from .....order import OrderStatus
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....product.models import ProductVariant
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ORDER_UPDATE_MUTATION = """
@@ -510,3 +514,75 @@ def test_order_update_invalid_address_skip_validation(
     assert order.shipping_address.validation_skipped is True
     assert order.billing_address.postal_code == invalid_postal_code
     assert order.billing_address.validation_skipped is True
+
+
+@patch(
+    "saleor.graphql.order.mutations.order_update.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_update_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    graphql_address_data,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(WebhookEventAsyncType.ORDER_UPDATED)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.save()
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    variables = {
+        "id": order_id,
+        "address": graphql_address_data,
+    }
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(ORDER_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["orderUpdate"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -1,12 +1,17 @@
 from decimal import Decimal
+from unittest.mock import call, patch
 
 import graphene
 import pytest
+from django.test import override_settings
 from prices import TaxedMoney
 
+from .....core.models import EventDelivery
 from .....core.taxes import zero_money, zero_taxed_money
 from .....order import OrderStatus
+from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ORDER_UPDATE_SHIPPING_QUERY = """
@@ -533,3 +538,84 @@ def test_order_shipping_update_mutation_properly_recalculate_total(
     content = get_graphql_content(response)
     data = content["data"]["orderUpdateShipping"]
     assert data["order"]["shippingMethod"] is None
+
+
+@patch(
+    "saleor.graphql.order.mutations.order_update_shipping.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_order_update_shipping_triggers_webhooks(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    shipping_method,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(WebhookEventAsyncType.ORDER_UPDATED)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = order_with_lines
+    order.base_shipping_price = zero_money(order.currency)
+    order.status = OrderStatus.UNCONFIRMED
+    order.save()
+
+    query = ORDER_UPDATE_SHIPPING_QUERY
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+    variables = {"order": order_id, "shippingMethod": method_id}
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["orderUpdateShipping"]["errors"]
+
+    # confirm that event delivery was generated for each webhook.
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_deliveries = EventDelivery.objects.filter(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    ).order_by("pk")
+    assert len(filter_shipping_deliveries) == 2
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            # FIXME: This is the issue with current way of caching filter shipping
+            #  webhooks. Mutation calls the webhook to validates the shipping methods.
+            #  WebhookPlugin makes a cache based on the order payload. Then when
+            #  tax-webhook exists, we can get different price values, which will
+            #  change the data used to build the cache key. This should be solved
+            #  after providing similar way of handling sync webhooks as we have for
+            #  tax webhooks.
+            call(filter_shipping_deliveries[0], timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+            call(tax_delivery),
+            call(filter_shipping_deliveries[1], timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -3,9 +3,10 @@ from collections import defaultdict
 from collections.abc import Iterable
 from copy import deepcopy
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, Callable, Optional, TypedDict
 from uuid import UUID
 
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import transaction
 
@@ -13,7 +14,11 @@ from ..account.models import User
 from ..core.exceptions import AllocationError, InsufficientStock, InsufficientStockData
 from ..core.tracing import traced_atomic_transaction
 from ..core.transactions import transaction_with_commit_on_errors
-from ..core.utils.events import call_event
+from ..core.utils.events import (
+    call_event,
+    call_event_including_protected_events,
+    webhook_async_event_requires_sync_webhooks_to_trigger,
+)
 from ..giftcard import GiftCardLineData
 from ..payment import (
     ChargeStatus,
@@ -26,6 +31,7 @@ from ..payment import (
 from ..payment.interface import RefundData
 from ..payment.models import Payment, Transaction, TransactionItem
 from ..payment.utils import create_payment, create_transaction_for_order
+from ..shipping.models import ShippingMethodChannelListing
 from ..warehouse.management import (
     deallocate_stock,
     deallocate_stock_for_order,
@@ -33,7 +39,10 @@ from ..warehouse.management import (
     get_order_lines_with_track_inventory,
 )
 from ..warehouse.models import Stock
+from ..webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ..webhook.utils import get_webhooks_for_multiple_events
 from . import (
+    ORDER_EDITABLE_STATUS,
     FulfillmentLineData,
     FulfillmentStatus,
     OrderChargeStatus,
@@ -42,6 +51,7 @@ from . import (
     events,
     utils,
 )
+from .calculations import fetch_order_prices_if_expired
 from .events import (
     draft_order_created_from_replace_event,
     fulfillment_refunded_event,
@@ -59,6 +69,7 @@ from .notifications import (
     send_payment_confirmation,
 )
 from .utils import (
+    get_valid_shipping_methods_for_order,
     order_line_needs_automatic_fulfillment,
     restock_fulfillment_lines,
     update_order_authorize_data,
@@ -72,6 +83,7 @@ if TYPE_CHECKING:
     from ..plugins.manager import PluginsManager
     from ..site.models import SiteSettings
     from ..warehouse.models import Warehouse
+    from ..webhook.models import Webhook
     from .fetch import OrderInfo
 
 logger = logging.getLogger(__name__)
@@ -87,6 +99,98 @@ class OrderFulfillmentLineInfo(TypedDict):
     quantity: int
 
 
+WEBHOOK_EVENTS_FOR_ORDER_FULFILLED = {
+    WebhookEventAsyncType.ORDER_FULFILLED,
+    WebhookEventAsyncType.ORDER_UPDATED,
+    *WebhookEventSyncType.ORDER_EVENTS,
+}
+
+WEBHOOK_EVENTS_FOR_ORDER_REFUNDED = {
+    WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
+    WebhookEventAsyncType.ORDER_REFUNDED,
+    WebhookEventAsyncType.ORDER_UPDATED,
+    *WebhookEventSyncType.ORDER_EVENTS,
+}
+WEBHOOK_EVENTS_FOR_ORDER_CANCELED = {
+    WebhookEventAsyncType.ORDER_CANCELLED,
+    WebhookEventAsyncType.ORDER_UPDATED,
+    *WebhookEventSyncType.ORDER_EVENTS,
+}
+WEBHOOK_EVENTS_FOR_FULLY_PAID = {
+    WebhookEventAsyncType.ORDER_UPDATED,
+    WebhookEventAsyncType.ORDER_FULLY_PAID,
+    *WebhookEventSyncType.ORDER_EVENTS,
+}
+WEBHOOK_EVENTS_FOR_ORDER_AUTHORIZED = {
+    WebhookEventAsyncType.ORDER_UPDATED,
+    *WebhookEventSyncType.ORDER_EVENTS,
+}
+
+WEBHOOK_EVENTS_FOR_ORDER_CHARGED = {
+    WebhookEventAsyncType.ORDER_PAID,
+}.union(WEBHOOK_EVENTS_FOR_FULLY_PAID)
+
+WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED = {
+    WebhookEventAsyncType.ORDER_CONFIRMED,
+    *WebhookEventSyncType.ORDER_EVENTS,
+}
+
+
+WEBHOOK_EVENTS_FOR_ORDER_CREATED = {
+    WebhookEventAsyncType.ORDER_CREATED,
+}.union(WEBHOOK_EVENTS_FOR_ORDER_CHARGED).union(WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED)
+
+
+def call_order_event(
+    manager: "PluginsManager",
+    event_func: Callable,
+    event_name: str,
+    order: "Order",
+    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    webhook_event_map: Optional[dict[str, set["Webhook"]]] = None,
+    **event_kwargs,
+):
+    if order.status not in ORDER_EDITABLE_STATUS:
+        call_event_including_protected_events(event_func, order, **event_kwargs)
+        return
+    if event_name == WebhookEventAsyncType.DRAFT_ORDER_DELETED:
+        call_event_including_protected_events(event_func, order, **event_kwargs)
+        return
+
+    if webhook_event_map is None:
+        webhook_event_map = get_webhooks_for_multiple_events(
+            [event_name, *WebhookEventSyncType.ORDER_EVENTS]
+        )
+    if not webhook_async_event_requires_sync_webhooks_to_trigger(
+        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
+    ):
+        call_event_including_protected_events(event_func, order, **event_kwargs)
+        return
+
+    if (
+        webhook_event_map.get(WebhookEventSyncType.ORDER_CALCULATE_TAXES)
+        and order.should_refresh_prices
+    ):
+        fetch_order_prices_if_expired(
+            order,
+            manager,
+            database_connection_name=database_connection_name,
+        )
+    if webhook_event_map.get(WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS):
+        shipping_listings = ShippingMethodChannelListing.objects.filter(
+            channel_id=order.channel_id
+        )
+        get_valid_shipping_methods_for_order(
+            order,
+            shipping_listings,
+            manager,
+            database_connection_name=database_connection_name,
+        )
+
+    call_event_including_protected_events(event_func, order, **event_kwargs)
+    return
+
+
 def order_created(
     order_info: "OrderInfo",
     user: Optional[User],
@@ -97,7 +201,18 @@ def order_created(
 ):
     order = order_info.order
     events.order_created_event(order=order, user=user, app=app, from_draft=from_draft)
-    call_event(manager.order_created, order)
+
+    webhook_event_map = get_webhooks_for_multiple_events(
+        WEBHOOK_EVENTS_FOR_ORDER_CREATED
+    )
+
+    call_order_event(
+        manager,
+        manager.order_created,
+        WebhookEventAsyncType.ORDER_CREATED,
+        order,
+        webhook_event_map=webhook_event_map,
+    )
     payment = order_info.payment
     if payment and order.is_pre_authorized():
         order_authorized(
@@ -107,6 +222,7 @@ def order_created(
             amount=payment.total,
             payment=payment,
             manager=manager,
+            webhook_event_map=webhook_event_map,
         )
     if order.charge_status in [OrderChargeStatus.FULL, OrderChargeStatus.OVERCHARGED]:
         order_charged(
@@ -118,11 +234,12 @@ def order_created(
             manager=manager,
             site_settings=site_settings,
             gateway=payment.gateway if payment else None,
+            webhook_event_map=webhook_event_map,
         )
 
     channel = order_info.channel
     if channel.automatically_confirm_all_new_orders:
-        order_confirmed(order, user, app, manager)
+        order_confirmed(order, user, app, manager, webhook_event_map=webhook_event_map)
 
 
 def order_confirmed(
@@ -131,13 +248,20 @@ def order_confirmed(
     app: Optional["App"],
     manager: "PluginsManager",
     send_confirmation_email: bool = False,
+    webhook_event_map: Optional[dict[str, set["Webhook"]]] = None,
 ):
     """Order confirmed.
 
     Trigger event, plugin hooks and optionally confirmation email.
     """
     events.order_confirmed_event(order=order, user=user, app=app)
-    call_event(manager.order_confirmed, order)
+    call_order_event(
+        manager,
+        manager.order_confirmed,
+        WebhookEventAsyncType.ORDER_CONFIRMED,
+        order,
+        webhook_event_map=webhook_event_map,
+    )
     if send_confirmation_email:
         send_order_confirmed(order, user, app, manager)
 
@@ -145,6 +269,7 @@ def order_confirmed(
 def handle_fully_paid_order(
     manager: "PluginsManager",
     order_info: "OrderInfo",
+    webhook_event_map: dict[str, set["Webhook"]],
     user: Optional[User] = None,
     app: Optional["App"] = None,
     site_settings: Optional["SiteSettings"] = None,
@@ -168,11 +293,23 @@ def handle_fully_paid_order(
             order, order_lines, site_settings, user, app, manager
         )
 
-    call_event(manager.order_fully_paid, order)
     if not order.is_draft() and order.channel.automatically_confirm_all_new_orders:
         update_order_status(order)
 
-    call_event(manager.order_updated, order)
+    call_order_event(
+        manager,
+        manager.order_fully_paid,
+        WebhookEventAsyncType.ORDER_FULLY_PAID,
+        order,
+        webhook_event_map=webhook_event_map,
+    )
+    call_order_event(
+        manager,
+        manager.order_updated,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        order,
+        webhook_event_map=webhook_event_map,
+    )
 
 
 def cancel_order(
@@ -180,8 +317,7 @@ def cancel_order(
     user: Optional[User],
     app: Optional["App"],
     manager: "PluginsManager",
-    webhooks_cancelled=None,
-    webhooks_updated=None,
+    webhook_event_map: Optional[dict[str, set["Webhook"]]] = None,
 ):
     """Cancel order.
 
@@ -193,9 +329,28 @@ def cancel_order(
         deallocate_stock_for_order(order, manager)
         order.status = OrderStatus.CANCELED
         order.save(update_fields=["status", "updated_at"])
-
-        call_event(manager.order_cancelled, order, webhooks=webhooks_cancelled)
-        call_event(manager.order_updated, order, webhooks=webhooks_updated)
+        if not webhook_event_map:
+            webhook_event_map = get_webhooks_for_multiple_events(
+                WEBHOOK_EVENTS_FOR_ORDER_CANCELED
+            )
+        call_order_event(
+            manager,
+            manager.order_cancelled,
+            WebhookEventAsyncType.ORDER_CANCELLED,
+            order,
+            webhook_event_map=webhook_event_map,
+            webhooks=webhook_event_map.get(
+                WebhookEventAsyncType.ORDER_CANCELLED, set()
+            ),
+        )
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
+            webhooks=webhook_event_map.get(WebhookEventAsyncType.ORDER_UPDATED, set()),
+        )
 
         call_event(send_order_canceled_confirmation, order, user, app, manager)
 
@@ -208,6 +363,7 @@ def order_refunded(
     payment: Optional["Payment"],
     manager: "PluginsManager",
     trigger_order_updated: bool = True,
+    webhook_event_map: Optional[dict[str, set["Webhook"]]] = None,
 ):
     if payment:
         call_event(
@@ -228,10 +384,26 @@ def order_refunded(
         order.currency,
         manager,
     )
+    if webhook_event_map is None:
+        webhook_event_map = get_webhooks_for_multiple_events(
+            WEBHOOK_EVENTS_FOR_ORDER_REFUNDED
+        )
 
-    call_event(manager.order_refunded, order)
+    call_order_event(
+        manager,
+        manager.order_refunded,
+        WebhookEventAsyncType.ORDER_REFUNDED,
+        order,
+        webhook_event_map=webhook_event_map,
+    )
     if trigger_order_updated:
-        call_event(manager.order_updated, order)
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
 
     total_refunded = Decimal(0)
     last_payment = payment if payment else order.get_last_payment()
@@ -252,7 +424,13 @@ def order_refunded(
     )
 
     if total_refunded >= order.total.gross.amount:
-        call_event(manager.order_fully_refunded, order)
+        call_order_event(
+            manager,
+            manager.order_fully_refunded,
+            WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
 
 
 def order_voided(
@@ -263,7 +441,9 @@ def order_voided(
     manager: "PluginsManager",
 ):
     events.payment_voided_event(order=order, user=user, app=app, payment=payment)
-    call_event(manager.order_updated, order)
+    call_order_event(
+        manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
+    )
 
 
 def order_returned(
@@ -285,9 +465,14 @@ def order_fulfilled(
     gift_card_lines_info: list[GiftCardLineData],
     site_settings: "SiteSettings",
     notify_customer=True,
+    webhook_event_map: Optional[dict[str, set["Webhook"]]] = None,
 ):
     from ..giftcard.utils import gift_cards_create
 
+    if webhook_event_map is None:
+        webhook_event_map = get_webhooks_for_multiple_events(
+            WEBHOOK_EVENTS_FOR_ORDER_FULFILLED
+        )
     order = fulfillments[0].order
     # transaction ensures webhooks are triggered only when order status and fulfillment
     # events are successfully created
@@ -304,12 +489,24 @@ def order_fulfilled(
         events.fulfillment_fulfilled_items_event(
             order=order, user=user, app=app, fulfillment_lines=fulfillment_lines
         )
-        call_event(manager.order_updated, order)
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
         for fulfillment in fulfillments:
             call_event(manager.fulfillment_created, fulfillment, notify_customer)
 
         if order.status == OrderStatus.FULFILLED:
-            call_event(manager.order_fulfilled, order)
+            call_order_event(
+                manager,
+                manager.order_fulfilled,
+                WebhookEventAsyncType.ORDER_FULFILLED,
+                order,
+                webhook_event_map=webhook_event_map,
+            )
             for fulfillment in fulfillments:
                 call_event(manager.fulfillment_approved, fulfillment)
 
@@ -326,15 +523,14 @@ def order_awaits_fulfillment_approval(
     app: Optional["App"],
     fulfillment_lines: list[FulfillmentLine],
     manager: "PluginsManager",
-    _gift_card_lines: list["GiftCardLineData"],
-    _site_settings: "SiteSettings",
-    _notify_customer=True,
 ):
     order = fulfillments[0].order
     events.fulfillment_awaits_approval_event(
         order=order, user=user, app=app, fulfillment_lines=fulfillment_lines
     )
-    call_event(manager.order_updated, order)
+    call_order_event(
+        manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
+    )
 
 
 def order_authorized(
@@ -344,11 +540,18 @@ def order_authorized(
     amount: "Decimal",
     payment: "Payment",
     manager: "PluginsManager",
+    webhook_event_map: Optional[dict[str, set["Webhook"]]] = None,
 ):
     events.payment_authorized_event(
         order=order, user=user, app=app, amount=amount, payment=payment
     )
-    call_event(manager.order_updated, order)
+    call_order_event(
+        manager,
+        manager.order_updated,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        order,
+        webhook_event_map=webhook_event_map,
+    )
 
 
 def order_charged(
@@ -360,17 +563,43 @@ def order_charged(
     manager: "PluginsManager",
     site_settings: Optional["SiteSettings"] = None,
     gateway: Optional[str] = None,
+    webhook_event_map: Optional[dict[str, set["Webhook"]]] = None,
 ):
     order = order_info.order
     if payment and amount is not None:
         events.payment_captured_event(
             order=order, user=user, app=app, amount=amount, payment=payment
         )
-    call_event(manager.order_paid, order)
+    if webhook_event_map is None:
+        webhook_event_map = get_webhooks_for_multiple_events(
+            WEBHOOK_EVENTS_FOR_ORDER_CHARGED
+        )
+
+    call_order_event(
+        manager,
+        manager.order_paid,
+        WebhookEventAsyncType.ORDER_PAID,
+        order,
+        webhook_event_map=webhook_event_map,
+    )
     if order.charge_status in [OrderChargeStatus.FULL, OrderChargeStatus.OVERCHARGED]:
-        handle_fully_paid_order(manager, order_info, user, app, site_settings, gateway)
+        handle_fully_paid_order(
+            manager,
+            order_info,
+            user=user,
+            app=app,
+            site_settings=site_settings,
+            gateway=gateway,
+            webhook_event_map=webhook_event_map,
+        )
     else:
-        call_event(manager.order_updated, order)
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
 
 
 def order_transaction_updated(
@@ -385,11 +614,37 @@ def order_transaction_updated(
     site_settings: Optional["SiteSettings"] = None,
 ):
     order_updated = False
+    order_charged_to_call = False
+    order_refunded_to_call = False
+    webhook_events = set()
     if transaction_item.authorized_value != previous_authorized_value:
+        webhook_events = {
+            WebhookEventAsyncType.ORDER_UPDATED,
+            *WebhookEventSyncType.ORDER_EVENTS,
+        }
         order_updated = True
+
     if transaction_item.charged_value > previous_charged_value:
         # order_updated False as order_charged triggers order_updated
         order_updated = False
+        order_charged_to_call = True
+        webhook_events = webhook_events.union(WEBHOOK_EVENTS_FOR_ORDER_CHARGED)
+
+    elif transaction_item.charged_value != previous_charged_value:
+        order_updated = True
+        webhook_events.add(WebhookEventAsyncType.ORDER_UPDATED)
+        webhook_events = webhook_events.union(WebhookEventSyncType.ORDER_EVENTS)
+
+    if transaction_item.refunded_value > previous_refunded_value:
+        # order_updated False as order_refunded triggers order_updated
+        order_updated = False
+        order_refunded_to_call = True
+        webhook_events = webhook_events.union(WEBHOOK_EVENTS_FOR_ORDER_REFUNDED)
+
+    webhook_event_map = (
+        get_webhooks_for_multiple_events(webhook_events) if webhook_events else None
+    )
+    if order_charged_to_call:
         order_charged(
             order_info,
             user,
@@ -398,13 +653,9 @@ def order_transaction_updated(
             payment=order_info.payment,
             site_settings=site_settings,
             manager=manager,
+            webhook_event_map=webhook_event_map,
         )
-    elif transaction_item.charged_value != previous_charged_value:
-        order_updated = True
-
-    if transaction_item.refunded_value > previous_refunded_value:
-        # order_updated False as order_refunded triggers order_updated
-        order_updated = False
+    if order_refunded_to_call:
         order_refunded(
             order=order_info.order,
             user=user,
@@ -412,10 +663,16 @@ def order_transaction_updated(
             amount=transaction_item.refunded_value - previous_refunded_value,
             payment=None,
             manager=manager,
+            webhook_event_map=webhook_event_map,
         )
-
     if order_updated:
-        call_event(manager.order_updated, order_info.order)
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order_info.order,
+            webhook_event_map=webhook_event_map,
+        )
 
 
 def fulfillment_tracking_updated(
@@ -433,7 +690,12 @@ def fulfillment_tracking_updated(
         fulfillment=fulfillment,
     )
     call_event(manager.tracking_number_updated, fulfillment)
-    call_event(manager.order_updated, fulfillment.order)
+    call_order_event(
+        manager,
+        manager.order_updated,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        fulfillment.order,
+    )
 
 
 def cancel_fulfillment(
@@ -465,7 +727,12 @@ def cancel_fulfillment(
         fulfillment.save(update_fields=["status"])
         update_order_status(fulfillment.order)
         call_event(manager.fulfillment_canceled, fulfillment)
-        call_event(manager.order_updated, fulfillment.order)
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            fulfillment.order,
+        )
     return fulfillment
 
 
@@ -494,7 +761,12 @@ def cancel_waiting_fulfillment(
         fulfillment.delete()
         update_order_status(fulfillment.order)
         call_event(manager.fulfillment_canceled, fulfillment)
-        call_event(manager.order_updated, fulfillment.order)
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            fulfillment.order,
+        )
 
 
 def approve_fulfillment(
@@ -571,10 +843,25 @@ def approve_fulfillment(
         order.refresh_from_db()
         update_order_status(order)
 
-        call_event(manager.order_updated, order)
+        webhook_event_map = get_webhooks_for_multiple_events(
+            WEBHOOK_EVENTS_FOR_ORDER_FULFILLED
+        )
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
         call_event(manager.fulfillment_approved, fulfillment, notify_customer)
         if order.status == OrderStatus.FULFILLED:
-            call_event(manager.order_fulfilled, order)
+            call_order_event(
+                manager,
+                manager.order_fulfilled,
+                WebhookEventAsyncType.ORDER_FULFILLED,
+                order,
+                webhook_event_map=webhook_event_map,
+            )
 
         if gift_card_lines_info:
             gift_cards_create(
@@ -617,8 +904,15 @@ def mark_order_as_paid_with_transaction(
             app=app,
             transaction_reference=external_reference,
         )
-        call_event(manager.order_fully_paid, order)
-        call_event(manager.order_updated, order)
+        call_order_event(
+            manager,
+            manager.order_fully_paid,
+            WebhookEventAsyncType.ORDER_FULLY_PAID,
+            order,
+        )
+        call_order_event(
+            manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
+        )
 
 
 def mark_order_as_paid_with_payment(
@@ -666,14 +960,28 @@ def mark_order_as_paid_with_payment(
             transaction_reference=external_reference,
         )
 
-        call_event(manager.order_fully_paid, order)
-        call_event(manager.order_updated, order)
-
         update_order_charge_data(
             order,
         )
         update_order_authorize_data(
             order,
+        )
+        webhook_event_map = get_webhooks_for_multiple_events(
+            WEBHOOK_EVENTS_FOR_FULLY_PAID
+        )
+        call_order_event(
+            manager,
+            manager.order_fully_paid,
+            WebhookEventAsyncType.ORDER_FULLY_PAID,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
         )
 
 
@@ -979,22 +1287,29 @@ def create_fulfillments(
 
         FulfillmentLine.objects.bulk_create(fulfillment_lines)
         order.refresh_from_db()
-        post_creation_func = (
-            order_fulfilled if approved else order_awaits_fulfillment_approval
-        )
-        transaction.on_commit(
-            lambda: post_creation_func(
-                fulfillments,
-                user,
-                app,
-                fulfillment_lines,
-                manager,
-                gift_card_lines_info,
-                site_settings,
-                notify_customer,
+        if approved:
+            transaction.on_commit(
+                lambda: order_fulfilled(
+                    fulfillments,
+                    user,
+                    app,
+                    fulfillment_lines,
+                    manager,
+                    gift_card_lines_info,
+                    site_settings,
+                    notify_customer,
+                )
             )
-        )
-
+        else:
+            transaction.on_commit(
+                lambda: order_awaits_fulfillment_approval(
+                    fulfillments,
+                    user,
+                    app,
+                    fulfillment_lines,
+                    manager,
+                )
+            )
     return fulfillments
 
 
@@ -1219,7 +1534,9 @@ def create_refund_fulfillment(
                 FulfillmentStatus.WAITING_FOR_APPROVAL,
             ],
         ).delete()
-        call_event(manager.order_updated, order)
+        call_order_event(
+            manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
+        )
 
     return refunded_fulfillment
 
@@ -1583,7 +1900,9 @@ def create_fulfillments_for_returned_products(
             ],
         ).delete()
 
-        call_event(manager.order_updated, order)
+        call_order_event(
+            manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
+        )
     return return_fulfillment, replace_fulfillment, new_order
 
 

--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -13,7 +13,7 @@ from ..discount.models import Voucher, VoucherCode, VoucherCustomer
 from ..payment.models import Payment, TransactionItem
 from ..plugins.manager import get_plugins_manager
 from ..warehouse.management import deallocate_stock_for_orders
-from ..webhook.event_types import WebhookEventAsyncType
+from ..webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..webhook.utils import get_webhooks_for_multiple_events
 from . import OrderEvents, OrderStatus
 from .actions import call_order_event
@@ -43,8 +43,20 @@ def recalculate_orders_task(order_ids: list[int]):
 @app.task
 def send_order_updated(order_ids):
     manager = get_plugins_manager(allow_replica=True)
+    webhook_event_map = get_webhooks_for_multiple_events(
+        [
+            WebhookEventAsyncType.ORDER_UPDATED,
+            *WebhookEventSyncType.ORDER_EVENTS,
+        ]
+    )
     for order in Order.objects.filter(id__in=order_ids):
-        manager.order_updated(order)
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
 
 
 def _bulk_release_voucher_usage(order_ids):
@@ -93,6 +105,7 @@ def _call_expired_order_events(order_ids, manager):
         [
             WebhookEventAsyncType.ORDER_EXPIRED,
             WebhookEventAsyncType.ORDER_UPDATED,
+            # *WebhookEventSyncType.ORDER_EVENTS,
         ]
     )
     for order in orders:

--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -9,14 +9,14 @@ from django.utils import timezone
 from ..celeryconf import app
 from ..channel.models import Channel
 from ..core.tracing import traced_atomic_transaction
-from ..core.utils.events import call_event
 from ..discount.models import Voucher, VoucherCode, VoucherCustomer
 from ..payment.models import Payment, TransactionItem
 from ..plugins.manager import get_plugins_manager
 from ..warehouse.management import deallocate_stock_for_orders
 from ..webhook.event_types import WebhookEventAsyncType
-from ..webhook.utils import get_webhooks_for_event
+from ..webhook.utils import get_webhooks_for_multiple_events
 from . import OrderEvents, OrderStatus
+from .actions import call_order_event
 from .models import Order, OrderEvent
 from .utils import invalidate_order_prices
 
@@ -89,11 +89,27 @@ def _call_expired_order_events(order_ids, manager):
         .filter(id__in=order_ids)
         .select_related("channel")
     )
-    webhooks_order_expired = get_webhooks_for_event(WebhookEventAsyncType.ORDER_EXPIRED)
-    webhooks_order_updated = get_webhooks_for_event(WebhookEventAsyncType.ORDER_UPDATED)
+    webhook_event_map = get_webhooks_for_multiple_events(
+        [
+            WebhookEventAsyncType.ORDER_EXPIRED,
+            WebhookEventAsyncType.ORDER_UPDATED,
+        ]
+    )
     for order in orders:
-        call_event(manager.order_expired, order, webhooks=webhooks_order_expired)
-        call_event(manager.order_updated, order, webhooks=webhooks_order_updated)
+        call_order_event(
+            manager,
+            manager.order_expired,
+            WebhookEventAsyncType.ORDER_EXPIRED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
+        call_order_event(
+            manager,
+            manager.order_updated,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            order,
+            webhook_event_map=webhook_event_map,
+        )
 
 
 def _order_expired_events(order_ids):

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -1,20 +1,25 @@
 import logging
 from datetime import timedelta
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
+from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
+from ...core.models import EventDelivery
 from ...discount.models import VoucherCustomer
 from ...warehouse.models import Allocation
+from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .. import OrderEvents, OrderStatus
+from ..actions import call_order_event
 from ..models import Order, OrderEvent, get_order_number
 from ..tasks import (
     _bulk_release_voucher_usage,
     delete_expired_orders_task,
     expire_orders_task,
+    send_order_updated,
 )
 
 
@@ -683,3 +688,76 @@ def test_bulk_release_voucher_usage_voucher_usage_mismatch(
     code.refresh_from_db()
     assert code.used == 0
     assert code.code in caplog.text
+
+
+@patch(
+    "saleor.order.tasks.call_order_event",
+    wraps=call_order_event,
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_send_order_updated(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    wrapped_call_order_event,
+    setup_order_webhooks,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        additional_order_webhook,
+    ) = setup_order_webhooks(
+        [
+            WebhookEventAsyncType.ORDER_UPDATED,
+            WebhookEventAsyncType.ORDER_FULLY_PAID,
+        ]
+    )
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(
+        update_fields=[
+            "status",
+            "should_refresh_prices",
+        ]
+    )
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        send_order_updated([order.pk])
+
+    # then
+    # confirm that event delivery was generated for each webhook.
+    order_updated_delivery = EventDelivery.objects.get(
+        webhook_id=additional_order_webhook.id,
+        event_type=WebhookEventAsyncType.ORDER_UPDATED,
+    )
+
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_updated_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    assert wrapped_call_order_event.called

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from decimal import Decimal
 from functools import partial
 from io import BytesIO
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 from unittest.mock import MagicMock
 
 import graphene
@@ -9550,6 +9550,191 @@ def setup_checkout_webhooks(
         return (
             tax_webhook,
             shipping_webhook,
+            shipping_filter_webhook,
+            additional_webhook,
+        )
+
+    return _setup
+
+
+@pytest.fixture
+def setup_order_webhooks(
+    permission_handle_taxes,
+    permission_manage_shipping,
+    permission_manage_orders,
+):
+    subscription_async_webhooks = """
+    fragment OrderFragment on Order {
+      shippingPrice {
+        gross {
+          amount
+        }
+      }
+      total {
+        gross {
+          amount
+        }
+      }
+    }
+
+    subscription {
+      event {
+        ... on OrderCreated {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderUpdated {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderPaid {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderExpired {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderRefunded {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderConfirmed {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderFullyPaid {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderFulfilled {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderCancelled {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderBulkCreated {
+          orders {
+            ...OrderFragment
+          }
+        }
+        ... on OrderFullyRefunded {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on OrderMetadataUpdated {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on DraftOrderCreated {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on DraftOrderUpdated {
+          order {
+            ...OrderFragment
+          }
+        }
+        ... on DraftOrderDeleted {
+          order {
+            ...OrderFragment
+          }
+        }
+      }
+    }
+    """
+
+    def _setup(additional_order_event: Union[str, list[str]]):
+        tax_app, shipping_app, additional_app = App.objects.bulk_create(
+            [
+                App(
+                    name="Sample tax app",
+                    is_active=True,
+                    identifier="saleor.app.tax",
+                ),
+                App(
+                    name="Sample shipping app",
+                    is_active=True,
+                    identifier="saleor.app.shipping",
+                ),
+                App(
+                    name="Sample async webhook app",
+                    is_active=True,
+                    identifier="saleor.app.additional",
+                ),
+            ]
+        )
+        tax_app.permissions.add(permission_handle_taxes)
+        shipping_app.permissions.set(
+            [permission_manage_shipping, permission_manage_orders]
+        )
+        additional_app.permissions.add(permission_manage_orders)
+        (
+            tax_webhook,
+            shipping_filter_webhook,
+            additional_webhook,
+        ) = Webhook.objects.bulk_create(
+            [
+                Webhook(
+                    name="Tax webhook",
+                    app=tax_app,
+                    target_url="http://127.0.0.1/test",
+                    subscription_query="subscription{ event{ ...on CalculateTaxes{ __typename } } }",
+                ),
+                Webhook(
+                    name="Shipping webhook",
+                    app=shipping_app,
+                    target_url="http://127.0.0.1/test",
+                    subscription_query="subscription { event { ... on OrderFilterShippingMethods { __typename } } }",
+                ),
+                Webhook(
+                    name="Checkout additional webhook",
+                    app=additional_app,
+                    target_url="http://127.0.0.1/test",
+                    subscription_query=subscription_async_webhooks,
+                ),
+            ]
+        )
+        if isinstance(additional_order_event, str):
+            additional_order_event = [
+                additional_order_event,
+            ]
+        additional_events = [
+            WebhookEvent(
+                event_type=event,
+                webhook_id=additional_webhook.id,
+            )
+            for event in additional_order_event
+        ]
+        WebhookEvent.objects.bulk_create(
+            [
+                WebhookEvent(
+                    event_type=WebhookEventSyncType.ORDER_CALCULATE_TAXES,
+                    webhook_id=tax_webhook.id,
+                ),
+                WebhookEvent(
+                    event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+                    webhook_id=shipping_filter_webhook.id,
+                ),
+            ]
+            + additional_events
+        )
+        return (
+            tax_webhook,
             shipping_filter_webhook,
             additional_webhook,
         )

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -936,6 +936,7 @@ class WebhookEventSyncType:
         CHECKOUT_FILTER_SHIPPING_METHODS,
         CHECKOUT_CALCULATE_TAXES,
     ]
+    ORDER_EVENTS = [ORDER_CALCULATE_TAXES, ORDER_FILTER_SHIPPING_METHODS]
 
     # Events that are used only in the mutation logic can be excluded from the
     # circular query check.

--- a/saleor/webhook/tests/test_utils.py
+++ b/saleor/webhook/tests/test_utils.py
@@ -197,7 +197,9 @@ def test_get_webhooks_for_multiple_events(
     )
 
     # then
-    assert webhook_map == {
+    assert dict(webhook_map) == {
+        WebhookEventAsyncType.ANY: set(),
+        WebhookEventAsyncType.ORDER_CREATED: set(),
         WebhookEventAsyncType.CHECKOUT_CREATED: {checkout_created_webhook},
         WebhookEventAsyncType.ATTRIBUTE_CREATED: {
             attribute_created_webhook,

--- a/saleor/webhook/transport/shipping.py
+++ b/saleor/webhook/transport/shipping.py
@@ -18,9 +18,7 @@ from ...settings import WEBHOOK_SYNC_TIMEOUT
 from ...shipping.interface import ShippingMethodData
 from ...webhook.utils import get_webhooks_for_event
 from ..const import APP_ID_PREFIX, CACHE_EXCLUDED_SHIPPING_TIME
-from .synchronous.transport import (
-    trigger_webhook_sync_if_not_cached,
-)
+from .synchronous.transport import trigger_webhook_sync_if_not_cached
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +108,7 @@ def get_cache_data_for_exclude_shipping_methods(payload: str) -> dict:
     # drop fields that change between requests but are not relevant for cache key
     source_object.pop("last_change", None)
     source_object.pop("meta", None)
+    source_object.pop("shipping_method", None)
     return payload_dict
 
 


### PR DESCRIPTION
I want to merge this change because it should solve the problem of empty subscription payloads for sync webhooks when called inside async webhook.

In the case of having subscription for order's sync and async webhooks, and invalid prices/shipping methods, Saleor generates the subscription for async webhook. Inside the async subscription some fields can trigger sync webhook like the one responsible for filtering shipping methods or calculating the taxes. This tries to build the subscription query for sync webhooks, but due to calling promise.get() inside the subscription logic, we break the promise loop. As a result, we don't send sync webhooks as the generated payload is empty.
As a temporary workaround, we're adding the wrapper for async events that would trigger sync webhooks first (if needed), then async events. With this approach, we are sure, that the sync webhook is sent, and async webhook can use denormalized/cached data to build the payload.

This is similar PR as we did for the checkout: https://github.com/saleor/saleor/pull/16393

Port of changes from: #16466

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
