### PR TITLE
Fix sucessful delivery cleanup with payload in database

### DIFF
--- a/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
@@ -247,6 +247,26 @@ def test_clear_successful_delivery(event_delivery):
     assert not private_storage.exists(event_payload.payload_file.name)
 
 
+def test_clear_successful_delivery_with_payload_in_database(
+    event_delivery_payload_in_database,
+):
+    # given
+    assert EventDelivery.objects.filter(
+        pk=event_delivery_payload_in_database.pk
+    ).exists()
+    event_delivery_payload_in_database.status = EventDeliveryStatus.SUCCESS
+    event_delivery_payload_in_database.save()
+    event_payload = event_delivery_payload_in_database.payload
+    assert not event_payload.payload_file
+    # when
+    clear_successful_delivery(event_delivery_payload_in_database)
+    # then
+    assert not EventDelivery.objects.filter(
+        pk=event_delivery_payload_in_database.pk
+    ).exists()
+    assert not EventPayload.objects.filter(pk=event_payload.pk).exists()
+
+
 def test_clear_successful_delivery_when_payload_in_multiple_deliveries(event_delivery):
     # given
     assert EventDelivery.objects.filter(pk=event_delivery.pk).exists()

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -434,6 +434,7 @@ def clear_successful_delivery(delivery: "EventDelivery"):
                 for event_payload in payloads_to_delete.using(
                     settings.DATABASE_CONNECTION_REPLICA_NAME
                 )
+                if event_payload.payload_file
             ]
             payloads_to_delete.delete()
             delete_files_from_private_storage_task(files_to_delete)


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
