### PR TITLE
Fix `ShippingMethodTranslation.name` API field to allow return nullable values

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4164,7 +4164,7 @@ type ShippingMethodTranslation implements Node @doc(category: "Shipping") {
   language: LanguageDisplay!
 
   """Translated shipping method name."""
-  name: String!
+  name: String
 
   """
   Translated description of the shipping method.

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -895,9 +895,7 @@ class ShippingMethodTranslation(
     id = graphene.GlobalID(
         required=True, description="The ID of the shipping method translation."
     )
-    name = graphene.String(
-        required=True, description="Translated shipping method name."
-    )
+    name = graphene.String(description="Translated shipping method name.")
     description = JSONString(
         description="Translated description of the shipping method." + RICH_CONTENT
     )


### PR DESCRIPTION
The `ShippingMethodTranslation.name` was mistakenly set as `required=True` in #13410.
The change was breaking the the API cause of mutation `shippingPriceTranslate` that allows to provide 
`ShippingMethodTranslation.name` with type `String|None` while we would be force to return type `String`.
Cause of the above we are forced to revert said change even if broading output type (`String` -> `String|None`) can be considered breaking change.

> [!Warning]
> Graphql inspector is expected to fail.

Port of https://github.com/saleor/saleor/pull/16626


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
