### PR TITLE
Fix webhook payload save on Azure Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed a potential crash when Checkout metadata is accessed with high concurrency - #16411 by @patrys
 - Add slugs to product/category/collection/page translations. Allow to query by translated slug - #16449 by @delemeator
 - Fixed a crash when the Decimal scalar is passed a non-normal value - #16520 by @patrys
+- Fixed a bug when saving webhook payload to Azure Storage - #16585 by @delemeator

--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -177,16 +177,17 @@ class EventPayload(models.Model):
 
     def get_payload(self):
         if self.payload_file:
-            with self.payload_file.open("rt") as f:
-                payload = f.read()
-                return payload
+            with self.payload_file.open("rb") as f:
+                payload_data = f.read()
+                return payload_data.decode("utf-8")
         return self.payload
 
     def save_payload_file(self, payload_data: str):
+        payload_bytes = payload_data.encode("utf-8")
         prefix = get_random_string(length=12)
         file_name = f"{self.pk}.json"
         file_path = safe_join(prefix, file_name)
-        self.payload_file.save(file_path, ContentFile(payload_data))
+        self.payload_file.save(file_path, ContentFile(payload_bytes))
 
 
 class EventDelivery(models.Model):

--- a/saleor/core/tests/test_event_payload.py
+++ b/saleor/core/tests/test_event_payload.py
@@ -1,0 +1,39 @@
+import pytest
+from django.core.files.base import ContentFile
+from django.utils.crypto import get_random_string
+from storages.utils import safe_join
+
+from ..models import EventPayload
+
+
+@pytest.fixture
+def payload_data():
+    return '{\n    "product": {\n        "name": "Żółta ćma"\n    }\n}\n'
+
+
+def test_reading_event_payload(payload_data):
+    # given
+    payload = EventPayload.objects.create()
+    payload.save_payload_file(payload_data)
+
+    # when
+    read_payload = payload.get_payload()
+
+    # then
+    assert read_payload == payload_data
+
+
+def test_reading_event_payload_saved_as_string(payload_data):
+    # given
+    # Force saving payload as string (as old payloads were)
+    payload = EventPayload.objects.create()
+    prefix = get_random_string(length=12)
+    file_name = f"{payload.pk}.json"
+    file_path = safe_join(prefix, file_name)
+    payload.payload_file.save(file_path, ContentFile(payload_data))
+
+    # when
+    read_payload = payload.get_payload()
+
+    # then
+    assert read_payload == payload_data


