### PR TITLE
New release workflows

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -1,0 +1,27 @@
+name: Create tag and release on release PR merge
+on:
+  pull_request:
+    types:
+     - closed
+
+jobs:
+  run-release-trigger:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    env:
+      GH_REF: ${{ github.event.pull_request.head.ref }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - run: echo "PR_TAG_REF=$GH_REF" | sed "s/release-//" >> $GITHUB_ENV
+      - name: Create tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${process.env.PR_TAG_REF}`,
+              sha: context.sha
+            })
+      - run: |
+          gh release create "$PR_TAG_REF" --repo="$GITHUB_REPOSITORY" --generate-notes --draft --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.pot
 *.pyc
 local_settings.py
+.base_ver_release.txt
 __pycache__/
 build/
 coverage/

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,11 +1,12 @@
 {
-  "github": {
-    "release": true,
-    "draft": true,
-    "releaseName": "${version}",
-    "assets": ["saleor/graphql/schema.graphql"]
+  "git": {
+    "commit": true,
+    "tag": false,
+    "push": false
   },
-
+  "github": {
+    "release": false
+  },
   "npm": {
     "publish": false
   },
@@ -22,5 +23,17 @@
         }
       ]
     }
+  },
+  "hooks": {
+    "before:bump": [
+      "git rev-parse --abbrev-ref HEAD > .base_ver_release.txt"
+    ],
+    "after:bump": [
+      "git checkout -B release-${version} --track"
+    ],
+    "after:release": [
+      "git push origin release-${version}",
+      "gh pr create --base `cat .base_ver_release.txt` --head release-${version} --title \"Release ${version}\" --body \"${changelog}\" --label release"
+    ]
   }
 }


### PR DESCRIPTION
I want to merge this change because it implements new release workflow
Context: [https://linear.app/saleor/issue/PE-232](https://linear.app/saleor/issue/PE-232/saleor-core-release-tool-is-broken-after-enabling-branch-protection#comment-eeaafed2)

This is a port of https://github.com/saleor/saleor/pull/16565

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
