### PR TITLE
Add deprecation notice to manager methods

### DIFF
--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -162,12 +162,18 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # is confirmed.
+    #
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     account_confirmed: Callable[["User", None], None]
 
     # Trigger when account confirmation is requested.
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # confirmation is requested.
+    #
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     account_confirmation_requested: Callable[
         ["User", str, str, Optional[str], None], None
     ]
@@ -176,108 +182,160 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # change email is requested.
+    #
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     account_change_email_requested: Callable[["User", str, str, str, str, None], None]
 
     # Trigger when account set password is requested.
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # set password is requested.
+    #
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     account_set_password_requested: Callable[["User", str, str, str, None], None]
 
     # Trigger when account delete is confirmed.
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # delete is confirmed.
+    #
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     account_deleted: Callable[["User", None], None]
 
     # Trigger when account email is changed.
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # email is changed.
+    #
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     account_email_changed: Callable[["User", None], None]
 
     # Trigger when account delete is requested.
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # delete is requested.
+    #
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     account_delete_requested: Callable[["User", str, str, str, None], None]
 
-    # Trigger when address is created.
+    # Triggered when an address is created.
     #
     # Overwrite this method if you need to trigger specific logic after an address is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     address_created: Callable[["Address", None], None]
 
-    # Trigger when address is deleted.
+    # Triggered when an address is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after an address is
     # deleted.
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     address_deleted: Callable[["Address", None], None]
 
-    # Trigger when address is updated.
+    # Triggered when an address is updated.
     #
     # Overwrite this method if you need to trigger specific logic after an address is
     # updated.
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     address_updated: Callable[["Address", None], None]
 
     # Trigger when app is installed.
     #
     # Overwrite this method if you need to trigger specific logic after an app is
     # installed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     app_installed: Callable[["App", None], None]
 
     # Trigger when app is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after an app is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     app_deleted: Callable[["App", None], None]
 
     # Trigger when app is updated.
     #
     # Overwrite this method if you need to trigger specific logic after an app is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     app_updated: Callable[["App", None], None]
 
     # Trigger when channel status is changed.
     #
     # Overwrite this method if you need to trigger specific logic after an app
     # status is changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     app_status_changed: Callable[["App", None], None]
 
     # Trigger when attribute is created.
     #
     # Overwrite this method if you need to trigger specific logic after an attribute is
     # installed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_created: Callable[["Attribute", None], None]
 
     # Trigger when attribute is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after an attribute is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_deleted: Callable[["Attribute", None, None], None]
 
     # Trigger when attribute is updated.
     #
     # Overwrite this method if you need to trigger specific logic after an attribute is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_updated: Callable[["Attribute", None, None], None]
 
     # Trigger when attribute value is created.
     #
     # Overwrite this method if you need to trigger specific logic after an attribute
     # value is installed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_value_created: Callable[["AttributeValue", None], None]
 
     # Trigger when attribute value is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after an attribute
     # value is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_value_deleted: Callable[["AttributeValue", None, None], None]
 
     # Trigger when attribute value is updated.
     #
     # Overwrite this method if you need to trigger specific logic after an attribute
     # value is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_value_updated: Callable[["AttributeValue", None], None]
 
     # Authenticate user which should be assigned to the request.
