### PR TITLE
Drop manager.perform_mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 
+- Drop the `manager.perform_mutation` method. - #16515 by @maarcingebala
+
 ### GraphQL API
 
 - Add `CheckoutCustomerNoteUpdate` mutation - #16315 by @pitkes22

--- a/saleor/graphql/account/mutations/authentication/set_password.py
+++ b/saleor/graphql/account/mutations/authentication/set_password.py
@@ -13,7 +13,6 @@ from ....core.context import disallow_replica_in_context
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import validation_error_to_error_type
 from ....core.types import AccountError
-from ....plugins.dataloaders import get_plugin_manager_promise
 from ..base import INVALID_TOKEN
 from . import CreateToken
 
@@ -41,15 +40,6 @@ class SetPassword(CreateToken):
         cls, root, info: ResolveInfo, /, *, email, password, token
     ):
         disallow_replica_in_context(info.context)
-        manager = get_plugin_manager_promise(info.context).get()
-        result = manager.perform_mutation(
-            mutation_cls=cls,
-            root=root,
-            info=info,
-            data={"email": email, "password": password, "token": token},
-        )
-        if result is not None:
-            return result
 
         try:
             cls._set_password_for_user(email, password, token)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -37,7 +37,6 @@ from ..core.doc_category import DOC_CATEGORY_MAP
 from ..core.validators import validate_one_of_args_is_in_mutation
 from ..meta.permissions import PRIVATE_META_PERMISSION_MAP, PUBLIC_META_PERMISSION_MAP
 from ..payment.utils import metadata_contains_empty_key
-from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
 from . import ResolveInfo
 from .context import disallow_replica_in_context, setup_context_user
@@ -517,12 +516,6 @@ class BaseMutation(graphene.Mutation):
 
         if not cls.check_permissions(info.context, data=data):
             raise PermissionDenied(permissions=cls._meta.permissions)
-        manager = get_plugin_manager_promise(info.context).get()
-        result = manager.perform_mutation(
-            mutation_cls=cls, root=root, info=info, data=data
-        )
-        if result is not None:
-            return result
 
         try:
             response = cls.perform_mutation(root, info, **data)
@@ -1045,12 +1038,6 @@ class BaseBulkMutation(BaseMutation):
 
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
-        manager = get_plugin_manager_promise(info.context).get()
-        result = manager.perform_mutation(
-            mutation_cls=cls, root=root, info=info, data=data
-        )
-        if result is not None:
-            return result
 
         count, errors = cls.perform_mutation(root, info, **data)
         if errors:

--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -3,16 +3,12 @@ from unittest import mock
 import graphene
 import pytest
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
-from graphql import GraphQLError
-from graphql.execution import ExecutionResult
 
 from ....core.jwt import create_access_token
 from ....graphql.tests.utils import get_graphql_content
 from ....order.models import Order
 from ....permission.enums import ProductPermissions
-from ....plugins.tests.sample_plugins import PluginSample
 from ....product.models import Product
 from ...order import types as order_types
 from ...product import types as product_types
@@ -235,135 +231,6 @@ def test_get_node_or_error_returns_null_for_empty_id():
     info = mock.Mock()
     response = Mutation.get_node_or_error(info, "", field="")
     assert response is None
