### PR TITLE
Add `TaxableObjectDiscountType` to inform tax apps how to distribute discounts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Add `CheckoutCustomerNoteUpdate` mutation - #16315 by @pitkes22
 - Add `customerNote` field to `Checkout` type to make it consistent with `Order` model - #16561 by @Air-t
+- Add `type` fields to `TaxableObjectDiscount` type - #16630 by @zedzior
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Add `CheckoutCustomerNoteUpdate` mutation - #16315 by @pitkes22
 - Add `customerNote` field to `Checkout` type to make it consistent with `Order` model - #16561 by @Air-t
-- Add `type` fields to `TaxableObjectDiscount` type - #16630 by @zedzior
+- Add `type` field to `TaxableObjectDiscount` type - #16630 by @zedzior
 
 ### Webhooks
 

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -676,28 +676,43 @@ def test_get_the_cheapest_line(checkout_with_items, channel_USD):
 
 
 @pytest.mark.parametrize(
-    ("value", "value_type", "subtotal_portion", "shipping_portion"),
+    (
+        "value",
+        "value_type",
+        "subtotal",
+        "shipping_price",
+        "subtotal_portion",
+        "shipping_portion",
+    ),
     [
-        (20, DiscountValueType.FIXED, 15, 5),
-        (100, DiscountValueType.FIXED, 30, 10),
-        (13.77, DiscountValueType.FIXED, Decimal("10.33"), Decimal("3.44")),
-        (0, DiscountValueType.FIXED, 0, 0),
-        (0, DiscountValueType.PERCENTAGE, 0, 0),
-        (50, DiscountValueType.PERCENTAGE, 15, 5),
-        (33.33, DiscountValueType.PERCENTAGE, 10, Decimal("3.33")),
-        (100, DiscountValueType.PERCENTAGE, 30, 10),
+        (20, DiscountValueType.FIXED, 30, 10, 15, 5),
+        (100, DiscountValueType.FIXED, 30, 10, 30, 10),
+        (13.77, DiscountValueType.FIXED, 30, 10, Decimal("10.33"), Decimal("3.44")),
+        (0, DiscountValueType.FIXED, 30, 10, 0, 0),
+        (20, DiscountValueType.FIXED, 0, 10, 0, 10),
+        (50, DiscountValueType.FIXED, 30, 0, 30, 0),
+        (50, DiscountValueType.FIXED, 0, 0, 0, 0),
+        (0, DiscountValueType.PERCENTAGE, 30, 10, 0, 0),
+        (50, DiscountValueType.PERCENTAGE, 30, 10, 15, 5),
+        (33.33, DiscountValueType.PERCENTAGE, 30, 10, 10, Decimal("3.33")),
+        (100, DiscountValueType.PERCENTAGE, 30, 10, 30, 10),
+        (50, DiscountValueType.PERCENTAGE, 0, 10, 0, 5),
+        (50, DiscountValueType.PERCENTAGE, 30, 0, 15, 0),
+        (50, DiscountValueType.PERCENTAGE, 0, 0, 0, 0),
     ],
 )
 def test_split_manual_discount(
     value,
     value_type,
+    subtotal,
+    shipping_price,
     subtotal_portion,
     shipping_portion,
     draft_order_with_fixed_discount_order,
 ):
     # given
-    subtotal = Money(Decimal(30), currency="USD")
-    shipping = Money(Decimal(10), currency="USD")
+    subtotal = Money(subtotal, currency="USD")
+    shipping = Money(shipping_price, currency="USD")
     discount = draft_order_with_fixed_discount_order.discounts.first()
     discount.value = value
     discount.value_type = value_type

--- a/saleor/discount/utils/manual_discount.py
+++ b/saleor/discount/utils/manual_discount.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 from prices import Money, TaxedMoney, fixed_discount, percentage_discount
 
+from ...core.prices import quantize_price
 from ...core.taxes import zero_money
 from .. import DiscountValueType
 from ..models import OrderDiscount
@@ -59,7 +60,9 @@ def split_manual_discount(
                 price_to_discount=total,
             )
             total_discount = total - discounted_total