### PR DESCRIPTION
This PR fixes bug when saving webhook payload on azure storage (https://github.com/saleor/saleor/issues/16584)

Bug seems to be caused by Django ContentFile using StringIO rather than BytesIO for strings:
https://github.com/django/django/blob/7adb6dd98d50a238f3eca8c15b16b5aec12575fd/django/core/files/base.py#L127

Bug traceback:
```
{
    "errors": [
        {
            "message": "Blob data should be of type bytes.",
            "locations": [
                {
                    "line": 2,
                    "column": 3
                }
            ],
            "path": [
                "productUpdate"
            ],
            "extensions": {
                "exception": {
                    "code": "TypeError",
                    "stacktrace": [
                        "Traceback (most recent call last):",
                        "  File \"/usr/local/lib/python3.9/site-packages/graphql/execution/executor.py\", line 452, in resolve_or_error",
                        "    return executor.execute(resolve_fn, source, info, **args)",
                        "  File \"/usr/local/lib/python3.9/site-packages/graphql/execution/executors/sync.py\", line 16, in execute",
                        "    return fn(*args, **kwargs)",
                        "  File \"/usr/local/lib/python3.9/contextlib.py\", line 79, in inner",
                        "    return func(*args, **kwds)",
                        "  File \"/app/saleor/graphql/core/mutations.py\", line 531, in mutate",
                        "    response = cls.perform_mutation(root, info, **data)",
                        "  File \"/app/saleor/graphql/product/mutations/product/product_create.py\", line 227, in perform_mutation",
                        "    response = super().perform_mutation(_root, info, **data)",
                        "  File \"/app/saleor/graphql/core/mutations.py\", line 812, in perform_mutation",
                        "    cls.post_save_action(info, instance, cleaned_input)",
                        "  File \"/app/saleor/graphql/product/mutations/product/product_update.py\", line 61, in post_save_action",
                        "    cls.call_event(manager.product_updated, product)",
                        "  File \"/app/saleor/graphql/core/mutations.py\", line 556, in call_event",
                        "    return call_event(func_obj, *func_args, **kwargs)",
                        "  File \"/app/saleor/core/utils/events.py\", line 127, in call_event",
                        "    call_event_including_protected_events(func_obj, *func_args, **func_kwargs)",
                        "  File \"/app/saleor/core/utils/events.py\", line 107, in call_event_including_protected_events",
                        "    func_obj(*func_args, **func_kwargs)",
                        "  File \"/app/saleor/plugins/manager.py\", line 773, in product_updated",
                        "    return self.__run_method_on_plugins(",
                        "  File \"/app/saleor/plugins/manager.py\", line 235, in __run_method_on_plugins",
                        "    value = self.__run_method_on_single_plugin(",
                        "  File \"/app/saleor/plugins/manager.py\", line 257, in __run_method_on_single_plugin",
                        "    returned_value = plugin_method(*args, **kwargs, previous_value=previous_value)  # type:ignore",
                        "  File \"/app/saleor/plugins/webhook/plugin.py\", line 1595, in product_updated",
                        "    self.trigger_webhooks_async(",
                        "  File \"/app/saleor/plugins/webhook/plugin.py\", line 249, in trigger_webhooks_async",
                        "    return trigger_webhooks_async(*args, **kwargs, allow_replica=self.allow_replica)  # type: ignore",
                        "  File \"/app/saleor/webhook/transport/asynchronous/transport.py\", line 226, in trigger_webhooks_async",
                        "    create_deliveries_for_subscriptions(",
                        "  File \"/app/saleor/webhook/transport/asynchronous/transport.py\", line 139, in create_deliveries_for_subscriptions",
                        "    EventPayload.objects.bulk_create_with_payload_files(",
                        "  File \"/usr/local/lib/python3.9/contextlib.py\", line 79, in inner",
                        "    return func(*args, **kwds)",
                        "  File \"/app/saleor/core/models.py\", line 163, in bulk_create_with_payload_files",
                        "    obj.save_payload_file(payload_data)",
                        "  File \"/app/saleor/core/models.py\", line 189, in save_payload_file",
                        "    self.payload_file.save(file_path, ContentFile(payload_data))",
                        "  File \"/usr/local/lib/python3.9/site-packages/django/db/models/fields/files.py\", line 89, in save",
                        "    self.name = self.storage.save(name, content, max_length=self.field.max_length)",
                        "  File \"/usr/local/lib/python3.9/site-packages/django/core/files/storage.py\", line 54, in save",
                        "    name = self._save(name, content)",
                        "  File \"/usr/local/lib/python3.9/site-packages/storages/backends/azure_storage.py\", line 295, in _save",
                        "    self.client.upload_blob(",
                        "  File \"/usr/local/lib/python3.9/site-packages/azure/core/tracing/decorator.py\", line 94, in wrapper_use_tracer",
                        "    return func(*args, **kwargs)",
                        "  File \"/usr/local/lib/python3.9/site-packages/azure/storage/blob/_container_client.py\", line 1125, in upload_blob",
                        "    blob.upload_blob(",
                        "  File \"/usr/local/lib/python3.9/site-packages/azure/core/tracing/decorator.py\", line 94, in wrapper_use_tracer",
                        "    return func(*args, **kwargs)",
                        "  File \"/usr/local/lib/python3.9/site-packages/azure/storage/blob/_blob_client.py\", line 775, in upload_blob",
                        "    return upload_block_blob(**options)",
                        "  File \"/usr/local/lib/python3.9/site-packages/azure/storage/blob/_upload_helpers.py\", line 96, in upload_block_blob",
                        "    raise TypeError('Blob data should be of type bytes.')",
                        "TypeError: Blob data should be of type bytes."
                    ]
                }
            }
        }
    ],
    "data": {
        "productUpdate": null
    },
    "extensions": {
        "cost": {
            "requestedQueryCost": 0,
            "maximumAvailable": 50000
        }
    }
}
```

# Impact

Unless I am missing something, there should not be any impact from this change for deployments using File Storage, S3 or GS. 

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] The changes are covered by test cases