-
-
-def test_mutation_plugin_perform_mutation_handles_graphql_error(
-    request,
-    settings,
-    plugin_configuration,
-    product,
-    channel_USD,
-):
-    settings.PLUGINS = [
-        "saleor.plugins.tests.sample_plugins.PluginSample",
-    ]
-
-    schema_context = request.getfixturevalue("schema_context")
-
-    product_id = graphene.Node.to_global_id("Product", product.pk)
-    variables = {"productId": product_id, "channel": channel_USD.slug}
-
-    with mock.patch.object(
-        PluginSample,
-        "perform_mutation",
-        return_value=GraphQLError("My Custom Error"),
-    ):
-        result = schema.execute(
-            TEST_MUTATION, variables=variables, context_value=schema_context
-        )
-    assert result.to_dict() == {
-        "data": {"test": None},
-        "errors": [
-            {
-                "locations": [{"column": 9, "line": 3}],
-                "message": "My Custom Error",
-                "path": ["test"],
-            }
-        ],
-    }
-
-
-def test_mutation_plugin_perform_mutation_handles_custom_execution_result(
-    request,
-    settings,
-    plugin_configuration,
-    product,
-    channel_USD,
-):
-    settings.PLUGINS = [
-        "saleor.plugins.tests.sample_plugins.PluginSample",
-    ]
-
-    schema_context = request.getfixturevalue("schema_context")
-
-    product_id = graphene.Node.to_global_id("Product", product.pk)
-    variables = {"productId": product_id, "channel": channel_USD.slug}
-
-    with mock.patch.object(
-        PluginSample,
-        "perform_mutation",
-        return_value=ExecutionResult(data={}, errors=[GraphQLError("My Custom Error")]),
-    ):
-        result = schema.execute(
-            TEST_MUTATION, variables=variables, context_value=schema_context
-        )
-    assert result.to_dict() == {
-        "data": {"test": None},
-        "errors": [
-            {
-                "locations": [{"column": 13, "line": 5}],
-                "message": "My Custom Error",
-                "path": ["test", "errors", 0],
-            }
-        ],
-    }
-
-
-@mock.patch.object(
-    PluginSample,
-    "perform_mutation",
-    return_value=ExecutionResult(data={}, errors=[GraphQLError("My Custom Error")]),
-)
-def test_mutation_calls_plugin_perform_mutation_after_permission_checks(
-    mocked_plugin,
-    request,
-    settings,
-    staff_user,
-    plugin_configuration,
-    product,
-    channel_USD,
-    permission_manage_products,
-):
-    mutation_query = """
-        mutation testRestrictedMutation($productId: ID!, $channel: String) {
-            restrictedMutation(productId: $productId, channel: $channel) {
-                name
-                errors {
-                    field
-                    message
-                }
-            }
-        }
-    """
-
-    settings.PLUGINS = [
-        "saleor.plugins.tests.sample_plugins.PluginSample",
-    ]
-
-    schema_context = request.getfixturevalue("schema_context")
-    schema_context.user = SimpleLazyObject(lambda: staff_user)
-
-    product_id = graphene.Node.to_global_id("Product", product.pk)
-    variables = {"productId": product_id, "channel": channel_USD.slug}
-
-    # When permission is missing, it should not return the custom error from plugin
-    result = schema.execute(
-        mutation_query, variables=variables, context_value=schema_context
-    )
-    assert len(result.errors) == 1, result.to_dict()
-    assert (
-        "To access this path, you need one of the following permissions"
-        in result.errors[0].message
-    )
-
-    # When permission is not missing, the execution of the plugin should happen
-    staff_user.user_permissions.set([permission_manage_products])
-    del staff_user._perm_cache  # force django to re-fetch permissions
-    result = schema.execute(
-        mutation_query, variables=variables, context_value=schema_context
-    )
-    assert len(result.errors) == 1, result.to_dict()
-    assert result.errors[0].message == "My Custom Error"
 
 
 def test_base_mutation_get_node_by_pk_with_order_qs_and_old_int_id(order):

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -14,7 +14,6 @@ from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.mutations import BaseMutation, ModelMutation
 from ...core.types import BaseInputObjectType, NonNullList, ProductError, Upload
 from ...meta.inputs import MetadataInput
