### PR TITLE
Add function to call multiple events for order and checkout

### DIFF
--- a/saleor/checkout/actions.py
+++ b/saleor/checkout/actions.py
@@ -77,6 +77,75 @@ def call_checkout_event(
     return
 
 
+def _trigger_checkout_sync_webhooks(
+    manager: "PluginsManager",
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
+    webhook_event_map: dict[str, set["Webhook"]],
+    address: Optional["Address"] = None,
+):
+    _ = checkout_info.all_shipping_methods
+
+    # + timedelta(seconds=10) to confirm that triggered webhooks will still have a
+    # valid prices. Triggered only when we have active sync tax webhook
+    if webhook_event_map.get(
+        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    ) and checkout_info.checkout.price_expiration < timezone.now() + timedelta(
+        seconds=10
+    ):
+        fetch_checkout_data(
+            checkout_info=checkout_info,
+            manager=manager,
+            lines=lines,
+            address=address
+            or checkout_info.shipping_address
+            or checkout_info.billing_address,
+            force_update=True,
+        )
+
+
+def call_checkout_events(
+    manager: "PluginsManager",
+    event_names: list[str],
+    checkout: "Checkout",
+):
+    missing_events = set(event_names).difference(CHECKOUT_WEBHOOK_EVENT_MAP.keys())
+    if missing_events:
+        raise ValueError(
+            f"Events {missing_events} not found in CHECKOUT_WEBHOOK_EVENT_MAP."
+        )
+
+    webhook_event_map = get_webhooks_for_multiple_events(
+        [*event_names, *WebhookEventSyncType.CHECKOUT_EVENTS]
+    )
+    any_event_requires_sync_webhooks = any(
+        webhook_async_event_requires_sync_webhooks_to_trigger(
+            event_name,
+            webhook_event_map,
+            possible_sync_events=WebhookEventSyncType.CHECKOUT_EVENTS,
+        )
+        for event_name in event_names
+    )
+    if any_event_requires_sync_webhooks:
+        lines_info, _ = fetch_checkout_lines(
+            checkout,
+        )
+        checkout_info = fetch_checkout_info(
+            checkout,
+            lines_info,
+            manager,
+        )
+        _trigger_checkout_sync_webhooks(
+            manager, checkout_info, lines_info, webhook_event_map=webhook_event_map
+        )
+
+    for event_name in event_names:
+        plugin_manager_method_name = CHECKOUT_WEBHOOK_EVENT_MAP[event_name]
+        webhooks = webhook_event_map.get(event_name, set())
+        event_func = getattr(manager, plugin_manager_method_name)
+        call_event_including_protected_events(event_func, checkout, webhooks=webhooks)
+
+
 def call_checkout_info_event(
     manager: "PluginsManager",
     event_name: str,
@@ -108,23 +177,13 @@ def call_checkout_info_event(
         call_event_including_protected_events(event_func, checkout, webhooks=webhooks)
         return None
 
-    _ = checkout_info.all_shipping_methods
-
-    # + timedelta(seconds=10) to confirm that triggered webhooks will still have a
-    # valid prices. Triggered only when we have active sync tax webhook
-    if (
-        WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES in webhook_event_map
-        and checkout.price_expiration < timezone.now() + timedelta(seconds=10)
-    ):
-        fetch_checkout_data(
-            checkout_info=checkout_info,
-            manager=manager,
-            lines=lines,
-            address=address
-            or checkout_info.shipping_address
-            or checkout_info.billing_address,
-            force_update=True,
-        )
+    _trigger_checkout_sync_webhooks(
+        manager,
+        checkout_info,
+        lines,
+        address=address,
+        webhook_event_map=webhook_event_map,
+    )
 
     call_event_including_protected_events(event_func, checkout, webhooks=webhooks)
     return None

--- a/saleor/checkout/actions.py
+++ b/saleor/checkout/actions.py
@@ -86,8 +86,8 @@ def _trigger_checkout_sync_webhooks(
 ):
     _ = checkout_info.all_shipping_methods
 
-    # + timedelta(seconds=10) to confirm that triggered webhooks will still have a
-    # valid prices. Triggered only when we have active sync tax webhook
+    # + timedelta(seconds=10) to confirm that triggered webhooks will still have
+    # valid prices. Triggered only when we have active sync tax webhook.
     if webhook_event_map.get(
         WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
     ) and checkout_info.checkout.price_expiration < timezone.now() + timedelta(

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from .....checkout.actions import call_checkout_info_event
+from .....checkout.actions import call_checkout_events
 from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from . import PRIVATE_KEY, PRIVATE_VALUE, PUBLIC_KEY, PUBLIC_VALUE
@@ -234,7 +234,7 @@ def test_add_metadata_for_checkout_triggers_checkout_updated_hook(
 
     # then
     assert response["data"]["updateMetadata"]["errors"] == []
-    mock_checkout_updated.assert_called_once_with(checkout)
+    mock_checkout_updated.assert_called_once_with(checkout, webhooks=set())
 
 
 def test_add_private_metadata_for_checkout(
@@ -364,8 +364,8 @@ def test_update_public_metadata_for_checkout_line(api_client, checkout_line):
 
 @freeze_time("2023-05-31 12:00:01")
 @patch(
-    "saleor.graphql.meta.extra_methods.call_checkout_info_event",
-    wraps=call_checkout_info_event,
+    "saleor.graphql.meta.extra_methods.call_checkout_events",
+    wraps=call_checkout_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -375,7 +375,7 @@ def test_update_public_metadata_for_checkout_line(api_client, checkout_line):
 def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_info_event,
+    wrapped_call_checkout_events,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -429,13 +429,13 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_info_event.called
+    assert wrapped_call_checkout_events.called
 
 
 @freeze_time("2023-05-31 12:00:01")
 @patch(
-    "saleor.graphql.meta.extra_methods.call_checkout_info_event",
-    wraps=call_checkout_info_event,
+    "saleor.graphql.meta.extra_methods.call_checkout_events",
+    wraps=call_checkout_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -445,7 +445,7 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
 def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_checkout_info_event,
+    wrapped_call_checkout_events,
     setup_checkout_webhooks,
     settings,
     api_client,
@@ -501,4 +501,4 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
             call(tax_delivery),
         ]
     )
-    assert wrapped_call_checkout_info_event.called
+    assert wrapped_call_checkout_events.called

--- a/saleor/graphql/meta/tests/mutations/test_update_metadata.py
+++ b/saleor/graphql/meta/tests/mutations/test_update_metadata.py
@@ -138,14 +138,14 @@ def test_meta_mutations_handle_validation_errors(staff_api_client):
     assert errors[0]["code"] == MetadataErrorCode.INVALID.name
 
 
-@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+@patch("saleor.graphql.meta.extra_methods.call_checkout_events")
 def test_base_metadata_mutation_handles_errors_from_extra_action(
-    mock_checkout_updated, api_client, checkout
+    mock_call_checkout_events, api_client, checkout
 ):
     # given
     error_field = "field"
     error_msg = "boom"
-    mock_checkout_updated.side_effect = ValidationError({error_field: error_msg})
+    mock_call_checkout_events.side_effect = ValidationError({error_field: error_msg})
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
 
     # when

--- a/saleor/graphql/order/tests/mutations/test_order_cancel.py
+++ b/saleor/graphql/order/tests/mutations/test_order_cancel.py
@@ -7,7 +7,7 @@ from .....core.models import EventDelivery
 from .....giftcard import GiftCardEvents
 from .....giftcard.events import gift_cards_bought_event
 from .....order import OrderStatus
-from .....order.actions import call_order_event, cancel_order
+from .....order.actions import call_order_events, cancel_order
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -133,8 +133,8 @@ def test_order_cancel_no_channel_access(
 
 
 @patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -146,7 +146,7 @@ def test_order_cancel_skip_trigger_webhooks(
     mock_clean_order_cancel,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     staff_api_client,
     permission_group_manage_orders,
@@ -218,4 +218,4 @@ def test_order_cancel_skip_trigger_webhooks(
         any_order=True,
     )
     assert not mocked_send_webhook_request_sync.called
-    assert wrapped_call_order_event.called
+    assert wrapped_call_order_events.called

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -9,7 +9,7 @@ from .....core.models import EventDelivery
 from .....giftcard import GiftCardEvents
 from .....giftcard.models import GiftCard, GiftCardEvent
 from .....order import FulfillmentStatus, OrderStatus
-from .....order.actions import call_order_event, order_fulfilled
+from .....order.actions import call_order_events, order_fulfilled
 from .....order.error_codes import OrderErrorCode
 from .....order.models import Fulfillment, FulfillmentLine
 from .....product.models import ProductVariant
@@ -1554,8 +1554,8 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
 
 
 @patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1565,7 +1565,7 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
 def test_order_fulfill_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     staff_api_client,
     order_with_lines,
@@ -1658,4 +1658,4 @@ def test_order_fulfill_triggers_webhooks(
         ],
         any_order=True,
     )
-    assert wrapped_call_order_event.called
+    assert wrapped_call_order_events.called

--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -15,7 +15,7 @@ from ..warehouse.management import deallocate_stock_for_orders
 from ..webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..webhook.utils import get_webhooks_for_multiple_events
 from . import OrderEvents, OrderStatus
-from .actions import call_order_event
+from .actions import call_order_event, call_order_events
 from .models import Order, OrderEvent
 from .utils import invalidate_order_prices
 
@@ -99,18 +99,16 @@ def _call_expired_order_events(order_ids, manager):
         [
             WebhookEventAsyncType.ORDER_EXPIRED,
             WebhookEventAsyncType.ORDER_UPDATED,
+            *WebhookEventSyncType.ORDER_EVENTS,
         ]
     )
     for order in orders:
-        call_order_event(
+        call_order_events(
             manager,
-            WebhookEventAsyncType.ORDER_EXPIRED,
-            order,
-            webhook_event_map=webhook_event_map,
-        )
-        call_order_event(
-            manager,
-            WebhookEventAsyncType.ORDER_UPDATED,
+            [
+                WebhookEventAsyncType.ORDER_EXPIRED,
+                WebhookEventAsyncType.ORDER_UPDATED,
+            ],
             order,
             webhook_event_map=webhook_event_map,
         )

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -36,6 +36,7 @@ from ..actions import (
     WEBHOOK_EVENTS_FOR_ORDER_REFUNDED,
     automatically_fulfill_digital_lines,
     call_order_event,
+    call_order_events,
     cancel_fulfillment,
     cancel_order,
     clean_mark_order_as_paid,
@@ -390,8 +391,8 @@ def test_handle_fully_paid_order_for_draft_order(
 
 
 @patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -401,7 +402,7 @@ def test_handle_fully_paid_order_for_draft_order(
 def test_handle_fully_paid_order_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     order_with_lines,
     customer_user,
@@ -481,22 +482,11 @@ def test_handle_fully_paid_order_triggers_webhooks(
             call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
         ]
     )
-    wrapped_call_order_event.assert_has_calls(
-        [
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_FULLY_PAID,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-        ],
-        any_order=True,
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
+        [WebhookEventAsyncType.ORDER_FULLY_PAID, WebhookEventAsyncType.ORDER_UPDATED],
+        order,
+        webhook_event_map=webhook_event_map,
     )
 
 
@@ -662,8 +652,8 @@ def test_cancel_order(
 
 
 @patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -673,7 +663,7 @@ def test_cancel_order(
 def test_cancel_order_dont_trigger_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     order_with_lines,
     settings,
@@ -745,22 +735,14 @@ def test_cancel_order_dont_trigger_webhooks(
     )
     assert not mocked_send_webhook_request_sync.called
 
-    wrapped_call_order_event.assert_has_calls(
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
         [
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_CANCELLED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
+            WebhookEventAsyncType.ORDER_CANCELLED,
+            WebhookEventAsyncType.ORDER_UPDATED,
         ],
-        any_order=True,
+        order,
+        webhook_event_map=webhook_event_map,
     )
 
 
@@ -831,8 +813,8 @@ def test_order_refunded_by_app(
 
 
 @patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -842,7 +824,7 @@ def test_order_refunded_by_app(
 def test_order_refunded_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     order_with_lines,
     settings,
@@ -936,28 +918,15 @@ def test_order_refunded_triggers_webhooks(
         ]
     )
 
-    wrapped_call_order_event.assert_has_calls(
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
         [
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_REFUNDED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
+            WebhookEventAsyncType.ORDER_REFUNDED,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
         ],
-        any_order=True,
+        order,
+        webhook_event_map=webhook_event_map,
     )
 
 
@@ -1042,8 +1011,8 @@ def test_order_voided_triggers_webhooks(
 
 
 @patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1053,7 +1022,7 @@ def test_order_voided_triggers_webhooks(
 def test_order_fulfilled_dont_trigger_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     fulfilled_order,
     settings,
@@ -1128,22 +1097,14 @@ def test_order_fulfilled_dont_trigger_webhooks(
     )
     assert not mocked_send_webhook_request_sync.called
 
-    wrapped_call_order_event.assert_has_calls(
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
         [
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                fulfilled_order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_FULFILLED,
-                fulfilled_order,
-                webhook_event_map=webhook_event_map,
-            ),
+            WebhookEventAsyncType.ORDER_UPDATED,
+            WebhookEventAsyncType.ORDER_FULFILLED,
         ],
-        any_order=True,
+        fulfilled_order,
+        webhook_event_map=webhook_event_map,
     )
 
 
@@ -1322,6 +1283,10 @@ def test_order_authorized_triggers_webhooks(
     "saleor.order.actions.call_order_event",
     wraps=call_order_event,
 )
+@patch(
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
+)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -1330,6 +1295,7 @@ def test_order_authorized_triggers_webhooks(
 def test_order_charged_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
+    wrapped_call_order_events,
     wrapped_call_order_event,
     setup_order_webhooks,
     order_with_lines,
@@ -1418,22 +1384,17 @@ def test_order_charged_triggers_webhooks(
             call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
         ]
     )
-    wrapped_call_order_event.assert_has_calls(
-        [
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_PAID,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_FULLY_PAID,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-        ],
-        any_order=True,
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
+        [WebhookEventAsyncType.ORDER_FULLY_PAID, WebhookEventAsyncType.ORDER_UPDATED],
+        order,
+        webhook_event_map=webhook_event_map,
+    )
+    wrapped_call_order_event.assert_called_once_with(
+        plugins_manager,
+        WebhookEventAsyncType.ORDER_PAID,
+        order,
+        webhook_event_map=webhook_event_map,
     )
 
 
@@ -1684,6 +1645,10 @@ def test_order_transaction_updated_order_fully_paid(
     "saleor.order.actions.call_order_event",
     wraps=call_order_event,
 )
+@patch(
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
+)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -1692,6 +1657,7 @@ def test_order_transaction_updated_order_fully_paid(
 def test_order_transaction_updated_for_charged_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
+    wrapped_call_order_events,
     wrapped_call_order_event,
     setup_order_webhooks,
     order_with_lines,
@@ -1792,28 +1758,17 @@ def test_order_transaction_updated_for_charged_triggers_webhooks(
         ]
     )
 
-    wrapped_call_order_event.assert_has_calls(
-        [
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_PAID,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_FULLY_PAID,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-        ],
-        any_order=True,
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
+        [WebhookEventAsyncType.ORDER_FULLY_PAID, WebhookEventAsyncType.ORDER_UPDATED],
+        order,
+        webhook_event_map=webhook_event_map,
+    )
+    wrapped_call_order_event.assert_called_once_with(
+        plugins_manager,
+        WebhookEventAsyncType.ORDER_PAID,
+        order,
+        webhook_event_map=webhook_event_map,
     )
 
 
@@ -1915,8 +1870,8 @@ def test_order_transaction_updated_for_authorized_triggers_webhooks(
 
 
 @patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -1926,7 +1881,7 @@ def test_order_transaction_updated_for_authorized_triggers_webhooks(
 def test_order_transaction_updated_for_refunded_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     order_with_lines,
     transaction_item_generator,
@@ -2025,29 +1980,15 @@ def test_order_transaction_updated_for_refunded_triggers_webhooks(
             call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
         ]
     )
-
-    wrapped_call_order_event.assert_has_calls(
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
         [
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_REFUNDED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
+            WebhookEventAsyncType.ORDER_REFUNDED,
+            WebhookEventAsyncType.ORDER_UPDATED,
+            WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
         ],
-        any_order=True,
+        order,
+        webhook_event_map=webhook_event_map,
     )
 
 
@@ -2441,7 +2382,7 @@ def test_order_transaction_updated_order_fully_refunded_with_transaction_and_pay
     wraps=call_event_including_protected_events,
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_call_order_event_for_order_event_triggers_sync_webhook(
+def test_call_order_event_triggers_sync_webhook(
     mocked_call_event_including_protected_events,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
@@ -2565,7 +2506,7 @@ def test_call_order_event_incorrect_webhook_event(
     wraps=call_event_including_protected_events,
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_call_order_event_for_order_event_missing_filter_shipping_method_webhook(
+def test_call_order_event_missing_filter_shipping_method_webhook(
     mocked_call_event_including_protected_events,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
@@ -2649,7 +2590,7 @@ def test_call_order_event_for_order_event_missing_filter_shipping_method_webhook
     wraps=call_event_including_protected_events,
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_call_order_event_for_order_event_skips_tax_webhook_when_prices_are_valid(
+def test_call_order_event_skips_tax_webhook_when_prices_are_valid(
     mocked_call_event_including_protected_events,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
@@ -2734,7 +2675,7 @@ def test_call_order_event_for_order_event_skips_tax_webhook_when_prices_are_vali
     wraps=call_event_including_protected_events,
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_call_order_event_for_order_event_skips_sync_webhooks_when_order_not_editable(
+def test_call_order_event_skips_sync_webhooks_when_order_not_editable(
     mocked_call_event_including_protected_events,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
@@ -2800,7 +2741,7 @@ def test_call_order_event_for_order_event_skips_sync_webhooks_when_order_not_edi
     wraps=call_event_including_protected_events,
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_call_order_event_for_order_event_skips_sync_webhooks_when_draft_order_deleted(
+def test_call_order_event_skips_sync_webhooks_when_draft_order_deleted(
     mocked_call_event_including_protected_events,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
@@ -2857,7 +2798,7 @@ def test_call_order_event_for_order_event_skips_sync_webhooks_when_draft_order_d
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_call_order_event_for_order_event_skips_when_async_webhooks_missing(
+def test_call_order_event_skips_when_async_webhooks_missing(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     setup_order_webhooks,
@@ -2908,7 +2849,7 @@ def test_call_order_event_for_order_event_skips_when_async_webhooks_missing(
     wraps=call_event_including_protected_events,
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
-def test_call_order_event_for_order_event_skips_when_sync_webhooks_missing(
+def test_call_order_event_skips_when_sync_webhooks_missing(
     mocked_call_event_including_protected_events,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
@@ -2952,9 +2893,629 @@ def test_call_order_event_for_order_event_skips_when_sync_webhooks_missing(
     )
 
 
+@pytest.mark.parametrize(
+    "webhook_event",
+    [
+        WebhookEventAsyncType.ORDER_CREATED,
+        WebhookEventAsyncType.ORDER_CONFIRMED,
+        WebhookEventAsyncType.ORDER_PAID,
+        WebhookEventAsyncType.ORDER_FULLY_PAID,
+        WebhookEventAsyncType.ORDER_REFUNDED,
+        WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        WebhookEventAsyncType.ORDER_CANCELLED,
+        WebhookEventAsyncType.ORDER_EXPIRED,
+        WebhookEventAsyncType.ORDER_FULFILLED,
+    ],
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
+    "saleor.order.actions.call_event_including_protected_events",
+    wraps=call_event_including_protected_events,
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_triggers_sync_webhook(
+    mocked_call_event_including_protected_events,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    setup_order_webhooks,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+    webhook_event,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        call_order_events(
+            plugins_manager,
+            [
+                webhook_event,
+                WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+            ],
+            order,
+        )
+
+    # then
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_has_calls(
+        [
+            call(tax_delivery),
+            call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
+        ]
+    )
+    mocked_call_event_including_protected_events.assert_has_calls(
+        [
+            call(
+                ANY,
+                order_with_lines,
+                webhooks={order_webhook},
+            ),
+            call(
+                plugins_manager.order_metadata_updated, order_with_lines, webhooks=set()
+            ),
+        ]
+    )
+
+
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
+    "saleor.order.actions.call_event_including_protected_events",
+    wraps=call_event_including_protected_events,
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_incorrect_webhook_event(
+    mocked_call_event_including_protected_events,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    setup_order_webhooks,
+    order_with_lines,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    mocked_send_webhook_request_sync.return_value = []
+    setup_order_webhooks(WebhookEventAsyncType.ORDER_CREATED)
+
+    incorrect_event = WebhookEventAsyncType.CHECKOUT_UPDATED
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        with pytest.raises(
+            ValueError,
+            match=f"Events { {incorrect_event} } not found in ORDER_WEBHOOK_EVENT_MAP.",
+        ):
+            call_order_events(
+                plugins_manager,
+                [
+                    incorrect_event,
+                    WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+                ],
+                order,
+            )
+
+    # then
+    assert not mocked_send_webhook_request_async.called
+    assert not mocked_send_webhook_request_sync.called
+    assert not mocked_call_event_including_protected_events.called
+
+
+@pytest.mark.parametrize(
+    "webhook_event",
+    [
+        WebhookEventAsyncType.ORDER_CREATED,
+        WebhookEventAsyncType.ORDER_CONFIRMED,
+        WebhookEventAsyncType.ORDER_PAID,
+        WebhookEventAsyncType.ORDER_FULLY_PAID,
+        WebhookEventAsyncType.ORDER_REFUNDED,
+        WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        WebhookEventAsyncType.ORDER_CANCELLED,
+        WebhookEventAsyncType.ORDER_EXPIRED,
+        WebhookEventAsyncType.ORDER_FULFILLED,
+    ],
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
+    "saleor.order.actions.call_event_including_protected_events",
+    wraps=call_event_including_protected_events,
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_missing_filter_shipping_method_webhook(
+    mocked_call_event_including_protected_events,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    setup_order_webhooks,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+    webhook_event,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    shipping_filter_webhook.is_active = False
+    shipping_filter_webhook.save(update_fields=["is_active"])
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        call_order_events(
+            plugins_manager,
+            [
+                webhook_event,
+                WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+            ],
+            order,
+        )
+
+    # then
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.get(webhook_id=tax_webhook.id)
+    filter_shipping_delivery = EventDelivery.objects.filter(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    ).first()
+    assert not filter_shipping_delivery
+
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_called_once_with(tax_delivery)
+    mocked_call_event_including_protected_events.assert_has_calls(
+        [
+            call(
+                ANY,
+                order_with_lines,
+                webhooks={order_webhook},
+            ),
+            call(
+                plugins_manager.order_metadata_updated, order_with_lines, webhooks=set()
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "webhook_event",
+    [
+        WebhookEventAsyncType.ORDER_CREATED,
+        WebhookEventAsyncType.ORDER_CONFIRMED,
+        WebhookEventAsyncType.ORDER_PAID,
+        WebhookEventAsyncType.ORDER_FULLY_PAID,
+        WebhookEventAsyncType.ORDER_REFUNDED,
+        WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        WebhookEventAsyncType.ORDER_CANCELLED,
+        WebhookEventAsyncType.ORDER_EXPIRED,
+        WebhookEventAsyncType.ORDER_FULFILLED,
+        WebhookEventAsyncType.DRAFT_ORDER_CREATED,
+        WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
+    ],
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
+    "saleor.order.actions.call_event_including_protected_events",
+    wraps=call_event_including_protected_events,
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_skips_tax_webhook_when_prices_are_valid(
+    mocked_call_event_including_protected_events,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    setup_order_webhooks,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+    webhook_event,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.save(
+        update_fields=[
+            "status",
+        ]
+    )
+
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        call_order_events(
+            plugins_manager,
+            [
+                webhook_event,
+                WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+            ],
+            order,
+        )
+
+    # then
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.filter(webhook_id=tax_webhook.id).first()
+    filter_shipping_delivery = EventDelivery.objects.get(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+    assert not tax_delivery
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    mocked_send_webhook_request_sync.assert_called_once_with(
+        filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
+    )
+    mocked_call_event_including_protected_events.assert_has_calls(
+        [
+            call(
+                ANY,
+                order_with_lines,
+                webhooks={order_webhook},
+            ),
+            call(
+                plugins_manager.order_metadata_updated, order_with_lines, webhooks=set()
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "webhook_event",
+    [
+        WebhookEventAsyncType.ORDER_CREATED,
+        WebhookEventAsyncType.ORDER_CONFIRMED,
+        WebhookEventAsyncType.ORDER_PAID,
+        WebhookEventAsyncType.ORDER_FULLY_PAID,
+        WebhookEventAsyncType.ORDER_REFUNDED,
+        WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        WebhookEventAsyncType.ORDER_CANCELLED,
+        WebhookEventAsyncType.ORDER_EXPIRED,
+        WebhookEventAsyncType.ORDER_FULFILLED,
+        WebhookEventAsyncType.DRAFT_ORDER_CREATED,
+        WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
+    ],
+)
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
+    "saleor.order.actions.call_event_including_protected_events",
+    wraps=call_event_including_protected_events,
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_skips_sync_webhooks_when_order_not_editable(
+    mocked_call_event_including_protected_events,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    setup_order_webhooks,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+    webhook_event,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.UNFULFILLED
+    order.save(
+        update_fields=[
+            "status",
+        ]
+    )
+
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(webhook_event)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        call_order_events(
+            plugins_manager,
+            [
+                webhook_event,
+                WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+            ],
+            order,
+        )
+
+    # then
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.filter(webhook_id=tax_webhook.id).first()
+    filter_shipping_delivery = EventDelivery.objects.filter(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    ).first()
+    assert not filter_shipping_delivery
+    assert not tax_delivery
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    assert not mocked_send_webhook_request_sync.called
+    mocked_call_event_including_protected_events.assert_has_calls(
+        [
+            call(
+                ANY,
+                order_with_lines,
+                webhooks={order_webhook},
+            ),
+            call(
+                plugins_manager.order_metadata_updated, order_with_lines, webhooks=set()
+            ),
+        ]
+    )
+
+
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
+    "saleor.order.actions.call_event_including_protected_events",
+    wraps=call_event_including_protected_events,
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_skips_sync_webhooks_when_draft_order_deleted(
+    mocked_call_event_including_protected_events,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    setup_order_webhooks,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order.save(update_fields=["status"])
+
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        order_webhook,
+    ) = setup_order_webhooks(WebhookEventAsyncType.DRAFT_ORDER_DELETED)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        call_order_events(
+            plugins_manager,
+            [
+                WebhookEventAsyncType.DRAFT_ORDER_DELETED,
+                WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+            ],
+            order,
+        )
+
+    # then
+    order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
+    tax_delivery = EventDelivery.objects.filter(webhook_id=tax_webhook.id).first()
+    filter_shipping_delivery = EventDelivery.objects.filter(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    ).first()
+    assert not filter_shipping_delivery
+    assert not tax_delivery
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    assert not mocked_send_webhook_request_sync.called
+    mocked_call_event_including_protected_events.assert_has_calls(
+        [
+            call(
+                plugins_manager.draft_order_deleted,
+                order_with_lines,
+                webhooks={order_webhook},
+            ),
+            call(
+                plugins_manager.order_metadata_updated, order_with_lines, webhooks=set()
+            ),
+        ]
+    )
+
+
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_skips_when_async_webhooks_missing(
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    setup_order_webhooks,
+    order_with_lines,
+    settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    mocked_send_webhook_request_sync.return_value = []
+    (
+        tax_webhook,
+        shipping_filter_webhook,
+        checkout_webhook,
+    ) = setup_order_webhooks(WebhookEventAsyncType.CHECKOUT_CREATED)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        call_order_events(
+            plugins_manager,
+            [
+                WebhookEventAsyncType.ORDER_CREATED,
+                WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+            ],
+            order,
+        )
+
+    # then
+    tax_delivery = EventDelivery.objects.filter(webhook_id=tax_webhook.id).first()
+    filter_shipping_delivery = EventDelivery.objects.filter(
+        webhook_id=shipping_filter_webhook.id,
+        event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    ).first()
+    assert not filter_shipping_delivery
+    assert not tax_delivery
+    assert not mocked_send_webhook_request_async.called
+    assert not mocked_send_webhook_request_sync.called
+
+
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
+    "saleor.order.actions.call_event_including_protected_events",
+    wraps=call_event_including_protected_events,
+)
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_call_order_events_skips_when_sync_webhooks_missing(
+    mocked_call_event_including_protected_events,
+    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_sync,
+    order_with_lines,
+    settings,
+    webhook,
+    permission_manage_orders,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    plugins_manager = get_plugins_manager(False)
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+
+    webhook.app.permissions.add(permission_manage_orders)
+
+    mocked_send_webhook_request_sync.return_value = []
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        call_order_events(
+            plugins_manager,
+            [
+                WebhookEventAsyncType.ORDER_CREATED,
+                WebhookEventAsyncType.ORDER_METADATA_UPDATED,
+            ],
+            order,
+        )
+
+    # then
+    order_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={"event_delivery_id": order_delivery.id},
+        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
+    )
+    assert not mocked_send_webhook_request_sync.called
+    mocked_call_event_including_protected_events.assert_has_calls(
+        [
+            call(
+                plugins_manager.order_created,
+                order_with_lines,
+                webhooks={webhook},
+            ),
+            call(
+                plugins_manager.order_metadata_updated, order_with_lines, webhooks=set()
+            ),
+        ]
+    )
+
+
 @patch(
     "saleor.order.actions.call_order_event",
     wraps=call_order_event,
+)
+@patch(
+    "saleor.order.actions.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -2964,6 +3525,7 @@ def test_call_order_event_for_order_event_skips_when_sync_webhooks_missing(
 def test_order_created_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
+    wrapped_call_order_events,
     wrapped_call_order_event,
     setup_order_webhooks,
     order_with_lines,
@@ -3060,6 +3622,12 @@ def test_order_created_triggers_webhooks(
             call(filter_shipping_delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT),
         ]
     )
+    wrapped_call_order_events.assert_called_once_with(
+        plugins_manager,
+        [WebhookEventAsyncType.ORDER_FULLY_PAID, WebhookEventAsyncType.ORDER_UPDATED],
+        order,
+        webhook_event_map=webhook_event_map,
+    )
     wrapped_call_order_event.assert_has_calls(
         [
             call(
@@ -3077,18 +3645,6 @@ def test_order_created_triggers_webhooks(
             call(
                 plugins_manager,
                 WebhookEventAsyncType.ORDER_PAID,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_FULLY_PAID,
-                order,
-                webhook_event_map=webhook_event_map,
-            ),
-            call(
-                plugins_manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
                 order,
                 webhook_event_map=webhook_event_map,
             ),

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -13,7 +13,7 @@ from ...discount.models import VoucherCustomer
 from ...warehouse.models import Allocation
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .. import OrderEvents, OrderStatus
-from ..actions import call_order_event
+from ..actions import call_order_event, call_order_events
 from ..models import Order, OrderEvent, get_order_number
 from ..tasks import (
     _bulk_release_voucher_usage,
@@ -382,8 +382,8 @@ def test_expire_orders_task_after(order_list, allocations, channel_USD):
 
 
 @patch(
-    "saleor.order.tasks.call_order_event",
-    wraps=call_order_event,
+    "saleor.order.tasks.call_order_events",
+    wraps=call_order_events,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
@@ -393,7 +393,7 @@ def test_expire_orders_task_after(order_list, allocations, channel_USD):
 def test_expire_orders_task_do_not_call_sync_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
+    wrapped_call_order_events,
     setup_order_webhooks,
     order_list,
     channel_USD,
@@ -461,7 +461,7 @@ def test_expire_orders_task_do_not_call_sync_webhooks(
     )
 
     assert not mocked_send_webhook_request_sync.called
-    assert wrapped_call_order_event.called
+    assert wrapped_call_order_events.called
 
 
 @freeze_time("2020-03-18 12:00:00")


### PR DESCRIPTION
I want to merge this change because it adds handlers to call multiple order/checkout events.

Port of changes from: #16554

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
