### PR TITLE
Protect the Decimal scalar from non-normal numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi
 - Fixed a potential crash when Checkout metadata is accessed with high concurrency - #16411 by @patrys
+- Fixed a crash when the Decimal scalar is passed a non-normal value - #16520 by @patrys

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -33,7 +33,14 @@ class Decimal(graphene.Float):
             # Converting the float to str before parsing it to Decimal is
             # necessary to keep the decimal places as typed
             value = str(value)
-            return decimal.Decimal(value)
+            value = decimal.Decimal(value)
+            if value.is_infinite():
+                return None
+            if value.is_nan():
+                return None
+            if value.is_subnormal():
+                return None
+            return value
         except decimal.DecimalException:
             return None
 
@@ -46,7 +53,7 @@ class PositiveDecimal(Decimal):
 
     @staticmethod
     def parse_value(value):
-        value = super(PositiveDecimal, PositiveDecimal).parse_value(value)
+        value = Decimal.parse_value(value)
         if value and value < 0:
             return None
         return value
@@ -125,19 +132,19 @@ class WeightScalar(graphene.Scalar):
 class UUID(graphene.UUID):
     @staticmethod
     def serialize(uuid):
-        return super(UUID, UUID).serialize(uuid)
+        return graphene.UUID.serialize(uuid)
 
     @staticmethod
     def parse_literal(node):
         try:
-            return super(UUID, UUID).parse_literal(node)
+            return graphene.UUID.parse_literal(node)
         except ValueError:
             return None
 
     @staticmethod
     def parse_value(value):
         try:
-            return super(UUID, UUID).parse_value(value)
+            return graphene.UUID.parse_value(value)
         except ValueError:
             return None
 
@@ -153,7 +160,7 @@ class DateTime(graphene.DateTime):
 
     @staticmethod
     def parse_value(value):
-        parsed_value = super(DateTime, DateTime).parse_value(value)
+        parsed_value = graphene.DateTime.parse_value(value)
         if parsed_value is not None and isinstance(parsed_value, datetime):
             if parsed_value.year in [MINYEAR, MAXYEAR]:
                 try:
@@ -177,7 +184,7 @@ class Date(graphene.Date):
         # The current graphene version returning unhandled `IndexError`.
         if isinstance(value, str) and not value:
             return None
-        return super(Date, Date).parse_value(value)
+        return graphene.Date.parse_value(value)
 
 
 class Minute(graphene.Int):

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -5,6 +5,7 @@ import pytest
 from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
+from ..scalars import Decimal, PositiveDecimal
 from ..utils import to_global_id_or_none
 
 QUERY_CHECKOUT = """
@@ -419,3 +420,15 @@ def test_correct_date_time_as_input(
 
     # then
     get_graphql_content(response)
+
+
+@pytest.mark.parametrize("invalid_value", ["NaN", "-Infinity", "1e-9999999", "-", "x"])
+def test_decimal_scalar_invalid_value(invalid_value):
+    result = Decimal.parse_value(invalid_value)
+    assert result is None
+
+
+@pytest.mark.parametrize("invalid_value", ["NaN", "-Infinity", "1e-9999999", "-1"])
+def test_positive_decimal_scalar_invalid_value(invalid_value):
+    result = PositiveDecimal.parse_value(invalid_value)
+    assert result is None


### PR DESCRIPTION
The current implementation raises unhandled exceptions when passed values such as `"NaN"`.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
