### PR TITLE
Fix webhook payload save on Azure Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2685,8 +2685,4 @@ Just so you know, changes mentioned in this section are in a preview state and c
 
 - Add createdb note to getting started for Windows - #3106 by @ajostergaard
 - Update docs on pipenv - #3045 by @jxltom
-- Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi
-- Fixed a potential crash when Checkout metadata is accessed with high concurrency - #16411 by @patrys
-- Add slugs to product/category/collection/page translations. Allow to query by translated slug - #16449 by @delemeator
-- Fixed a crash when the Decimal scalar is passed a non-normal value - #16520 by @patrys
 - Fixed a bug when saving webhook payload to Azure Storage - #16585 by @delemeator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2685,3 +2685,8 @@ Just so you know, changes mentioned in this section are in a preview state and c
 
 - Add createdb note to getting started for Windows - #3106 by @ajostergaard
 - Update docs on pipenv - #3045 by @jxltom
+- Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi
+- Fixed a potential crash when Checkout metadata is accessed with high concurrency - #16411 by @patrys
+- Add slugs to product/category/collection/page translations. Allow to query by translated slug - #16449 by @delemeator
+- Fixed a crash when the Decimal scalar is passed a non-normal value - #16520 by @patrys
+- Fixed a bug when saving webhook payload to Azure Storage - #16585 by @delemeator

--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -177,16 +177,17 @@ class EventPayload(models.Model):
 
     def get_payload(self):
         if self.payload_file:
-            with self.payload_file.open("rt") as f:
-                payload = f.read()
-                return payload
+            with self.payload_file.open("rb") as f:
+                payload_data = f.read()
+                return payload_data.decode("utf-8")
         return self.payload
 
     def save_payload_file(self, payload_data: str):
+        payload_bytes = payload_data.encode("utf-8")
         prefix = get_random_string(length=12)
         file_name = f"{self.pk}.json"
         file_path = safe_join(prefix, file_name)
-        self.payload_file.save(file_path, ContentFile(payload_data))
+        self.payload_file.save(file_path, ContentFile(payload_bytes))
 
 
 class EventDelivery(models.Model):

--- a/saleor/core/tests/test_event_payload.py
+++ b/saleor/core/tests/test_event_payload.py
@@ -1,0 +1,39 @@
+import pytest
+from django.core.files.base import ContentFile
+from django.utils.crypto import get_random_string
+from storages.utils import safe_join
+
+from ..models import EventPayload
+
+
+@pytest.fixture
+def payload_data():
+    return '{\n    "product": {\n        "name": "Żółta ćma"\n    }\n}\n'
+
+
+def test_reading_event_payload(payload_data):
+    # given
+    payload = EventPayload.objects.create()
+    payload.save_payload_file(payload_data)
+
+    # when
+    read_payload = payload.get_payload()
+
+    # then
+    assert read_payload == payload_data
+
+
+def test_reading_event_payload_saved_as_string(payload_data):
+    # given
+    # Force saving payload as string (as old payloads were)
+    payload = EventPayload.objects.create()
+    prefix = get_random_string(length=12)
+    file_name = f"{payload.pk}.json"
+    file_path = safe_join(prefix, file_name)
+    payload.payload_file.save(file_path, ContentFile(payload_data))
+
+    # when
+    read_payload = payload.get_payload()
+
+    # then
+    assert read_payload == payload_data


### PR DESCRIPTION
* Fix saving webhook to Azure Storage by using bytes rather than string

* Test reading event payload

* Add changelog for azure storage webhook fix

---------

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
