### PR TITLE
Fix failing static payload for variant-stock-updated

### DIFF
--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1681,8 +1681,8 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data_generator = (
-                generate_product_variant_with_stock_payload([stock], self.requestor)
+            product_variant_data_generator = partial(
+                generate_product_variant_with_stock_payload, [stock], self.requestor
             )
             self.trigger_webhooks_async(
                 None,

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -881,6 +881,7 @@ def test_product_variant_out_of_stock(
         legacy_data_generator=ANY,
         allow_replica=False,
     )
+    assert callable(mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"])
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
@@ -911,6 +912,38 @@ def test_product_variant_back_in_stock(
         legacy_data_generator=ANY,
         allow_replica=False,
     )
+    assert callable(mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"])
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
+
+
+@freeze_time("2014-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+def test_product_variant_stock_updated(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    variant_with_many_stocks,
+):
+    variant = variant_with_many_stocks.stocks.first()
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    manager = get_plugins_manager(allow_replica=False)
+    manager.product_variant_stock_updated(variant)
+
+    mocked_webhook_trigger.assert_called_once_with(
+        None,
+        WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED,
+        [any_webhook],
+        variant,
+        None,
+        legacy_data_generator=ANY,
+        allow_replica=False,
+    )
+    assert callable(mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"])
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )


### PR DESCRIPTION
I want to merge this change because right now static payload for product-variant-stock-updated doesn't work. Additionally, we always generate the payload - even if we send events based on subscription queries. 

Port of changes from: #16627

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
