### PR TITLE
Generate sync checkout taxes webhook payloads in the dataloaders

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -35,12 +35,14 @@ def checkout_shipping_price(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> "TaxedMoney":
     """Return checkout shipping price.
 
     It takes in account all plugins.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     currency = checkout_info.checkout.currency
     checkout_info, _ = fetch_checkout_data(
         checkout_info,
@@ -78,12 +80,14 @@ def checkout_subtotal(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> "TaxedMoney":
     """Return the total cost of all the checkout lines, taxes included.
 
     It takes in account all plugins.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     currency = checkout_info.checkout.currency
     checkout_info, _ = fetch_checkout_data(
         checkout_info,
@@ -100,8 +104,10 @@ def calculate_checkout_total_with_gift_cards(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> "TaxedMoney":
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     total = (
         checkout_total(
             manager=manager,
@@ -122,7 +128,7 @@ def checkout_total(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> "TaxedMoney":
     """Return the total cost of the checkout.
 
@@ -131,6 +137,8 @@ def checkout_total(
 
     It takes in account all plugins.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     currency = checkout_info.checkout.currency
     checkout_info, _ = fetch_checkout_data(
         checkout_info,
@@ -163,12 +171,14 @@ def checkout_line_total(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     checkout_line_info: "CheckoutLineInfo",
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> TaxedMoney:
     """Return the total price of provided line, taxes included.
 
     It takes in account all plugins.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     currency = checkout_info.checkout.currency
     address = checkout_info.shipping_address or checkout_info.billing_address
     _, lines = fetch_checkout_data(
@@ -188,12 +198,14 @@ def checkout_line_unit_price(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     checkout_line_info: "CheckoutLineInfo",
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> TaxedMoney:
     """Return the unit price of provided line, taxes included.
 
     It takes in account all plugins.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     currency = checkout_info.checkout.currency
     address = checkout_info.shipping_address or checkout_info.billing_address
     _, lines = fetch_checkout_data(
@@ -236,7 +248,7 @@ def _fetch_checkout_prices_if_expired(
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"] = None,
     force_update: bool = False,
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> tuple["CheckoutInfo", Iterable["CheckoutLineInfo"]]:
     """Fetch checkout prices with taxes.
 
@@ -246,6 +258,9 @@ def _fetch_checkout_prices_if_expired(
     Prices can be updated only if force_update == True, or if time elapsed from the
     last price update is greater than settings.CHECKOUT_PRICES_TTL.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
+
     checkout = checkout_info.checkout
 
     if not force_update and checkout.price_expiration > timezone.now():
@@ -338,8 +353,10 @@ def _calculate_and_add_tax(
     lines: Iterable["CheckoutLineInfo"],
     prices_entered_with_tax: bool,
     address: Optional["Address"] = None,
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ):
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     if tax_calculation_strategy == TaxCalculationStrategy.TAX_APP:
         # Call the tax plugins.
         _apply_tax_data_from_plugins(checkout, manager, checkout_info, lines, address)
@@ -506,13 +523,15 @@ def fetch_checkout_data(
     force_update: bool = False,
     checkout_transactions: Optional[Iterable["TransactionItem"]] = None,
     force_status_update: bool = False,
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ):
     """Fetch checkout data.
 
     This function refreshes prices if they have expired. If the checkout total has
     changed as a result, it will update the payment statuses accordingly.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     previous_total_gross = checkout_info.checkout.total.gross
     checkout_info, lines = _fetch_checkout_prices_if_expired(
         checkout_info=checkout_info,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -412,7 +412,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(62):
+    with django_assert_num_queries(64):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -430,7 +430,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(62):
+    with django_assert_num_queries(64):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -681,7 +681,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(78):
+    with django_assert_num_queries(80):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -695,7 +695,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(78):
+    with django_assert_num_queries(80):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -940,7 +940,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(77):
+    with django_assert_num_queries(79):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -953,7 +953,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(77):
+    with django_assert_num_queries(79):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,

--- a/saleor/graphql/webhook/dataloaders.py
+++ b/saleor/graphql/webhook/dataloaders.py
@@ -1,8 +1,30 @@
 from collections import defaultdict
+from typing import Any
+
+from django.utils import timezone
+from promise import Promise
 
 from ...core.models import EventPayload
+from ...tax import TaxCalculationStrategy
+from ...tax.utils import (
+    get_tax_calculation_strategy,
+    get_tax_configuration_for_checkout,
+)
+from ...webhook.event_types import WebhookEventSyncType
 from ...webhook.models import Webhook, WebhookEvent
+from ...webhook.utils import get_webhooks_for_event
+from ..app.dataloaders import AppByIdLoader
+from ..checkout.dataloaders import (
+    CheckoutInfoByCheckoutTokenLoader,
+    CheckoutLinesInfoByCheckoutTokenLoader,
+)
 from ..core.dataloaders import DataLoader
+from ..utils import get_user_or_app_from_context
+from .subscription_payload import (
+    generate_payload_promise_from_subscription,
+    initialize_request,
+)
+from .utils import get_subscription_query_hash
 
 
 class PayloadByIdLoader(DataLoader[str, str]):
@@ -45,3 +67,102 @@ class WebhooksByAppIdLoader(DataLoader):
         for webhook in webhooks:
             webhooks_by_app_map[webhook.app_id].append(webhook)
         return [webhooks_by_app_map.get(app_id, []) for app_id in keys]
+
+
+class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
+    context_key = "pregenerated_checkout_tax_payloads_by_checkout_token"
+
+    def batch_load(self, keys):
+        """Fetch pregenerated tax payloads for checkouts.
+
+        This loader is used to fetch pregenerated tax payloads for checkouts.
+
+        return: A dict of tax payloads for checkouts.
+
+        Example:
+        {
+            "checkout_token": {
+                "app_id": {
+                    "query_hash": {
+                        <payload>
+                    }
+                }
+            }
+        }
+
+        """
+        results: dict[str, dict[int, dict[str, dict[str, Any]]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+
+        event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+        requestor = get_user_or_app_from_context(self.context)
+        request_context = initialize_request(
+            requestor,
+            sync_event=True,
+            allow_replica=False,
+            event_type=event_type,
+        )
+        webhooks = get_webhooks_for_event(event_type)
+        apps_ids = [webhook.app_id for webhook in webhooks]
+
+        def generate_payloads(data):
+            checkouts_info, checkout_lines_info, apps = data
+            apps_map = {app.id: app for app in apps}
+            promises = []
+            for checkout_info, lines_info in zip(checkouts_info, checkout_lines_info):
+                (
+                    tax_configuration,
+                    country_tax_configuration,
+                ) = get_tax_configuration_for_checkout(checkout_info, lines_info)
+                tax_strategy = get_tax_calculation_strategy(
+                    tax_configuration, country_tax_configuration
+                )
+
+                if (
+                    tax_strategy == TaxCalculationStrategy.TAX_APP
+                    and checkout_info.checkout.price_expiration <= timezone.now()
+                ):
+                    for webhook in webhooks:
+                        app_id = webhook.app_id
+                        app = apps_map[app_id]
+                        if webhook.subscription_query:
+                            query_hash = get_subscription_query_hash(
+                                webhook.subscription_query
+                            )
+                            checkout = checkout_info.checkout
+                            checkout_token = str(checkout.pk)
+
+                            promise_payload = (
+                                generate_payload_promise_from_subscription(
+                                    event_type=event_type,
+                                    subscribable_object=checkout,
+                                    subscription_query=webhook.subscription_query,
+                                    request=request_context,
+                                    app=app,
+                                )
+                            )
+                            promises.append(promise_payload)
+
+                            def store_payload(
+                                payload,
+                                checkout_token=checkout_token,
+                                app_id=app_id,
+                                query_hash=query_hash,
+                            ):
+                                if payload:
+                                    results[checkout_token][app_id][
+                                        query_hash
+                                    ] = payload
+
+                            promise_payload.then(store_payload)
+
+            def return_payloads(_payloads):
+                return [results[str(checkout_token)] for checkout_token in keys]
+
+            return Promise.all(promises).then(return_payloads)
+
+        checkouts_info = CheckoutInfoByCheckoutTokenLoader(self.context).load_many(keys)
+        lines = CheckoutLinesInfoByCheckoutTokenLoader(self.context).load_many(keys)
+        apps = AppByIdLoader(self.context).load_many(apps_ids)
+        return Promise.all([checkouts_info, lines, apps]).then(generate_payloads)

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -65,6 +65,90 @@ def get_event_payload(event):
     return event
 
 
+def generate_payload_promise_from_subscription(
+    event_type: str,
+    subscribable_object,
+    subscription_query: str,
+    request: SaleorContext,
+    app: Optional[App] = None,
+) -> Promise[Optional[dict[str, Any]]]:
+    """Generate webhook payload from subscription query.
+
+    It uses a graphql's engine to build payload by using the same logic as response.
+    As an input it expects given event type and object and the query which will be
+    used to resolve a payload.
+    event_type: is an event which will be triggered.
+    subscribable_object: is an object which have a dedicated own type in Subscription
+    definition.
+    subscription_query: query used to prepare a payload via graphql engine.
+    request: A dummy request used to share context between apps in order to use
+    dataloaders benefits.
+    app: the owner of the given payload. Required in case when webhook contains
+    protected fields.
+    return: A payload ready to send via webhook. None if the function was not able to
+    generate a payload
+    """
+
+    from ..api import schema
+    from ..context import get_context_value
+
+    graphql_backend = get_default_backend()
+    ast = parse(subscription_query)
+    document = graphql_backend.document_from_string(
+        schema,
+        ast,
+    )
+    app_id = app.pk if app else None
+    request.app = app
+    results_promise = document.execute(
+        allow_subscriptions=True,
+        root=(event_type, subscribable_object),
+        context=get_context_value(request),
+        return_promise=True,
+    )
+
+    def return_payload_promise(
+        results, app_id=app_id, subscription_query=subscription_query
+    ):
+        if hasattr(results, "errors"):
+            logger.warning(
+                "Unable to build a payload for subscription. \n"
+                f"error: {str(results.errors)}",
+                extra={"query": subscription_query, "app": app_id},
+            )
+            return None
+
+        payload: list[Any] = []
+        results.subscribe(payload.append)
+
+        if not payload:
+            logger.warning(
+                "Subscription did not return a payload.",
+                extra={"query": subscription_query, "app": app_id},
+            )
+            return None
+
+        payload_instance = payload[0]
+        event_payload = payload_instance.data.get("event") or {}
+
+        def check_errors(event_payload, payload_instance=payload_instance):
+            if payload_instance.errors:
+                event_payload["errors"] = [
+                    format_error(error, (GraphQLError, PermissionDenied))
+                    for error in payload_instance.errors
+                ]
+            return event_payload
+
+        if isinstance(event_payload, Promise):
+            return event_payload.then(check_errors)
+        return check_errors(event_payload)
+
+    if isinstance(results_promise, Promise):
+        return results_promise.then(return_payload_promise)
+    result = return_payload_promise(results_promise)
+    return Promise.resolve(result)
+
+
 def generate_payload_from_subscription(
     event_type: str,
     subscribable_object,
@@ -81,7 +165,7 @@ def generate_payload_from_subscription(
     subscribable_object: is an object which have a dedicated own type in Subscription
     definition.
     subscription_query: query used to prepare a payload via graphql engine.
-    context: A dummy request used to share context between apps in order to use
+    request: A dummy request used to share context between apps in order to use
     dataloaders benefits.
     app: the owner of the given payload. Required in case when webhook contains
     protected fields.
@@ -123,7 +207,7 @@ def generate_payload_from_subscription(
         return None
 
     payload_instance = payload[0]
-    event_payload = get_event_payload(payload_instance.data.get("event"))
+    event_payload = get_event_payload(payload_instance.data.get("event")) or {}
 
     if payload_instance.errors:
         event_payload["errors"] = [

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -1,0 +1,370 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.test import override_settings
+from django.utils import timezone
+
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_total_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_subtotal_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                subtotalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_total_balance_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalBalance {
+                    amount
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_shipping_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                shippingPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                    tax {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_authorize_status_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                authorizeStatus
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_charge_status_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                chargeStatus
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_line_unit_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout_with_item,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout_with_item.price_expiration = timezone.now() - timedelta(days=1)
+    checkout_with_item.save()
+    checkout_global_id = to_global_id_or_none(checkout_with_item)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                lines {
+                    unitPrice {
+                        net {
+                            amount
+                        }
+                        gross {
+                            amount
+                        }
+                        tax {
+                            amount
+                        }
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_checkout_line_total_price_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout_with_item,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout_with_item.price_expiration = timezone.now() - timedelta(days=1)
+    checkout_with_item.save()
+    checkout_global_id = to_global_id_or_none(checkout_with_item)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                lines {
+                    totalPrice {
+                        net {
+                            amount
+                        }
+                        gross {
+                            amount
+                        }
+                        tax {
+                            amount
+                        }
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_tax_configurations_with_pregenerated_payloads.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_tax_configurations_with_pregenerated_payloads.py
@@ -1,0 +1,375 @@
+from collections import defaultdict
+from datetime import timedelta
+from unittest import mock
+
+from django.test import override_settings
+from django.utils import timezone
+
+from .....checkout.calculations import fetch_checkout_data
+from .....tax import TaxCalculationStrategy
+from .....tax.models import TaxConfiguration
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_tax_app_price_entered_with_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_tax_app_price_entered_without_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = False
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_selected_external_tax_app_price_entered_without_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = False
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_external_tax_app_price_entered_with_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_called_once()
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_all_apps_price_entered_with_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    # Set response for tax calculation to None to ensure that all apps are called
+    mock_request.return_value = None
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    assert mock_request.call_count == 2
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_pregenerated_payload_with_all_apps_price_entered_without_tax(
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+    external_tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = False
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    # Set response for tax calculation to None to ensure that all apps are called
+    mock_request.return_value = None
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    mock_generate_payload.assert_not_called()
+    assert mock_request.call_count == 2
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+@mock.patch(
+    "saleor.checkout.calculations.fetch_checkout_data",
+    wraps=fetch_checkout_data,
+)
+def test_pregenerated_payload_skipped_when_checkout_not_expired(
+    mock_fetch_checkout_data,
+    mock_generate_payload,
+    mock_request,
+    checkout,
+    api_client,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    tax_configuration = TaxConfiguration.objects.get()
+    tax_configuration.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.save()
+    checkout.price_expiration = timezone.now() + timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    checkout_total_price_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = tax_data_response
+
+    # when
+    response = api_client.post_graphql(checkout_total_price_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    mock_generate_payload.assert_not_called()
+    mock_request.assert_not_called()
+    mock_fetch_checkout_data.assert_called_once()
+    assert mock_fetch_checkout_data.call_args.kwargs[
+        "pregenerated_subscription_payloads"
+    ] == defaultdict(dict)

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_utils.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_utils.py
@@ -1,0 +1,104 @@
+from .....webhook.models import Webhook
+from ...utils import get_pregenerated_subscription_payload, get_subscription_query_hash
+
+
+def test_get_subscription_query_hash():
+    # given
+    subscription_query = "subscription { orderCreated { id } }"
+
+    # when
+    query_hash = get_subscription_query_hash(subscription_query)
+
+    # then
+    assert query_hash == "6553179c22234d0b8e07d8db49ac9bd2"
+
+
+def test_get_pregenerated_subscription_payload(webhook_app):
+    # given
+    example_payload = {"payload": "example"}
+    subscription_query = "subscription { orderCreated { id } }"
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=subscription_query,
+    )
+
+    pregenerated_subscription_payloads = {
+        webhook_app.pk: {"6553179c22234d0b8e07d8db49ac9bd2": example_payload}
+    }
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload == example_payload
+
+
+def test_get_pregenerated_subscription_payload_payload_for_other_app(webhook_app):
+    # given
+    example_payload = {"payload": "example"}
+    subscription_query = "subscription { orderCreated { id } }"
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=subscription_query,
+    )
+    invalid_app_id = webhook_app.pk + 1
+
+    pregenerated_subscription_payloads = {
+        invalid_app_id: {"6553179c22234d0b8e07d8db49ac9bd2": example_payload}
+    }
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload is None
+
+
+def test_get_pregenerated_subscription_payload_empty_pregenerated_dict(webhook_app):
+    # given
+    subscription_query = "subscription { orderCreated { id } }"
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=subscription_query,
+    )
+
+    pregenerated_subscription_payloads = {}
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload is None
+
+
+def test_get_pregenerated_subscription_payload_webhook_without_subscription(
+    webhook_app,
+):
+    # given
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+    )
+
+    pregenerated_subscription_payloads = {}
+
+    # when
+    payload = get_pregenerated_subscription_payload(
+        webhook, pregenerated_subscription_payloads
+    )
+
+    # then
+    assert payload is None

--- a/saleor/graphql/webhook/tests/test_subscription_payload.py
+++ b/saleor/graphql/webhook/tests/test_subscription_payload.py
@@ -1,9 +1,12 @@
+import graphene
 from django.test import override_settings
 from django.utils import timezone
 
-from ....webhook.event_types import WebhookEventAsyncType
+from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....webhook.models import Webhook
 from ..subscription_payload import (
+    generate_payload_from_subscription,
+    generate_payload_promise_from_subscription,
     generate_pre_save_payloads,
     get_pre_save_payload_key,
     initialize_request,
@@ -117,3 +120,327 @@ def test_generate_pre_save_payloads(webhook_app, variant):
     key = get_pre_save_payload_key(webhook, variant)
     assert key in pre_save_payloads
     assert pre_save_payloads[key]
+
+
+def test_generate_payload_from_subscription(
+    checkout,
+    subscription_webhook,
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ... on Checkout {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request()
+    checkout_global_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    assert payload["taxBase"]["sourceObject"]["id"] == checkout_global_id
+
+
+def test_generate_payload_from_subscription_missing_permissions(
+    gift_card, subscription_gift_card_created_webhook, permission_manage_gift_card
+):
+    # given
+
+    webhook = subscription_gift_card_created_webhook
+    app = webhook.app
+    app.permissions.remove(permission_manage_gift_card)
+    request = initialize_request(requestor=app, sync_event=False)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventAsyncType.GIFT_CARD_CREATED,
+        subscribable_object=gift_card,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    error_code = "PermissionDenied"
+    assert "errors" in payload.keys()
+    assert not payload["giftCard"]
+    error = payload["errors"][0]
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_from_subscription_circular_call(
+    checkout, subscription_webhook, permission_handle_taxes
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    error_code = "CircularSubscriptionSyncEvent"
+    assert list(payload.keys()) == ["errors"]
+    error = payload["errors"][0]
+    assert (
+        error["message"] == "Resolving this field is not allowed in synchronous events."
+    )
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_from_subscription_unable_to_build_payload(
+    checkout, subscription_webhook
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on OrderCalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    assert payload is None
+
+
+def test_generate_payload_promise_from_subscription(
+    checkout,
+    subscription_webhook,
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ... on Checkout {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request()
+    checkout_global_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    payload = payload.get()
+    assert payload["taxBase"]["sourceObject"]["id"] == checkout_global_id
+
+
+def test_generate_payload_promise_from_subscription_missing_permissions(
+    gift_card, subscription_gift_card_created_webhook, permission_manage_gift_card
+):
+    # given
+
+    webhook = subscription_gift_card_created_webhook
+    app = webhook.app
+    app.permissions.remove(permission_manage_gift_card)
+    request = initialize_request(requestor=app, sync_event=False)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventAsyncType.GIFT_CARD_CREATED,
+        subscribable_object=gift_card,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+
+    # then
+    payload = payload.get()
+    error_code = "PermissionDenied"
+    assert "errors" in payload.keys()
+    assert not payload["giftCard"]
+    error = payload["errors"][0]
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_promise_from_subscription_circular_call(
+    checkout, subscription_webhook, permission_handle_taxes
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    payload = payload.get()
+    error_code = "CircularSubscriptionSyncEvent"
+    assert list(payload.keys()) == ["errors"]
+    error = payload["errors"][0]
+    assert (
+        error["message"] == "Resolving this field is not allowed in synchronous events."
+    )
+    assert error["extensions"]["exception"]["code"] == error_code
+
+
+def test_generate_payload_promise_from_subscription_unable_to_build_payload(
+    checkout, subscription_webhook
+):
+    # given
+    query = """
+    subscription {
+      event {
+        ... on OrderCalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Checkout{
+                totalPrice {
+                  gross {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    webhook = subscription_webhook(
+        query,
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+    )
+    app = webhook.app
+    request = initialize_request(requestor=app, sync_event=True)
+
+    # when
+    payload = generate_payload_promise_from_subscription(
+        event_type=WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+        subscribable_object=checkout,
+        subscription_query=webhook.subscription_query,
+        request=request,
+        app=app,
+    )
+    # then
+    payload = payload.get()
+    assert payload is None

--- a/saleor/graphql/webhook/utils.py
+++ b/saleor/graphql/webhook/utils.py
@@ -1,0 +1,24 @@
+import hashlib
+import logging
+from typing import Optional
+
+from ...webhook.models import Webhook
+
+logger = logging.getLogger(__name__)
+
+
+def get_subscription_query_hash(subscription_query: str) -> str:
+    return hashlib.md5(subscription_query.encode("utf-8")).hexdigest()
+
+
+def get_pregenerated_subscription_payload(
+    webhook: Webhook,
+    pregenerated_subscription_payloads: Optional[dict] = {},
+) -> Optional[dict]:
+    if webhook.subscription_query is None or pregenerated_subscription_payloads is None:
+        return None
+
+    query_hash = get_subscription_query_hash(webhook.subscription_query)
+    return pregenerated_subscription_payloads.get(webhook.app_id, {}).get(
+        query_hash, None
+    )

--- a/saleor/graphql/webhook/utils.py
+++ b/saleor/graphql/webhook/utils.py
@@ -13,8 +13,10 @@ def get_subscription_query_hash(subscription_query: str) -> str:
 
 def get_pregenerated_subscription_payload(
     webhook: Webhook,
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> Optional[dict]:
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
     if webhook.subscription_query is None or pregenerated_subscription_payloads is None:
         return None
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -604,7 +604,7 @@ class BasePlugin:
     ]
 
     get_taxes_for_checkout: Callable[
-        ["CheckoutInfo", Iterable["CheckoutLineInfo"], Any],
+        ["CheckoutInfo", Iterable["CheckoutLineInfo"], Any, Optional[dict]],
         Optional["TaxData"],
     ]
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -596,8 +596,10 @@ class PluginsManager(PaymentInterface):
         self,
         checkout_info,
         lines,
-        pregenerated_subscription_payloads: Optional[dict] = {},
+        pregenerated_subscription_payloads: Optional[dict] = None,
     ) -> Optional[TaxData]:
+        if pregenerated_subscription_payloads is None:
+            pregenerated_subscription_payloads = {}
         return self.__run_plugin_method_until_first_success(
             "get_taxes_for_checkout",
             checkout_info,

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -592,11 +592,17 @@ class PluginsManager(PaymentInterface):
             or default_value
         )
 
-    def get_taxes_for_checkout(self, checkout_info, lines) -> Optional[TaxData]:
+    def get_taxes_for_checkout(
+        self,
+        checkout_info,
+        lines,
+        pregenerated_subscription_payloads: Optional[dict] = {},
+    ) -> Optional[TaxData]:
         return self.__run_plugin_method_until_first_success(
             "get_taxes_for_checkout",
             checkout_info,
             lines,
+            pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             channel_slug=checkout_info.channel.slug,
         )
 
@@ -2195,13 +2201,14 @@ class PluginsManager(PaymentInterface):
         *args,
         channel_slug: Optional[str],
         plugins: Optional[list["BasePlugin"]] = None,
+        **kwargs,
     ):
         if plugins is None:
             plugins = self.get_plugins(channel_slug=channel_slug, active_only=True)
         if plugins:
             for plugin in plugins:
                 result = self.__run_method_on_single_plugin(
-                    plugin, method_name, None, *args
+                    plugin, method_name, None, *args, **kwargs
                 )
                 if result is not None:
                     return result

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -297,7 +297,7 @@ class PluginSample(BasePlugin):
         checkout_info: "CheckoutInfo",
         lines,
         previous_value,
-        pregenerated_subscription_payloads={},
+        pregenerated_subscription_payloads=None,
     ) -> Optional["TaxData"]:
         return sample_tax_data(checkout_info.checkout)
 

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -293,7 +293,11 @@ class PluginSample(BasePlugin):
         return Decimal("0.080").quantize(Decimal(".01"))
 
     def get_taxes_for_checkout(
-        self, checkout_info: "CheckoutInfo", lines, previous_value
+        self,
+        checkout_info: "CheckoutInfo",
+        lines,
+        previous_value,
+        pregenerated_subscription_payloads={},
     ) -> Optional["TaxData"]:
         return sample_tax_data(checkout_info.checkout)
 

--- a/saleor/plugins/webhook/conftest.py
+++ b/saleor/plugins/webhook/conftest.py
@@ -6,34 +6,6 @@ from ..manager import get_plugins_manager
 
 
 @pytest.fixture
-def tax_line_data_response():
-    return {
-        "id": "1234",
-        "currency": "PLN",
-        "unit_net_amount": 12.34,
-        "unit_gross_amount": 12.34,
-        "total_gross_amount": 12.34,
-        "total_net_amount": 12.34,
-        "tax_rate": 23,
-    }
-
-
-@pytest.fixture
-def tax_data_response(tax_line_data_response):
-    return {
-        "currency": "PLN",
-        "total_net_amount": 12.34,
-        "total_gross_amount": 12.34,
-        "subtotal_net_amount": 12.34,
-        "subtotal_gross_amount": 12.34,
-        "shipping_price_gross_amount": 12.34,
-        "shipping_price_net_amount": 12.34,
-        "shipping_tax_rate": 23,
-        "lines": [tax_line_data_response] * 5,
-    }
-
-
-@pytest.fixture
 def tax_app(app, permission_handle_taxes, webhook):
     app.permissions.add(permission_handle_taxes)
     return app

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2998,8 +2998,10 @@ class WebhookPlugin(BasePlugin):
         checkout_info,
         lines,
         previous_value,
-        pregenerated_subscription_payloads: Optional[dict] = {},
+        pregenerated_subscription_payloads: Optional[dict] = None,
     ) -> Optional["TaxData"]:
+        if pregenerated_subscription_payloads is None:
+            pregenerated_subscription_payloads = {}
         return trigger_all_webhooks_sync(
             WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
             lambda: generate_checkout_payload_for_tax_calculation(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2994,7 +2994,11 @@ class WebhookPlugin(BasePlugin):
         )
 
     def get_taxes_for_checkout(
-        self, checkout_info, lines, previous_value
+        self,
+        checkout_info,
+        lines,
+        previous_value,
+        pregenerated_subscription_payloads: Optional[dict] = {},
     ) -> Optional["TaxData"]:
         return trigger_all_webhooks_sync(
             WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
@@ -3005,6 +3009,7 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             checkout_info.checkout,
             self.requestor,
+            pregenerated_subscription_payloads=pregenerated_subscription_payloads,
         )
 
     def get_taxes_for_order(

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -105,7 +105,7 @@ def get_tax_calculation_strategy_for_order(order: "Order"):
     return get_tax_calculation_strategy(tax_configuration, country_tax_configuration)
 
 
-def _get_tax_configuration_for_checkout(
+def get_tax_configuration_for_checkout(
     checkout_info: "CheckoutInfo", lines: Iterable["CheckoutLineInfo"]
 ) -> tuple["TaxConfiguration", Optional["TaxConfigurationPerCountry"]]:
     tax_configuration = checkout_info.tax_configuration
@@ -129,7 +129,7 @@ def get_charge_taxes_for_checkout(
     checkout_info: "CheckoutInfo", lines: Iterable["CheckoutLineInfo"]
 ):
     """Get charge_taxes value for checkout."""
-    tax_configuration, country_tax_configuration = _get_tax_configuration_for_checkout(
+    tax_configuration, country_tax_configuration = get_tax_configuration_for_checkout(
         checkout_info, lines
     )
     return get_charge_taxes(tax_configuration, country_tax_configuration)
@@ -139,7 +139,7 @@ def get_tax_calculation_strategy_for_checkout(
     checkout_info: "CheckoutInfo", lines: Iterable["CheckoutLineInfo"]
 ):
     """Get tax_calculation_strategy value for checkout."""
-    tax_configuration, country_tax_configuration = _get_tax_configuration_for_checkout(
+    tax_configuration, country_tax_configuration = get_tax_configuration_for_checkout(
         checkout_info, lines
     )
     return get_tax_calculation_strategy(tax_configuration, country_tax_configuration)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -75,6 +75,7 @@ from ..discount.models import (
 )
 from ..giftcard import GiftCardEvents
 from ..giftcard.models import GiftCard, GiftCardEvent, GiftCardTag
+from ..graphql.core.utils import to_global_id_or_none
 from ..menu.models import Menu, MenuItem, MenuItemTranslation
 from ..order import OrderOrigin, OrderStatus
 from ..order.actions import cancel_fulfillment, fulfill_order_lines
@@ -7362,6 +7363,8 @@ def payment_method_process_tokenization_app(db, permission_manage_payments):
 @pytest.fixture
 def tax_app(db, permission_handle_taxes):
     app = App.objects.create(name="Tax App", is_active=True)
+    app.identifier = to_global_id_or_none(app)
+    app.save()
     app.permissions.add(permission_handle_taxes)
 
     webhook = Webhook.objects.create(
@@ -7380,6 +7383,70 @@ def tax_app(db, permission_handle_taxes):
         ]
     )
     return app
+
+
+@pytest.fixture
+def external_tax_app(db, permission_handle_taxes):
+    app = App.objects.create(
+        name="External App",
+        is_active=True,
+        type=AppType.THIRDPARTY,
+        identifier="mirumee.app.simple.tax",
+        about_app="About app text.",
+        data_privacy="Data privacy text.",
+        data_privacy_url="http://www.example.com/privacy/",
+        homepage_url="http://www.example.com/homepage/",
+        support_url="http://www.example.com/support/contact/",
+        configuration_url="http://www.example.com/app-configuration/",
+        app_url="http://www.example.com/app/",
+    )
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_handle_taxes)
+
+    webhook = Webhook.objects.create(
+        name="external-tax-webhook-1",
+        app=app,
+        target_url="https://tax-app.example.com/api/",
+        subscription_query=CALCULATE_TAXES_SUBSCRIPTION_QUERY,
+    )
+    webhook.events.bulk_create(
+        [
+            WebhookEvent(event_type=event_type, webhook=webhook)
+            for event_type in [
+                WebhookEventSyncType.ORDER_CALCULATE_TAXES,
+                WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES,
+            ]
+        ]
+    )
+    return app
+
+
+@pytest.fixture
+def tax_line_data_response():
+    return {
+        "id": "1234",
+        "currency": "PLN",
+        "unit_net_amount": 12.34,
+        "unit_gross_amount": 12.34,
+        "total_gross_amount": 12.34,
+        "total_net_amount": 12.34,
+        "tax_rate": 23,
+    }
+
+
+@pytest.fixture
+def tax_data_response(tax_line_data_response):
+    return {
+        "currency": "PLN",
+        "total_net_amount": 12.34,
+        "total_gross_amount": 12.34,
+        "subtotal_net_amount": 12.34,
+        "subtotal_gross_amount": 12.34,
+        "shipping_price_gross_amount": 12.34,
+        "shipping_price_net_amount": 12.34,
+        "shipping_tax_rate": 23,
+        "lines": [tax_line_data_response] * 5,
+    }
 
 
 @pytest.fixture

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -314,7 +314,7 @@ def trigger_all_webhooks_sync(
     subscribable_object=None,
     requestor=None,
     allow_replica=False,
-    pregenerated_subscription_payloads: Optional[dict] = {},
+    pregenerated_subscription_payloads: Optional[dict] = None,
 ) -> Optional[R]:
     """Send all synchronous webhook request for given event type.
 
@@ -324,6 +324,9 @@ def trigger_all_webhooks_sync(
     If no webhook responds with expected response,
     this function returns None.
     """
+    if pregenerated_subscription_payloads is None:
+        pregenerated_subscription_payloads = {}
+
     webhooks = get_webhooks_for_event(event_type)
     request_context = None
     event_payload = None

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -18,6 +18,7 @@ from ....graphql.webhook.subscription_payload import (
     initialize_request,
 )
 from ....graphql.webhook.subscription_types import WEBHOOK_TYPES_MAP
+from ....graphql.webhook.utils import get_pregenerated_subscription_payload
 from ....payment.models import TransactionEvent
 from ....payment.utils import (
     create_transaction_event_from_request_and_webhook_response,
@@ -211,6 +212,7 @@ def create_delivery_for_subscription_sync_event(
     requestor=None,
     request=None,
     allow_replica=False,
+    pregenerated_payload: Optional[dict] = None,
 ) -> Optional[EventDelivery]:
     """Generate webhook payload based on subscription query and create delivery object.
 
@@ -222,8 +224,9 @@ def create_delivery_for_subscription_sync_event(
     :param webhook: webhook object for which delivery will be created.
     :param requestor: used in subscription webhooks to generate meta data for payload.
     :param request: used to share context between sync event calls
-    :return: List of event deliveries to send via webhook tasks.
     :param allow_replica: use replica database.
+    :param pregenerated_payload: Pregenerated payload to use instead of generating one when creating delivery.
+    :return: List of event deliveries to send via webhook tasks.
     """
     if event_type not in WEBHOOK_TYPES_MAP:
         logger.info(
@@ -238,13 +241,17 @@ def create_delivery_for_subscription_sync_event(
             event_type=event_type,
             allow_replica=allow_replica,
         )
-    data = generate_payload_from_subscription(
-        event_type=event_type,
-        subscribable_object=subscribable_object,
-        subscription_query=webhook.subscription_query,
-        request=request,
-        app=webhook.app,
-    )
+    if not pregenerated_payload:
+        data = generate_payload_from_subscription(
+            event_type=event_type,
+            subscribable_object=subscribable_object,
+            subscription_query=webhook.subscription_query,
+            request=request,
+            app=webhook.app,
+        )
+    else:
+        data = pregenerated_payload
+
     if not data:
         logger.info(
             "No payload was generated with subscription for event: %s", event_type
@@ -270,6 +277,7 @@ def trigger_webhook_sync(
     subscribable_object=None,
     timeout=None,
     request=None,
+    pregenerated_subscription_payload: Optional[dict] = None,
 ) -> Optional[dict[Any, Any]]:
     """Send a synchronous webhook request."""
     if webhook.subscription_query:
@@ -279,6 +287,7 @@ def trigger_webhook_sync(
             webhook=webhook,
             request=request,
             allow_replica=allow_replica,
+            pregenerated_payload=pregenerated_subscription_payload,
         )
         if not delivery:
             return None
@@ -305,6 +314,7 @@ def trigger_all_webhooks_sync(
     subscribable_object=None,
     requestor=None,
     allow_replica=False,
+    pregenerated_subscription_payloads: Optional[dict] = {},
 ) -> Optional[R]:
     """Send all synchronous webhook request for given event type.
 
@@ -327,12 +337,17 @@ def trigger_all_webhooks_sync(
                     event_type=event_type,
                 )
 
+            pregenerated_payload = get_pregenerated_subscription_payload(
+                webhook, pregenerated_subscription_payloads
+            )
+
             delivery = create_delivery_for_subscription_sync_event(
                 event_type=event_type,
                 subscribable_object=subscribable_object,
                 webhook=webhook,
                 request=request_context,
                 requestor=requestor,
+                pregenerated_payload=pregenerated_payload,
             )
             if not delivery:
                 return None


### PR DESCRIPTION
Port #16086

I want to merge this change because generating sync webhook payloads in the dataloaders. 

TODO:
- [x] Adjust flow to handle multiple webhooks flows 
- [x] create pre-payloads generated dataloader
- [x] Use created dataloader in all checkout resolvers with price recalcualtion
- [x] Cover flow with prices entered with taxes

In separate PR. 
- Cover draft orders flow.
- Cover flow for other sync webhooks called via resolvers 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