@@ -394,48 +452,72 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after a category is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     category_created: Callable[["Category", None], None]
 
     # Trigger when category is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a category is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     category_deleted: Callable[["Category", None, None], None]
 
     # Trigger when category is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a category is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     category_updated: Callable[["Category", None], None]
 
     # Trigger when channel is created.
     #
     # Overwrite this method if you need to trigger specific logic after a channel is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     channel_created: Callable[["Channel", None], None]
 
     # Trigger when channel is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a channel is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     channel_deleted: Callable[["Channel", None], None]
 
     # Trigger when channel is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a channel is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     channel_updated: Callable[["Channel", None, None], None]
 
     # Trigger when channel status is changed.
     #
     # Overwrite this method if you need to trigger specific logic after a channel
     # status is changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     channel_status_changed: Callable[["Channel", None], None]
 
     # Trigger when channel metadata is changed.
     #
     # Overwrite this method if you need to trigger specific logic after a channel
     # metadata is changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     channel_metadata_updated: Callable[["Channel", None], None]
 
     change_user_address: Callable[
@@ -449,48 +531,72 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic when a checkout is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_created: Callable[["Checkout", Any, None], Any]
 
     # Trigger when checkout is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a checkout is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_updated: Callable[["Checkout", Any, None], Any]
 
     # Trigger when checkout is fully paid with transactions.
     #
     # Overwrite this method if you need to trigger specific logic when a checkout is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_fully_paid: Callable[["Checkout", Any, None], Any]
 
     # Trigger when checkout metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a checkout
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_metadata_updated: Callable[["Checkout", Any, None], Any]
 
     # Trigger when collection is created.
     #
     # Overwrite this method if you need to trigger specific logic after a collection is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     collection_created: Callable[["Collection", Any], Any]
 
     # Trigger when collection is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a collection is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     collection_deleted: Callable[["Collection", Any, None], Any]
 
     # Trigger when collection is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a collection is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     collection_updated: Callable[["Collection", Any], Any]
 
     # Trigger when collection metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a collection
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     collection_metadata_updated: Callable[["Collection", Any], Any]
 
     confirm_payment: Callable[["PaymentData", Any], GatewayResponse]
@@ -499,24 +605,36 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after a user is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     customer_created: Callable[["User", Any], Any]
 
     # Trigger when user is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a user is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     customer_deleted: Callable[["User", Any, None], Any]
 
     # Trigger when user is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a user is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     customer_updated: Callable[["User", Any, None], Any]
 
     # Trigger when user metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a user
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     customer_metadata_updated: Callable[["User", Any, None], Any]
 
     # Handle authentication request.
@@ -556,24 +674,36 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic when a fulfillment is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_created: Callable[["Fulfillment", bool, Any], Any]
 
     # Trigger when fulfillment is cancelled.
     #
     # Overwrite this method if you need to trigger specific logic when a fulfillment is
     # cancelled.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_canceled: Callable[["Fulfillment", Any], Any]
 
     # Trigger when fulfillment is approved.
     #
     # Overwrite this method if you need to trigger specific logic when a fulfillment is
     # approved.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_approved: Callable[["Fulfillment", Any], Any]
 
     # Trigger when fulfillment metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a fulfillment
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_metadata_updated: Callable[["Fulfillment", Any], Any]
 
     get_checkout_line_tax_rate: Callable[
@@ -597,11 +727,15 @@ class BasePlugin:
         Any,
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     get_taxes_for_checkout: Callable[
         ["CheckoutInfo", Iterable["CheckoutLineInfo"], str, Any, Optional[dict]],
         Optional["TaxData"],
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     get_taxes_for_order: Callable[["Order", str, Any], Optional["TaxData"]]
 
     get_client_token: Callable[[Any, Any], Any]
@@ -614,6 +748,8 @@ class BasePlugin:
     get_order_shipping_tax_rate: Callable[["Order", Any], Any]
     get_payment_config: Callable[[Any], Any]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     get_shipping_methods_for_checkout: Callable[
         ["Checkout", Any], list["ShippingMethodData"]
     ]
@@ -641,54 +777,81 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after a gift card is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_created: Callable[["GiftCard", None, None], None]
 
     # Trigger when gift card is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a gift card is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_deleted: Callable[["GiftCard", None, None], None]
 
     # Trigger when gift card is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a gift card is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_updated: Callable[["GiftCard", None], None]
 
     # Trigger when gift card metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a gift card
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_metadata_updated: Callable[["GiftCard", None], None]
 
     # Trigger when gift card status is changed.
     #
     # Overwrite this method if you need to trigger specific logic after a gift card
     # status is changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_status_changed: Callable[["GiftCard", None, None], None]
 
     # Trigger when gift cards export is completed.
     #
     # Overwrite this method if you need to trigger specific logic after a gift cards
     # export is completed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_export_completed: Callable[["ExportFile", None], None]
 
     # Trigger when draft order is created.
     #
     # Overwrite this method if you need to trigger specific logic after an order is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     draft_order_created: Callable[["Order", Any, None], Any]
 
     # Trigger when draft order is updated.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     draft_order_updated: Callable[["Order", Any, None], Any]
 
     # Trigger when draft order is deleted.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     draft_order_deleted: Callable[["Order", Any, None], Any]
 
     initialize_payment: Callable[
@@ -699,6 +862,9 @@ class BasePlugin:
     #
     # Perform any extra logic before the invoice gets deleted.
     # Note there is no need to run invoice.delete() as it will happen in mutation.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     invoice_delete: Callable[["Invoice", Any], Any]
 
     # Trigger when invoice creation starts.
@@ -709,15 +875,22 @@ class BasePlugin:
     ]
 
     # Trigger after invoice is sent.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     invoice_sent: Callable[["Invoice", str, Any], Any]
 
     list_payment_sources: Callable[[str, Any], list["CustomerSource"]]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     list_stored_payment_methods: Callable[
         ["ListStoredPaymentMethodsRequestData", list["PaymentMethodData"]],
         list["PaymentMethodData"],
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     stored_payment_method_request_delete: Callable[
         [
             "StoredPaymentMethodRequestDeleteData",
@@ -726,6 +899,8 @@ class BasePlugin:
         "StoredPaymentMethodRequestDeleteResponseData",
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     payment_gateway_initialize_tokenization: Callable[
         [
             "PaymentGatewayInitializeTokenizationRequestData",
@@ -734,6 +909,8 @@ class BasePlugin:
         "PaymentGatewayInitializeTokenizationResponseData",
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     payment_method_initialize_tokenization: Callable[
         [
             "PaymentMethodInitializeTokenizationRequestData",
@@ -742,6 +919,8 @@ class BasePlugin:
         "PaymentMethodTokenizationResponseData",
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     payment_method_process_tokenization: Callable[
         [
             "PaymentMethodProcessTokenizationRequestData",
@@ -754,36 +933,54 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after a menu is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     menu_created: Callable[["Menu", None], None]
 
     # Trigger when menu is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a menu is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     menu_deleted: Callable[["Menu", None, None], None]
 
     # Trigger when menu is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a menu is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     menu_updated: Callable[["Menu", None], None]
 
     # Trigger when menu item is created.
     #
     # Overwrite this method if you need to trigger specific logic after a menu item is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     menu_item_created: Callable[["MenuItem", None], None]
 
     # Trigger when menu item is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a menu item is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     menu_item_deleted: Callable[["MenuItem", None, None], None]
 
     # Trigger when menu item is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a menu item is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     menu_item_updated: Callable[["MenuItem", None], None]
 
     # Handle notification request.
@@ -795,12 +992,18 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # canceled.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_cancelled: Callable[["Order", Any, None], Any]
 
     # Trigger when order is expired.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # expired.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_expired: Callable[["Order", Any, None], Any]
 
     # Trigger when order is confirmed by staff.
@@ -813,108 +1016,162 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after an order is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_created: Callable[["Order", Any, None], Any]
 
     # Trigger when order is fulfilled.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # fulfilled.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_fulfilled: Callable[["Order", Any, None], Any]
 
     # Trigger when order is fully paid.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # fully paid.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_fully_paid: Callable[["Order", Any, None], Any]
 
     # Trigger when order is paid.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # received the payment.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_paid: Callable[["Order", Any, None], Any]
 
     # Trigger when order is refunded.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # refunded.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_refunded: Callable[["Order", Any, None], Any]
 
     # Trigger when order is fully refunded.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # fully refunded.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_fully_refunded: Callable[["Order", Any, None], Any]
 
     # Trigger when order is updated.
     #
     # Overwrite this method if you need to trigger specific logic when an order is
     # changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_updated: Callable[["Order", Any, None], Any]
 
     # Trigger when order metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic when an order
     # metadata is changed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_metadata_updated: Callable[["Order", Any, None], Any]
 
     # Trigger when orders are imported.
     #
     # Overwrite this method if you need to trigger specific logic when an order
     # is imported.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     order_bulk_created: Callable[[list["Order"], Any], Any]
 
     # Trigger when page is created.
     #
     # Overwrite this method if you need to trigger specific logic when a page is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     page_created: Callable[["Page", Any], Any]
 
     # Trigger when page is deleted.
     #
     # Overwrite this method if you need to trigger specific logic when a page is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     page_deleted: Callable[["Page", Any], Any]
 
     # Trigger when page is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a page is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     page_updated: Callable[["Page", Any], Any]
 
     # Trigger when page type is created.
     #
     # Overwrite this method if you need to trigger specific logic when a page type is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     page_type_created: Callable[["PageType", Any], Any]
 
     # Trigger when page type is deleted.
     #
     # Overwrite this method if you need to trigger specific logic when a page type is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     page_type_deleted: Callable[["PageType", Any], Any]
 
     # Trigger when page type is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a page type is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     page_type_updated: Callable[["PageType", Any], Any]
 
     # Trigger when permission group is created.
     #
     # Overwrite this method if you need to trigger specific logic when a permission
     # group is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     permission_group_created: Callable[["Group", Any], Any]
 
     # Trigger when permission group type is deleted.
     #
     # Overwrite this method if you need to trigger specific logic when a permission
     # group is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     permission_group_deleted: Callable[["Group", Any], Any]
 
     # Trigger when permission group is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a permission
     # group is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     permission_group_updated: Callable[["Group", Any], Any]
 
     # Trigger directly before order creation.
@@ -932,12 +1189,20 @@ class BasePlugin:
 
     process_payment: Callable[["PaymentData", Any], Any]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_charge_requested: Callable[["TransactionActionData", None], None]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_cancelation_requested: Callable[["TransactionActionData", None], None]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_refund_requested: Callable[["TransactionActionData", None], None]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     payment_gateway_initialize_session: Callable[
         [
             Decimal,
@@ -948,10 +1213,14 @@ class BasePlugin:
         list["PaymentGatewayData"],
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_initialize_session: Callable[
         ["TransactionSessionData", None], "TransactionSessionResult"
     ]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_process_session: Callable[
         ["TransactionSessionData", None], "TransactionSessionResult"
     ]
@@ -960,96 +1229,144 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic when a transaction
     # item metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_item_metadata_updated: Callable[["TransactionItem", Any], Any]
 
     # Trigger when product is created.
     #
     # Overwrite this method if you need to trigger specific logic after a product is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_created: Callable[["Product", Any, None], Any]
 
     # Trigger when product is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a product is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_deleted: Callable[["Product", list[int], Any, None], Any]
 
     # Trigger when product is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a product is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_updated: Callable[["Product", Any, None], Any]
 
     # Trigger when product media is created.
     #
     # Overwrite this method if you need to trigger specific logic after a product media
     # is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_media_created: Callable[["ProductMedia", Any], Any]
 
     # Trigger when product media is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a product media
     # is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_media_updated: Callable[["ProductMedia", Any], Any]
 
     # Trigger when product media is created.
     #
     # Overwrite this method if you need to trigger specific logic after a product media
     # is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_media_deleted: Callable[["ProductMedia", Any], Any]
 
     # Trigger when product metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_metadata_updated: Callable[["Product", Any], Any]
 
     # Trigger when product variant is created.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_created: Callable[["ProductVariant", Any, None], Any]
 
     # Trigger when product variant is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_deleted: Callable[["ProductVariant", Any, None], Any]
 
     # Trigger when product variant is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_updated: Callable[["ProductVariant", Any, None], Any]
 
     # Trigger when product variant metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # variant metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_metadata_updated: Callable[["ProductVariant", Any], Any]
 
     # Trigger when product variant is out of stock.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is out of stock.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_out_of_stock: Callable[["Stock", None, None], Any]
 
     # Trigger when product variant is back in stock.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is back in stock.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_back_in_stock: Callable[["Stock", None, None], Any]
 
     # Trigger when product variant stock is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # variant stock is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_stock_updated: Callable[["Stock", None, None], Any]
 
     # Trigger when a product export is completed.
     #
     # Overwrite this method if you need to trigger specific logic after a product
     # export is completed.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     product_export_completed: Callable[["ExportFile", None], None]
 
     refund_payment: Callable[["PaymentData", Any], GatewayResponse]
@@ -1057,18 +1374,27 @@ class BasePlugin:
     # Trigger when sale is created.
     #
     # Overwrite this method if you need to trigger specific logic after sale is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     sale_created: Callable[["Promotion", defaultdict[str, set[str]], Any], Any]
 
     # Trigger when sale is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a sale is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     sale_deleted: Callable[["Promotion", defaultdict[str, set[str]], Any], Any]
 
     # Trigger when sale is updated.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a sale is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     sale_updated: Callable[
         ["Promotion", defaultdict[str, set[str]], defaultdict[str, set[str]], Any], Any
     ]
@@ -1077,117 +1403,177 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after promotion
     # is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_created: Callable[["Promotion", Any], Any]
 
     # Trigger when promotion is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_deleted: Callable[["Promotion", Any, None], Any]
 
     # Trigger when promotion is updated.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_updated: Callable[["Promotion", Any], Any]
 
     # Trigger when promotion is started.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is started.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_started: Callable[["Promotion", Any], Any]
 
     # Trigger when promotion is ended.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is ended.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_ended: Callable[["Promotion", Any], Any]
 
     # Trigger when promotion rule is created.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a promotion rule is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_rule_created: Callable[["PromotionRule", Any], Any]
 
     # Trigger when promotion rule is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a promotion rule is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_rule_deleted: Callable[["PromotionRule", Any], Any]
 
     # Trigger when promotion rule is updated.
     #
     # Overwrite this method if you need to trigger specific logic after
     # a promotion rule is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_rule_updated: Callable[["PromotionRule", Any], Any]
 
     # Trigger when shipping price is created.
     #
     # Overwrite this method if you need to trigger specific logic after a shipping
     # price is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_price_created: Callable[["ShippingMethod", None], None]
 
     # Trigger when shipping price is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a shipping
     # price is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_price_deleted: Callable[["ShippingMethod", None, None], None]
 
     # Trigger when shipping price is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a shipping
     # price is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_price_updated: Callable[["ShippingMethod", None], None]
 
     # Trigger when shipping zone is created.
     #
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # is created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_created: Callable[["ShippingZone", None], None]
 
     # Trigger when shipping zone is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # is deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_deleted: Callable[["ShippingZone", None, None], None]
 
     # Trigger when shipping zone is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_updated: Callable[["ShippingZone", None], None]
 
     # Trigger when shipping zone metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_metadata_updated: Callable[["ShippingZone", None], None]
 
     # Trigger when staff user is created.
     #
     # Overwrite this method if you need to trigger specific logic after a staff user is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     staff_created: Callable[["User", Any], Any]
 
     # Trigger when staff user is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a staff user is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     staff_updated: Callable[["User", Any], Any]
 
     # Trigger when staff user is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a staff user is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     staff_deleted: Callable[["User", Any, None], Any]
 
     # Trigger when setting a password for staff is requested.
     #
     # Overwrite this method if you need to trigger specific logic after set
     # password for staff is requested.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     staff_set_password_requested: Callable[["User", str, str, str, None], None]
 
     # Trigger when thumbnail is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     thumbnail_created: Callable[["Thumbnail", Any], Any]
 
     # Trigger when tracking number is updated.
@@ -1199,68 +1585,103 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after a warehouse is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_created: Callable[["Warehouse", None], None]
 
     # Trigger when warehouse is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a warehouse is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_deleted: Callable[["Warehouse", None], None]
 
     # Trigger when warehouse is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a warehouse is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_updated: Callable[["Warehouse", None], None]
 
     # Trigger when warehouse metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a warehouse
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_metadata_updated: Callable[["Warehouse", None], None]
 
     # Trigger when voucher is created.
     #
     # Overwrite this method if you need to trigger specific logic after a voucher is
     # created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_created: Callable[["Voucher", str, None], None]
 
     # Trigger when voucher is deleted.
     #
     # Overwrite this method if you need to trigger specific logic after a voucher is
     # deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_deleted: Callable[["Voucher", str, None, None], None]
 
     # Trigger when voucher is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a voucher is
     # updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_updated: Callable[["Voucher", str, None], None]
 
     # Trigger when voucher codes are created.
     #
     # Overwrite this method if you need to trigger specific logic after voucher codes
     # are created.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_codes_created: Callable[[list["VoucherCode"], None, None], None]
 
     # Trigger when voucher code are deleted.
     #
     # Overwrite this method if you need to trigger specific logic after voucher codes
     # are deleted.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_codes_deleted: Callable[[list["VoucherCode"], None, None], None]
 
     # Trigger when voucher metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a voucher
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_metadata_updated: Callable[["Voucher", None], None]
 
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_code_export_completed: Callable[["ExportFile", None], None]
 
     # Trigger when shop metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic after a shop
     # metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     shop_metadata_updated: Callable[["SiteSettings", None], None]
 
     # Handle received http request.
@@ -1269,6 +1690,9 @@ class BasePlugin:
     webhook: Callable[[WSGIRequest, str, Any], HttpResponse]
 
     # Triggers retry mechanism for event delivery
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
     event_delivery_retry: Callable[["EventDelivery", Any], EventDelivery]
 
     # Invoked before each mutation is executed
@@ -1280,6 +1704,8 @@ class BasePlugin:
     #    - null if the execution shall continue
     #    - an execution result
     #    - graphql.GraphQLError
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     perform_mutation: Callable[
         [
             Optional[Union[ExecutionResult, GraphQLError]],  # previous value

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -654,6 +654,8 @@ class PluginsManager(PaymentInterface):
             or default_value
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def get_taxes_for_checkout(
         self,
         checkout_info,
@@ -672,6 +674,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=checkout_info.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def get_taxes_for_order(self, order: "Order", app_identifier) -> Optional[TaxData]:
         return self.__run_plugin_method_until_first_success(
             "get_taxes_for_order",
@@ -694,12 +698,16 @@ class PluginsManager(PaymentInterface):
             channel_slug=checkout_info.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def customer_created(self, customer: "User"):
         default_value = None
         return self.__run_method_on_plugins(
             "customer_created", default_value, customer, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def customer_deleted(self, customer: "User", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -710,6 +718,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def customer_updated(self, customer: "User", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -720,6 +730,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def customer_metadata_updated(self, customer: "User", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -730,18 +742,24 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def collection_created(self, collection: "Collection"):
         default_value = None
         return self.__run_method_on_plugins(
             "collection_created", default_value, collection, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def collection_updated(self, collection: "Collection"):
         default_value = None
         return self.__run_method_on_plugins(
             "collection_updated", default_value, collection, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def collection_deleted(self, collection: "Collection", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -752,12 +770,16 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def collection_metadata_updated(self, collection: "Collection"):
         default_value = None
         return self.__run_method_on_plugins(
             "collection_metadata_updated", default_value, collection, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_created(self, product: "Product", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -768,6 +790,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_updated(self, product: "Product", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -778,6 +802,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_deleted(self, product: "Product", variants: list[int], webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -789,30 +815,40 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_media_created(self, media: "ProductMedia"):
         default_value = None
         return self.__run_method_on_plugins(
             "product_media_created", default_value, media, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_media_updated(self, media: "ProductMedia"):
         default_value = None
         return self.__run_method_on_plugins(
             "product_media_updated", default_value, media, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_media_deleted(self, media: "ProductMedia"):
         default_value = None
         return self.__run_method_on_plugins(
             "product_media_deleted", default_value, media, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_metadata_updated(self, product: "Product"):
         default_value = None
         return self.__run_method_on_plugins(
             "product_metadata_updated", default_value, product, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_created(self, product_variant: "ProductVariant", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -823,6 +859,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_updated(
         self, product_variant: "ProductVariant", webhooks=None, **kwargs
     ):
@@ -836,6 +874,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_deleted(self, product_variant: "ProductVariant", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -846,6 +886,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_out_of_stock(self, stock: "Stock", webhooks=None):
         default_value = None
         self.__run_method_on_plugins(
@@ -856,6 +898,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_back_in_stock(self, stock: "Stock", webhooks=None):
         default_value = None
         self.__run_method_on_plugins(
@@ -866,6 +910,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_stock_updated(self, stock: "Stock", webhooks=None):
         default_value = None
         self.__run_method_on_plugins(
@@ -876,6 +922,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_metadata_updated(self, product_variant: "ProductVariant"):
         default_value = None
         self.__run_method_on_plugins(
@@ -885,12 +933,16 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def product_export_completed(self, export: "ExportFile"):
         default_value = None
         return self.__run_method_on_plugins(
             "product_export_completed", default_value, export, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_created(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -901,6 +953,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def event_delivery_retry(self, event_delivery: "EventDelivery"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -917,6 +971,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def draft_order_created(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -927,6 +983,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def draft_order_updated(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -937,6 +995,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def draft_order_deleted(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -947,12 +1007,16 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def sale_created(self, sale: "Promotion", current_catalogue):
         default_value = None
         return self.__run_method_on_plugins(
             "sale_created", default_value, sale, current_catalogue, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def sale_deleted(self, sale: "Promotion", previous_catalogue, webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -964,6 +1028,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def sale_updated(self, sale: "Promotion", previous_catalogue, current_catalogue):
         default_value = None
         return self.__run_method_on_plugins(
@@ -986,18 +1052,24 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_created(self, promotion: "Promotion"):
         default_value = None
         return self.__run_method_on_plugins(
             "promotion_created", default_value, promotion, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_updated(self, promotion: "Promotion"):
         default_value = None
         return self.__run_method_on_plugins(
             "promotion_updated", default_value, promotion, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_deleted(self, promotion: "Promotion", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1008,6 +1080,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_started(self, promotion: "Promotion", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1018,6 +1092,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_ended(self, promotion: "Promotion", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1028,18 +1104,24 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_rule_created(self, promotion_rule: "PromotionRule"):
         default_value = None
         return self.__run_method_on_plugins(
             "promotion_rule_created", default_value, promotion_rule, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_rule_updated(self, promotion_rule: "PromotionRule"):
         default_value = None
         return self.__run_method_on_plugins(
             "promotion_rule_updated", default_value, promotion_rule, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_rule_deleted(self, promotion_rule: "PromotionRule"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1059,6 +1141,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=order.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def invoice_delete(self, invoice: "Invoice"):
         default_value = None
         channel_slug = invoice.order.channel.slug if invoice.order else None
@@ -1069,6 +1153,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def invoice_sent(self, invoice: "Invoice", email: str):
         default_value = None
         channel_slug = invoice.order.channel.slug if invoice.order else None
@@ -1080,6 +1166,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_fully_paid(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1090,6 +1178,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_paid(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1100,6 +1190,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_fully_refunded(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1110,6 +1202,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_refunded(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1120,6 +1214,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_updated(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1130,6 +1226,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_cancelled(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1140,6 +1238,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_expired(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1150,6 +1250,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_fulfilled(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1160,6 +1262,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_metadata_updated(self, order: "Order", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1170,12 +1274,16 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def order_bulk_created(self, orders: list["Order"]):
         default_value = None
         return self.__run_method_on_plugins(
             "order_bulk_created", default_value, orders, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_created(
         self, fulfillment: "Fulfillment", notify_customer: Optional[bool] = True
     ):
@@ -1188,6 +1296,8 @@ class PluginsManager(PaymentInterface):
             notify_customer=notify_customer,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_canceled(self, fulfillment: "Fulfillment"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1197,6 +1307,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=fulfillment.order.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_approved(
         self, fulfillment: "Fulfillment", notify_customer: Optional[bool] = True
     ):
@@ -1209,6 +1321,8 @@ class PluginsManager(PaymentInterface):
             notify_customer=notify_customer,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_metadata_updated(self, fulfillment: "Fulfillment"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1227,6 +1341,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=fulfillment.order.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_created(self, checkout: "Checkout", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1237,6 +1353,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_updated(self, checkout: "Checkout", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1247,6 +1365,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_fully_paid(self, checkout: "Checkout", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1257,6 +1377,8 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_metadata_updated(self, checkout: "Checkout", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1267,60 +1389,80 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def page_created(self, page: "Page"):
         default_value = None
         return self.__run_method_on_plugins(
             "page_created", default_value, page, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def page_updated(self, page: "Page"):
         default_value = None
         return self.__run_method_on_plugins(
             "page_updated", default_value, page, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def page_deleted(self, page: "Page"):
         default_value = None
         return self.__run_method_on_plugins(
             "page_deleted", default_value, page, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def page_type_created(self, page_type: "PageType"):
         default_value = None
         return self.__run_method_on_plugins(
             "page_type_created", default_value, page_type, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def page_type_updated(self, page_type: "PageType"):
         default_value = None
         return self.__run_method_on_plugins(
             "page_type_updated", default_value, page_type, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def page_type_deleted(self, page_type: "PageType"):
         default_value = None
         return self.__run_method_on_plugins(
             "page_type_deleted", default_value, page_type, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def permission_group_created(self, group: "Group"):
         default_value = None
         return self.__run_method_on_plugins(
             "permission_group_created", default_value, group, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def permission_group_updated(self, group: "Group"):
         default_value = None
         return self.__run_method_on_plugins(
             "permission_group_updated", default_value, group, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def permission_group_deleted(self, group: "Group"):
         default_value = None
         return self.__run_method_on_plugins(
             "permission_group_deleted", default_value, group, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_charge_requested(
         self, payment_data: "TransactionActionData", channel_slug: str
     ):
@@ -1332,6 +1474,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_refund_requested(
         self, payment_data: "TransactionActionData", channel_slug: str
     ):
@@ -1343,6 +1487,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_cancelation_requested(
         self, payment_data: "TransactionActionData", channel_slug: str
     ):
@@ -1354,6 +1500,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def payment_gateway_initialize_session(
         self,
         amount: Decimal,
@@ -1370,6 +1518,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=source_object.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_initialize_session(
         self,
         transaction_session_data: "TransactionSessionData",
@@ -1382,6 +1532,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=transaction_session_data.source_object.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_process_session(
         self,
         transaction_session_data: "TransactionSessionData",
@@ -1394,6 +1546,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=transaction_session_data.source_object.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_item_metadata_updated(self, transaction_item: "TransactionItem"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1403,12 +1557,16 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def account_confirmed(self, user: "User"):
         default_value = None
         return self.__run_method_on_plugins(
             "account_confirmed", default_value, user, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def account_confirmation_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: Optional[str]
     ):
@@ -1423,6 +1581,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def account_change_email_requested(
         self,
         user: "User",
@@ -1443,6 +1603,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def account_email_changed(
         self,
         user: "User",
@@ -1455,6 +1617,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def account_set_password_requested(
         self,
         user: "User",
@@ -1473,6 +1637,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def account_delete_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: str
     ):
@@ -1487,60 +1653,80 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def account_deleted(self, user: "User"):
         default_value = None
         return self.__run_method_on_plugins(
             "account_deleted", default_value, user, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def address_created(self, address: "Address"):
         default_value = None
         return self.__run_method_on_plugins(
             "address_created", default_value, address, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def address_updated(self, address: "Address"):
         default_value = None
         return self.__run_method_on_plugins(
             "address_updated", default_value, address, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def address_deleted(self, address: "Address"):
         default_value = None
         return self.__run_method_on_plugins(
             "address_deleted", default_value, address, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def app_installed(self, app: "App"):
         default_value = None
         return self.__run_method_on_plugins(
             "app_installed", default_value, app, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def app_updated(self, app: "App"):
         default_value = None
         return self.__run_method_on_plugins(
             "app_updated", default_value, app, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def app_deleted(self, app: "App"):
         default_value = None
         return self.__run_method_on_plugins(
             "app_deleted", default_value, app, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def app_status_changed(self, app: "App"):
         default_value = None
         return self.__run_method_on_plugins(
             "app_status_changed", default_value, app, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_created(self, attribute: "Attribute"):
         default_value = None
         return self.__run_method_on_plugins(
             "attribute_created", default_value, attribute, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_updated(self, attribute: "Attribute", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1551,6 +1737,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_deleted(self, attribute: "Attribute", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1561,6 +1749,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_value_created(self, attribute_value: "AttributeValue", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1571,12 +1761,16 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_value_updated(self, attribute_value: "AttributeValue"):
         default_value = None
         return self.__run_method_on_plugins(
             "attribute_value_updated", default_value, attribute_value, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_value_deleted(self, attribute_value: "AttributeValue", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1587,18 +1781,24 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def category_created(self, category: "Category"):
         default_value = None
         return self.__run_method_on_plugins(
             "category_created", default_value, category, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def category_updated(self, category: "Category"):
         default_value = None
         return self.__run_method_on_plugins(
             "category_updated", default_value, category, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def category_deleted(self, category: "Category", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1609,12 +1809,16 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def channel_created(self, channel: "Channel"):
         default_value = None
         return self.__run_method_on_plugins(
             "channel_created", default_value, channel, channel_slug=channel.slug
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def channel_updated(self, channel: "Channel", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1625,18 +1829,24 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def channel_deleted(self, channel: "Channel"):
         default_value = None
         return self.__run_method_on_plugins(
             "channel_deleted", default_value, channel, channel_slug=None
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def channel_status_changed(self, channel: "Channel"):
         default_value = None
         return self.__run_method_on_plugins(
             "channel_status_changed", default_value, channel, channel_slug=channel.slug
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def channel_metadata_updated(self, channel: "Channel"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1646,6 +1856,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_created(self, gift_card: "GiftCard", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1656,6 +1868,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_updated(self, gift_card: "GiftCard"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1665,6 +1879,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_deleted(self, gift_card: "GiftCard", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1686,6 +1902,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_status_changed(self, gift_card: "GiftCard", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1696,6 +1914,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_metadata_updated(self, gift_card: "GiftCard"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1705,6 +1925,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_export_completed(self, export: "ExportFile"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1714,6 +1936,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def menu_created(self, menu: "Menu"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1723,6 +1947,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def menu_updated(self, menu: "Menu"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1732,6 +1958,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def menu_deleted(self, menu: "Menu", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1742,6 +1970,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def menu_item_created(self, menu_item: "MenuItem"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1751,6 +1981,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def menu_item_updated(self, menu_item: "MenuItem"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1760,6 +1992,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def menu_item_deleted(self, menu_item: "MenuItem", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1770,6 +2004,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_price_created(self, shipping_method: "ShippingMethod"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1779,6 +2015,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_price_updated(self, shipping_method: "ShippingMethod"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1788,6 +2026,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_price_deleted(self, shipping_method: "ShippingMethod", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1798,6 +2038,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_created(self, shipping_zone: "ShippingZone"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1807,6 +2049,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_updated(self, shipping_zone: "ShippingZone"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1816,6 +2060,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_deleted(self, shipping_zone: "ShippingZone", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1826,6 +2072,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_metadata_updated(self, shipping_zone: "ShippingZone"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1835,6 +2083,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def staff_created(self, staff_user: "User"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1844,6 +2094,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def staff_updated(self, staff_user: "User"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1853,6 +2105,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def staff_deleted(self, staff_user: "User", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1863,6 +2117,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def staff_set_password_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: str
     ):
@@ -1877,6 +2133,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def thumbnail_created(
         self,
         thumbnail: "Thumbnail",
@@ -1889,6 +2147,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_created(self, warehouse: "Warehouse"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1898,6 +2158,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_updated(self, warehouse: "Warehouse"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1907,6 +2169,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_deleted(self, warehouse: "Warehouse"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1916,6 +2180,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_metadata_updated(self, warehouse: "Warehouse"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1925,6 +2191,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_created(self, voucher: "Voucher", code: str):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1935,6 +2203,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_updated(self, voucher: "Voucher", code: str):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1945,6 +2215,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_deleted(self, voucher: "Voucher", code: str, webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1956,6 +2228,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_codes_created(self, voucher_codes: list["VoucherCode"], webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1966,6 +2240,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_codes_deleted(self, voucher_codes: list["VoucherCode"], webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1976,6 +2252,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_metadata_updated(self, voucher: "Voucher"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1985,6 +2263,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_code_export_completed(self, export: "ExportFile"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1994,6 +2274,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def shop_metadata_updated(self, shop: "SiteSettings"):
         default_value = None
         return self.__run_method_on_plugins(
@@ -2103,6 +2385,8 @@ class PluginsManager(PaymentInterface):
             )
         raise Exception(f"Payment plugin {gateway} is inaccessible!")
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def list_stored_payment_methods(
         self,
         list_stored_payment_methods_data: "ListStoredPaymentMethodsRequestData",
@@ -2115,6 +2399,8 @@ class PluginsManager(PaymentInterface):
             channel_slug=list_stored_payment_methods_data.channel.slug,
         )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def stored_payment_method_request_delete(
         self,
         request_delete_data: "StoredPaymentMethodRequestDeleteData",
@@ -2131,6 +2417,8 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def payment_gateway_initialize_tokenization(
         self,
         request_data: "PaymentGatewayInitializeTokenizationRequestData",
@@ -2149,6 +2437,8 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def payment_method_initialize_tokenization(
         self,
         request_data: "PaymentMethodProcessTokenizationRequestData",
@@ -2167,6 +2457,9 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules..
+    # Any webhook-related functionality will be moved from plugin to core modules.
     def payment_method_process_tokenization(
         self,
         request_data: "PaymentMethodProcessTokenizationRequestData",

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3212,6 +3212,8 @@ class WebhookPlugin(BasePlugin):
                 self.requestor,
             )
 
+    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def get_shipping_methods_for_checkout(
         self, checkout: "Checkout", previous_value: Any
     ) -> list["ShippingMethodData"]:


### PR DESCRIPTION
Mark webhook-related manager methods as deprecated, as they are going to be moved from plugin to core in Saleor 3.21.

Docs: https://github.com/saleor/saleor-docs/pull/1306

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
