### PR TITLE
Do not call sync webhooks before async webhook when webhook's subscription query is missing

### DIFF
--- a/saleor/core/utils/events.py
+++ b/saleor/core/utils/events.py
@@ -8,7 +8,7 @@ from ...webhook.event_types import WebhookEventAsyncType
 from ...webhook.models import Webhook
 
 
-def any_wehook_has_subscription(
+def any_webhook_has_subscription(
     events: list[str], webhook_event_map: dict[str, set["Webhook"]]
 ) -> bool:
     event_has_subscription = False
@@ -79,13 +79,13 @@ def webhook_async_event_requires_sync_webhooks_to_trigger(
     if not any_webhook_is_active_for_events(possible_sync_events, webhook_event_map):
         return False
 
-    async_webhooks_have_subscriptions = any_wehook_has_subscription(
+    async_webhooks_have_subscriptions = any_webhook_has_subscription(
         [event_name], webhook_event_map
     )
     if not async_webhooks_have_subscriptions:
         return False
 
-    sync_events_have_subscriptions = any_wehook_has_subscription(
+    sync_events_have_subscriptions = any_webhook_has_subscription(
         possible_sync_events, webhook_event_map
     )
     if not sync_events_have_subscriptions:

--- a/saleor/core/utils/events.py
+++ b/saleor/core/utils/events.py
@@ -44,6 +44,25 @@ def webhook_async_event_requires_sync_webhooks_to_trigger(
     )
     if not active_webhook_events.intersection(possible_sync_events):
         return False
+    if all(
+        [
+            not bool(webhook.subscription_query)
+            for webhook in webhook_event_map[event_name]
+        ]
+    ):
+        return False
+    sync_event_has_subscription = False
+    for sync_event in possible_sync_events:
+        sync_event_has_subscription = any(
+            [
+                bool(webhook.subscription_query)
+                for webhook in webhook_event_map.get(sync_event, [])
+            ]
+        )
+        if sync_event_has_subscription:
+            break
+    if not sync_event_has_subscription:
+        return False
     return True
 
 


### PR DESCRIPTION
I want to merge this change because it add logic to skip synchronous webhooks before asynchronous webhooks when webhook subscription query is missing.

Currently for order&checkout types, we're calling sync webhooks before triggering asynchronous webhooks. As explained in: https://github.com/saleor/saleor/pull/16466 and https://github.com/saleor/saleor/pull/16393

This PR, add logic to skip sync webhook when:
- all webhooks for async event don't have subscription_query
- OR all sync webhooks don't have subscription_query

Calling sync before async is not needed when at least one of these conditions is valid.

Port of changes from: #16535

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
