### PR TITLE
Add discount distribution flags for tax payload.

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -76,6 +76,10 @@ def is_order_level_voucher(voucher: Optional[Voucher]):
     )
 
 
+def is_shipping_voucher(voucher: Optional[Voucher]):
+    return bool(voucher and voucher.type == VoucherType.SHIPPING)
+
+
 def has_checkout_order_promotion(checkout_info: "CheckoutInfo") -> bool:
     return next(
         (
@@ -87,8 +91,9 @@ def has_checkout_order_promotion(checkout_info: "CheckoutInfo") -> bool:
     )
 
 
-def is_shipping_voucher(voucher: Optional[Voucher]):
-    return bool(voucher and voucher.type == VoucherType.SHIPPING)
+def should_discount_shipping(discount: OrderDiscount) -> bool:
+    """Check if the discount should be distributed over shipping price."""
+    return discount.type != DiscountType.ORDER_PROMOTION
 
 
 def increase_voucher_usage(

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -76,10 +76,6 @@ def is_order_level_voucher(voucher: Optional[Voucher]):
     )
 
 
-def is_shipping_voucher(voucher: Optional[Voucher]):
-    return bool(voucher and voucher.type == VoucherType.SHIPPING)
-
-
 def has_checkout_order_promotion(checkout_info: "CheckoutInfo") -> bool:
     return next(
         (
@@ -89,6 +85,10 @@ def has_checkout_order_promotion(checkout_info: "CheckoutInfo") -> bool:
         ),
         False,
     )
+
+
+def is_shipping_voucher(voucher: Optional[Voucher]):
+    return bool(voucher and voucher.type == VoucherType.SHIPPING)
 
 
 def should_discount_shipping(discount: OrderDiscount) -> bool:

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -402,25 +402,22 @@ class TaxableObject(BaseObjectType):
                 if not checkout.discount:
                     return []
 
-                if is_order_level_voucher(checkout_info.voucher):
+                has_order_promotion = has_checkout_order_promotion(checkout_info)
+                has_order_level_voucher = is_order_level_voucher(checkout_info.voucher)
+                # order promotion (currently we handle SUBTOTAL_PROMOTION only) applies
+                # to subtotal only
+                distribute_over_shipping = not has_order_promotion
+
+                if has_order_level_voucher or has_order_promotion:
                     return [
                         {
                             "name": discount_name,
                             "amount": checkout.discount,
                             "distribute_over_subtotal": True,
-                            "distribute_over_shipping": True,
+                            "distribute_over_shipping": distribute_over_shipping,
                         }
                     ]
 
-                if has_checkout_order_promotion(checkout_info):
-                    return [
-                        {
-                            "name": discount_name,
-                            "amount": checkout.discount,
-                            "distribute_over_subtotal": True,
-                            "distribute_over_shipping": False,
-                        }
-                    ]
                 return []
 
             return (

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -36110,6 +36110,12 @@ type TaxableObjectDiscount @doc(category: "Taxes") {
 
   """The amount of the discount."""
   amount: Money!
+
+  """Determines if the discount should be distributed over subtotal price."""
+  distributeOverSubtotal: Boolean!
+
+  """Determines if the discount should be distributed over shipping price."""
+  distributeOverShipping: Boolean!
 }
 
 type TaxableObjectLine @doc(category: "Taxes") {

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -1810,7 +1810,14 @@ def test_generate_checkout_payload_for_tax_calculation_entire_order_voucher(
             "slug": checkout.channel.slug,
         },
         "currency": currency,
-        "discounts": [{"amount": str(discount_amount), "name": voucher.name}],
+        "discounts": [
+            {
+                "amount": str(discount_amount),
+                "name": voucher.name,
+                "distribute_over_subtotal": True,
+                "distribute_over_shipping": True,
+            }
+        ],
         "included_taxes_in_prices": prices_entered_with_tax,
         "lines": mocked_serialized_checkout_lines,
         "metadata": {"meta_key": "meta_value"},
@@ -2015,7 +2022,15 @@ def test_generate_checkout_payload_for_tax_calculation_order_discount(
             "slug": checkout.channel.slug,
         },
         "currency": currency,
-        "discounts": [{"amount": str(discount_amount), "name": rule.name}],
+        "discounts": [
+            {
+                "amount": str(discount_amount),
+                "name": rule.name,
+                # subtotal discount is not distributed to shipping price
+                "distribute_over_shipping": False,
+                "distribute_over_subtotal": True,
+            }
+        ],
         "included_taxes_in_prices": prices_entered_with_tax,
         "lines": mocked_serialized_checkout_lines,
         "metadata": {"meta_key": "meta_value"},


### PR DESCRIPTION
I want to merge this change because it adds `distribute_over_subtotal` and `distribute_over_shipping` flags to `TaxableObjectDiscount` and tax app payloads, which will inform Avatax app how to distribute order level discounts.

Issue: https://linear.app/saleor/issue/SHOPX-1145


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
