### PR TITLE
Return proper discounts in order tax calculation static payload.

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -92,6 +92,13 @@ def is_shipping_voucher(voucher: Optional[Voucher]):
     return bool(voucher and voucher.type == VoucherType.SHIPPING)
 
 
+def is_order_level_discount(discount: OrderDiscount) -> bool:
+    return discount.type in [
+        DiscountType.MANUAL,
+        DiscountType.ORDER_PROMOTION,
+    ] or is_order_level_voucher(discount.voucher)
+
+
 def increase_voucher_usage(
     voucher: "Voucher",
     code: "VoucherCode",

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -7,8 +7,11 @@ from promise import Promise
 from ....checkout import base_calculations
 from ....checkout.models import Checkout, CheckoutLine
 from ....core.prices import quantize_price
-from ....discount import DiscountType
-from ....discount.utils import has_checkout_order_promotion, is_order_level_voucher
+from ....discount.utils import (
+    has_checkout_order_promotion,
+    is_order_level_discount,
+    is_order_level_voucher,
+)
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
 from ....tax.utils import get_charge_taxes
@@ -406,10 +409,7 @@ class TaxableObject(BaseObjectType):
                 for discount in discounts
                 # Only order level discounts, like entire order vouchers,
                 # order promotions and manual discounts should be taken into account
-                if (
-                    discount.type in [DiscountType.MANUAL, DiscountType.ORDER_PROMOTION]
-                    or is_order_level_voucher(discount.voucher)
-                )
+                if is_order_level_discount(discount)
             ]
 
         return (

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -404,6 +404,8 @@ class TaxableObject(BaseObjectType):
             return [
                 {"name": discount.name, "amount": discount.amount}
                 for discount in discounts
+                # Only order level discounts, like entire order vouchers,
+                # order promotions and manual discounts should be taken into account
                 if (
                     discount.type in [DiscountType.MANUAL, DiscountType.ORDER_PROMOTION]
                     or is_order_level_voucher(discount.voucher)

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -31,7 +31,7 @@ from ..core.utils.anonymization import (
     generate_fake_user,
 )
 from ..core.utils.json_serializer import CustomJsonEncoder
-from ..discount import VoucherType
+from ..discount import DiscountType, VoucherType
 from ..discount.utils import is_order_level_voucher
 from ..order import FulfillmentStatus, OrderStatus
 from ..order.models import Fulfillment, FulfillmentLine, Order, OrderLine
@@ -1406,7 +1406,12 @@ def generate_order_payload_for_tax_calculation(order: "Order"):
     discounts = order.discounts.all()
     discounts_dict = []
     for discount in discounts:
-        if is_order_level_voucher(discount.voucher):
+        # Only order level discounts, like entire order vouchers,
+        # order promotions and manual discounts should be taken into account
+        if not (
+            discount.type in [DiscountType.MANUAL, DiscountType.ORDER_PROMOTION]
+            or is_order_level_voucher(discount.voucher)
+        ):
             continue
         quantize_price_fields(discount, ("amount_value",), order.currency)
         discount_amount = quantize_price(discount.amount_value, order.currency)

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -31,8 +31,8 @@ from ..core.utils.anonymization import (
     generate_fake_user,
 )
 from ..core.utils.json_serializer import CustomJsonEncoder
-from ..discount import DiscountType, VoucherType
-from ..discount.utils import is_order_level_voucher
+from ..discount import VoucherType
+from ..discount.utils import is_order_level_discount, is_order_level_voucher
 from ..order import FulfillmentStatus, OrderStatus
 from ..order.models import Fulfillment, FulfillmentLine, Order, OrderLine
 from ..order.utils import get_order_country
@@ -1408,10 +1408,7 @@ def generate_order_payload_for_tax_calculation(order: "Order"):
     for discount in discounts:
         # Only order level discounts, like entire order vouchers,
         # order promotions and manual discounts should be taken into account
-        if not (
-            discount.type in [DiscountType.MANUAL, DiscountType.ORDER_PROMOTION]
-            or is_order_level_voucher(discount.voucher)
-        ):
+        if not is_order_level_discount(discount):
             continue
         quantize_price_fields(discount, ("amount_value",), order.currency)
         discount_amount = quantize_price(discount.amount_value, order.currency)


### PR DESCRIPTION
I want to merge this change because it correct discounts returned in static tax payload for orders. We were accidentally excluding entire order vouchers (order level discount).

Internal issue: https://linear.app/saleor/issue/SHOPX-1217

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