-            subtotal_discount = subtotal / total * total_discount
+            subtotal_discount = quantize_price(
+                subtotal / total * total_discount, currency
+            )
             shipping_discount = total_discount - subtotal_discount
 
     return subtotal_discount, shipping_discount

--- a/saleor/discount/utils/manual_discount.py
+++ b/saleor/discount/utils/manual_discount.py
@@ -33,6 +33,7 @@ def apply_discount_to_value(
 def split_manual_discount(
     discount: OrderDiscount, subtotal: Money, shipping_price: Money
 ) -> tuple[Money, Money]:
+    """Discounts sent to tax app must be split into subtotal and shipping portion."""
     currency = subtotal.currency
     subtotal_discount, shipping_discount = zero_money(currency), zero_money(currency)
     if discount.value_type == DiscountValueType.PERCENTAGE:
@@ -60,9 +61,9 @@ def split_manual_discount(
                 price_to_discount=total,
             )
             total_discount = total - discounted_total
-            subtotal_discount = quantize_price(
-                subtotal / total * total_discount, currency
-            )
+            subtotal_discount = subtotal / total * total_discount
             shipping_discount = total_discount - subtotal_discount
 
-    return subtotal_discount, shipping_discount
+    return quantize_price(subtotal_discount, currency), quantize_price(
+        shipping_discount, currency
+    )

--- a/saleor/discount/utils/manual_discount.py
+++ b/saleor/discount/utils/manual_discount.py
@@ -4,7 +4,9 @@ from typing import Optional, Union
 
 from prices import Money, TaxedMoney, fixed_discount, percentage_discount
 
+from ...core.taxes import zero_money
 from .. import DiscountValueType
+from ..models import OrderDiscount
 
 
 def apply_discount_to_value(
@@ -25,3 +27,39 @@ def apply_discount_to_value(
         **discount_kwargs,
     )
     return discount(price_to_discount)
+
+
+def split_manual_discount(
+    discount: OrderDiscount, subtotal: Money, shipping_price: Money
+) -> tuple[Money, Money]:
+    currency = subtotal.currency
+    subtotal_discount, shipping_discount = zero_money(currency), zero_money(currency)
+    if discount.value_type == DiscountValueType.PERCENTAGE:
+        discounted_subtotal = apply_discount_to_value(
+            value=discount.value,
+            value_type=discount.value_type,
+            currency=currency,
+            price_to_discount=subtotal,
+        )
+        subtotal_discount = subtotal - discounted_subtotal
+        discounted_shipping_price = apply_discount_to_value(
+            value=discount.value,
+            value_type=discount.value_type,
+            currency=currency,
+            price_to_discount=shipping_price,
+        )
+        shipping_discount = shipping_price - discounted_shipping_price
+    elif discount.value_type == DiscountValueType.FIXED:
+        total = subtotal + shipping_price
+        if total.amount > 0:
+            discounted_total = apply_discount_to_value(
+                value=discount.value,
+                value_type=discount.value_type,
+                currency=currency,
+                price_to_discount=total,
+            )
+            total_discount = total - discounted_total
+            subtotal_discount = subtotal / total * total_discount
+            shipping_discount = total_discount - subtotal_discount
+
+    return subtotal_discount, shipping_discount

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -380,7 +380,13 @@ class TaxableObject(BaseObjectType):
                 checkout = checkout_info.checkout
                 discount_name = checkout.discount_name
                 return (
-                    [{"name": discount_name, "amount": checkout.discount}]
+                    [
+                        {
+                            "name": discount_name,
+                            "amount": checkout.discount,
+                            "type": TaxableObjectDiscountTypeEnum.SUBTOTAL,
+                        }
+                    ]
                     if checkout.discount
                     and (
                         is_order_level_voucher(checkout_info.voucher)
@@ -403,7 +409,7 @@ class TaxableObject(BaseObjectType):
             for discount in discounts:
                 if discount.type != DiscountType.MANUAL:
                     continue
-                subtotal = root.subtotal
+                subtotal = root.subtotal.net
                 shipping = root.base_shipping_price
                 subtotal_discount, shipping_discount = split_manual_discount(
                     discount, subtotal, shipping
@@ -412,12 +418,12 @@ class TaxableObject(BaseObjectType):
                     [
                         {
                             "name": discount.name,
-                            "amount": subtotal_discount.amount,
+                            "amount": subtotal_discount,
                             "type": TaxableObjectDiscountTypeEnum.SUBTOTAL,
                         },
                         {
                             "name": discount.name,
-                            "amount": shipping_discount.amount,
+                            "amount": shipping_discount,
                             "type": TaxableObjectDiscountTypeEnum.SHIPPING,
                         },
                     ]
@@ -431,10 +437,11 @@ class TaxableObject(BaseObjectType):
                         "type": TaxableObjectDiscountTypeEnum.SUBTOTAL,
                     }
                     for discount in discounts
-                    if is_order_level_voucher(discount)
+                    if is_order_level_voucher(discount.voucher)
                     or discount.type == DiscountType.ORDER_PROMOTION
                 ]
             )
+
             return taxable_discounts
 
         return (

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -36,6 +36,7 @@ from ...tax.dataloaders import (
     TaxConfigurationByChannelId,
     TaxConfigurationPerCountryByTaxConfigurationIDLoader,
 )
+from ...tax.enums import TaxableObjectDiscountTypeEnum
 from .. import ResolveInfo
 from .common import NonNullList
 from .money import Money
@@ -266,6 +267,11 @@ class TaxableObjectDiscount(BaseObjectType):
     name = graphene.String(description="The name of the discount.")
     amount = graphene.Field(
         Money, description="The amount of the discount.", required=True
+    )
+    type = TaxableObjectDiscountTypeEnum(
+        required=True,
+        default_value=TaxableObjectDiscountTypeEnum.SUBTOTAL,
+        description="Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.",
     )
 
     class Meta:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -36535,6 +36535,19 @@ type TaxableObjectDiscount @doc(category: "Taxes") {
 
   """The amount of the discount."""
   amount: Money!
+
+  """
+  Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
+  """
+  type: TaxableObjectDiscountTypeEnum!
+}
+
+"""
+Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
+"""
+enum TaxableObjectDiscountTypeEnum @doc(category: "Taxes") {
+  SUBTOTAL
+  SHIPPING
 }
 
 type TaxableObjectLine @doc(category: "Taxes") {

--- a/saleor/graphql/tax/enums.py
+++ b/saleor/graphql/tax/enums.py
@@ -1,4 +1,9 @@
-from ...tax import TaxCalculationStrategy as InternalTaxCalculationStrategy
+from ...tax import (
+    TaxableObjectDiscountType,
+)
+from ...tax import (
+    TaxCalculationStrategy as InternalTaxCalculationStrategy,
+)
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.enums import to_enum
 
@@ -17,3 +22,10 @@ TaxCalculationStrategy = to_enum(
     type_name="TaxCalculationStrategy",
 )
 TaxCalculationStrategy.doc_category = DOC_CATEGORY_TAXES
+
+
+TaxableObjectDiscountTypeEnum = to_enum(
+    TaxableObjectDiscountType,
+    description="Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.",
+)
+TaxableObjectDiscountTypeEnum.doc_category = DOC_CATEGORY_TAXES

--- a/saleor/tax/__init__.py
+++ b/saleor/tax/__init__.py
@@ -3,3 +3,10 @@ class TaxCalculationStrategy:
     TAX_APP = "TAX_APP"
 
     CHOICES = [(FLAT_RATES, "Flat rates"), (TAX_APP, "Tax app")]
+
+
+class TaxableObjectDiscountType:
+    SUBTOTAL = "SUBTOTAL"
+    SHIPPING = "SHIPPING"
+
+    CHOICES = [(SUBTOTAL, "Subtotal"), (SHIPPING, "Shipping")]


### PR DESCRIPTION
I want to merge this change because the Avatax app does not have enough information on how to distribute order-level discounts over the lines, resulting in incorrect tax calculations.

RFC: https://github.com/saleor/saleor/issues/16613
Internal issue: https://linear.app/saleor/issue/SHOPX-1145/enrich-avatax-payload-with-info-how-to-distribute-order-level-discount

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
