### PR TITLE
Do not call filter-shipping-methods webhook for non-editable orders

### DIFF
--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -16,14 +16,8 @@ from ..core.utils.country import get_active_country
 from ..core.utils.translations import get_translation
 from ..core.weight import zero_weight
 from ..discount import DiscountType, DiscountValueType
-from ..discount.models import (
-    OrderDiscount,
-    OrderLineDiscount,
-    VoucherType,
-)
-from ..discount.utils.manual_discount import (
-    apply_discount_to_value,
-)
+from ..discount.models import OrderDiscount, OrderLineDiscount, VoucherType
+from ..discount.utils.manual_discount import apply_discount_to_value
 from ..discount.utils.promotion import (
     get_discount_name,
     get_discount_translated_name,
@@ -698,8 +692,11 @@ def get_valid_shipping_methods_for_order(
     if not valid_methods:
         return []
 
-    excluded_methods = manager.excluded_shipping_methods_for_order(order, valid_methods)
-    initialize_shipping_method_active_status(valid_methods, excluded_methods)
+    if order.status in ORDER_EDITABLE_STATUS:
+        excluded_methods = manager.excluded_shipping_methods_for_order(
+            order, valid_methods
+        )
+        initialize_shipping_method_active_status(valid_methods, excluded_methods)
 
     return valid_methods
 

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -7,6 +7,7 @@ import pytest
 
 from ....core.models import EventDelivery
 from ....graphql.tests.utils import get_graphql_content
+from ....order import OrderStatus
 from ....webhook.const import CACHE_EXCLUDED_SHIPPING_TIME
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
@@ -435,6 +436,8 @@ def test_order_shipping_methods(
     settings,
 ):
     # given
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    order_with_lines.save(update_fields=["status"])
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     webhook_reason = "spanish-inquisition"
     excluded_shipping_method_id = order_with_lines.shipping_method.id
@@ -452,6 +455,97 @@ def test_order_shipping_methods(
     assert len(shipping_methods) == 1
     assert not shipping_methods[0]["active"]
     assert shipping_methods[0]["message"] == webhook_reason
+
+
+@mock.patch(
+    "saleor.plugins.webhook.plugin.WebhookPlugin.excluded_shipping_methods_for_order"
+)
+def test_draft_order_shipping_methods(
+    mocked_webhook,
+    staff_api_client,
+    order_with_lines,
+    permission_group_manage_orders,
+    settings,
+):
+    # given
+    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.save(update_fields=["status"])
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    webhook_reason = "spanish-inquisition"
+    excluded_shipping_method_id = order_with_lines.shipping_method.id
+    mocked_webhook.return_value = [
+        ExcludedShippingMethod(excluded_shipping_method_id, webhook_reason)
+    ]
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    query = """
+      query DraftOrdersQuery {
+       draftOrders(first: 1) {
+         edges {
+           node {
+             shippingMethods {
+               id
+               name
+               active
+               message
+             }
+           }
+         }
+       }
+      }
+    """
+    # when
+    response = staff_api_client.post_graphql(query)
+    content = get_graphql_content(response)
+    order_data = content["data"]["draftOrders"]["edges"][0]["node"]
+
+    shipping_methods = order_data["shippingMethods"]
+    # then
+    assert len(shipping_methods) == 1
+    assert not shipping_methods[0]["active"]
+    assert shipping_methods[0]["message"] == webhook_reason
+
+
+@pytest.mark.parametrize(
+    "order_status",
+    [
+        OrderStatus.UNFULFILLED,
+        OrderStatus.PARTIALLY_FULFILLED,
+        OrderStatus.FULFILLED,
+        OrderStatus.CANCELED,
+        OrderStatus.EXPIRED,
+        OrderStatus.RETURNED,
+        OrderStatus.PARTIALLY_RETURNED,
+    ],
+)
+@mock.patch(
+    "saleor.plugins.webhook.plugin.WebhookPlugin.excluded_shipping_methods_for_order"
+)
+def test_order_shipping_methods_skips_sync_webhook_for_non_editable_statuses(
+    mocked_webhook,
+    order_status,
+    staff_api_client,
+    order_with_lines,
+    permission_group_manage_orders,
+    settings,
+):
+    # given
+    order_with_lines.status = order_status
+    order_with_lines.save(update_fields=["status"])
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_QUERY_SHIPPING_METHOD)
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+
+    shipping_methods = order_data["shippingMethods"]
+
+    # then
+    assert not mocked_webhook.called
+    assert len(shipping_methods) == 1
+    assert shipping_methods[0]["active"]
 
 
 @pytest.mark.parametrize(
@@ -472,6 +566,8 @@ def test_order_available_shipping_methods(
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    order_with_lines.save(update_fields=["status"])
     shipping_method = order_with_lines.shipping_method
 
     def respond(*args, **kwargs):


### PR DESCRIPTION
I want to merge this change because it removes the sync webhook call for filter-shipping-methods, when the order is not editable.

Port of changes from: #16498

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
