### PR TITLE
Clean up the input arguments for order and checkout call_event logic

### DIFF
--- a/saleor/checkout/actions.py
+++ b/saleor/checkout/actions.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from datetime import timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from django.utils import timezone
 
@@ -25,24 +25,37 @@ from .payment_utils import update_refundable_for_checkout
 
 if TYPE_CHECKING:
     from ..account.models import Address
-    from ..plugins.manager import PluginsManager
     from ..webhook.models import Webhook
 
+from ..plugins.manager import PluginsManager
 
-def call_checkout_event_for_checkout(
+CHECKOUT_WEBHOOK_EVENT_MAP = {
+    WebhookEventAsyncType.CHECKOUT_CREATED: PluginsManager.checkout_created.__name__,
+    WebhookEventAsyncType.CHECKOUT_UPDATED: PluginsManager.checkout_updated.__name__,
+    WebhookEventAsyncType.CHECKOUT_FULLY_PAID: PluginsManager.checkout_fully_paid.__name__,
+    WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED: PluginsManager.checkout_metadata_updated.__name__,
+}
+
+
+def call_checkout_event(
     manager: "PluginsManager",
-    event_func: Callable,
     event_name: str,
     checkout: "Checkout",
 ):
+    if event_name not in CHECKOUT_WEBHOOK_EVENT_MAP:
+        raise ValueError(f"Event {event_name} not found in CHECKOUT_WEBHOOK_EVENT_MAP.")
+
     webhook_event_map = get_webhooks_for_multiple_events(
         [event_name, *WebhookEventSyncType.CHECKOUT_EVENTS]
     )
+
     if not webhook_async_event_requires_sync_webhooks_to_trigger(
         event_name,
         webhook_event_map,
         possible_sync_events=WebhookEventSyncType.CHECKOUT_EVENTS,
     ):
+        plugin_manager_method_name = CHECKOUT_WEBHOOK_EVENT_MAP[event_name]
+        event_func = getattr(manager, plugin_manager_method_name)
         call_event_including_protected_events(event_func, checkout)
         return
 
@@ -54,9 +67,8 @@ def call_checkout_event_for_checkout(
         lines_info,
         manager,
     )
-    call_checkout_event_for_checkout_info(
+    call_checkout_info_event(
         manager=manager,
-        event_func=event_func,
         event_name=event_name,
         checkout_info=checkout_info,
         lines=lines_info,
@@ -65,9 +77,8 @@ def call_checkout_event_for_checkout(
     return
 
 
-def call_checkout_event_for_checkout_info(
+def call_checkout_info_event(
     manager: "PluginsManager",
-    event_func: Callable,
     event_name: str,
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
@@ -79,6 +90,11 @@ def call_checkout_event_for_checkout_info(
         webhook_event_map = get_webhooks_for_multiple_events(
             [event_name, *WebhookEventSyncType.CHECKOUT_EVENTS]
         )
+    if event_name not in CHECKOUT_WEBHOOK_EVENT_MAP:
+        raise ValueError(f"Event {event_name} not found in CHECKOUT_WEBHOOK_EVENT_MAP.")
+
+    plugin_manager_method_name = CHECKOUT_WEBHOOK_EVENT_MAP[event_name]
+    event_func = getattr(manager, plugin_manager_method_name)
 
     # No need to trigger additional sync webhook when we don't have active webhook or
     # we don't have active sync checkout webhooks
@@ -156,9 +172,8 @@ def transaction_amounts_for_checkout_updated(
         update_refundable_for_checkout(checkout.pk)
 
     if not previous_charge_status_is_fully_paid and current_status_is_fully_paid:
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_fully_paid,
             event_name=WebhookEventAsyncType.CHECKOUT_FULLY_PAID,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -1,7 +1,7 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import (
     fetch_checkout_info,
@@ -121,9 +121,8 @@ class CheckoutAddPromoCode(BaseMutation):
             recalculate_discount=False,
             save=True,
         )
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager=manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ....checkout import AddressType
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import change_billing_address_in_checkout, invalidate_checkout
 from ....core.tracing import traced_atomic_transaction
@@ -108,9 +108,8 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
                 + invalidate_prices_updated_fields
             )
 
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager=manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -4,7 +4,7 @@ import graphene
 from django.conf import settings
 
 from ....checkout import AddressType, models
-from ....checkout.actions import call_checkout_event_for_checkout
+from ....checkout.actions import call_checkout_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.utils import add_variants_to_checkout
 from ....core.tracing import traced_atomic_transaction
@@ -408,9 +408,8 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         checkout = response.checkout
         apply_gift_reward_if_applicable_on_checkout_creation(response.checkout)
         manager = get_plugin_manager_promise(info.context).get()
-        call_checkout_event_for_checkout(
+        call_checkout_event(
             manager,
-            event_func=manager.checkout_created,
             event_name=WebhookEventAsyncType.CHECKOUT_CREATED,
             checkout=checkout,
         )

--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -1,7 +1,7 @@
 import graphene
 from django.forms import ValidationError
 
-from ....checkout.actions import call_checkout_event_for_checkout
+from ....checkout.actions import call_checkout_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....core.exceptions import PermissionDenied
 from ....permission.auth_filters import AuthorizationFilters
@@ -118,9 +118,8 @@ class CheckoutCustomerAttach(BaseMutation):
         checkout.save(update_fields=["email", "user", "last_change"])
         manager = get_plugin_manager_promise(info.context).get()
 
-        call_checkout_event_for_checkout(
+        call_checkout_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )

--- a/saleor/graphql/checkout/mutations/checkout_customer_detach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_detach.py
@@ -1,8 +1,6 @@
 import graphene
 
-from ....checkout.actions import (
-    call_checkout_event_for_checkout,
-)
+from ....checkout.actions import call_checkout_event
 from ....core.exceptions import PermissionDenied
 from ....permission.auth_filters import AuthorizationFilters
 from ....permission.enums import AccountPermissions
@@ -72,9 +70,8 @@ class CheckoutCustomerDetach(BaseMutation):
         checkout.save(update_fields=["user", "last_change"])
         manager = get_plugin_manager_promise(info.context).get()
 
-        call_checkout_event_for_checkout(
+        call_checkout_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -4,7 +4,7 @@ from typing import Optional
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import (
     CheckoutInfo,
@@ -270,9 +270,8 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             update_fields=checkout_fields_to_update + invalidate_prices_updated_fields
         )
         get_or_create_checkout_metadata(checkout).save()
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_email_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_email_update.py
@@ -1,7 +1,7 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.actions import call_checkout_event_for_checkout
+from ....checkout.actions import call_checkout_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
@@ -80,9 +80,8 @@ class CheckoutEmailUpdate(BaseMutation):
         cls.clean_instance(info, checkout)
         checkout.save(update_fields=["email", "last_change"])
         manager = get_plugin_manager_promise(info.context).get()
-        call_checkout_event_for_checkout(
+        call_checkout_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )

--- a/saleor/graphql/checkout/mutations/checkout_language_code_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_language_code_update.py
@@ -1,6 +1,6 @@
 import graphene
 
-from saleor.checkout.actions import call_checkout_event_for_checkout
+from saleor.checkout.actions import call_checkout_event
 from saleor.webhook.event_types import WebhookEventAsyncType
 
 from ...core import ResolveInfo
@@ -67,9 +67,8 @@ class CheckoutLanguageCodeUpdate(BaseMutation):
         checkout.language_code = language_code
         checkout.save(update_fields=["language_code", "last_change"])
         manager = get_plugin_manager_promise(info.context).get()
-        call_checkout_event_for_checkout(
+        call_checkout_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )

--- a/saleor/graphql/checkout/mutations/checkout_line_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_line_delete.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import invalidate_checkout
@@ -82,9 +82,8 @@ class CheckoutLineDelete(BaseMutation):
         checkout_info = fetch_checkout_info(checkout, lines, manager)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         invalidate_checkout(checkout_info, lines, manager, save=True)
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import (
     fetch_checkout_info,
@@ -216,9 +216,8 @@ class CheckoutLinesAdd(BaseMutation):
         update_checkout_external_shipping_method_if_invalid(checkout_info, lines)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         invalidate_checkout(checkout_info, lines, manager, save=True)
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -1,7 +1,7 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import invalidate_checkout
@@ -101,9 +101,8 @@ class CheckoutLinesDelete(BaseMutation):
         checkout_info = fetch_checkout_info(checkout, lines, manager)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         invalidate_checkout(checkout_info, lines, manager, save=True)
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from graphql.error import GraphQLError
 
 from ....checkout import models
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import (
@@ -109,9 +109,8 @@ class CheckoutRemovePromoCode(BaseMutation):
             recalculate_discount=True,
             save=True,
         )
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -5,7 +5,7 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from ....checkout import AddressType, models
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import (
     CheckoutLineInfo,
@@ -216,9 +216,8 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             + invalidate_prices_updated_fields
         )
 
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -3,7 +3,7 @@ from typing import Optional
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.actions import call_checkout_event_for_checkout_info
+from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import (
@@ -224,9 +224,8 @@ class CheckoutShippingMethodUpdate(BaseMutation):
         )
         get_checkout_metadata(checkout).save()
 
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,
@@ -265,9 +264,8 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             + invalidate_prices_updated_fields
         )
         get_checkout_metadata(checkout).save()
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,
@@ -290,9 +288,8 @@ class CheckoutShippingMethodUpdate(BaseMutation):
         )
         get_checkout_metadata(checkout).save()
 
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from prices import Money
 
 from .....checkout import base_calculations, calculations
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.utils import add_variant_to_checkout, set_external_shipping_id
@@ -1543,8 +1543,8 @@ def test_with_active_problems_flow(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_add_promo_code.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_add_promo_code.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1554,7 +1554,7 @@ def test_with_active_problems_flow(
 def test_checkout_add_voucher_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -1610,4 +1610,4 @@ def test_checkout_add_voucher_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -4,7 +4,7 @@ from unittest.mock import call, patch
 import pytest
 from django.test import override_settings
 
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.utils import invalidate_checkout
 from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
@@ -646,8 +646,8 @@ def test_checkout_billing_address_skip_validation_by_app(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_billing_address_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_billing_address_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -657,7 +657,7 @@ def test_checkout_billing_address_skip_validation_by_app(
 def test_checkout_billing_address_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     user_api_client,
@@ -718,4 +718,4 @@ def test_checkout_billing_address_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from .....channel.utils import DEPRECATION_WARNING_MESSAGE
 from .....checkout import AddressType
-from .....checkout.actions import call_checkout_event_for_checkout
+from .....checkout.actions import call_checkout_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_lines
 from .....checkout.models import Checkout
@@ -2648,8 +2648,8 @@ def test_checkout_create_skip_validation_billing_address_by_app(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_create.call_checkout_event_for_checkout",
-    wraps=call_checkout_event_for_checkout,
+    "saleor.graphql.checkout.mutations.checkout_create.call_checkout_event",
+    wraps=call_checkout_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -2659,7 +2659,7 @@ def test_checkout_create_skip_validation_billing_address_by_app(
 def test_checkout_create_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_event,
     api_client,
     stock,
     graphql_address_data,
@@ -2731,4 +2731,4 @@ def test_checkout_create_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -4,7 +4,7 @@ import graphene
 from django.test import override_settings
 
 from .....account.models import User
-from .....checkout.actions import call_checkout_event_for_checkout
+from .....checkout.actions import call_checkout_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
@@ -236,8 +236,8 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_customer_attach.call_checkout_event_for_checkout",
-    wraps=call_checkout_event_for_checkout,
+    "saleor.graphql.checkout.mutations.checkout_customer_attach.call_checkout_event",
+    wraps=call_checkout_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -247,7 +247,7 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
 def test_checkout_customer_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_event,
     setup_checkout_webhooks,
     settings,
     user_api_client,
@@ -309,4 +309,4 @@ def test_checkout_customer_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -3,7 +3,7 @@ from unittest.mock import call, patch
 from django.test import override_settings
 
 from .....account.models import User
-from .....checkout.actions import call_checkout_event_for_checkout
+from .....checkout.actions import call_checkout_event
 from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
@@ -115,8 +115,8 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_customer_detach.call_checkout_event_for_checkout",
-    wraps=call_checkout_event_for_checkout,
+    "saleor.graphql.checkout.mutations.checkout_customer_detach.call_checkout_event",
+    wraps=call_checkout_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -126,7 +126,7 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
 def test_checkout_customer_detach_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_event,
     setup_checkout_webhooks,
     settings,
     user_api_client,
@@ -185,4 +185,4 @@ def test_checkout_customer_detach_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -6,7 +6,7 @@ import pytest
 from django.test import override_settings
 
 from .....account.models import Address
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.utils import PRIVATE_META_APP_SHIPPING_ID, invalidate_checkout
@@ -1009,8 +1009,8 @@ def test_checkout_delivery_method_update_from_cc_to_all_warehouses_disabled_cc(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_delivery_method_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_delivery_method_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1020,7 +1020,7 @@ def test_checkout_delivery_method_update_from_cc_to_all_warehouses_disabled_cc(
 def test_checkout_delivery_method_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -1081,12 +1081,12 @@ def test_checkout_delivery_method_update_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_delivery_method_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_delivery_method_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1096,7 +1096,7 @@ def test_checkout_delivery_method_update_triggers_webhooks(
 def test_checkout_delivery_method_update_cc_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -1164,12 +1164,12 @@ def test_checkout_delivery_method_update_cc_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_delivery_method_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_delivery_method_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1184,7 +1184,7 @@ def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
     mock_clean_delivery,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -1259,4 +1259,4 @@ def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -2,7 +2,7 @@ from unittest.mock import call, patch
 
 from django.test import override_settings
 
-from .....checkout.actions import call_checkout_event_for_checkout
+from .....checkout.actions import call_checkout_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
@@ -88,8 +88,8 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_email_update.call_checkout_event_for_checkout",
-    wraps=call_checkout_event_for_checkout,
+    "saleor.graphql.checkout.mutations.checkout_email_update.call_checkout_event",
+    wraps=call_checkout_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -99,7 +99,7 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
 def test_checkout_email_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_event,
     setup_checkout_webhooks,
     settings,
     user_api_client,
@@ -156,4 +156,4 @@ def test_checkout_email_update_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -2,7 +2,7 @@ from unittest.mock import call, patch
 
 from django.test import override_settings
 
-from .....checkout.actions import call_checkout_event_for_checkout
+from .....checkout.actions import call_checkout_event
 from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
@@ -71,8 +71,8 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_language_code_update.call_checkout_event_for_checkout",
-    wraps=call_checkout_event_for_checkout,
+    "saleor.graphql.checkout.mutations.checkout_language_code_update.call_checkout_event",
+    wraps=call_checkout_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -82,7 +82,7 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
 def test_checkout_update_language_code_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_event,
     setup_checkout_webhooks,
     settings,
     user_api_client,
@@ -138,4 +138,4 @@ def test_checkout_update_language_code_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -5,7 +5,7 @@ import graphene
 from django.test import override_settings
 
 from .....checkout import base_calculations
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.utils import (
@@ -206,8 +206,8 @@ def test_checkout_line_delete_non_removable_gift(user_api_client, checkout_line)
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_line_delete.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_line_delete.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -217,7 +217,7 @@ def test_checkout_line_delete_non_removable_gift(user_api_client, checkout_line)
 def test_checkout_line_delete_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -285,4 +285,4 @@ def test_checkout_line_delete_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -10,7 +10,7 @@ from django.test import override_settings
 from django.utils import timezone
 from prices import Money
 
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
@@ -1756,8 +1756,8 @@ def test_with_active_problems_flow(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_lines_add.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_lines_add.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1767,7 +1767,7 @@ def test_with_active_problems_flow(
 def test_checkout_lines_add_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     user_api_client,
@@ -1836,4 +1836,4 @@ def test_checkout_lines_add_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -4,7 +4,7 @@ from unittest.mock import call, patch
 import graphene
 from django.test import override_settings
 
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import CheckoutLine
@@ -203,8 +203,8 @@ def test_checkout_lines_delete_not_associated_with_checkout(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_lines_delete.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_lines_delete.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -214,7 +214,7 @@ def test_checkout_lines_delete_not_associated_with_checkout(
 def test_checkout_lines_delete_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -275,4 +275,4 @@ def test_checkout_lines_delete_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -8,7 +8,7 @@ import pytest
 from django.test import override_settings
 from django.utils import timezone
 
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout, CheckoutLine
@@ -1363,8 +1363,8 @@ def test_checkout_lines_update_quantity_gift(user_api_client, checkout_with_item
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_lines_add.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_lines_add.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1374,7 +1374,7 @@ def test_checkout_lines_update_quantity_gift(user_api_client, checkout_with_item
 def test_checkout_lines_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -1440,4 +1440,4 @@ def test_checkout_lines_update_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from prices import Money
 
 from .....checkout import base_calculations
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....core.models import EventDelivery
@@ -708,8 +708,8 @@ def test_with_active_problems_flow(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_remove_promo_code.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_remove_promo_code.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -719,7 +719,7 @@ def test_with_active_problems_flow(
 def test_checkout_remove_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -773,4 +773,4 @@ def test_checkout_remove_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -6,7 +6,7 @@ import pytest
 from django.test import override_settings
 from django.utils import timezone
 
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
@@ -1078,8 +1078,8 @@ def test_checkout_shipping_address_skip_validation_by_app(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_shipping_address_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_shipping_address_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1089,7 +1089,7 @@ def test_checkout_shipping_address_skip_validation_by_app(
 def test_checkout_shipping_address_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     user_api_client,
@@ -1150,4 +1150,4 @@ def test_checkout_shipping_address_update_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -6,7 +6,7 @@ import pytest
 from django.test import override_settings
 
 from .....account.models import Address
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.utils import PRIVATE_META_APP_SHIPPING_ID, invalidate_checkout
@@ -479,8 +479,8 @@ def test_with_active_problems_flow(
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_shipping_method_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_shipping_method_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -490,7 +490,7 @@ def test_with_active_problems_flow(
 def test_checkout_shipping_method_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     address,
@@ -552,12 +552,12 @@ def test_checkout_shipping_method_update_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_shipping_method_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_shipping_method_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -567,7 +567,7 @@ def test_checkout_shipping_method_update_triggers_webhooks(
 def test_checkout_shipping_method_update_external_shipping_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     address,
@@ -643,12 +643,12 @@ def test_checkout_shipping_method_update_external_shipping_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called
 
 
 @patch(
-    "saleor.graphql.checkout.mutations.checkout_shipping_method_update.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.checkout.mutations.checkout_shipping_method_update.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -658,7 +658,7 @@ def test_checkout_shipping_method_update_external_shipping_triggers_webhooks(
 def test_checkout_shipping_method_update_to_none_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     address,
@@ -719,4 +719,4 @@ def test_checkout_shipping_method_update_to_none_triggers_webhooks(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/meta/extra_methods.py
+++ b/saleor/graphql/meta/extra_methods.py
@@ -1,4 +1,4 @@
-from ...checkout.actions import call_checkout_event_for_checkout_info
+from ...checkout.actions import call_checkout_info_event
 from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...core.utils.events import webhook_async_event_requires_sync_webhooks_to_trigger
 from ...order.actions import call_order_event
@@ -37,17 +37,15 @@ def extra_checkout_actions(instance, info: ResolveInfo, **data):
             lines_info,
             manager,
         )
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager=manager,
-            event_func=manager.checkout_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout_info=checkout_info,
             lines=lines_info,
             webhook_event_map=webhook_event_map,
         )
-        call_checkout_event_for_checkout_info(
+        call_checkout_info_event(
             manager=manager,
-            event_func=manager.checkout_metadata_updated,
             event_name=WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED,
             checkout_info=checkout_info,
             lines=lines_info,
@@ -82,7 +80,6 @@ def extra_order_actions(instance, info: ResolveInfo, **data):
     manager = get_plugin_manager_promise(info.context).get()
     call_order_event(
         manager,
-        manager.order_metadata_updated,
         WebhookEventAsyncType.ORDER_METADATA_UPDATED,
         instance,
     )

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from .....checkout.actions import call_checkout_event_for_checkout_info
+from .....checkout.actions import call_checkout_info_event
 from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from . import PRIVATE_KEY, PRIVATE_VALUE, PUBLIC_KEY, PUBLIC_VALUE
@@ -364,8 +364,8 @@ def test_update_public_metadata_for_checkout_line(api_client, checkout_line):
 
 @freeze_time("2023-05-31 12:00:01")
 @patch(
-    "saleor.graphql.meta.extra_methods.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.meta.extra_methods.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -375,7 +375,7 @@ def test_update_public_metadata_for_checkout_line(api_client, checkout_line):
 def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -429,13 +429,13 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called
 
 
 @freeze_time("2023-05-31 12:00:01")
 @patch(
-    "saleor.graphql.meta.extra_methods.call_checkout_event_for_checkout_info",
-    wraps=call_checkout_event_for_checkout_info,
+    "saleor.graphql.meta.extra_methods.call_checkout_info_event",
+    wraps=call_checkout_info_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -445,7 +445,7 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
 def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_event_for_checkout,
+    wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -501,4 +501,4 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_event_for_checkout.called
+    assert wrapped_call_checkout_info_event.called

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -595,14 +595,12 @@ class DraftOrderCreate(
             if is_new_instance:
                 call_order_event(
                     manager,
-                    manager.draft_order_created,
                     WebhookEventAsyncType.DRAFT_ORDER_CREATED,
                     instance,
                 )
             else:
                 call_order_event(
                     manager,
-                    manager.draft_order_updated,
                     WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
                     instance,
                 )

--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -58,7 +58,6 @@ class DraftOrderDelete(
             response = super().perform_mutation(_root, info, **data)
             call_order_event(
                 manager,
-                manager.draft_order_deleted,
                 WebhookEventAsyncType.DRAFT_ORDER_DELETED,
                 order,
             )

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -109,7 +109,6 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
             instance.save()
             call_order_event(
                 manager,
-                manager.order_updated,
                 WebhookEventAsyncType.ORDER_UPDATED,
                 instance,
             )

--- a/saleor/graphql/order/mutations/order_update_shipping.py
+++ b/saleor/graphql/order/mutations/order_update_shipping.py
@@ -136,7 +136,5 @@ class OrderUpdateShipping(
 
         order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
         # Post-process the results
-        call_order_event(
-            manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
-        )
+        call_order_event(manager, WebhookEventAsyncType.ORDER_UPDATED, order)
         return OrderUpdateShipping(order=order)

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -150,14 +150,11 @@ def call_event_by_order_status(order, manager):
     if order.status == OrderStatus.DRAFT:
         call_order_event(
             manager,
-            manager.draft_order_updated,
             WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
             order,
         )
     else:
-        call_order_event(
-            manager, manager.order_updated, WebhookEventAsyncType.ORDER_UPDATED, order
-        )
+        call_order_event(manager, WebhookEventAsyncType.ORDER_UPDATED, order)
 
 
 def try_payment_action(order, user, app, payment, func, *args, **kwargs):

--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -52,7 +52,6 @@ def send_order_updated(order_ids):
     for order in Order.objects.filter(id__in=order_ids):
         call_order_event(
             manager,
-            manager.order_updated,
             WebhookEventAsyncType.ORDER_UPDATED,
             order,
             webhook_event_map=webhook_event_map,
@@ -111,14 +110,12 @@ def _call_expired_order_events(order_ids, manager):
     for order in orders:
         call_order_event(
             manager,
-            manager.order_expired,
             WebhookEventAsyncType.ORDER_EXPIRED,
             order,
             webhook_event_map=webhook_event_map,
         )
         call_order_event(
             manager,
-            manager.order_updated,
             WebhookEventAsyncType.ORDER_UPDATED,
             order,
             webhook_event_map=webhook_event_map,


### PR DESCRIPTION
I want to merge this change because this is clean-up for `call_event` logic for `Checkout` and `Order`. 
The part introduced in: https://github.com/saleor/saleor/pull/16466, https://github.com/saleor/saleor/pull/16393

Scpe of changes:
- simplify the `call_x_event`, to use single event_name instead of `event_name`, `plugins_manager_func`.
- add more tests
- drop the flush_post_commit from the tests related to `call_x_event`

Port of changes from #16489

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
