### PR TITLE
fix unhandled none cases with shipping method list and add tests

### DIFF
--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -1172,3 +1172,42 @@ def test_parse_list_shipping_methods_with_metadata(app):
     # then
     assert response[0].metadata == response_data_with_meta[0]["metadata"]
     assert response[0].description == response_data_with_meta[0]["description"]
+
+
+def test_parse_list_shipping_methods_with_metadata_in_incorrect_format(app):
+    # given
+    response_data_with_meta = [
+        {
+            "id": 123,
+            "amount": 10,
+            "currency": "USD",
+            "name": "shipping",
+            "description": "Description",
+            "maximum_delivery_days": 10,
+            "minimum_delivery_days": 2,
+            "metadata": {"field": None},
+        }
+    ]
+    # when
+    response = parse_list_shipping_methods_response(response_data_with_meta, app)
+    # then
+    assert response[0].metadata == {}
+
+
+def test_parse_list_shipping_methods_metadata_absent_in_response(app):
+    # given
+    response_data_with_meta = [
+        {
+            "id": 123,
+            "amount": 10,
+            "currency": "USD",
+            "name": "shipping",
+            "description": "Description",
+            "maximum_delivery_days": 10,
+            "minimum_delivery_days": 2,
+        }
+    ]
+    # when
+    response = parse_list_shipping_methods_response(response_data_with_meta, app)
+    # then
+    assert response[0].metadata == {}

--- a/saleor/webhook/transport/shipping.py
+++ b/saleor/webhook/transport/shipping.py
@@ -74,7 +74,7 @@ def parse_list_shipping_methods_response(
         method_maximum_delivery_days = shipping_method_data.get("maximum_delivery_days")
         method_minimum_delivery_days = shipping_method_data.get("minimum_delivery_days")
         method_description = shipping_method_data.get("description")
-        method_metadata = shipping_method_data.get("metadata")
+        method_metadata = shipping_method_data.get("metadata") or {}
         if method_metadata:
             method_metadata = (
                 method_metadata if method_metadata_is_valid(method_metadata) else {}


### PR DESCRIPTION
I want to merge this change because it fixes unhandled cases of returning `None` in external shipping app `metadata`  payload or no metadata would result in errors when resolving shipping methods metadata. 

⚠️ Important: 
I've tested that if a broken external shipping was already saved into checkout or order it would be saved and resolved properly (with metadata as `[]`  so there is no need to make a migration for those cases. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