-from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import DigitalContent, DigitalContentUrl, ProductVariant
 
 
@@ -180,12 +179,6 @@ class DigitalContentDelete(BaseMutation):
         disallow_replica_in_context(info.context)
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
-        manager = get_plugin_manager_promise(info.context).get()
-        result = manager.perform_mutation(
-            mutation_cls=cls, root=root, info=info, data={"variant_id": variant_id}
-        )
-        if result is not None:
-            return result
 
         variant = cls.get_node_or_error(
             info, variant_id, field="id", only_type=ProductVariant

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1063,6 +1063,7 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
 
     @staticmethod
     def resolve_tax_type(root: ChannelContext[models.Product], info):
+        @allow_writer_in_context(info.context)
         def with_tax_class(data):
             tax_class, manager = data
             tax_data = manager.get_tax_code_from_object_meta(
@@ -1725,6 +1726,7 @@ class ProductType(ModelObjectType[models.ProductType]):
 
     @staticmethod
     def resolve_tax_type(root: models.ProductType, info):
+        @allow_writer_in_context(info.context)
         def with_tax_class(data):
             tax_class, manager = data
             tax_data = manager.get_tax_code_from_object_meta(tax_class)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10419,7 +10419,7 @@ type Shop implements ObjectWithMetadata {
   
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
-  limits: LimitInfo!
+  limits: LimitInfo! @deprecated(reason: "This field will be removed in Saleor 4.0.")
 
   """
   Saleor API version.

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -332,6 +332,7 @@ class Shop(graphene.ObjectType):
         LimitInfo,
         required=True,
         description="Resource limitations and current usage if any set for a shop",
+        deprecation_reason=(f"{DEPRECATED_IN_3X_FIELD}"),
         permissions=[AuthorizationFilters.AUTHENTICATED_STAFF_USER],
     )
     version = PermissionsField(

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -14,14 +14,10 @@ from typing import (
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
 from django.utils.functional import SimpleLazyObject
-from graphene import Mutation
-from graphql import GraphQLError
-from graphql.execution import ExecutionResult
 from prices import TaxedMoney
 from promise.promise import Promise
 
 from ..core.models import EventDelivery
-from ..graphql.core import ResolveInfo
 from ..payment.interface import (
     CustomerSource,
     GatewayResponse,
@@ -1258,26 +1254,6 @@ class BasePlugin:
 
     # Triggers retry mechanism for event delivery
     event_delivery_retry: Callable[["EventDelivery", Any], EventDelivery]
-
-    # Invoked before each mutation is executed
-    #
-    # This allows to trigger specific logic before the mutation is executed
-    # but only once the permissions are checked.
-    #
-    # Returns one of:
-    #    - null if the execution shall continue
-    #    - an execution result
-    #    - graphql.GraphQLError
-    perform_mutation: Callable[
-        [
-            Optional[Union[ExecutionResult, GraphQLError]],  # previous value
-            Mutation,  # mutation class
-            Any,  # mutation root
-            ResolveInfo,  # resolve info
-            dict,  # mutation data
-        ],
-        Optional[Union[ExecutionResult, GraphQLError]],
-    ]
 
     def token_is_required_as_payment_input(self, previous_value):
         return previous_value

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -7,9 +7,6 @@ import opentracing
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.module_loading import import_string
-from graphene import Mutation
-from graphql import GraphQLError
-from graphql.execution import ExecutionResult
 from prices import TaxedMoney
 
 from ..channel.models import Channel
@@ -19,7 +16,7 @@ from ..core.models import EventDelivery
 from ..core.payments import PaymentInterface
 from ..core.prices import quantize_price
 from ..core.taxes import TaxData, TaxType, zero_money, zero_taxed_money
-from ..graphql.core import ResolveInfo, SaleorContext
+from ..graphql.core import SaleorContext
 from ..order import base_calculations as base_order_calculations
 from ..order.base_calculations import (
     base_order_line_total,
@@ -2538,29 +2535,6 @@ class PluginsManager(PaymentInterface):
             checkout,
             available_shipping_methods,
             channel_slug=channel.slug,
-        )
-
-    def perform_mutation(
-        self, mutation_cls: Mutation, root, info: ResolveInfo, data: dict
-    ) -> Optional[Union[ExecutionResult, GraphQLError]]:
-        """Invoke before each mutation is executed.
-
-        This allows to trigger specific logic before the mutation is executed
-        but only once the permissions are checked.
-
-        Returns one of:
-            - null if the execution shall continue
-            - graphql.GraphQLError
-            - graphql.execution.ExecutionResult
-        """
-        return self.__run_method_on_plugins(
-            "perform_mutation",
-            default_value=None,
-            mutation_cls=mutation_cls,
-            root=root,
-            info=info,
-            data=data,
-            channel_slug=None,
         )
 
     def is_event_active_for_any_plugin(

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -10,9 +10,6 @@ from typing import (
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
-from graphene import Mutation
-from graphql import GraphQLError, ResolveInfo
-from graphql.execution import ExecutionResult
 from prices import Money, TaxedMoney
 
 from ...account.models import User
@@ -312,16 +309,6 @@ class PluginSample(BasePlugin):
 
     def event_delivery_retry(self, delivery: "EventDelivery", previous_value: Any):
         return True
-
-    def perform_mutation(
-        self,
-        mutation_cls: Mutation,
-        root,
-        info: ResolveInfo,
-        data: dict,
-        previous_value: Optional[Union[ExecutionResult, GraphQLError]],
-    ) -> Optional[Union[ExecutionResult, GraphQLError]]:
-        return None
 
     def payment_gateway_initialize_session(
         self,


### PR DESCRIPTION
The `manager.perform_mutation` is deprecated in 3.20 and removed in 3.21. 

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
