### PR TITLE
[Test] Should be able to remove draft orders in bulk

### DIFF
--- a/saleor/tests/e2e/orders/test_bulk_delete_draft_orders.py
+++ b/saleor/tests/e2e/orders/test_bulk_delete_draft_orders.py
@@ -1,0 +1,82 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_bulk_delete,
+    draft_order_create,
+    order_lines_create,
+    order_query,
+)
+
+
+@pytest.mark.e2e
+def test_delete_draft_orders_in_bulk_CORE_0248(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    price = 10
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    orders_list = []
+    for i in range(5):
+        user_email = f"test_user_{i +1}@test.com"
+        draft_order_input = {
+            "channelId": channel_id,
+            "userEmail": user_email,
+            "shippingAddress": DEFAULT_ADDRESS,
+            "billingAddress": DEFAULT_ADDRESS,
+        }
+        data = draft_order_create(
+            e2e_staff_api_client,
+            draft_order_input,
+        )
+        order_id = order_id = data["order"]["id"]
+        lines = [
+            {
+                "variantId": product_variant_id,
+                "quantity": 1,
+            }
+        ]
+        order_lines_create(
+            e2e_staff_api_client,
+            order_id,
+            lines,
+        )
+        orders_list.append(order_id)
+
+    # Step 1 - Remove draft orders in bulk
+    data = draft_order_bulk_delete(e2e_staff_api_client, orders_list)
+    assert data["errors"] == []
+    assert data["count"] == 5
+
+    # Step 2 - Try to query the deleted draft orders
+    for order_id in orders_list:
+        data = order_query(e2e_staff_api_client, order_id)
+        assert data is None

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -1,3 +1,4 @@
+from .draft_order_bulk_delete import draft_order_bulk_delete
 from .draft_order_complete import draft_order_complete, raw_draft_order_complete
 from .draft_order_create import draft_order_create
 from .draft_order_delete import draft_order_delete
@@ -35,5 +36,6 @@ __all__ = [
     "order_fulfillment_cancel",
     "order_invoice_create",
     "order_update_shipping",
+    "draft_order_bulk_delete",
     "order_line_update",
 ]

--- a/saleor/tests/e2e/orders/utils/draft_order_bulk_delete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_bulk_delete.py
@@ -1,0 +1,28 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+DRAFT_ORDER_BULK_DELETE_MUTATION = """
+mutation DraftBulkDelete($ids: [ID!]!) {
+  draftOrderBulkDelete(ids: $ids) {
+    errors {
+      field
+      code
+      message
+    }
+    count
+  }
+}
+"""
+
+
+def draft_order_bulk_delete(api_client, ids_list):
+    variables = {"ids": ids_list}
+
+    response = api_client.post_graphql(
+        DRAFT_ORDER_BULK_DELETE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["draftOrderBulkDelete"]
+
+    return data


### PR DESCRIPTION
I want to merge this change because it adds tests to cover [draft orders bulk delete CORE_0248](https://saleor.testmo.net/repositories/5?group_id=112&pagination_current=2&case_id=24370)



<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
