### PR TITLE
Adjust `order.totalRemainingGrant` calculations

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order_amounts.py
+++ b/saleor/graphql/order/tests/queries/test_order_amounts.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+import pytest
+
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -815,8 +817,8 @@ def test_order_total_remaining_grant_query_with_transactions_by_staff_user(
     # then
     order_data = content["data"]["orders"]["edges"][0]["node"]
     total_remaining_grant = order_data["totalRemainingGrant"]
-    assert total_remaining_grant["amount"] == granted_refund_amount - (
-        pending_refund_amount + refund_amount
+    assert total_remaining_grant["amount"] == max(
+        granted_refund_amount - (pending_refund_amount + refund_amount), 0
     )
 
 
@@ -873,8 +875,8 @@ def test_order_total_remaining_grant_query_with_transactions_by_app(
     # then
     order_data = content["data"]["orders"]["edges"][0]["node"]
     total_remaining_grant = order_data["totalRemainingGrant"]
-    assert total_remaining_grant["amount"] == granted_refund_amount - (
-        pending_refund_amount + refund_amount
+    assert total_remaining_grant["amount"] == max(
+        granted_refund_amount - (pending_refund_amount + refund_amount), 0
     )
 
 
@@ -958,3 +960,244 @@ def test_order_total_remaining_grant_query_with_payment_by_app(
     assert total_remaining_grant["amount"] == granted_refund_amount - (
         first_refund_amount + second_refund_amount
     )
+
+
+@pytest.mark.parametrize(
+    "amount_charged, "
+    "amount_authorized, "
+    "amount_refunded, "
+    "amount_canceled, "
+    "amount_charge_pending, "
+    "amount_authorize_pending, "
+    "amount_refund_pending, "
+    "amount_cancel_pending, "
+    "remaining_grant_amount, ",
+    [
+        ("60", "0", "0", "0", "0", "0", "0", "0", 150),
+        ("0", "60", "0", "0", "0", "0", "0", "0", 150),
+        ("0", "0", "60", "0", "0", "0", "0", "0", 150),
+        ("0", "0", "0", "60", "0", "0", "0", "0", 150),
+        ("0", "0", "0", "0", "60", "0", "0", "0", 150),
+        ("0", "0", "0", "0", "0", "60", "0", "0", 150),
+        ("0", "0", "0", "0", "0", "0", "60", "0", 150),
+        ("0", "0", "0", "0", "0", "0", "0", "60", 150),
+        ("0", "20", "0", "40", "0", "0", "0", "0", 150),
+        ("45", "0", "15", "0", "0", "0", "0", "0", 150),
+        ("-60", "0", "0", "0", "0", "0", "60", "0", 90),
+        ("-60", "0", "60", "0", "0", "0", "0", "0", 90),
+        ("-60", "60", "60", "0", "0", "0", "0", "0", 150),
+    ],
+)
+def test_order_total_remaining_grant_query_with_transactions_total_charged(
+    amount_charged,
+    amount_authorized,
+    amount_refunded,
+    amount_canceled,
+    amount_charge_pending,
+    amount_authorize_pending,
+    amount_refund_pending,
+    amount_cancel_pending,
+    remaining_grant_amount,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+    staff_user,
+):
+    # given
+    order = fulfilled_order
+    order_total = Decimal("200.00")
+    order.total_gross_amount = order_total
+    order.total_net_amount = order_total
+    order.save(update_fields=["total_gross_amount", "total_net_amount"])
+
+    granted_refund_amount = Decimal("150.00")
+    order.granted_refunds.create(
+        amount_value=granted_refund_amount,
+        currency="USD",
+        reason="Test reason",
+        user=staff_user,
+    )
+    order.payment_transactions.create(
+        charged_value=Decimal(amount_charged),
+        authorized_value=Decimal(amount_authorized),
+        refunded_value=Decimal(amount_refunded),
+        canceled_value=Decimal(amount_canceled),
+        charge_pending_value=Decimal(amount_charge_pending),
+        authorize_pending_value=Decimal(amount_authorize_pending),
+        refund_pending_value=Decimal(amount_refund_pending),
+        cancel_pending_value=Decimal(amount_cancel_pending),
+        currency="USD",
+    )
+    order.payment_transactions.create(charged_value=order_total, currency="USD")
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_QUERY_WITH_AMOUNT_FIELDS)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    total_remaining_grant = order_data["totalRemainingGrant"]
+    assert total_remaining_grant["amount"] == remaining_grant_amount
+
+
+@pytest.mark.parametrize(
+    "amount_charged, "
+    "amount_authorized, "
+    "amount_refunded, "
+    "amount_canceled, "
+    "amount_charge_pending, "
+    "amount_authorize_pending, "
+    "amount_refund_pending, "
+    "amount_cancel_pending, "
+    "remaining_grant_amount, ",
+    [
+        ("60", "0", "0", "0", "0", "0", "0", "0", 10),
+        ("0", "60", "0", "0", "0", "0", "0", "0", 10),
+        ("0", "0", "60", "0", "0", "0", "0", "0", 0),
+        ("0", "0", "0", "60", "0", "0", "0", "0", 0),
+        ("0", "0", "0", "0", "60", "0", "0", "0", 10),
+        ("0", "0", "0", "0", "0", "60", "0", "0", 10),
+        ("0", "0", "0", "0", "0", "0", "60", "0", 0),
+        ("0", "0", "0", "0", "0", "0", "0", "60", 0),
+        ("0", "20", "0", "40", "0", "0", "0", "0", 0),
+        ("0", "80", "0", "40", "0", "0", "0", "0", 30),
+        ("45", "0", "15", "0", "0", "0", "0", "0", 0),
+        ("-60", "0", "0", "0", "0", "0", "60", "0", 0),
+        ("-60", "0", "60", "0", "0", "0", "0", "0", 0),
+        ("-60", "60", "60", "0", "0", "0", "0", "0", 0),
+    ],
+)
+def test_order_total_remaining_grant_query_with_transactions_total_refunded(
+    amount_charged,
+    amount_authorized,
+    amount_refunded,
+    amount_canceled,
+    amount_charge_pending,
+    amount_authorize_pending,
+    amount_refund_pending,
+    amount_cancel_pending,
+    remaining_grant_amount,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+    staff_user,
+):
+    # given
+    order = fulfilled_order
+    order_total = Decimal("200.00")
+    order.total_gross_amount = order_total
+    order.total_net_amount = order_total
+    order.save(update_fields=["total_gross_amount", "total_net_amount"])
+
+    granted_refund_amount = Decimal("150.00")
+    order.granted_refunds.create(
+        amount_value=granted_refund_amount,
+        currency="USD",
+        reason="Test reason",
+        user=staff_user,
+    )
+    order.payment_transactions.create(
+        charged_value=Decimal(amount_charged),
+        authorized_value=Decimal(amount_authorized),
+        refunded_value=Decimal(amount_refunded),
+        canceled_value=Decimal(amount_canceled),
+        charge_pending_value=Decimal(amount_charge_pending),
+        authorize_pending_value=Decimal(amount_authorize_pending),
+        refund_pending_value=Decimal(amount_refund_pending),
+        cancel_pending_value=Decimal(amount_cancel_pending),
+        currency="USD",
+    )
+    order.payment_transactions.create(refunded_value=order_total, currency="USD")
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_QUERY_WITH_AMOUNT_FIELDS)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    total_remaining_grant = order_data["totalRemainingGrant"]
+    assert total_remaining_grant["amount"] == remaining_grant_amount
+
+
+@pytest.mark.parametrize(
+    "amount_charged, "
+    "amount_authorized, "
+    "amount_refunded, "
+    "amount_canceled, "
+    "amount_charge_pending, "
+    "amount_authorize_pending, "
+    "amount_refund_pending, "
+    "amount_cancel_pending, "
+    "remaining_grant_amount, ",
+    [
+        ("60", "0", "0", "0", "0", "0", "0", "0", 85),
+        ("0", "60", "0", "0", "0", "0", "0", "0", 85),
+        ("0", "0", "60", "0", "0", "0", "0", "0", 25),
+        ("0", "0", "0", "60", "0", "0", "0", "0", 25),
+        ("0", "0", "0", "0", "60", "0", "0", "0", 85),
+        ("0", "0", "0", "0", "0", "60", "0", "0", 85),
+        ("0", "0", "0", "0", "0", "0", "60", "0", 25),
+        ("0", "0", "0", "0", "0", "0", "0", "60", 25),
+        ("0", "20", "0", "40", "0", "0", "0", "0", 45),
+        ("0", "80", "0", "40", "0", "0", "0", "0", 105),
+        ("45", "0", "15", "0", "0", "0", "0", "0", 70),
+        ("-60", "0", "0", "0", "0", "0", "60", "0", 0),
+        ("-60", "0", "60", "0", "0", "0", "0", "0", 0),
+        ("-60", "60", "60", "0", "0", "0", "0", "0", 25),
+    ],
+)
+def test_order_total_remaining_grant_query_with_transactions_partially_refunded(
+    amount_charged,
+    amount_authorized,
+    amount_refunded,
+    amount_canceled,
+    amount_charge_pending,
+    amount_authorize_pending,
+    amount_refund_pending,
+    amount_cancel_pending,
+    remaining_grant_amount,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+    staff_user,
+):
+    # given
+    order = fulfilled_order
+    order_total = Decimal("200.00")
+    order.total_gross_amount = order_total
+    order.total_net_amount = order_total
+    order.save(update_fields=["total_gross_amount", "total_net_amount"])
+
+    granted_refund_amount = Decimal("150.00")
+    order.granted_refunds.create(
+        amount_value=granted_refund_amount,
+        currency="USD",
+        reason="Test reason",
+        user=staff_user,
+    )
+    order.payment_transactions.create(
+        charged_value=Decimal(amount_charged),
+        authorized_value=Decimal(amount_authorized),
+        refunded_value=Decimal(amount_refunded),
+        canceled_value=Decimal(amount_canceled),
+        charge_pending_value=Decimal(amount_charge_pending),
+        authorize_pending_value=Decimal(amount_authorize_pending),
+        refund_pending_value=Decimal(amount_refund_pending),
+        cancel_pending_value=Decimal(amount_cancel_pending),
+        currency="USD",
+    )
+    order.payment_transactions.create(
+        refund_pending_value=Decimal("125"), charged_value=Decimal("75"), currency="USD"
+    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_QUERY_WITH_AMOUNT_FIELDS)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    total_remaining_grant = order_data["totalRemainingGrant"]
+    assert total_remaining_grant["amount"] == remaining_grant_amount

--- a/saleor/graphql/order/tests/queries/test_order_amounts.py
+++ b/saleor/graphql/order/tests/queries/test_order_amounts.py
@@ -963,15 +963,17 @@ def test_order_total_remaining_grant_query_with_payment_by_app(
 
 
 @pytest.mark.parametrize(
-    "amount_charged, "
-    "amount_authorized, "
-    "amount_refunded, "
-    "amount_canceled, "
-    "amount_charge_pending, "
-    "amount_authorize_pending, "
-    "amount_refund_pending, "
-    "amount_cancel_pending, "
-    "remaining_grant_amount, ",
+    (
+        "amount_charged",
+        "amount_authorized",
+        "amount_refunded",
+        "amount_canceled",
+        "amount_charge_pending",
+        "amount_authorize_pending",
+        "amount_refund_pending",
+        "amount_cancel_pending",
+        "remaining_grant_amount",
+    ),
     [
         ("60", "0", "0", "0", "0", "0", "0", "0", 150),
         ("0", "60", "0", "0", "0", "0", "0", "0", 150),
@@ -1042,15 +1044,17 @@ def test_order_total_remaining_grant_query_with_transactions_total_charged(
 
 
 @pytest.mark.parametrize(
-    "amount_charged, "
-    "amount_authorized, "
-    "amount_refunded, "
-    "amount_canceled, "
-    "amount_charge_pending, "
-    "amount_authorize_pending, "
-    "amount_refund_pending, "
-    "amount_cancel_pending, "
-    "remaining_grant_amount, ",
+    (
+        "amount_charged",
+        "amount_authorized",
+        "amount_refunded",
+        "amount_canceled",
+        "amount_charge_pending",
+        "amount_authorize_pending",
+        "amount_refund_pending",
+        "amount_cancel_pending",
+        "remaining_grant_amount",
+    ),
     [
         ("60", "0", "0", "0", "0", "0", "0", "0", 10),
         ("0", "60", "0", "0", "0", "0", "0", "0", 10),
@@ -1122,15 +1126,17 @@ def test_order_total_remaining_grant_query_with_transactions_total_refunded(
 
 
 @pytest.mark.parametrize(
-    "amount_charged, "
-    "amount_authorized, "
-    "amount_refunded, "
-    "amount_canceled, "
-    "amount_charge_pending, "
-    "amount_authorize_pending, "
-    "amount_refund_pending, "
-    "amount_cancel_pending, "
-    "remaining_grant_amount, ",
+    (
+        "amount_charged",
+        "amount_authorized",
+        "amount_refunded",
+        "amount_canceled",
+        "amount_charge_pending",
+        "amount_authorize_pending",
+        "amount_refund_pending",
+        "amount_cancel_pending",
+        "remaining_grant_amount",
+    ),
     [
         ("60", "0", "0", "0", "0", "0", "0", "0", 85),
         ("0", "60", "0", "0", "0", "0", "0", "0", 85),

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -2263,15 +2263,41 @@ class Order(ModelObjectType[models.Order]):
         def _resolve_total_remaining_grant_for_transactions(
             transactions, total_granted_refund
         ):
-            total_pending_refund = sum(
-                [transaction.amount_refund_pending for transaction in transactions],
+            amount_fields = [
+                "amount_charged",
+                "amount_authorized",
+                "amount_refunded",
+                "amount_charge_pending",
+                "amount_authorize_pending",
+                "amount_refund_pending",
+            ]
+            # Calculate total processed amount, it excluded the cancel amounts
+            # as it's the amount that never has been charged
+            processed_amount = sum(
+                [
+                    sum(
+                        [getattr(transaction, field) for field in amount_fields],
+                        zero_money(root.currency),
+                    )
+                    for transaction in transactions
+                ],
                 zero_money(root.currency),
             )
-            total_refund = sum(
-                [transaction.amount_refunded for transaction in transactions],
+            refunded_amount = sum(
+                [
+                    transaction.amount_refunded + transaction.amount_refund_pending
+                    for transaction in transactions
+                ],
                 zero_money(root.currency),
             )
-            return total_granted_refund - (total_pending_refund + total_refund)
+            already_granted_refund = max(
+                refunded_amount - (processed_amount - root.total.gross),
+                zero_money(root.currency),
+            )
+
+            return max(
+                total_granted_refund - already_granted_refund, zero_money(root.currency)
+            )
 
         def _resolve_total_remaining_grant(data):
             transactions, payments, granted_refunds = data
@@ -2279,6 +2305,8 @@ class Order(ModelObjectType[models.Order]):
                 [granted_refund.amount for granted_refund in granted_refunds],
                 zero_money(root.currency),
             )
+            # total_granted_refund cannot be bigger than order.total
+            total_granted_refund = min(total_granted_refund, root.total.gross)
 
             def _resolve_total_remaining_grant_for_payment(payment_transactions):
                 total_refund_amount = Decimal(0)
@@ -2337,9 +2365,9 @@ class Order(ModelObjectType[models.Order]):
     def resolve_shipping_tax_class(cls, root: models.Order, info):
         if root.shipping_method_id:
             return cls.resolve_shipping_method(root, info).then(
-                lambda shipping_method_data: shipping_method_data.tax_class
-                if shipping_method_data
-                else None
+                lambda shipping_method_data: (
+                    shipping_method_data.tax_class if shipping_method_data else None
+                )
             )
         return None
 

--- a/saleor/payment/tests/test_transaction_item_calculations.py
+++ b/saleor/payment/tests/test_transaction_item_calculations.py
@@ -1075,6 +1075,36 @@ def test_with_cancel_request_and_success_events_different_psp_references(
     )
 
 
+def test_with_authorization_success_and_refund_success_events(
+    transaction_item_generator, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_generator()
+    authorization_value = Decimal("11.00")
+    refund_value = Decimal("11.00")
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+            TransactionEventType.REFUND_SUCCESS,
+        ],
+        amounts=[authorization_value, refund_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        authorized_value=authorization_value,
+        refunded_value=authorization_value,
+        charged_value=-authorization_value,
+    )
+
+
 def test_event_without_psp_reference(
     transaction_item_generator, transaction_events_generator
 ):


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/16486

Adjust `totalRemainingGrant`calculations.
Previously the value showed the wrong value as it didn't take into consideration overcharging of the order.

The `totalRemainingGrant` value says what amount still needs to be refunded to reach the following state:
`order.total - grantedTotal == chargedTotal`.

The new formula is:
`totalRemainingGrant = max(grantedTotal - refunded, 0)`

where:
`processedAmounts = sum(charged, authorized, refunded, pending_charge, pending_authorize, pending_refnd). (excluding cancel amounts)`

`refunded = max(sum(refunded, pending_refund) - processedAmounts - order.total, 0)`

`grantedTotal = min(sum(grantedRefund), order.total)`

*The sum is the sum of amounts from all transactions.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
