### PR TITLE
Fix order level discounts with tax app strategy.

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -76,6 +76,17 @@ def is_order_level_voucher(voucher: Optional[Voucher]):
     )
 
 
+def has_checkout_order_promotion(checkout_info: "CheckoutInfo") -> bool:
+    return next(
+        (
+            True
+            for discount in checkout_info.discounts
+            if discount.type == DiscountType.ORDER_PROMOTION
+        ),
+        False,
+    )
+
+
 def is_shipping_voucher(voucher: Optional[Voucher]):
     return bool(voucher and voucher.type == VoucherType.SHIPPING)
 

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -8,7 +8,7 @@ from ....checkout import base_calculations
 from ....checkout.models import Checkout, CheckoutLine
 from ....core.prices import quantize_price
 from ....discount import DiscountType
-from ....discount.utils import is_order_level_voucher
+from ....discount.utils import has_checkout_order_promotion, is_order_level_voucher
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
 from ....tax.utils import get_charge_taxes
@@ -387,7 +387,10 @@ class TaxableObject(BaseObjectType):
                 return (
                     [{"name": discount_name, "amount": checkout.discount}]
                     if checkout.discount
-                    and is_order_level_voucher(checkout_info.voucher)
+                    and (
+                        is_order_level_voucher(checkout_info.voucher)
+                        or has_checkout_order_promotion(checkout_info)
+                    )
                     else []
                 )
 
@@ -402,7 +405,7 @@ class TaxableObject(BaseObjectType):
                 {"name": discount.name, "amount": discount.amount}
                 for discount in discounts
                 if (
-                    discount.type == DiscountType.MANUAL
+                    discount.type in [DiscountType.MANUAL, DiscountType.ORDER_PROMOTION]
                     or is_order_level_voucher(discount.voucher)
                 )
             ]

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -176,7 +176,7 @@ def apply_order_discounts(
 ) -> tuple[Money, Money]:
     """Calculate prices after applying order level discounts.
 
-    Handles manual discounts and ENTIRE_ORDER vouchers.
+    Handles manual discounts, ENTIRE_ORDER vouchers and ORDER_PROMOTION.
     Shipping vouchers are included in the base shipping price.
     Specific product vouchers are included in line base prices.
     Entire order vouchers are recalculated and updated in this function

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -9,6 +9,7 @@ from prices import Money, TaxedMoney, fixed_discount
 
 from .....core.prices import quantize_price
 from .....discount import DiscountValueType, VoucherType
+from .....discount.models import PromotionRule
 from .....graphql.core.utils import to_global_id_or_none
 from .....order import OrderStatus
 from .....order.calculations import fetch_order_prices_if_expired
@@ -359,6 +360,68 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
             "shippingPrice": {"amount": 0.0},
             "sourceObject": {
                 "id": to_global_id_or_none(checkout_with_voucher),
+                "__typename": "Checkout",
+            },
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_calculate_taxes_with_order_promotion(
+    checkout_with_item_and_order_discount,
+    webhook_app,
+    permission_handle_taxes,
+):
+    # given
+    checkout = checkout_with_item_and_order_discount
+    line = checkout.lines.get()
+    line_price = line.variant.channel_listings.get(
+        channel=checkout.channel
+    ).price_amount
+    channel_id = to_global_id_or_none(checkout.channel)
+    webhook_app.permissions.add(permission_handle_taxes)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+    discount_amount = PromotionRule.objects.get().reward_value
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(
+        event_type, checkout, webhook
+    )
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": None,
+            "currency": "USD",
+            "discounts": [{"amount": {"amount": float(discount_amount)}}],
+            "channel": {"id": channel_id},
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": "Test product",
+                    "productSku": "123",
+                    "quantity": line.quantity,
+                    "sourceLine": {
+                        "id": to_global_id_or_none(line),
+                        "__typename": "CheckoutLine",
+                    },
+                    "totalPrice": {"amount": float(line_price * 3)},
+                    "unitPrice": {"amount": float(line_price)},
+                    "variantName": "",
+                }
+            ],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": 0.0},
+            "sourceObject": {
+                "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
             },
         },
@@ -975,6 +1038,69 @@ def test_order_calculate_taxes_empty_order(
             "pricesEnteredWithTax": True,
             "shippingPrice": {"amount": 0.0},
             "channel": {"id": to_global_id_or_none(order.channel)},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+            },
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_order_calculate_taxes_order_promotion(
+    order_with_lines_and_order_promotion, subscription_calculate_taxes_for_order
+):
+    # given
+    order = order_with_lines_and_order_promotion
+    order.status = OrderStatus.DRAFT
+    order.save(update_fields=["status"])
+    webhook = subscription_calculate_taxes_for_order
+
+    webhook.subscription_query = TAXES_SUBSCRIPTION_QUERY
+    webhook.save(update_fields=["subscription_query"])
+
+    discount_amount = PromotionRule.objects.get().reward_value
+
+    expected_shipping_price = Money("2.00", order.currency)
+    order.undiscounted_base_shipping_price = expected_shipping_price
+    order.base_shipping_price = expected_shipping_price
+    order.shipping_price = TaxedMoney(
+        net=expected_shipping_price, gross=expected_shipping_price
+    )
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(
+        WebhookEventSyncType.ORDER_CALCULATE_TAXES, order, webhook
+    )
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {"id": to_global_id_or_none(order.shipping_address)},
+            "currency": "USD",
+            "discounts": [{"amount": {"amount": float(discount_amount)}}],
+            "channel": {"id": to_global_id_or_none(order.channel)},
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": line.product_name,
+                    "productSku": line.product_sku,
+                    "quantity": line.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line),
+                    },
+                    "totalPrice": {
+                        "amount": float(line.base_unit_price_amount * line.quantity)
+                    },
+                    "unitPrice": {"amount": float(line.base_unit_price_amount)},
+                    "variantName": line.variant_name,
+                }
+                for line in order.lines.all()
+            ],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": float(float(expected_shipping_price.amount))},
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),


### PR DESCRIPTION
This feature branch fixes order-level discounts in conjunction with avatax app and avatax plugin.
Internal issue: https://linear.app/saleor/issue/SHOPX-1122

**TODO:**
- [x] Fix `TaxableObject.discounts` resolver (https://github.com/saleor/saleor/pull/16467)
- [ ] Enrich avatax payload with info how to distribute order level discount

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
