### PR TITLE
fix get_product_image_thumbnail when None is returned

### DIFF
--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -144,8 +144,10 @@ def format_datetime(this, date, date_format=None):
 
 def get_product_image_thumbnail(this, size: int, image_data):
     """Use provided size to get a correct image."""
+    if image_data is None:
+        return
     expected_size = get_thumbnail_size(size)
-    return image_data["original"][str(expected_size)]
+    return image_data.get("original", {}).get(str(expected_size))
 
 
 def compare(this, val1, compare_operator, val2):

--- a/saleor/plugins/tests/test_email_common.py
+++ b/saleor/plugins/tests/test_email_common.py
@@ -114,3 +114,14 @@ def test_get_product_image_thumbnail_simulate_json_dump_and_load(product_with_im
 
     # then
     assert thumbnail == image_data["original"]["128"]
+
+
+def test_get_product_image_thumbnail_image_missing(product_with_image):
+    # given
+    image_data = None
+
+    # when
+    thumbnail = get_product_image_thumbnail(None, 100, image_data)
+
+    # then
+    assert thumbnail is None


### PR DESCRIPTION
I want to merge this change because it fixes case when `get_product_image_thumbnail ` input data is None
 Fixes: https://linear.app/saleor/issue/SHOPX-640/typeerror-nonetype-object-is-not-subscriptable

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
