### PR TITLE
Fix test assertions

### DIFF
--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -2133,9 +2133,10 @@ def test_complete_checkout_invalid_shipping_method(
     )
     assert not voucher_customer.exists()
 
-    mocked_payment_refund_or_void.called_once_with(
-        payment, manager, channel_slug=checkout.channel.slug
-    )
+    assert mocked_payment_refund_or_void.call_args_list == [
+        mock.call(payment, manager, channel_slug=checkout.channel.slug),
+        mock.call(payment, manager, channel_slug=checkout.channel.slug),
+    ]
     checkout.refresh_from_db()
     assert checkout.is_voucher_usage_increased is False
 

--- a/saleor/csv/tests/test_tasks.py
+++ b/saleor/csv/tests/test_tasks.py
@@ -171,7 +171,7 @@ def test_on_task_failure_for_app(send_export_failed_info_mock, app_export_file):
         "error_type": info_type,
     }
 
-    send_export_failed_info_mock.called_once_with(app_export_file, ANY)
+    send_export_failed_info_mock.assert_called_once_with(app_export_file, ANY)
 
 
 def test_on_task_success(user_export_file):

--- a/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 
@@ -858,7 +858,7 @@ def test_customers_bulk_update_metadata_empty_key_in_one_input(
         customer_2.private_metadata.get(private_metadata_2["key"])
         == private_metadata_2["value"]
     )
-    mocked_customer_metadata_updated.called_once_with(customer_2)
+    mocked_customer_metadata_updated.assert_called_once_with(customer_2, webhooks=ANY)
 
 
 def test_customers_bulk_update_trigger_gift_card_search_vector_update(

--- a/saleor/payment/tests/test_gateway.py
+++ b/saleor/payment/tests/test_gateway.py
@@ -1381,7 +1381,7 @@ def test_payment_refund_or_void_refund_called(refund_mock, payment):
     )
 
     # then
-    assert refund_mock.called_once()
+    refund_mock.assert_called_once()
 
 
 @patch("saleor.payment.gateway.refund")
@@ -1442,7 +1442,7 @@ def test_payment_refund_or_void_refund_called_txn_exist(refund_mock, payment):
     )
 
     # then
-    assert refund_mock.called_once()
+    refund_mock.assert_called_once()
 
 
 @patch("saleor.payment.gateway.refund")
@@ -1475,7 +1475,7 @@ def test_payment_refund_or_void_refund_called_no_txn_with_given_transaction_id(
     )
 
     # then
-    assert refund_mock.called_once()
+    refund_mock.assert_called_once()
 
 
 @patch("saleor.payment.gateway.void")
@@ -1492,7 +1492,7 @@ def test_payment_refund_or_void_void_called(void_mock, payment):
     )
 
     # then
-    assert void_mock.called_once()
+    void_mock.assert_called_once()
 
 
 @patch("saleor.payment.gateway.void")

--- a/saleor/plugins/user_email/tests/test_tasks.py
+++ b/saleor/plugins/user_email/tests/test_tasks.py
@@ -248,8 +248,8 @@ def test_send_user_change_email_notification_task_default_template(
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
     # confirm that email changed task was triggered
-    assert mocked_email_changed_task.called_once_with(
-        customer_user.id, expected_task_payload
+    mocked_email_changed_task.assert_called_once_with(
+        user_id=str(customer_user.id), parameters=expected_task_payload
     )
 
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -2007,8 +2007,8 @@ def test_send_webhook_request_async_when_webhook_is_disabled(
     event_delivery.refresh_from_db()
 
     # then
-    mocked_clear_delivery.not_called()
-    mocked_observability.not_called()
+    assert not mocked_clear_delivery.called
+    assert not mocked_observability.called
     assert event_delivery.status == EventDeliveryStatus.FAILED
 
 

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -210,9 +210,7 @@ def test_recalculate_discounted_price_for_products_task_updates_only_dirty_listi
 
     # then
     assert update_discounted_prices_for_promotion_mock.called
-    recalculate_discounted_price_for_products_task_mock.called_once_with(
-        listing_marked_as_dirty.product, only_dirty_products=True
-    )
+    recalculate_discounted_price_for_products_task_mock.assert_called_once_with()
 
 
 @patch("saleor.product.tasks.recalculate_discounted_price_for_products_task.delay")


### PR DESCRIPTION
While working on Python 3.12 compatibility, I found calls to non-existent mock methods used in assertions. It turns out that a few of our tests were not actually testing anything.

This will be prevented by `mock` itself once we upgrade to Python 3.12.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
