### PR TITLE
Drop unused manager argument in clean_tax_code

### DIFF
--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -195,8 +195,7 @@ class ProductCreate(ModelMutation):
             except ValidationError as exc:
                 raise ValidationError({"attributes": exc})
 
-        manager = get_plugin_manager_promise(info.context).get()
-        clean_tax_code(cleaned_input, manager)
+        clean_tax_code(cleaned_input)
 
         clean_seo_fields(cleaned_input)
         return cleaned_input

--- a/saleor/graphql/product/mutations/product_type/product_type_create.py
+++ b/saleor/graphql/product/mutations/product_type/product_type_create.py
@@ -12,7 +12,6 @@ from ....core.mutations import ModelMutation
 from ....core.scalars import WeightScalar
 from ....core.types import BaseInputObjectType, NonNullList, ProductError
 from ....core.validators import validate_slug_and_generate_if_needed
-from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import ProductTypeKindEnum
 from ...types import ProductType
 from ..utils import clean_tax_code
@@ -117,8 +116,7 @@ class ProductTypeCreate(ModelMutation):
             error.code = ProductErrorCode.REQUIRED.value
             raise ValidationError({"slug": error})
 
-        manager = get_plugin_manager_promise(info.context).get()
-        clean_tax_code(cleaned_input, manager)
+        clean_tax_code(cleaned_input)
 
         cls.validate_attributes(cleaned_input)
         return cleaned_input

--- a/saleor/graphql/product/mutations/utils.py
+++ b/saleor/graphql/product/mutations/utils.py
@@ -1,10 +1,9 @@
 from django.db.models import Q
 
-from ....plugins.manager import PluginsManager
 from ....tax.models import TaxClass
 
 
-def clean_tax_code(cleaned_input: dict, manager: PluginsManager):
+def clean_tax_code(cleaned_input: dict):
     """Clean deprecated `taxCode` field.
 
     This function provides backwards compatibility for the `taxCode` input field. If the

--- a/saleor/graphql/product/tests/deprecated/test_utils.py
+++ b/saleor/graphql/product/tests/deprecated/test_utils.py
@@ -1,15 +1,13 @@
-from .....plugins.manager import get_plugins_manager
 from .....tax.models import TaxClass
 from ...mutations.utils import clean_tax_code
 
 
 def test_clean_tax_code_does_nothing_when_empty_data():
     # given
-    manager = get_plugins_manager(allow_replica=False)
     data = {}
 
     # when
-    clean_tax_code(data, manager)
+    clean_tax_code(data)
 
     # then
     assert data == {}
@@ -17,11 +15,10 @@ def test_clean_tax_code_does_nothing_when_empty_data():
 
 def test_clean_tax_code_does_nothing_when_tax_class_provided():
     # given
-    manager = get_plugins_manager(allow_replica=False)
     data = {"tax_code": "P0000000", "tax_class": "VGF4Q2xhc3M6MQ=="}
 
     # when
-    clean_tax_code(data, manager)
+    clean_tax_code(data)
 
     # then
     assert data == {"tax_code": "P0000000", "tax_class": "VGF4Q2xhc3M6MQ=="}
@@ -29,13 +26,12 @@ def test_clean_tax_code_does_nothing_when_tax_class_provided():
 
 def test_clean_tax_code_when_tax_class_exists_by_name():
     # given
-    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     tax_class = TaxClass.objects.create(name=tax_code)
     data = {"tax_code": tax_code}
 
     # when
-    clean_tax_code(data, manager)
+    clean_tax_code(data)
 
     # then
     assert data["tax_class"] == tax_class
@@ -43,13 +39,12 @@ def test_clean_tax_code_when_tax_class_exists_by_name():
 
 def test_clean_tax_code_when_tax_class_exists_by_avatax():
     # given
-    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     tax_class = TaxClass.objects.create(name="Test", metadata={"avatax.code": tax_code})
     data = {"tax_code": tax_code}
 
     # when
-    clean_tax_code(data, manager)
+    clean_tax_code(data)
 
     # then
     assert data["tax_class"] == tax_class
@@ -57,7 +52,6 @@ def test_clean_tax_code_when_tax_class_exists_by_avatax():
 
 def test_clean_tax_code_when_tax_class_exists_by_vatlayer():
     # given
-    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     tax_class = TaxClass.objects.create(
         name="Test", metadata={"vatlayer.code": tax_code}
@@ -65,7 +59,7 @@ def test_clean_tax_code_when_tax_class_exists_by_vatlayer():
     data = {"tax_code": tax_code}
 
     # when
-    clean_tax_code(data, manager)
+    clean_tax_code(data)
 
     # then
     assert data["tax_class"] == tax_class
@@ -73,13 +67,12 @@ def test_clean_tax_code_when_tax_class_exists_by_vatlayer():
 
 def test_clean_tax_code_when_tax_class_does_not_exists():
     # given
-    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     TaxClass.objects.all().delete()
     data = {"tax_code": tax_code}
 
     # when
-    clean_tax_code(data, manager)
+    clean_tax_code(data)
 
     # then
     assert data["tax_class"] is None


### PR DESCRIPTION
Dropped unused `manager` argument in `clean_tax_code`.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
