### PR TITLE
Skip obsolete payload save and cleanup for successful sync webhooks

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
         id: check-latest
         env:
           VERSION: ${{ steps.set-version.outputs.VERSION }}
-        run: | 
+        run: |
           latest=$(gh api --jq .name /repos/saleor/saleor/releases/latest)
           if [ "$VERSION" \> "$latest" ]
           then
@@ -71,7 +71,7 @@ jobs:
           export GITHUB_TOKEN=$( \
             curl --request GET --url ${{ secrets.VAULT_URL}} --header "Authorization: JWT ${{ secrets.VAULT_JWT }}" | jq -r .token \
           )
-          
+
           payload=$(
               jq --arg version "$VERSION" --null-input '
                 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added validation for tax data received from tax app - #16720 by @zedzior
 - Fixed order-level discounts handling when using tax app for tax calculation - #16696 by @zedzior
 - Fixed bug when manual line discount doesn't override line-level vouchers - #16738 by @zedzior
+- Skipped obsolete payload save and cleanup for successful sync webhooks - #16632 by @cmiacz

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -396,7 +396,9 @@ def test_call_checkout_event_triggers_sync_webhook_when_needed(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_created_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -480,7 +482,9 @@ def test_call_checkout_event_skips_tax_webhook_when_not_expired(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_created_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -715,7 +719,9 @@ def test_call_checkout_info_event_triggers_sync_webhook_when_needed(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_created_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -810,7 +816,9 @@ def test_call_checkout_info_event_skips_tax_webhook_when_not_expired(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_created_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1014,7 +1022,9 @@ def test_transaction_amounts_for_checkout_fully_paid_triggers_sync_webhook(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_fully_paid_webhook.id
+    ).exists()
 
     tax_delivery_call, shipping_methods_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1143,7 +1153,9 @@ def test_call_checkout_events_triggers_sync_webhook_when_needed(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_created_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1235,7 +1247,9 @@ def test_call_checkout_events_skips_tax_webhook_when_not_expired(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_created_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -189,6 +189,12 @@ class EventPayload(models.Model):
         file_path = safe_join(prefix, file_name)
         self.payload_file.save(file_path, ContentFile(payload_bytes))
 
+    def save_as_file(self):
+        payload_data = self.payload
+        self.payload = ""
+        self.save()
+        self.save_payload_file(payload_data)
+
 
 class EventDelivery(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1598,7 +1598,9 @@ def test_checkout_add_voucher_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -706,7 +706,9 @@ def test_checkout_billing_address_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -2720,7 +2720,9 @@ def test_checkout_create_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_created_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -297,7 +297,9 @@ def test_checkout_customer_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -173,7 +173,9 @@ def test_checkout_customer_detach_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
@@ -137,7 +137,9 @@ def test_checkout_customer_note_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -1069,7 +1069,9 @@ def test_checkout_delivery_method_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1162,7 +1164,9 @@ def test_checkout_delivery_method_update_cc_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1267,7 +1271,9 @@ def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -144,7 +144,9 @@ def test_checkout_email_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -126,7 +126,9 @@ def test_checkout_update_language_code_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -273,7 +273,9 @@ def test_checkout_line_delete_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1824,7 +1824,9 @@ def test_checkout_lines_add_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -263,7 +263,9 @@ def test_checkout_lines_delete_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1428,7 +1428,9 @@ def test_checkout_lines_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -783,7 +783,9 @@ def test_checkout_remove_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -1138,7 +1138,9 @@ def test_checkout_shipping_address_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -540,7 +540,9 @@ def test_checkout_shipping_method_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -641,7 +643,9 @@ def test_checkout_shipping_method_update_external_shipping_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -727,7 +731,9 @@ def test_checkout_shipping_method_update_to_none_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -415,7 +415,9 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
 
     # confirm each sync webhook con was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -495,7 +497,9 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
 
     # confirm each sync webhook con was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=checkout_metadata_updated_webhook.id
+    ).exists()
 
     shipping_methods_call, filter_shipping_call, tax_delivery_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/meta/tests/mutations/test_order.py
+++ b/saleor/graphql/meta/tests/mutations/test_order.py
@@ -643,7 +643,9 @@ def test_change_in_public_metadata_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -718,7 +720,9 @@ def test_change_in_private_metadata_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1591,7 +1591,9 @@ def test_draft_order_complete_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -3705,7 +3705,9 @@ def test_draft_order_create_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=draft_order_created_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -2330,7 +2330,9 @@ def test_draft_order_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=draft_order_updated_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -2417,7 +2419,9 @@ def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
 
     # confirm each sync webhook was called without saving event delivery
     mocked_send_webhook_request_sync.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=draft_order_updated_webhook.id
+    ).exists()
 
     filter_shipping_call = mocked_send_webhook_request_sync.mock_calls[0]
 

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -264,7 +264,9 @@ def test_order_capture_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -375,7 +375,7 @@ def test_order_line_delete_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_order_line_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_update.py
@@ -651,7 +651,7 @@ def test_order_line_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -1314,7 +1314,7 @@ def test_order_lines_create_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_order_note_add.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_add.py
@@ -243,7 +243,7 @@ def test_order_note_add_user_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_order_note_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_update.py
@@ -287,7 +287,7 @@ def test_order_note_update_user_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update.py
@@ -576,7 +576,7 @@ def test_order_update_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -602,7 +602,7 @@ def test_order_update_shipping_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     # FIXME: This is the issue with current way of caching filter shipping
     #  webhooks. Mutation calls the webhook to validates the shipping methods.

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -474,7 +474,9 @@ def test_handle_fully_paid_order_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -919,7 +921,9 @@ def test_order_refunded_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1011,7 +1015,9 @@ def test_order_voided_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1203,7 +1209,9 @@ def test_order_awaits_fulfillment_approval_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1294,7 +1302,9 @@ def test_order_authorized_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1414,7 +1424,9 @@ def test_order_charged_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1796,7 +1808,9 @@ def test_order_transaction_updated_for_charged_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -1905,7 +1919,9 @@ def test_order_transaction_updated_for_authorized_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -2033,7 +2049,10 @@ def test_order_transaction_updated_for_refunded_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -2496,7 +2515,7 @@ def test_call_order_event_triggers_sync_webhook(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -2629,7 +2648,8 @@ def test_call_order_event_missing_filter_shipping_method_webhook(
     )
 
     mocked_send_webhook_request_sync.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
+
     tax_delivery = mocked_send_webhook_request_sync.mock_calls[0].args[0]
     assert tax_delivery.webhook_id == tax_webhook.id
 
@@ -2712,7 +2732,7 @@ def test_call_order_event_skips_tax_webhook_when_prices_are_valid(
 
     # confirm each sync webhook was called without saving event delivery
     mocked_send_webhook_request_sync.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     filter_shipping_call = mocked_send_webhook_request_sync.mock_calls[0]
     filter_shipping_delivery = filter_shipping_call.args[0]
@@ -2800,7 +2820,7 @@ def test_call_order_event_skips_sync_webhooks_when_order_not_editable(
         retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
     mocked_call_event_including_protected_events.assert_called_once_with(
         ANY, order_with_lines, webhooks={order_webhook}
     )
@@ -3037,7 +3057,7 @@ def test_call_order_events_triggers_sync_webhook(
     )
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -3192,7 +3212,8 @@ def test_call_order_events_missing_filter_shipping_method_webhook(
 
     # confirm each sync webhook was called without saving event delivery
     mocked_send_webhook_request_sync.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
+
     tax_delivery = mocked_send_webhook_request_sync.mock_calls[0].args[0]
     assert tax_delivery.webhook_id == tax_webhook.id
 
@@ -3286,7 +3307,7 @@ def test_call_order_events_skips_tax_webhook_when_prices_are_valid(
 
     # confirm each sync webhook was called without saving event delivery
     mocked_send_webhook_request_sync.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
     filter_shipping_call = mocked_send_webhook_request_sync.mock_calls[0]
     filter_shipping_delivery = filter_shipping_call.args[0]
@@ -3699,7 +3720,9 @@ def test_order_created_triggers_webhooks(
     )
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls
@@ -3804,7 +3827,9 @@ def test_order_confirmed_triggers_webhooks(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -833,7 +833,9 @@ def test_send_order_updated(
 
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exclude(
+        webhook_id=additional_order_webhook.id
+    ).exists()
 
     tax_delivery_call, filter_shipping_call = (
         mocked_send_webhook_request_sync.mock_calls

--- a/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
+++ b/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import graphene
 
+from ....core.models import EventDelivery
 from ....payment.interface import ListStoredPaymentMethodsRequestData
 from ....settings import WEBHOOK_SYNC_TIMEOUT
 from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
@@ -72,7 +73,7 @@ def test_list_stored_payment_methods_with_static_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     mocked_cache_get.assert_called_once_with(expected_cache_key)
     mocked_cache_set.assert_called_once_with(
@@ -121,7 +122,7 @@ def test_list_stored_payment_methods_subscription_issuing_principal(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     delivery_subscription_payload = json.loads(delivery.payload.get_payload())
@@ -169,7 +170,7 @@ def test_list_stored_payment_methods_subscription_issuing_principal_as_app(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     delivery_subscription_payload = json.loads(delivery.payload.get_payload())
@@ -231,7 +232,7 @@ def test_list_stored_payment_methods_with_subscription_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     mocked_cache_get.assert_called_once_with(expected_cache_key)
     mocked_cache_set.assert_called_once_with(
@@ -346,7 +347,7 @@ def test_list_stored_payment_methods_app_returns_incorrect_response(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     mocked_cache_get.assert_called_once_with(expected_cache_key)
     assert not mocked_cache_set.called

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
@@ -4,6 +4,7 @@ from unittest import mock
 import graphene
 import pytest
 
+from ....core.models import EventDelivery
 from ....payment.interface import (
     PaymentGatewayInitializeTokenizationRequestData,
     PaymentGatewayInitializeTokenizationResponseData,
@@ -74,7 +75,7 @@ def test_payment_gateway_initialize_tokenization_with_static_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -131,7 +132,7 @@ def test_payment_gateway_initialize_tokenization_with_subscription_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -187,7 +188,7 @@ def test_payment_gateway_initialize_tokenization_missing_correct_response_from_w
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     assert response == PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
@@ -236,7 +237,7 @@ def test_payment_gateway_initialize_tokenization_failure_from_app(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {

--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -4,6 +4,7 @@ from unittest import mock
 import graphene
 import pytest
 
+from ....core.models import EventDelivery
 from ....payment import TokenizedPaymentFlow
 from ....payment.interface import (
     ListStoredPaymentMethodsRequestData,
@@ -84,7 +85,7 @@ def test_payment_method_initialize_tokenization_with_static_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -147,7 +148,7 @@ def test_payment_method_initialize_tokenization_with_subscription_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -209,7 +210,7 @@ def test_payment_method_initialize_tokenization_missing_correct_response_from_we
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
@@ -260,7 +261,7 @@ def test_payment_method_initialize_tokenization_failure_from_app(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -320,7 +321,7 @@ def test_payment_method_initialize_tokenization_additional_action_required(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -388,7 +389,7 @@ def test_payment_method_initialize_tokenization_missing_required_id(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -505,7 +506,7 @@ def test_expected_result_invalidates_cache_for_app(
     # then
     mocked_request.assert_called()
     assert mocked_request.mock_calls[-1].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mocked_request.mock_calls[-1].args[0]
     assert (

--- a/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
@@ -4,6 +4,7 @@ from unittest import mock
 import graphene
 import pytest
 
+from ....core.models import EventDelivery
 from ....payment.interface import (
     ListStoredPaymentMethodsRequestData,
     PaymentMethodProcessTokenizationRequestData,
@@ -86,7 +87,7 @@ def test_payment_method_process_tokenization_with_static_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -152,7 +153,7 @@ def test_payment_method_process_tokenization_with_subscription_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -215,7 +216,7 @@ def test_payment_method_process_tokenization_missing_correct_response_from_webho
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
@@ -269,7 +270,7 @@ def test_payment_method_process_tokenization_failure_from_app(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -331,7 +332,7 @@ def test_payment_method_process_tokenization_additional_action_required(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -401,7 +402,7 @@ def test_payment_method_process_tokenization_missing_required_id(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
@@ -520,7 +521,7 @@ def test_expected_result_invalidates_cache_for_app(
     # then
     mocked_request.assert_called()
     assert mocked_request.mock_calls[-1].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mocked_request.mock_calls[-1].args[0]
     assert json.loads(delivery.payload.get_payload()) == {

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -73,7 +73,7 @@ def test_trigger_webhook_sync(mock_request, payment_app):
         WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app.webhooks.first(), False
     )
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
 
 @mock.patch(
@@ -158,7 +158,7 @@ def test_send_webhook_request_sync_successful_attempt(
     # then
     mock_clear_delivery.assert_called_once_with(event_delivery)
     mock_observability.assert_called_once()
-    # TODO (PE-371): Assert EventDeliveryAttempt DB object wasn't created
+    assert not EventDeliveryAttempt.objects.exists()
 
     attempt = mock_observability.mock_calls[0].args[0]
     assert event_delivery.status == EventDeliveryStatus.SUCCESS

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -5,6 +5,7 @@ from unittest.mock import call
 import graphene
 import pytest
 
+from ....core.models import EventDelivery
 from ....graphql.tests.utils import get_graphql_content
 from ....order import OrderStatus
 from ....webhook.const import CACHE_EXCLUDED_SHIPPING_TIME
@@ -681,7 +682,7 @@ def test_trigger_webhook_sync(mock_request, shipping_app):
         WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, webhook, False
     )
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
 
 @mock.patch("saleor.webhook.transport.synchronous.transport.cache.set")

--- a/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
@@ -4,6 +4,7 @@ from unittest import mock
 import graphene
 import pytest
 
+from ....core.models import EventDelivery
 from ....payment.interface import (
     ListStoredPaymentMethodsRequestData,
     StoredPaymentMethodRequestDeleteData,
@@ -80,7 +81,7 @@ def test_stored_payment_method_request_delete_with_static_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(
@@ -137,7 +138,7 @@ def test_stored_payment_method_request_delete_with_subscription_payload(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(
@@ -194,7 +195,7 @@ def test_stored_payment_method_request_delete_failure_from_app(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(
@@ -252,7 +253,7 @@ def test_stored_payment_method_request_delete_missing_response_from_webhook(
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELIVER,
@@ -301,7 +302,7 @@ def test_stored_payment_method_request_delete_incorrect_result_response_from_web
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE,
@@ -350,7 +351,7 @@ def test_stored_payment_method_request_delete_missing_result_in_response_from_we
     # then
     mock_request.assert_called_once()
     assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE,
@@ -446,7 +447,7 @@ def test_stored_payment_method_request_delete_invalidates_cache_for_app(
     # then
     mocked_request.assert_called()
     assert mocked_request.mock_calls[-1].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mocked_request.mock_calls[-1].args[0]
     assert (

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....core import EventDeliveryStatus
+from ....core.models import EventDelivery
 from ....core.taxes import TaxType
 from ....graphql.webhook.utils import get_subscription_query_hash
 from ....webhook.event_types import WebhookEventSyncType
@@ -66,7 +67,7 @@ def test_get_taxes_for_order(
 
     # then
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == generate_order_payload_for_tax_calculation(
@@ -184,7 +185,7 @@ def test_get_taxes_for_order_with_sync_subscription(
 
     # then
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(
@@ -238,7 +239,7 @@ def test_get_taxes_for_checkout_with_sync_subscription(
         app=tax_app,
     )
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(expected_payload)
@@ -293,7 +294,7 @@ def test_get_taxes_for_checkout_with_sync_subscription_with_pregenerated_payload
     # then
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(expected_payload)

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -121,10 +121,8 @@ def _assert_with_static_payload(
 def _assert_fields(payload, webhook, expected_response, response, mock_request):
     webhook_app = webhook.app
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
-
+    assert not EventDelivery.objects.exists()
     delivery = mock_request.mock_calls[0].args[0]
-
     assert json.loads(delivery.payload.get_payload()) == payload
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION

--- a/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
@@ -105,10 +105,8 @@ def _assert_with_static_payload(
 def _assert_fields(payload, webhook, expected_response, response, mock_request):
     webhook_app = webhook.app
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
-
+    assert not EventDelivery.objects.exists()
     delivery = mock_request.mock_calls[0].args[0]
-
     assert json.loads(delivery.payload.get_payload()) == payload
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_PROCESS_SESSION

--- a/saleor/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_webhook.py
@@ -78,7 +78,7 @@ def test_trigger_webhook_sync_with_subscription(
 
     # then
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == expected_payment_payload

--- a/saleor/webhook/tests/test_tax_webhook_tasks.py
+++ b/saleor/webhook/tests/test_tax_webhook_tasks.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from ...core import EventDeliveryStatus
+from ...core.models import EventDelivery
 from ..event_types import WebhookEventSyncType
 from ..models import Webhook, WebhookEvent
 from ..transport.synchronous import trigger_all_webhooks_sync
@@ -55,8 +56,7 @@ def test_trigger_tax_webhook_sync(
 
     # then
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
-
+    assert not EventDelivery.objects.exists()
     delivery = mock_request.mock_calls[0].args[0]
 
     assert delivery.payload.get_payload() == data
@@ -83,8 +83,7 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_first(
     # then
     successful_webhook = tax_checkout_webhooks[0]
     mock_request.assert_called_once()
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
-
+    assert not EventDelivery.objects.exists()
     delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == data
     assert delivery.status == EventDeliveryStatus.PENDING
@@ -109,7 +108,7 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_last(
 
     # then
     assert mock_request.call_count == 3
-    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    assert not EventDelivery.objects.exists()
 
     for call, webhook in zip(mock_request.mock_calls, tax_checkout_webhooks):
         delivery = call.args[0]


### PR DESCRIPTION
I want to merge this change because we want to skip saving EventDelivery and EventPayload objects in case of successful sync webhook delivery to avoid obsolete DB and S3 operations (writing objects to delete them right away)

Tests covering this feature are added in next PR: https://github.com/saleor/saleor/pull/16807

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
