### PR TITLE
Add check if fulfillment does not exceed order line unfulfilled allocation

### DIFF
--- a/saleor/order/tests/test_actions.py
+++ b/saleor/order/tests/test_actions.py
@@ -4,7 +4,12 @@ import pytest
 
 from ...webhook.utils import get_webhooks_for_multiple_events
 from .. import OrderStatus
-from ..actions import WEBHOOK_EVENTS_FOR_ORDER_CREATED, order_confirmed, order_created
+from ..actions import (
+    WEBHOOK_EVENTS_FOR_ORDER_CREATED,
+    _check_if_fulfillment_quantity_exceeds_order_quantity,
+    order_confirmed,
+    order_created,
+)
 from ..fetch import OrderInfo
 
 parametrize_order_statuses = [(status,) for status, _ in OrderStatus.CHOICES]
@@ -64,3 +69,52 @@ def test_order_created_order_confirmed_with_turned_flag_off(
 
     # then
     mock_order_confirmed.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("quantity", "expected_result"), [(5, False), (10, False), (11, True)]
+)
+def test_check_if_fulfillment_quantity_exceeds_order_quantity(
+    quantity, expected_result, order_line
+):
+    # given
+    order_line.quantity_fulfilled = 0
+    order_line.quantity = 10
+
+    # when
+    result = _check_if_fulfillment_quantity_exceeds_order_quantity(order_line, quantity)
+
+    # then
+    assert result is expected_result
+
+
+@pytest.mark.parametrize(
+    ("quantity", "expected_result"), [(5, False), (10, False), (11, True)]
+)
+def test_check_if_fulfillment_quantity_exceeds_order_quantity_when_no_allocations(
+    quantity, expected_result, order_line
+):
+    # given
+    order_line.quantity_fulfilled = 0
+    order_line.quantity = 10
+    order_line.allocations.all().delete()
+
+    # when
+    result = _check_if_fulfillment_quantity_exceeds_order_quantity(order_line, quantity)
+
+    # then
+    assert result is expected_result
+
+
+def test_check_if_fulfillment_quantity_exceeds_order_quantity_when_quantity_fulfilled_is_greater_than_quantity(
+    order_line,
+):
+    # given
+    order_line.quantity_fulfilled = 10
+    order_line.quantity = 10
+
+    # when
+    result = _check_if_fulfillment_quantity_exceeds_order_quantity(order_line, 1)
+
+    # then
+    assert result is True


### PR DESCRIPTION
I want to merge this change because those changes will prevent the creating simultaneously more than one fulfillment records that could exceed the order line quantity, thus creating a possibility to generate fulfillment records that combined exceed the number of items in the order.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
