### PR TITLE
Prevent tax lines with negative values and enhance logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add slugs to product/category/collection/page translations. Allow to query by translated slug - #16449 by @delemeator
 - Fixed a crash when the Decimal scalar is passed a non-normal value - #16520 by @patrys
 - Fixed a bug when saving webhook payload to Azure Storage - #16585 by @delemeator
+- Prevent applying tax data with negative line values - #16593 by @zedzior

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -315,7 +315,7 @@ def _fetch_checkout_prices_if_expired(
                 database_connection_name=database_connection_name,
                 pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             )
-        except TaxEmptyData as e:
+        except (TaxEmptyData, TaxDataWithNegativeValues) as e:
             _set_checkout_base_prices(checkout, checkout_info, lines)
             checkout.tax_error = str(e)
 
@@ -342,7 +342,7 @@ def _fetch_checkout_prices_if_expired(
                     database_connection_name=database_connection_name,
                     pregenerated_subscription_payloads=pregenerated_subscription_payloads,
                 )
-            except TaxEmptyData as e:
+            except (TaxEmptyData, TaxDataWithNegativeValues) as e:
                 _set_checkout_base_prices(checkout, checkout_info, lines)
                 checkout.tax_error = str(e)
         else:
@@ -527,7 +527,7 @@ def _apply_tax_data(
 
     if check_negative_values_in_tax_data(tax_data):
         logger.error(
-            "Tax data contains negative values",
+            "Tax data contains negative values.",
             extra={
                 "checkout_id": graphene.Node.to_global_id("Checkout", checkout.pk),
             },

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -414,7 +414,7 @@ def _calculate_and_add_tax(
                 tax_app_identifier,
                 pregenerated_subscription_payloads,
             )
-            validate_tax_data(tax_data, checkout_info, lines, log_only=True)
+            validate_tax_data(tax_data, checkout_info, lines, allow_empty_tax_data=True)
             _apply_tax_data(checkout, lines, tax_data)
         else:
             _call_plugin_or_tax_app(
@@ -674,7 +674,7 @@ def validate_tax_data(
     tax_data: Optional[TaxData],
     checkout_info: "CheckoutInfo",
     checkout_lines_info: Iterable["CheckoutLineInfo"],
-    log_only: bool = False,
+    allow_empty_tax_data: bool = False,
 ):
     from .utils import (
         checkout_info_for_logs,
@@ -683,11 +683,10 @@ def validate_tax_data(
 
     if tax_data is None:
         log_address_if_validation_skipped_for_checkout(checkout_info, logger)
-        if not log_only:
+        if not allow_empty_tax_data:
             raise TaxEmptyData("Empty tax data.")
 
     if check_negative_values_in_tax_data(tax_data):
         extra = checkout_info_for_logs(checkout_info, checkout_lines_info)
         logger.error("Tax data contains negative values.", extra=extra)
-        if not log_only:
-            raise TaxDataWithNegativeValues("Tax data contains negative values.")
+        raise TaxDataWithNegativeValues("Tax data contains negative values.")

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -529,7 +529,6 @@ def _apply_tax_data(
         logger.error(
             "Tax data contains negative values",
             extra={
-                "tax_data": tax_data,
                 "checkout_id": graphene.Node.to_global_id("Checkout", checkout.pk),
             },
         )

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -29,6 +29,7 @@ from ..tax.utils import (
     get_charge_taxes_for_checkout,
     get_tax_app_identifier_for_checkout,
     get_tax_calculation_strategy_for_checkout,
+    get_tax_data_for_logs,
     normalize_tax_rate_for_db,
 )
 from .fetch import find_checkout_line_info
@@ -688,5 +689,6 @@ def validate_tax_data(
 
     if check_negative_values_in_tax_data(tax_data):
         extra = checkout_info_for_logs(checkout_info, checkout_lines_info)
+        extra.update({"tax_data": get_tax_data_for_logs(tax_data)})
         logger.error("Tax data contains negative values.", extra=extra)
         raise TaxDataWithNegativeValues("Tax data contains negative values.")

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -839,4 +839,5 @@ def test_fetch_checkout_data_tax_data_with_negative_values(
 
     # then
     assert checkout_info.checkout.tax_error == "Tax data contains negative values."
+    assert "Tax data contains negative values" in caplog.text
     mock_set_base_prices.assert_called_once()

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -840,4 +840,7 @@ def test_fetch_checkout_data_tax_data_with_negative_values(
     # then
     assert checkout_info.checkout.tax_error == "Tax data contains negative values."
     assert "Tax data contains negative values" in caplog.text
+    extra_log_info = caplog.records[0]
+    assert extra_log_info.checkout
+    assert extra_log_info.tax_data["lines"][0]["total_gross_amount"] == Decimal("-3")
     mock_set_base_prices.assert_called_once()

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -574,7 +574,7 @@ def test_fetch_checkout_data_calls_plugin(
 
 
 @freeze_time()
-@patch("saleor.order.calculations.validate_tax_data")
+@patch("saleor.checkout.calculations.validate_tax_data")
 @patch("saleor.plugins.manager.PluginsManager.calculate_checkout_total")
 @patch("saleor.plugins.manager.PluginsManager.get_taxes_for_checkout")
 @patch("saleor.checkout.calculations._apply_tax_data")
@@ -767,6 +767,46 @@ def test_validate_tax_data_with_negative_values(checkout_info, caplog):
     lines_info = checkout_info.lines
 
     tax_data = TaxData(
+        shipping_price_net_amount=Decimal("-1"),
+        shipping_price_gross_amount=Decimal("1.5"),
+        shipping_tax_rate=Decimal("50"),
+        lines=[
+            TaxLineData(
+                total_net_amount=Decimal("2"),
+                total_gross_amount=Decimal("3"),
+                tax_rate=Decimal("50"),
+            )
+        ],
+    )
+
+    # when & then
+    with pytest.raises(TaxDataWithNegativeValues):
+        validate_tax_data(tax_data, checkout_info, lines_info)
+
+    assert "Tax data contains negative values" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("prices_entered_with_tax", "tax_app_id"),
+    [(True, None), (True, "test.app"), (False, None), (False, "test.app")],
+)
+@patch("saleor.checkout.calculations._set_checkout_base_prices")
+def test_fetch_checkout_data_tax_data_with_negative_values(
+    mock_set_base_prices,
+    prices_entered_with_tax,
+    tax_app_id,
+    checkout_with_single_item,
+    caplog,
+):
+    # given
+    checkout = checkout_with_single_item
+
+    channel = checkout.channel
+    channel.tax_configuration.tax_app_id = tax_app_id
+    channel.tax_configuration.prices_entered_with_tax = prices_entered_with_tax
+    channel.tax_configuration.save()
+
+    tax_data = TaxData(
         shipping_price_net_amount=Decimal("1"),
         shipping_price_gross_amount=Decimal("1.5"),
         shipping_tax_rate=Decimal("50"),
@@ -779,8 +819,24 @@ def test_validate_tax_data_with_negative_values(checkout_info, caplog):
         ],
     )
 
-    # when & then
-    with pytest.raises(TaxDataWithNegativeValues):
-        validate_tax_data(tax_data, checkout_info, lines_info)
+    zero_money = zero_taxed_money(checkout.currency)
+    manager_methods = {
+        "calculate_checkout_total": Mock(return_value=zero_money),
+        "calculate_checkout_subtotal": Mock(return_value=zero_money),
+        "calculate_checkout_line_total": Mock(return_value=zero_money),
+        "calculate_checkout_shipping": Mock(return_value=zero_money),
+        "get_checkout_shipping_tax_rate": Mock(return_value=Decimal("0.00")),
+        "get_checkout_line_tax_rate": Mock(return_value=Decimal("0.00")),
+        "get_taxes_for_checkout": Mock(return_value=tax_data),
+    }
+    manager = Mock(**manager_methods)
 
-    assert "Tax data contains negative values" in caplog.text
+    checkout_lines_info, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, checkout_lines_info, manager)
+
+    # when
+    fetch_checkout_data(checkout_info, manager, checkout_lines_info, force_update=True)
+
+    # then
+    assert checkout_info.checkout.tax_error == "Tax data contains negative values."
+    mock_set_base_prices.assert_called_once()

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -764,7 +764,7 @@ def test_calculate_and_add_tax_empty_tax_data_logging_address(
 
 def test_validate_tax_data_with_negative_values(checkout_info, caplog):
     # given
-    lines = checkout_info.checkout.lines.all()
+    lines_info = checkout_info.lines
 
     tax_data = TaxData(
         shipping_price_net_amount=Decimal("1"),
@@ -781,12 +781,6 @@ def test_validate_tax_data_with_negative_values(checkout_info, caplog):
 
     # when & then
     with pytest.raises(TaxDataWithNegativeValues):
-        validate_tax_data(
-            tax_data,
-            checkout_info,
-            [
-                Mock(spec=CheckoutLineInfo, line=line, variant=line.variant)
-                for line in lines
-            ],
-        )
+        validate_tax_data(tax_data, checkout_info, lines_info)
+
     assert "Tax data contains negative values" in caplog.text

--- a/saleor/checkout/tests/test_utils.py
+++ b/saleor/checkout/tests/test_utils.py
@@ -1,9 +1,12 @@
 from decimal import Decimal
 
+import graphene
 import pytest
 from prices import Money, TaxedMoney
 
+from ...discount import DiscountType, DiscountValueType
 from ...tax.calculations import get_taxed_undiscounted_price
+from ..utils import checkout_info_for_logs
 
 BASE = Money("35.00", "USD")
 
@@ -50,3 +53,39 @@ def test_get_taxed_undiscounted_price(price, tax_rate, prices_entered_with_tax, 
     )
 
     assert result_price == result
+
+
+def test_checkout_info_for_logs(checkout_info, voucher, order_promotion_with_rule):
+    # given
+    checkout = checkout_info.checkout
+    voucher_code = voucher.codes.first().code
+    checkout.voucher_code = voucher_code
+
+    checkout_discount = checkout.discounts.create(
+        type=DiscountType.ORDER_PROMOTION,
+        value_type=DiscountValueType.FIXED,
+        value=Decimal(5),
+        amount_value=Decimal(5),
+        promotion_rule=order_promotion_with_rule.rules.first(),
+        currency=checkout.currency,
+    )
+    checkout_info.discounts = [checkout_discount]
+
+    lines_info = checkout_info.lines
+    line_discount = lines_info[0].line.discounts.create(
+        type=DiscountType.VOUCHER,
+        value_type=DiscountValueType.FIXED,
+        value=Decimal(5),
+        currency=checkout.currency,
+        amount_value=Decimal(5),
+        voucher=voucher,
+    )
+    lines_info[0].discounts = [line_discount]
+
+    # when
+    extra = checkout_info_for_logs(checkout_info, lines_info)
+
+    # then
+    assert extra["checkout_id"] == graphene.Node.to_global_id("Checkout", checkout.pk)
+    assert extra["discounts"]
+    assert extra["lines"][0]["discounts"]

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1070,3 +1070,104 @@ def get_address_for_checkout_taxes(
 ) -> Optional["Address"]:
     shipping_address = checkout_info.delivery_method_info.shipping_address
     return shipping_address or checkout_info.billing_address
+
+
+def checkout_info_for_logs(
+    checkout_info: "CheckoutInfo",
+    checkout_lines_info: Iterable["CheckoutLineInfo"],
+):
+    checkout = checkout_info.checkout
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    tax_configuration = checkout_info.tax_configuration
+    channel = checkout.channel
+
+    return {
+        "checkout_id": checkout_id,
+        "checkoutId": checkout_id,
+        "checkout": {
+            "currency": checkout.currency,
+            "total_net_amount": checkout.total_net_amount,
+            "total_gross_amount": checkout.total_gross_amount,
+            "base_total_amount": checkout.base_total_amount,
+            "subtotal_net_amount": checkout.subtotal_net_amount,
+            "subtotal_gross_amount": checkout.subtotal_gross_amount,
+            "base_subtotal_amount": checkout.base_subtotal_amount,
+            "shipping_price_net_amount": checkout.shipping_price_net_amount,
+            "shipping_price_gross_amount": checkout.shipping_price_gross_amount,
+            "discount_amount": checkout.discount_amount,
+            "has_voucher_code": bool(checkout.voucher_code),
+            "tax_exemption": checkout.tax_exemption,
+            "tax_error": checkout.tax_error,
+        },
+        "tax_configuration": {
+            "charge_taxes": tax_configuration.charge_taxes,
+            "tax_calculation_strategy": tax_configuration.tax_calculation_strategy,
+            "prices_entered_with_tax": tax_configuration.prices_entered_with_tax,
+            "tax_app_id": tax_configuration.tax_app_id,
+        },
+        "discounts": _discounts_for_logs(checkout_info.discounts),
+        "lines": [
+            {
+                "id": graphene.Node.to_global_id("CheckoutLine", line_info.line.pk),
+                "quantity": line_info.line.quantity,
+                "is_gift": line_info.line.is_gift,
+                "price_override": line_info.line.price_override,
+                "total_price_net_amount": line_info.line.total_price_net_amount,
+                "total_price_gross_amount": line_info.line.total_price_gross_amount,
+                "variant_id": graphene.Node.to_global_id(
+                    "ProductVariant", line_info.line.variant_id
+                ),
+                "variant_listing_price": line_info.variant.channel_listings.get(
+                    channel=channel
+                ).price_amount,
+                "variant_listing_discounted_price": line_info.variant.channel_listings.get(
+                    channel=channel
+                ).discounted_price_amount,
+                "product_listing_discounted_price": line_info.product.channel_listings.get(
+                    channel=channel
+                ).discounted_price_amount,
+                "product_discounted_price_dirty": line_info.product.channel_listings.get(
+                    channel=channel
+                ).discounted_price_dirty,
+                "discounts": _discounts_for_logs(line_info.discounts),
+            }
+            for line_info in checkout_lines_info
+        ],
+    }
+
+
+def _discounts_for_logs(discounts):
+    return [
+        {
+            "type": discount.type,
+            "value_type": discount.value_type,
+            "value": discount.value,
+            "amount_value": discount.amount_value,
+            "reason": discount.reason,
+            "promotion_rule": {
+                "id": graphene.Node.to_global_id(
+                    "PromotionRule", discount.promotion_rule.id
+                ),
+                "promotion_id": graphene.Node.to_global_id(
+                    "Promotion", discount.promotion_rule.promotion_id
+                ),
+                "catalogue_predicate": discount.promotion_rule.catalogue_predicate,
+                "order_predicate": discount.promotion_rule.order_predicate,
+                "reward_value_type": discount.promotion_rule.reward_value_type,
+                "reward_value": discount.promotion_rule.reward_value,
+                "reward_type": discount.promotion_rule.reward_type,
+                "variants_dirty": discount.promotion_rule.variants_dirty,
+            }
+            if discount.promotion_rule
+            else None,
+            "voucher": {
+                "id": graphene.Node.to_global_id("Voucher", discount.voucher.id),
+                "type": discount.voucher.type,
+                "discount_value_type": discount.voucher.discount_value_type,
+                "apply_once_per_order": discount.voucher.apply_once_per_order,
+            }
+            if discount.voucher
+            else None,
+        }
+        for discount in discounts
+    ]

--- a/saleor/core/taxes.py
+++ b/saleor/core/taxes.py
@@ -12,6 +12,10 @@ class TaxEmptyData(Exception):
     """Empty tax data received from Tax App error."""
 
 
+class TaxDataWithNegativeValues(Exception):
+    """Tax data with negative values received from Tax App error."""
+
+
 def zero_money(currency: str) -> Money:
     """Return a money object set to zero.
 

--- a/saleor/discount/utils/shared.py
+++ b/saleor/discount/utils/shared.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from decimal import Decimal
 from typing import TYPE_CHECKING, Optional, Union
 
+import graphene
+
 from .. import DiscountType
 from ..models import (
     CheckoutDiscount,
@@ -92,3 +94,40 @@ def is_order_level_discount(discount: OrderDiscount) -> bool:
         DiscountType.MANUAL,
         DiscountType.ORDER_PROMOTION,
     ] or is_order_level_voucher(discount.voucher)
+
+
+def discount_info_for_logs(discounts):
+    return [
+        {
+            "type": discount.type,
+            "value_type": discount.value_type,
+            "value": discount.value,
+            "amount_value": discount.amount_value,
+            "reason": discount.reason,
+            "promotion_rule": {
+                "id": graphene.Node.to_global_id(
+                    "PromotionRule", discount.promotion_rule.id
+                ),
+                "promotion_id": graphene.Node.to_global_id(
+                    "Promotion", discount.promotion_rule.promotion_id
+                ),
+                "catalogue_predicate": discount.promotion_rule.catalogue_predicate,
+                "order_predicate": discount.promotion_rule.order_predicate,
+                "reward_value_type": discount.promotion_rule.reward_value_type,
+                "reward_value": discount.promotion_rule.reward_value,
+                "reward_type": discount.promotion_rule.reward_type,
+                "variants_dirty": discount.promotion_rule.variants_dirty,
+            }
+            if discount.promotion_rule
+            else None,
+            "voucher": {
+                "id": graphene.Node.to_global_id("Voucher", discount.voucher.id),
+                "type": discount.voucher.type,
+                "discount_value_type": discount.voucher.discount_value_type,
+                "apply_once_per_order": discount.voucher.apply_once_per_order,
+            }
+            if discount.voucher
+            else None,
+        }
+        for discount in discounts
+    ]

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -169,7 +169,7 @@ def _recalculate_prices(
                 prices_entered_with_tax,
                 database_connection_name=database_connection_name,
             )
-        except TaxEmptyData as e:
+        except (TaxEmptyData, TaxDataWithNegativeValues) as e:
             order.tax_error = str(e)
 
         if not should_charge_tax:
@@ -192,7 +192,7 @@ def _recalculate_prices(
                     prices_entered_with_tax,
                     database_connection_name=database_connection_name,
                 )
-            except TaxEmptyData as e:
+            except (TaxEmptyData, TaxDataWithNegativeValues) as e:
                 order.tax_error = str(e)
         else:
             _remove_tax(order, lines)
@@ -372,7 +372,7 @@ def _apply_tax_data(
 
     if check_negative_values_in_tax_data(tax_data):
         logger.error(
-            "Tax data contains negative values",
+            "Tax data contains negative values.",
             extra={"order_id": graphene.Node.to_global_id("Order", order.pk)},
         )
         raise TaxDataWithNegativeValues("Tax data contains negative values.")

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -373,10 +373,7 @@ def _apply_tax_data(
     if check_negative_values_in_tax_data(tax_data):
         logger.error(
             "Tax data contains negative values",
-            extra={
-                "tax_data": tax_data,
-                "order_id": graphene.Node.to_global_id("Order", order.pk),
-            },
+            extra={"order_id": graphene.Node.to_global_id("Order", order.pk)},
         )
         raise TaxDataWithNegativeValues("Tax data contains negative values.")
 

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -29,6 +29,7 @@ from ..tax.utils import (
     get_charge_taxes_for_order,
     get_tax_app_identifier_for_order,
     get_tax_calculation_strategy_for_order,
+    get_tax_data_for_logs,
     normalize_tax_rate_for_db,
 )
 from . import ORDER_EDITABLE_STATUS
@@ -752,5 +753,6 @@ def validate_tax_data(
 
     if check_negative_values_in_tax_data(tax_data):
         extra = order_info_for_logs(order, lines)
+        extra.update({"tax_data": get_tax_data_for_logs(tax_data)})
         logger.error("Tax data contains negative values.", extra=extra)
         raise TaxDataWithNegativeValues("Tax data contains negative values.")

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -1187,6 +1187,7 @@ def test_fetch_order_data_calls_plugin(
     mock_get_taxes.assert_not_called()
 
 
+@patch("saleor.order.calculations.validate_tax_data")
 @patch("saleor.plugins.manager.PluginsManager.calculate_order_total")
 @patch("saleor.plugins.manager.PluginsManager.get_taxes_for_order")
 @patch("saleor.order.calculations._apply_tax_data")
@@ -1195,6 +1196,7 @@ def test_fetch_order_data_calls_tax_app(
     mock_apply_tax_data,
     mock_get_taxes,
     mock_calculate_order_total,
+    mock_validate_tax_data,
     order_with_lines,
     order_lines,
 ):
@@ -1285,7 +1287,7 @@ def test_recalculate_prices_empty_tax_data_logging_address(
     )
 
 
-def test_apply_tax_data_with_negative_values(order_line, caplog):
+def test_validate_tax_data_with_negative_values(order_line, caplog):
     # given
     tax_data = TaxData(
         shipping_price_net_amount=Decimal("1"),
@@ -1302,5 +1304,5 @@ def test_apply_tax_data_with_negative_values(order_line, caplog):
 
     # when & then
     with pytest.raises(TaxDataWithNegativeValues):
-        calculations._apply_tax_data(order_line.order, order_line, tax_data, True)
+        calculations.validate_tax_data(tax_data, order_line.order, [order_line])
     assert "Tax data contains negative values" in caplog.text

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -1305,4 +1305,5 @@ def test_validate_tax_data_with_negative_values(order_line, caplog):
     # when & then
     with pytest.raises(TaxDataWithNegativeValues):
         calculations.validate_tax_data(tax_data, order_line.order, [order_line])
+
     assert "Tax data contains negative values" in caplog.text

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -1,12 +1,11 @@
 from decimal import Decimal
-from unittest.mock import Mock
 
 import before_after
 import graphene
 import pytest
 
 from ...core.prices import quantize_price
-from ...core.taxes import TaxData, TaxLineData, zero_money, zero_taxed_money
+from ...core.taxes import zero_money
 from ...discount import DiscountType, DiscountValueType, VoucherType
 from ...discount.models import (
     OrderDiscount,
@@ -16,7 +15,6 @@ from ...discount.models import (
 from ...tax import TaxCalculationStrategy
 from ...tests.utils import round_down, round_up
 from .. import OrderStatus, calculations
-from ..interface import OrderTaxedPricesData
 
 
 @pytest.fixture
@@ -2654,59 +2652,3 @@ def test_fetch_order_prices_voucher_shipping_percentage(
         order.undiscounted_total_gross_amount
         == subtotal.amount + undiscounted_shipping_price
     )
-
-
-@pytest.mark.parametrize(
-    ("prices_entered_with_tax", "tax_app_id"),
-    [(True, None), (True, "test.app"), (False, None), (False, "test.app")],
-)
-def test_fetch_order_prices_tax_data_with_negative_values(
-    prices_entered_with_tax,
-    tax_app_id,
-    order_with_lines,
-    caplog,
-):
-    # given
-    order = order_with_lines
-
-    channel = order.channel
-    channel.tax_configuration.tax_app_id = tax_app_id
-    channel.tax_configuration.prices_entered_with_tax = prices_entered_with_tax
-    channel.tax_configuration.save()
-
-    tax_data = TaxData(
-        shipping_price_net_amount=Decimal("1"),
-        shipping_price_gross_amount=Decimal("1.5"),
-        shipping_tax_rate=Decimal("50"),
-        lines=[
-            TaxLineData(
-                total_net_amount=Decimal("2"),
-                total_gross_amount=Decimal("-3"),
-                tax_rate=Decimal("50"),
-            )
-        ],
-    )
-    order = order_with_lines
-    zero_money = zero_taxed_money(order.currency)
-    zero_prices = OrderTaxedPricesData(
-        undiscounted_price=zero_money,
-        price_with_discounts=zero_money,
-    )
-
-    manager_methods = {
-        "calculate_order_line_unit": Mock(return_value=zero_prices),
-        "calculate_order_line_total": Mock(return_value=zero_prices),
-        "calculate_order_total": Mock(return_value=zero_money),
-        "calculate_order_shipping": Mock(return_value=zero_money),
-        "get_order_line_tax_rate": Mock(return_value=Decimal("0.00")),
-        "get_order_shipping_tax_rate": Mock(return_value=Decimal("0.00")),
-        "get_taxes_for_order": Mock(return_value=tax_data),
-    }
-    manager = Mock(**manager_methods)
-
-    # when
-    calculations.fetch_order_prices_if_expired(order, manager, None, True)
-
-    # then
-    assert order.tax_error == "Tax data contains negative values."
-    assert "Tax data contains negative values" in caplog.text

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -54,7 +54,7 @@ from . import (
     OrderStatus,
     events,
 )
-from .fetch import OrderLineInfo
+from .fetch import OrderLineInfo, fetch_draft_order_lines_info
 from .models import Order, OrderGrantedRefund, OrderLine
 
 if TYPE_CHECKING:
@@ -1210,3 +1210,71 @@ def get_address_for_order_taxes(order: "Order"):
     else:
         address = order.shipping_address or order.billing_address
     return address
+
+
+def order_info_for_logs(order: Order, lines: Iterable[OrderLine]):
+    from ..discount.utils.shared import discount_info_for_logs
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    tax_configuration = order.channel.tax_configuration
+    lines_info = fetch_draft_order_lines_info(order, lines)
+
+    return {
+        "order_id": order_id,
+        "orderId": order_id,
+        "order": {
+            "currency": order.currency,
+            "status": order.status,
+            "origin": order.origin,
+            "checkout_id": order.checkout_token,
+            "undiscounted_base_shipping_price_amount": order.undiscounted_base_shipping_price_amount,
+            "base_shipping_price_amount": order.base_shipping_price_amount,
+            "shipping_price_net_amount": order.shipping_price_net_amount,
+            "shipping_price_gross_amount": order.shipping_price_gross_amount,
+            "undiscounted_total_net_amount": order.undiscounted_total_net_amount,
+            "total_net_amount": order.total_net_amount,
+            "undiscounted_total_gross_amount": order.undiscounted_total_gross_amount,
+            "total_gross_amount": order.total_gross_amount,
+            "subtotal_net_amount": order.subtotal_net_amount,
+            "subtotal_gross_amount": order.subtotal_gross_amount,
+            "has_voucher_code": bool(order.voucher_code),
+            "tax_exemption": order.tax_exemption,
+            "tax_error": order.tax_error,
+        },
+        "tax_configuration": {
+            "charge_taxes": tax_configuration.charge_taxes,
+            "tax_calculation_strategy": tax_configuration.tax_calculation_strategy,
+            "prices_entered_with_tax": tax_configuration.prices_entered_with_tax,
+            "tax_app_id": tax_configuration.tax_app_id,
+        },
+        "discounts": discount_info_for_logs(order.discounts.all()),
+        "lines": [
+            {
+                "id": graphene.Node.to_global_id("OrderLine", line_info.line.pk),
+                "variant_id": graphene.Node.to_global_id(
+                    "ProductVariant", line_info.line.variant_id
+                ),
+                "quantity": line_info.line.quantity,
+                "is_gift_card": line_info.line.is_gift_card,
+                "is_price_overridden": line_info.line.is_price_overridden,
+                "undiscounted_base_unit_price_amount": line_info.line.undiscounted_base_unit_price_amount,
+                "base_unit_price_amount": line_info.line.base_unit_price_amount,
+                "undiscounted_unit_price_net_amount": line_info.line.undiscounted_unit_price_net_amount,
+                "undiscounted_unit_price_gross_amount": line_info.line.undiscounted_unit_price_gross_amount,
+                "unit_price_net_amount": line_info.line.unit_price_net_amount,
+                "unit_price_gross_amount": line_info.line.unit_price_gross_amount,
+                "undiscounted_total_price_net_amount": line_info.line.undiscounted_total_price_net_amount,
+                "undiscounted_total_price_gross_amount": line_info.line.undiscounted_total_price_gross_amount,
+                "total_price_net_amount": line_info.line.total_price_net_amount,
+                "total_price_gross_amount": line_info.line.total_price_gross_amount,
+                "has_voucher_code": bool(line_info.line.voucher_code),
+                "variant_listing_price": line_info.channel_listing.price_amount,
+                "variant_listing_discounted_price": line_info.channel_listing.discounted_price_amount,
+                "unit_discount_amount": line_info.line.unit_discount_amount,
+                "unit_discount_type": line_info.line.unit_discount_type,
+                "unit_discount_reason": line_info.line.unit_discount_reason,
+                "discounts": discount_info_for_logs(line_info.discounts),
+            }
+            for line_info in lines_info
+        ],
+    }

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -754,12 +754,15 @@ class AvataxPlugin(BasePlugin):
 
         if check_negative_values_in_tax_data_from_plugin(response):
             logger.error(
-                "Tax data contains negative values",
+                "Tax data contains negative values.",
                 extra={
                     "checkout_id": graphene.Node.to_global_id(
                         "Checkout", checkout_info.checkout.pk
                     ),
                 },
+            )
+            self._set_checkout_tax_error(
+                checkout_info, lines_info, message="Tax data contains negative values."
             )
             return None
 
@@ -769,10 +772,11 @@ class AvataxPlugin(BasePlugin):
         self,
         checkout_info: "CheckoutInfo",
         lines_info: Iterable["CheckoutLineInfo"],
+        message: Optional[str] = "Empty tax data.",
     ) -> None:
         app_identifier = get_tax_app_identifier_for_checkout(checkout_info, lines_info)
         if app_identifier == self.PLUGIN_IDENTIFIER:
-            checkout_info.checkout.tax_error = "Empty tax data."
+            checkout_info.checkout.tax_error = message
 
     def _get_order_tax_data(
         self, order: "Order", base_value: Union[Decimal, OrderTaxedPricesData]
@@ -793,19 +797,24 @@ class AvataxPlugin(BasePlugin):
 
         if check_negative_values_in_tax_data_from_plugin(response):
             logger.error(
-                "Tax data contains negative values",
+                "Tax data contains negative values.",
                 extra={
                     "order_id": graphene.Node.to_global_id("Order", order.pk),
                 },
+            )
+            self._set_order_tax_error(
+                order, message="Tax data contains negative values."
             )
             return None
 
         return response
 
-    def _set_order_tax_error(self, order: "Order") -> None:
+    def _set_order_tax_error(
+        self, order: "Order", message: Optional[str] = "Empty tax data."
+    ) -> None:
         app_identifier = get_tax_app_identifier_for_order(order)
         if app_identifier == self.PLUGIN_IDENTIFIER:
-            order.tax_error = "Empty tax data."
+            order.tax_error = message
 
     @staticmethod
     def _get_unit_tax_rate(

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -756,7 +756,6 @@ class AvataxPlugin(BasePlugin):
             logger.error(
                 "Tax data contains negative values",
                 extra={
-                    "tax_data": response,
                     "checkout_id": graphene.Node.to_global_id(
                         "Checkout", checkout_info.checkout.pk
                     ),
@@ -796,7 +795,6 @@ class AvataxPlugin(BasePlugin):
             logger.error(
                 "Tax data contains negative values",
                 extra={
-                    "tax_data": response,
                     "order_id": graphene.Node.to_global_id("Order", order.pk),
                 },
             )

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -16,7 +16,10 @@ from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...checkout import base_calculations
 from ...checkout.fetch import fetch_checkout_lines
-from ...checkout.utils import log_address_if_validation_skipped_for_checkout
+from ...checkout.utils import (
+    checkout_info_for_logs,
+    log_address_if_validation_skipped_for_checkout,
+)
 from ...core.taxes import TaxError, TaxType, zero_taxed_money
 from ...order import base_calculations as order_base_calculation
 from ...order.interface import OrderTaxedPricesData
@@ -753,14 +756,8 @@ class AvataxPlugin(BasePlugin):
             return None
 
         if check_negative_values_in_tax_data_from_plugin(response):
-            logger.error(
-                "Tax data contains negative values.",
-                extra={
-                    "checkout_id": graphene.Node.to_global_id(
-                        "Checkout", checkout_info.checkout.pk
-                    ),
-                },
-            )
+            extra = checkout_info_for_logs(checkout_info, lines_info)
+            logger.error("Tax data contains negative values.", extra=extra)
             self._set_checkout_tax_error(
                 checkout_info, lines_info, message="Tax data contains negative values."
             )

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_negative_values_in_tax_data.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_negative_values_in_tax_data.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "123", "discounted": false, "description": "Test product",
+      "ref1": "123"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR000000", "taxIncluded":
+      true, "itemCode": "Shipping", "discounted": false, "description": null}], "code":
+      "f7f6327c-62a4-4f31-97b4-a473e73f5c62", "date": "2024-02-12", "customerCode":
+      0, "discount": null, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2":
+      "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode": "53-601"},
+      "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "USD", "email": "user@email.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '844'
+      User-Agent:
+      - Saleor/3.19
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":0,"code":"f7f6327c-62a4-4f31-97b4-a473e73f5c62","companyId":7799660,"date":"2024-02-12","paymentDate":"2024-02-12","status":"Temporary","type":"SalesOrder","batchCode":"","currencyCode":"USD","exchangeRateCurrencyCode":"USD","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","totalAmount":32.52,"totalExempt":0.0,"totalDiscount":0.0,"totalTax":7.48,"totalTaxable":32.52,"totalTaxCalculated":7.48,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2024-02-12","exchangeRate":1.0,"email":"user@email.com","modifiedDate":"2024-02-12T11:19:08.2259891Z","modifiedUserId":6479978,"taxDate":"2024-02-12","lines":[{"id":0,"transactionId":0,"lineNumber":"1","customerUsageType":"","entityUseCode":"","description":"Test
+        product","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"123","lineAmount":-24.3900,"quantity":3.0,"ref1":"123","ref2":"","reportingDate":"2024-02-12","tax":5.61,"taxableAmount":24.39,"taxCalculated":5.61,"taxCode":"O9999999","taxCodeId":9111,"taxDate":"2024-02-12","taxIncluded":true,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":5.61,"taxableAmount":24.39,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":5.61,"rateType":"Standard","rateTypeCode":"S","taxableUnits":24.3900,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":24.39,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":5.61,"reportingTaxCalculated":5.61,"liabilityType":"Seller","chargedTo":"Buyer"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230C","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"2","customerUsageType":"","entityUseCode":"","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"Shipping","lineAmount":8.1300,"quantity":1.0,"ref1":"","ref2":"","reportingDate":"2024-02-12","tax":1.87,"taxableAmount":8.13,"taxCalculated":1.87,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2024-02-12","taxIncluded":true,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":1.87,"taxableAmount":8.13,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":1.87,"rateType":"Standard","rateTypeCode":"S","taxableUnits":8.1300,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":8.13,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":1.87,"reportingTaxCalculated":1.87,"liabilityType":"Seller","chargedTo":"Buyer"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230D","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Olawska
+        10","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-105","country":"PL","taxRegionId":205102,"latitude":"","longitude":""},{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102,"latitude":"","longitude":""}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":32.52,"rate":0.230000,"tax":7.48,"taxCalculated":7.48,"nonTaxable":0.0,"exemption":0.0}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 12 Feb 2024 11:19:08 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/0
+      ServerDuration:
+      - '00:00:00.0214210'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 83b49b18-3c89-4f64-94ce-884c6469b640
+      x-correlation-id:
+      - 83b49b18-3c89-4f64-94ce-884c6469b640
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_order_negative_values_in_tax_data.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_order_negative_values_in_tax_data.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
+      "lines": [{"quantity": 3, "amount": "30.000", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "SKU_A", "discounted": false, "description": "Test product"},
+      {"quantity": 1, "amount": "10.000", "taxCode": "FR000000", "taxIncluded": true,
+      "itemCode": "Shipping", "discounted": false, "description": null}], "code":
+      "5e313a0c-17f2-46ab-8534-74f59021045c", "date": "2024-02-12", "customerCode":
+      0, "discount": null, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2":
+      "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode": "53-601"},
+      "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "USD", "email": "test@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '836'
+      User-Agent:
+      - Saleor/3.19
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":85049238694171,"code":"5e313a0c-17f2-46ab-8534-74f59021045c","companyId":7799660,"date":"2024-02-12","status":"Saved","type":"SalesInvoice","batchCode":"","currencyCode":"USD","exchangeRateCurrencyCode":"USD","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","taxOverrideType":"None","taxOverrideAmount":0.0,"taxOverrideReason":"","totalAmount":32.52,"totalExempt":0.0,"totalDiscount":0.0,"totalTax":7.48,"totalTaxable":32.52,"totalTaxCalculated":7.48,"adjustmentReason":"NotAdjusted","adjustmentDescription":"","locked":false,"region":"","country":"PL","version":1,"softwareVersion":"24.1.0.0","originAddressId":85049238694173,"destinationAddressId":85049238694172,"exchangeRateEffectiveDate":"2024-02-12","exchangeRate":1.0,"description":"","email":"test@example.com","businessIdentificationNo":"","modifiedDate":"2024-02-12T11:19:08.2378352Z","modifiedUserId":6479978,"taxDate":"2024-02-12","lines":[{"id":85049238694177,"transactionId":85049238694171,"lineNumber":"1","boundaryOverrideId":0,"customerUsageType":"","entityUseCode":"","description":"Test
+        product","destinationAddressId":85049238694172,"originAddressId":85049238694173,"discountAmount":0.0,"discountTypeId":0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"isSSTP":false,"itemCode":"SKU_A","lineAmount":24.3900,"quantity":3.0,"ref1":"","ref2":"","reportingDate":"2024-02-12","revAccount":"","sourcing":"Destination","tax":5.61,"taxableAmount":24.39,"taxCalculated":5.61,"taxCode":"O9999999","taxCodeId":9111,"taxDate":"2024-02-12","taxEngine":"","taxOverrideType":"None","businessIdentificationNo":"","taxOverrideAmount":0.0,"taxOverrideReason":"","taxIncluded":true,"details":[{"id":85049238694199,"transactionLineId":85049238694177,"transactionId":85049238694171,"addressId":85049238694172,"country":"PL","region":"PL","countyFIPS":"","stateFIPS":"","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"PL","jurisName":"POLAND","jurisdictionId":200102,"signatureCode":"","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.230000,"rateRuleId":411502,"rateSourceId":0,"serCode":"","sourcing":"Destination","tax":5.6100,"taxableAmount":24.3900,"taxType":"Output","taxSubTypeId":"O","taxTypeGroupId":"InputAndOutput","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxRegionId":205102,"taxCalculated":5.6100,"taxOverride":0.0000,"rateType":"Standard","rateTypeCode":"S","taxableUnits":24.3900,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":24.39,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":5.61,"reportingTaxCalculated":5.61,"liabilityType":"Seller","chargedTo":"Buyer"}],"nonPassthroughDetails":[],"lineLocationTypes":[{"documentLineLocationTypeId":85049238694180,"documentLineId":85049238694177,"documentAddressId":85049238694173,"locationTypeCode":"ShipFrom"},{"documentLineLocationTypeId":85049238694181,"documentLineId":85049238694177,"documentAddressId":85049238694172,"locationTypeCode":"ShipTo"}],"parameters":[{"name":"Transport","value":"None"},{"name":"IsMarketplace","value":"False"},{"name":"IsTriangulation","value":"false"},{"name":"IsGoodsSecondHand","value":"false"}],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230C","vatNumberTypeId":0},{"id":85049238694178,"transactionId":85049238694171,"lineNumber":"2","boundaryOverrideId":0,"customerUsageType":"","entityUseCode":"","description":"","destinationAddressId":85049238694172,"originAddressId":85049238694173,"discountAmount":0.0,"discountTypeId":0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"isSSTP":false,"itemCode":"Shipping","lineAmount":-8.1300,"quantity":1.0,"ref1":"","ref2":"","reportingDate":"2024-02-12","revAccount":"","sourcing":"Destination","tax":1.87,"taxableAmount":8.13,"taxCalculated":1.87,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2024-02-12","taxEngine":"","taxOverrideType":"None","businessIdentificationNo":"","taxOverrideAmount":0.0,"taxOverrideReason":"","taxIncluded":true,"details":[{"id":85049238694220,"transactionLineId":85049238694178,"transactionId":85049238694171,"addressId":85049238694172,"country":"PL","region":"PL","countyFIPS":"","stateFIPS":"","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"PL","jurisName":"POLAND","jurisdictionId":200102,"signatureCode":"","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.230000,"rateRuleId":411502,"rateSourceId":0,"serCode":"","sourcing":"Destination","tax":1.8700,"taxableAmount":8.1300,"taxType":"Output","taxSubTypeId":"O","taxTypeGroupId":"InputAndOutput","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxRegionId":205102,"taxCalculated":1.8700,"taxOverride":0.0000,"rateType":"Standard","rateTypeCode":"S","taxableUnits":8.1300,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":8.13,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":1.87,"reportingTaxCalculated":1.87,"liabilityType":"Seller","chargedTo":"Buyer"}],"nonPassthroughDetails":[],"lineLocationTypes":[{"documentLineLocationTypeId":85049238694201,"documentLineId":85049238694178,"documentAddressId":85049238694173,"locationTypeCode":"ShipFrom"},{"documentLineLocationTypeId":85049238694202,"documentLineId":85049238694178,"documentAddressId":85049238694172,"locationTypeCode":"ShipTo"}],"parameters":[{"name":"Transport","value":"None"},{"name":"IsMarketplace","value":"False"},{"name":"IsTriangulation","value":"false"},{"name":"IsGoodsSecondHand","value":"false"}],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230D","vatNumberTypeId":0}],"addresses":[{"id":85049238694172,"transactionId":85049238694171,"boundaryLevel":"Zip5","line1":"Olawska
+        10","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-105","country":"PL","taxRegionId":205102},{"id":85049238694173,"transactionId":85049238694171,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102}],"locationTypes":[{"documentLocationTypeId":85049238694175,"documentId":85049238694171,"documentAddressId":85049238694173,"locationTypeCode":"ShipFrom"},{"documentLocationTypeId":85049238694176,"documentId":85049238694171,"documentAddressId":85049238694172,"locationTypeCode":"ShipTo"}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":32.52,"rate":0.230000,"tax":7.48,"taxCalculated":7.48,"nonTaxable":0.00,"exemption":0.00}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 12 Feb 2024 11:19:08 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/85049238694171
+      ServerDuration:
+      - '00:00:00.0578062'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - b6f21e3e-54aa-4436-ac49-4cbc056c3e39
+      x-correlation-id:
+      - b6f21e3e-54aa-4436-ac49-4cbc056c3e39
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -6376,6 +6376,7 @@ def test_calculate_checkout_negative_values_in_tax_data(
     plugin_configuration,
     caplog,
 ):
+    # given
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
 

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -6376,6 +6376,11 @@ def test_calculate_checkout_negative_values_in_tax_data(
     plugin_configuration,
     caplog,
 ):
+    """Test Saleor behaviour when Avatax plugin return negative line values.
+
+    Since this is an anomaly and we don't know how to trigger such a case, cassette was
+    updated manually.
+    """
     # given
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
@@ -6404,6 +6409,9 @@ def test_calculate_checkout_negative_values_in_tax_data(
     # then
     assert checkout_info.checkout.tax_error == "Tax data contains negative values."
     assert "Tax data contains negative values" in caplog.text
+    extra_log_info = caplog.records[2]
+    assert extra_log_info.checkout
+    assert extra_log_info.tax_data[0]["line_amount"] == -24.39
 
 
 @pytest.mark.vcr
@@ -6411,6 +6419,11 @@ def test_calculate_checkout_negative_values_in_tax_data(
 def test_calculate_order_negative_values_in_tax_data(
     order_line, shipping_zone, site_settings, address, plugin_configuration, caplog
 ):
+    """Test Saleor behaviour when Avatax plugin return negative line values.
+
+    Since this is an anomaly and we don't know how to trigger such a case, cassette was
+    updated manually.
+    """
     # given
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
@@ -6435,3 +6448,6 @@ def test_calculate_order_negative_values_in_tax_data(
     # then
     assert order.tax_error == "Tax data contains negative values."
     assert "Tax data contains negative values" in caplog.text
+    extra_log_info = caplog.records[2]
+    assert extra_log_info.order
+    assert extra_log_info.tax_data[1]["line_amount"] == -8.13

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 from django.conf import settings
 from prices import TaxedMoney
 
+from ..core.taxes import TaxData
 from ..core.utils.country import get_active_country
 from . import TaxCalculationStrategy
 
@@ -248,3 +249,17 @@ def get_shipping_tax_class_kwargs_for_order(tax_class: Optional["TaxClass"]):
         "shipping_tax_class_private_metadata": tax_class.private_metadata,
         "shipping_tax_class_metadata": tax_class.metadata,
     }
+
+
+def check_negative_values_in_tax_data(tax_data: TaxData) -> bool:
+    if (
+        tax_data.shipping_price_gross_amount < 0
+        or tax_data.shipping_price_net_amount < 0
+    ):
+        return True
+
+    for line in tax_data.lines:
+        if line.total_gross_amount < 0 or line.total_net_amount < 0:
+            return True
+
+    return False

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from django.conf import settings
 from prices import TaxedMoney
@@ -262,4 +262,11 @@ def check_negative_values_in_tax_data(tax_data: TaxData) -> bool:
         if line.total_gross_amount < 0 or line.total_net_amount < 0:
             return True
 
+    return False
+
+
+def check_negative_values_in_tax_data_from_plugin(tax_data: dict[str, Any]) -> bool:
+    for line in tax_data.get("lines", []):
+        if line.get("lineAmount", 0) < 0:
+            return True
     return False

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -296,3 +296,20 @@ def get_tax_data_for_logs(tax_data: Optional[TaxData]):
             for line in tax_data.lines
         ],
     }
+
+
+def get_plugin_tax_data_for_logs(tax_data: dict[str, Any]):
+    if not tax_data:
+        return {}
+
+    return [
+        {
+            "line_amount": line.get("lineAmount"),
+            "discount_amount": line.get("discountAmount"),
+            "variant_sku": line.get("itemCode"),
+            "quantity": line.get("quantity"),
+            "tax": line.get("tax"),
+            "taxable_amount": line.get("taxableAmount"),
+        }
+        for line in tax_data.get("lines", [])
+    ]

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -277,3 +277,22 @@ def check_negative_values_in_tax_data_from_plugin(tax_data: dict[str, Any]) -> b
             return True
 
     return False
+
+
+def get_tax_data_for_logs(tax_data: Optional[TaxData]):
+    if not tax_data:
+        return {}
+
+    return {
+        "shipping_price_gross_amount": tax_data.shipping_price_gross_amount,
+        "shipping_price_net_amount": tax_data.shipping_price_net_amount,
+        "shipping_ta_rate": tax_data.shipping_tax_rate,
+        "lines": [
+            {
+                "total_gross_amount": line.total_gross_amount,
+                "total_net_amount": line.total_net_amount,
+                "tax_rate": line.tax_rate,
+            }
+            for line in tax_data.lines
+        ],
+    }

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -251,7 +251,10 @@ def get_shipping_tax_class_kwargs_for_order(tax_class: Optional["TaxClass"]):
     }
 
 
-def check_negative_values_in_tax_data(tax_data: TaxData) -> bool:
+def check_negative_values_in_tax_data(tax_data: Optional[TaxData]) -> bool:
+    if not tax_data:
+        return False
+
     if (
         tax_data.shipping_price_gross_amount < 0
         or tax_data.shipping_price_net_amount < 0
@@ -266,7 +269,11 @@ def check_negative_values_in_tax_data(tax_data: TaxData) -> bool:
 
 
 def check_negative_values_in_tax_data_from_plugin(tax_data: dict[str, Any]) -> bool:
+    if not tax_data:
+        return False
+
     for line in tax_data.get("lines", []):
         if line.get("lineAmount", 0) < 0:
             return True
+
     return False


### PR DESCRIPTION
I want to merge this change because it adds additional validation to tax data received from Avalara. When the data contains negative line values it logs the occurrence and raises an error.

This PR also adds functions that can be used in logger's `extra` parameter to log details of order/checkout when some anomaly occur.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
