### PR TITLE
Use graphene ID in gift card payment log

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -287,7 +287,10 @@ def test_checkout_complete(
 
     assert not len(Reservation.objects.all())
 
-    assert str(checkout_info.checkout.pk) == caplog.records[0].checkout_id
+    assert (
+        graphene.Node.to_global_id("Checkout", checkout_info.checkout.pk)
+        == caplog.records[0].checkout_id
+    )
     assert gift_card.initial_balance_amount == Decimal(
         caplog.records[0].gift_card_compensation
     )

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1300,7 +1300,10 @@ def test_checkout_complete(
 
     assert not len(Reservation.objects.all())
 
-    assert str(checkout_info.checkout.pk) == caplog.records[0].checkout_id
+    assert (
+        graphene.Node.to_global_id("Checkout", checkout_info.checkout.pk)
+        == caplog.records[0].checkout_id
+    )
     assert gift_card.initial_balance_amount == Decimal(
         caplog.records[0].gift_card_compensation
     )

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from decimal import Decimal
 from typing import TYPE_CHECKING, Optional, cast
 
+import graphene
 from django.db.models import QuerySet, Sum
 from django.utils import timezone
 from prices import Money, TaxedMoney
@@ -477,7 +478,9 @@ def add_gift_cards_to_order(
     gift_card_compensation = total_before_gift_card_compensation - total_price_left
     if gift_card_compensation.amount > 0:
         details = {
-            "checkout_id": str(checkout_info.checkout.pk),
+            "checkout_id": graphene.Node.to_global_id(
+                "Checkout", checkout_info.checkout.pk
+            ),
             "gift_card_compensation": str(gift_card_compensation.amount),
             "total_after_gift_card_compensation": str(total_price_left.amount),
         }


### PR DESCRIPTION
Use graphene ID in gift card payment log instead of DB id

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
