### PR TITLE
Bump requests-hardened to 1.0.0b4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3964,6 +3964,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4068,12 +4069,12 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-hardened"
-version = "1.0.0b3"
+version = "1.0.0b4"
 description = "A library that overrides the default behaviors of the requests library, and adds new security features."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-hardened-1.0.0b3.tar.gz", hash = "sha256:125057fb864e4283c926021f594c9e4695432036f13fd76fee3ef738510231e2"},
+    {file = "requests_hardened-1.0.0b4.tar.gz", hash = "sha256:1fc29dbae273a61980d015f1948404374ee1f7b0f9e464a564af12b9d0c5ebde"},
 ]
 
 [package.dependencies]
@@ -5471,4 +5472,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "09b96aef8b0b45b987120bf17f6ad2949f1dff485c9cdc87a5f263a226954000"
+content-hash = "e46276a0e26c8a5fb9de7888d0fa46925a0e9315b3bb6e8dc2e44933c4862a1d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ documentation = "https://docs.saleor.io/"
   Authlib = "^1.0.0"
   pillow-avif-plugin = "^1.3.1"
   semantic-version = "^2.10.0"
-  requests-hardened = "1.0.0b3"
+  requests-hardened = "1.0.0b4"
 
     [tool.poetry.dependencies.django]
     version = "^3.2.16"


### PR DESCRIPTION
I want to merge this change because it bumps requests-hardened to 1.0.0b4.
Internal issue: https://linear.app/saleor/issue/PE-392/

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
