### PR TITLE
Fix fetching available collection points

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -5,7 +5,6 @@ from unittest import mock
 import graphene
 import pytest
 from django.core.exceptions import ValidationError
-from django.db.models import Sum
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django_countries.fields import Country
@@ -888,15 +887,27 @@ def test_available_collection_points_for_preorders_and_regular_variants_in_check
     api_client,
     staff_api_client,
     checkout_with_preorders_and_regular_variant,
+    preorder_variant_with_end_date,
     warehouses_for_cc,
 ):
-    expected_collection_points = [{"name": warehouses_for_cc[1].name}]
+    # given
+    warehouse = warehouses_for_cc[1]
+    Stock.objects.create(
+        warehouse=warehouse,
+        product_variant=preorder_variant_with_end_date,
+        quantity=10,
+    )
+    expected_collection_points = [{"name": warehouse.name}]
+
+    # wne
     response = staff_api_client.post_graphql(
         QUERY_GET_ALL_COLLECTION_POINTS_FROM_CHECKOUT,
         variables={
             "id": to_global_id_or_none(checkout_with_preorders_and_regular_variant)
         },
     )
+
+    # then
     response_content = get_graphql_content(response)
     assert (
         expected_collection_points
@@ -980,27 +991,77 @@ def test_checkout_available_collection_points_two_lines_for_same_checkout(
     assert all(c in expected_collection_points for c in received_collection_points)
 
 
-def test_checkout_avail_collect_points_exceeded_quantity_shows_only_all_warehouse(
-    api_client, checkout_with_items_for_cc, stocks_for_cc
+def test_checkout_avail_collect_points_only_all_warehouse_quantity_collected(
+    api_client, checkout_with_item_for_cc, warehouses_for_cc
 ):
+    # given
     query = GET_CHECKOUT_AVAILABLE_COLLECTION_POINTS
-    line = checkout_with_items_for_cc.lines.last()
-    line.quantity = (
-        Stock.objects.filter(product_variant=line.variant)
-        .aggregate(total_quantity=Sum("quantity"))
-        .get("total_quantity")
-        + 1
-    )
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 5
     line.save(update_fields=["quantity"])
-    checkout_with_items_for_cc.refresh_from_db()
 
-    variables = {"id": to_global_id_or_none(checkout_with_items_for_cc)}
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse_1 = warehouses_for_cc[2]
+    local_warehouse_2 = warehouses_for_cc[3]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line.variant, quantity=2
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line.variant, quantity=4
+            ),
+        ]
+    )
+
+    variables = {"id": to_global_id_or_none(checkout_with_item_for_cc)}
+
+    # when
     response = api_client.post_graphql(query, variables)
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["checkout"]
 
     assert data["availableCollectionPoints"] == [
-        {"address": {"streetAddress1": "Tęczowa 7"}, "name": "Warehouse2"}
+        {"address": {"streetAddress1": "Tęczowa 7"}, "name": all_warehouse.name}
+    ]
+
+
+def test_checkout_avail_collect_points_all_warehouse_quantity_from_disabled_warehouse(
+    api_client, checkout_with_item_for_cc, warehouses_for_cc
+):
+    # given
+    query = GET_CHECKOUT_AVAILABLE_COLLECTION_POINTS
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 5
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    disabled_warehouse = warehouses_for_cc[0]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(
+                warehouse=disabled_warehouse, product_variant=line.variant, quantity=10
+            ),
+        ]
+    )
+
+    variables = {"id": to_global_id_or_none(checkout_with_item_for_cc)}
+
+    # when
+    response = api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    assert data["availableCollectionPoints"] == [
+        {"address": {"streetAddress1": "Tęczowa 7"}, "name": all_warehouse.name}
     ]
 
 

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -20,7 +20,7 @@ from .....order.utils import (
 from .....payment import ChargeStatus, TransactionAction
 from .....payment.models import TransactionEvent, TransactionItem
 from .....shipping.models import ShippingMethod, ShippingMethodChannelListing
-from .....warehouse.models import Warehouse
+from .....warehouse.models import Stock, Warehouse
 from ....order.enums import OrderAuthorizeStatusEnum, OrderChargeStatusEnum
 from ....payment.types import PaymentChargeStatusEnum
 from ....tests.utils import (
@@ -493,6 +493,45 @@ def test_order_query_total_price_is_0(
         order_data["paymentStatusDisplay"]
         == dict(ChargeStatus.CHOICES)[payment_charge_status.value]
     )
+
+
+def test_order_avail_collect_points_all_warehouse_quantity_from_disabled_warehouse(
+    staff_api_client,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
+    order_line,
+    warehouses_for_cc,
+):
+    # given
+    order = order_line.order
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
+
+    line = order.lines.first()
+    line.quantity = 5
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    disabled_warehouse = warehouses_for_cc[0]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(
+                warehouse=disabled_warehouse, product_variant=line.variant, quantity=10
+            ),
+        ]
+    )
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    order_line = order_data["lines"][0]
+    assert len(order_data["availableCollectionPoints"]) == 1
+    assert order_data["availableCollectionPoints"][0]["name"] == all_warehouse.name
 
 
 def test_order_query_shows_non_draft_orders(

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1441,6 +1441,7 @@ def order_generator(customer_user, channel_USD):
             private_metadata=private_metadata,
             checkout_token=checkout_token,
             status=status,
+            undiscounted_base_shipping_price_amount=Decimal("0.0"),
         )
         if search_vector_class:
             search_vector = search_vector_class(
@@ -4575,6 +4576,7 @@ def order_line_with_allocation_in_many_stocks(
         user=customer_user,
         channel=channel_USD,
         origin=OrderOrigin.CHECKOUT,
+        undiscounted_base_shipping_price_amount=Decimal("0.0"),
     )
 
     product = variant.product

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -11,7 +11,17 @@ from typing import (
 )
 
 from django.db import models
-from django.db.models import Count, Exists, F, OuterRef, Prefetch, Q, Sum
+from django.db.models import (
+    Count,
+    Exists,
+    F,
+    IntegerField,
+    OuterRef,
+    Prefetch,
+    Q,
+    Sum,
+    Value,
+)
 from django.db.models.expressions import Subquery
 from django.db.models.functions import Coalesce
 from django.db.models.query import QuerySet
@@ -33,9 +43,16 @@ if TYPE_CHECKING:
     class WithAvailableQuantity(TypedDict):
         available_quantity: int
 
+    class WithTotalAvailableQuantity(TypedDict):
+        available_quantity: int
+
     StockWithAvailableQuantity = WithAnnotations["Stock", WithAvailableQuantity]
+    StockWithTotalAvailableQuantity = WithAnnotations[
+        "Stock", WithTotalAvailableQuantity
+    ]
 else:
     StockWithAvailableQuantity = "Stock"
+    StockWithTotalAvailableQuantity = "Stock"
 
 
 class WarehouseQueryset(models.QuerySet["Warehouse"]):
@@ -96,10 +113,26 @@ class WarehouseQueryset(models.QuerySet["Warehouse"]):
             return self._for_channel_click_and_collect(channel_id)
 
         stocks_qs = Stock.objects.filter(
-            product_variant__id__in=lines_qs.values("variant_id"),
-        ).select_related("product_variant")
+            product_variant_id__in=lines_qs.values("variant_id"),
+        )
 
-        return self._for_channel_lines_and_stocks(lines_qs, stocks_qs, channel_id)
+        number_of_variants = (
+            lines_qs.order_by().distinct("variant_id").only("variant_id").count()
+        )
+
+        warehouse_ids_with_stock_available = self._for_channel_lines_and_stocks(
+            number_of_variants, stocks_qs, channel_id
+        ).values("id")
+        lookup = Q(id__in=warehouse_ids_with_stock_available)
+        # if the stocks can cover the all variants, all C&C warehouses with
+        # `ALL_WAREHOUSES` option should be returned, as there is an option
+        # to ship the products to this point from another warehouse
+        stocks_count = len(set(stocks_qs.values_list("product_variant_id", flat=True)))
+        if stocks_count == number_of_variants:
+            lookup |= Q(
+                click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES
+            )
+        return self.for_channel(channel_id).filter(lookup)
 
     def applicable_for_click_and_collect(
         self,
@@ -109,9 +142,15 @@ class WarehouseQueryset(models.QuerySet["Warehouse"]):
         """Return Warehouses which support click and collect.
 
         Note additional check of stocks quantity for given `CheckoutLine`s.
-        For `WarehouseClickAndCollect.LOCAL` all `CheckoutLine`s must be available from
-        a single warehouse.
+
+        For WarehouseClickAndCollect.LOCAL, all CheckoutLine items must be available for
+        collection from a single warehouse.
+        For WarehouseClickAndCollect.ALL, each CheckoutLine item must be available
+        for collection from any warehouse. Variants may be collected from different
+        warehouses, and the quantity of a single variant can be split across multiple
+        warehouses.
         """
+        warehouse_cc_option_enum = WarehouseClickAndCollectOption
         if all(
             line.variant.is_preorder_active() if line.variant else False
             for line in lines_qs.select_related("variant").only("variant_id")
@@ -126,6 +165,7 @@ class WarehouseQueryset(models.QuerySet["Warehouse"]):
             .values("prod_sum")
         )
 
+        # Fetch the stocks that can cover the ordered lines quantities
         stocks_qs = (
             Stock.objects.using(self.db)
             .annotate_available_quantity()
@@ -138,29 +178,67 @@ class WarehouseQueryset(models.QuerySet["Warehouse"]):
             .select_related("product_variant")
         )
 
-        return self._for_channel_lines_and_stocks(lines_qs, stocks_qs, channel_id)
+        number_of_variants = (
+            lines_qs.order_by().distinct("variant_id").only("variant_id").count()
+        )
+        warehouses_for_channel = self.for_channel(channel_id)
+        warehouse_ids_with_stock_available = self._for_channel_lines_and_stocks(
+            number_of_variants, stocks_qs, channel_id
+        ).values("id")
+        # if there is any valid local warehouse it means that it is possible
+        # to ship products to any warehouse with `all warehouses` option
+        if warehouse_ids_with_stock_available.exists():
+            return warehouses_for_channel.filter(
+                Q(id__in=warehouse_ids_with_stock_available)
+                | Q(click_and_collect_option=warehouse_cc_option_enum.ALL_WAREHOUSES)
+            )
+
+        # Check if the ordered line quantities can be fulfilled using stock from
+        # different warehouses.
+        # First, stock is annotated with the `total_available_quantity` variable, which
+        # represents the total available quantity for each variant.
+        # Next, the queryset is annotated with `line_quantity`, indicating whether
+        # the available stock can cover the ordered line quantities.
+        # A positive `line_quantity` value means the order can be fulfilled.
+        stocks_qs = (
+            Stock.objects.using(self.db)
+            .annotate_total_available_quantity_per_variant()
+            .annotate(
+                line_quantity=F("total_available_quantity") - Subquery(lines_quantity)
+            )
+            .filter(
+                product_variant__id__in=lines_qs.values("variant_id"),
+                line_quantity__gte=0,
+            )
+            .values("product_variant_id", "total_available_quantity")
+        )
+        # If the total number of product_variants with available stock is equal to
+        # the number of ordered variants, it means that all ordered variants can be
+        # covered by the stock from different warehouses
+        if stocks_qs.count() == number_of_variants:
+            return self.for_channel(channel_id).filter(
+                click_and_collect_option=warehouse_cc_option_enum.ALL_WAREHOUSES
+            )
+        return self.none()
 
     def _for_channel_lines_and_stocks(
         self,
-        lines_qs: Union[QuerySet[CheckoutLine], QuerySet[OrderLine]],
+        number_of_variants: int,
         stocks_qs: QuerySet["Stock"],
         channel_id: int,
     ) -> QuerySet["Warehouse"]:
         warehouse_cc_option_enum = WarehouseClickAndCollectOption
-
-        number_of_variants = (
-            lines_qs.order_by("variant_id").distinct("variant_id").count()
-        )
-
         return (
             self.for_channel(channel_id)
             .prefetch_related(Prefetch("stock_set", queryset=stocks_qs))
             .filter(stock__in=stocks_qs)
-            .annotate(stock_num=Count("stock__id", distinct=True))
+            .annotate(stock_num=Count("stock__id"))
             .filter(
-                Q(stock_num=number_of_variants)
-                & Q(click_and_collect_option=warehouse_cc_option_enum.LOCAL_STOCK)
-                | Q(click_and_collect_option=warehouse_cc_option_enum.ALL_WAREHOUSES)
+                stock_num__gte=number_of_variants,
+                click_and_collect_option__in=[
+                    warehouse_cc_option_enum.LOCAL_STOCK,
+                    warehouse_cc_option_enum.ALL_WAREHOUSES,
+                ],
             )
         )
 
@@ -242,6 +320,25 @@ class StockQuerySet(models.QuerySet["Stock"]):
                         filter=Q(allocations__quantity_allocated__gt=0),
                     ),
                     0,
+                )
+            ),
+        )
+
+    def annotate_total_available_quantity_per_variant(
+        self,
+    ) -> QuerySet[StockWithTotalAvailableQuantity]:
+        allocation_quantity = (
+            Allocation.objects.filter(stock_id=OuterRef("id"))
+            .values("stock_id")
+            .annotate(total_allocated_quantity=Sum("quantity_allocated"))
+            .values("total_allocated_quantity")
+        )
+        return cast(
+            QuerySet[StockWithAvailableQuantity],
+            self.values("product_variant").annotate(
+                total_available_quantity=Sum(
+                    F("quantity") - Coalesce(Subquery(allocation_quantity), Value(0)),
+                    output_field=IntegerField(),
                 )
             ),
         )

--- a/saleor/warehouse/tests/test_warehouse.py
+++ b/saleor/warehouse/tests/test_warehouse.py
@@ -1,35 +1,65 @@
 import pytest
-from django.db.models import Sum
+from django.db.models import Q, Sum
 
+from ...order.models import OrderLine
 from .. import WarehouseClickAndCollectOption
 from ..models import Stock, Warehouse
 
 
 def test_applicable_for_click_and_collect_finds_warehouse_with_all_and_local(
-    stocks_for_cc, checkout_with_items_for_cc, channel_USD
+    stocks_for_cc, warehouses_for_cc, checkout_with_items_for_cc, channel_USD
 ):
-    expected_number_of_warehouses = 2
+    # given
 
-    lines = checkout_with_items_for_cc.lines.all()
-    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
-    result.get(click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES)
-    warehouse2 = result.get(
-        click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK
+    # all lines in local warehouse are available only in last CC
+    local_warehouse_id = warehouses_for_cc[3].id
+
+    # as there is a local warehouse from which the products can be shipped,
+    # all warehouses with `ALL_WAREHOUSES` option should be returned as well
+    expected_warehouses = Warehouse.objects.filter(
+        Q(click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES)
+        | Q(id=local_warehouse_id)
     )
 
-    assert result.count() == expected_number_of_warehouses
-    assert warehouse2.stock_set.count() == lines.count()
+    lines = checkout_with_items_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert set(result.values_list("id", flat=True)) == set(
+        expected_warehouses.values_list("id", flat=True)
+    )
 
 
-def test_applicable_for_click_and_collect_quantity_exceeded_for_local(
-    stocks_for_cc, checkout_with_items_for_cc, channel_USD
+def test_applicable_for_click_and_collect_warehouse_with_all_not_available_in_channel(
+    stocks_for_cc, warehouses_for_cc, checkout_with_items_for_cc, channel_USD
 ):
-    expected_number_of_warehouses = Warehouse.objects.filter(
-        click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES
-    ).count()
+    # given
+    # all lines in local warehouse are available only in last CC
+    local_warehouse_id = warehouses_for_cc[3].id
+
+    # remove the channel from the warehouse with `ALL_WAREHOUSES` option
+    all_warehouse = warehouses_for_cc[1]
+    all_warehouse.channels.remove(channel_USD)
 
     lines = checkout_with_items_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == local_warehouse_id
+
+
+def test_applicable_for_click_and_collect_quantity_exceeded(
+    stocks_for_cc, checkout_with_items_for_cc, channel_USD
+):
+    # given
+    lines = checkout_with_items_for_cc.lines.all()
     line = lines[2]
+    # line quantity is above the available stock in all warehouses
     quantity_above_available_in_stock = (
         Stock.objects.filter(product_variant=line.variant)
         .aggregate(total_quantity=Sum("quantity"))
@@ -41,7 +71,48 @@ def test_applicable_for_click_and_collect_quantity_exceeded_for_local(
     line.save(update_fields=["quantity"])
     checkout_with_items_for_cc.refresh_from_db()
 
+    # when
     result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert result.count() == 0
+
+
+def test_applicable_for_click_and_collect_quantity_exceeded_for_local(
+    stocks_for_cc, checkout_with_items_for_cc, channel_USD
+):
+    # given
+    expected_number_of_warehouses = Warehouse.objects.filter(
+        click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES
+    ).count()
+
+    lines = checkout_with_items_for_cc.lines.all()
+    line = lines[2]
+    # line quantity is above the available stock in local warehouse
+    quantity_above_local_available_in_stock = (
+        Stock.objects.filter(product_variant=line.variant)
+        .order_by("-quantity")
+        .first()
+        .quantity
+        + 1
+    )
+
+    line.quantity = quantity_above_local_available_in_stock
+    line.save(update_fields=["quantity"])
+
+    # ensure that the line quantity can be collected from different warehouses
+    assert (
+        Stock.objects.filter(product_variant=line.variant)
+        .aggregate(total_quantity=Sum("quantity"))
+        .get("total_quantity")
+    ) > quantity_above_local_available_in_stock
+
+    checkout_with_items_for_cc.refresh_from_db()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
     assert result.count() == expected_number_of_warehouses
     with pytest.raises(Warehouse.DoesNotExist):
         result.get(click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK)
@@ -50,52 +121,58 @@ def test_applicable_for_click_and_collect_quantity_exceeded_for_local(
 def test_applicable_for_click_and_collect_for_one_line_two_local_warehouses(
     stocks_for_cc, checkout_with_item_for_cc, channel_USD
 ):
-    expected_total_number_of_warehouses = Warehouse.objects.exclude(
-        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED
-    ).count()
-    expected_total_number_of_local_warehouses = Warehouse.objects.filter(
-        click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK
-    ).count()
-    expected_total_number_of_all_warehouses = (
-        expected_total_number_of_warehouses - expected_total_number_of_local_warehouses
+    # given
+
+    # line is available in two local warehouses,
+    # so also in warehouse with `ALL_WAREHOUSES` option, as the product can be shipped
+    # from one of the locals
+    warehouse_ids = set(
+        Stock.objects.filter(
+            Q(product_variant=checkout_with_item_for_cc.lines.first().variant)
+            & Q(
+                warehouse__click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK
+            )
+            | Q(
+                warehouse__click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES
+            )
+        ).values_list("warehouse_id", flat=True)
     )
 
     lines = checkout_with_item_for_cc.lines.all()
+
+    # when
     result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
-    assert result.count() == expected_total_number_of_warehouses
-    assert (
-        result.filter(
-            click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK
-        ).count()
-        == expected_total_number_of_local_warehouses
-    )
-    assert (
-        result.filter(
-            click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES
-        ).count()
-        == expected_total_number_of_all_warehouses
-    )
+
+    # then
+    assert result.count() == len(warehouse_ids)
+    assert set(result.values_list("id", flat=True)) == warehouse_ids
 
 
 def test_applicable_for_click_and_collect_does_not_show_warehouses_with_empty_stocks(
     stocks_for_cc, checkout_with_items_for_cc, channel_USD
 ):
-    expected_total_number_of_warehouses = 1
-    reduced_stock_quantity = 0
+    # given
+    line_with_empty_stock = checkout_with_items_for_cc.lines.last()
+
+    stocks = Stock.objects.filter(product_variant=line_with_empty_stock.variant)
+    empty_stock = stocks.filter(
+        warehouse__click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK
+    ).first()
+    empty_stock.quantity = 0
+    empty_stock.save(update_fields=["quantity"])
+
+    warehouse_ids = set(
+        stocks.exclude(id=empty_stock.id).values_list("warehouse_id", flat=True)
+    )
 
     lines = checkout_with_items_for_cc.lines.all()
-    stock = Stock.objects.filter(
-        warehouse__click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK
-    ).last()
-    stock.quantity = reduced_stock_quantity
-    stock.save(update_fields=["quantity"])
 
+    # when
     result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
-    assert result.count() == expected_total_number_of_warehouses
-    assert (
-        result.first().click_and_collect_option
-        == WarehouseClickAndCollectOption.ALL_WAREHOUSES
-    )
+
+    # then
+    assert result.count() == len(warehouse_ids)
+    assert set(result.values_list("id", flat=True)) == warehouse_ids
 
 
 def test_applicable_for_click_and_collect_additional_stock_does_not_change_availbility(
@@ -105,6 +182,7 @@ def test_applicable_for_click_and_collect_additional_stock_does_not_change_avail
     product_variant_list,
     channel_USD,
 ):
+    # given
     expected_total_number_of_stocks = 5
     expected_total_number_of_warehouses = 2
     expected_number_of_checkout_lines = 3
@@ -114,8 +192,10 @@ def test_applicable_for_click_and_collect_additional_stock_does_not_change_avail
     )
     lines = checkout_with_items_for_cc.lines.all()
 
+    # when
     result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
 
+    # then
     assert result.count() == expected_total_number_of_warehouses
     result.get(click_and_collect_option=WarehouseClickAndCollectOption.ALL_WAREHOUSES)
     warehouse = result.get(
@@ -143,9 +223,587 @@ def test_applicable_for_click_and_collect_returns_empty_collection_if_no_channel
 def test_applicable_for_click_and_collect_returns_empty_collection_if_different_channel(
     warehouse_for_cc, checkout_with_items_for_cc, channel_PLN
 ):
+    # given
     lines = checkout_with_items_for_cc.lines.all()
     warehouse_for_cc.shipping_zones.filter(name="Poland").delete()
 
+    # when
     result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_PLN.id)
 
+    # then
     assert not result
+
+
+def test_applicable_for_click_and_collect_stock_only_in_local_all_and_local_returned(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Esnure the `ALL` warehouse is returned when the stock is availble in local one.
+
+    When the stock is available only in local warehouse, but not
+    available in the warehouse with `ALL_WAREHOUSES` option, both warehouses
+    are returned.
+    """
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse = warehouses_for_cc[2]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(warehouse=local_warehouse, product_variant=line.variant, quantity=10),
+        ]
+    )
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 2
+    assert set(result.values_list("id", flat=True)) == {
+        all_warehouse.id,
+        local_warehouse.id,
+    }
+
+
+def test_applicable_for_click_and_collect_stock_only_in_warehouse_with_all_option(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure that only `ALL` warehouse is returned when stock is available only there.
+
+    When the stock is available only in warehouse with `ALL_WAREHOUSES`
+    click and collect option, only this one is returned.
+    """
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse = warehouses_for_cc[2]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=10),
+            Stock(warehouse=local_warehouse, product_variant=line.variant, quantity=0),
+        ]
+    )
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == all_warehouse.id
+
+
+def test_applicable_for_click_and_collect_all_returned_stock_collected_from_local(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure that stocks can be collected from local warehouse to `ALL` warehouse.
+
+    When the stock is not available in warehouse with `ALL_WAREHOUSES`
+    click and collect option, but can be collected from the different warehouses,
+    the warehouse with `ALL_WAREHOUSES` click and collect option is returned.
+    """
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 5
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse_1 = warehouses_for_cc[2]
+    local_warehouse_2 = warehouses_for_cc[3]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line.variant, quantity=2
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line.variant, quantity=4
+            ),
+        ]
+    )
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == all_warehouse.id
+
+
+def test_applicable_for_click_and_collect_stock_from_local_but_not_all_in_channel(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure the warehouse isn't returned when it's not available in the given channel.
+
+    When the stock is not available in warehouse with `ALL_WAREHOUSES`
+    click and collect option, but can be collected from the different warehouses,
+    and the all warehouse is not available in given channel, the warehouse
+    is not returned.
+    """
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 5
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse_1 = warehouses_for_cc[2]
+    local_warehouse_2 = warehouses_for_cc[3]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line.variant, quantity=2
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line.variant, quantity=4
+            ),
+        ]
+    )
+
+    all_warehouse.channels.remove(channel_USD)
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 0
+
+
+def test_applicable_for_click_and_collect_all_returned_stock_from_disabled_warehouse(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure that stocks can be collected from disabled warehouse to `ALL` warehouse.
+
+    When the stock is not available in warehouse with `ALL_WAREHOUSES`
+    click and collect option, but can be collected from the different warehouse
+    with `DISABLED` click and collect option, the warehouse with `ALL_WAREHOUSES`
+    option is returned.
+    """
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+
+    all_warehouse = warehouses_for_cc[1]
+    disabled_warehouse = warehouses_for_cc[0]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(
+                warehouse=disabled_warehouse, product_variant=line.variant, quantity=10
+            ),
+        ]
+    )
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == all_warehouse.id
+
+
+def test_applicable_for_click_and_collect_stock_collected_from_different_warehouses(
+    warehouses_for_cc, checkout_with_items_for_cc, channel_USD
+):
+    """Ensure that stock can be collected from mutliple different warehouses.
+
+    When the all stock is not available in warehouse with
+    `ALL_WAREHOUSES` click and collect option, but can be collected from the
+    different warehouses, the warehouse with `ALL_WAREHOUSES` click and collect
+    option is returned, only when the stock for all products can be collected.
+    """
+    # given
+    line_1, line_2, line_3 = checkout_with_items_for_cc.lines.all()
+    line_1.quantity = 5
+    line_2.quantity = 3
+    line_3.quantity = 7
+    OrderLine.objects.bulk_update([line_1, line_2, line_3], ["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse_1 = warehouses_for_cc[2]
+    local_warehouse_2 = warehouses_for_cc[3]
+    disabled_warehouse = warehouses_for_cc[0]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line_1.variant, quantity=0),
+            Stock(warehouse=all_warehouse, product_variant=line_2.variant, quantity=3),
+            Stock(warehouse=all_warehouse, product_variant=line_3.variant, quantity=0),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line_1.variant, quantity=3
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line_1.variant, quantity=4
+            ),
+            Stock(
+                warehouse=disabled_warehouse, product_variant=line_3.variant, quantity=5
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line_3.variant, quantity=3
+            ),
+        ]
+    )
+
+    lines = checkout_with_items_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == all_warehouse.id
+
+
+def test_applicable_for_click_and_collect_empty_result_when_not_all_products_available(
+    warehouses_for_cc, checkout_with_items_for_cc, channel_USD
+):
+    """Ensure that stocks for all lines must be covered to return the warehouse.
+
+    When there is no enough stock for at least one product, no warehouse
+    is returned.
+    """
+    # given
+    line_1, line_2, line_3 = checkout_with_items_for_cc.lines.all()
+    line_1.quantity = 5
+    line_2.quantity = 3
+    line_3.quantity = 7
+    OrderLine.objects.bulk_update([line_1, line_2, line_3], ["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse_1 = warehouses_for_cc[2]
+    local_warehouse_2 = warehouses_for_cc[3]
+    disabled_warehouse = warehouses_for_cc[0]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line_1.variant, quantity=0),
+            Stock(warehouse=all_warehouse, product_variant=line_2.variant, quantity=0),
+            Stock(warehouse=all_warehouse, product_variant=line_3.variant, quantity=0),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line_1.variant, quantity=3
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line_1.variant, quantity=4
+            ),
+            Stock(
+                warehouse=disabled_warehouse, product_variant=line_3.variant, quantity=5
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line_3.variant, quantity=3
+            ),
+        ]
+    )
+
+    lines = checkout_with_items_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 0
+
+
+def test_applicable_for_click_and_collect_additional_stocks(
+    warehouses_for_cc, checkout_with_items_for_cc, channel_USD, variant
+):
+    """Ensure that stock of another variant will be not taken into account.
+
+    When the warehouse has additional stock for another variant, and the warehouse stock
+    number is equal to the number of variants, the warehouse is not returned.
+    """
+    # given
+    line_1, line_2, line_3 = checkout_with_items_for_cc.lines.all()
+    line_1.quantity = 5
+    line_2.quantity = 3
+    line_3.quantity = 7
+    OrderLine.objects.bulk_update([line_1, line_2, line_3], ["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse_1 = warehouses_for_cc[2]
+    local_warehouse_2 = warehouses_for_cc[3]
+    disabled_warehouse = warehouses_for_cc[0]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line_1.variant, quantity=0),
+            Stock(warehouse=all_warehouse, product_variant=line_2.variant, quantity=3),
+            Stock(warehouse=all_warehouse, product_variant=line_3.variant, quantity=0),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line_1.variant, quantity=3
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line_1.variant, quantity=4
+            ),
+            Stock(
+                warehouse=disabled_warehouse, product_variant=line_3.variant, quantity=5
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line_3.variant, quantity=3
+            ),
+            # stocks for different variant, causes that the number of stocks for
+            # local_warehouse_2 is equal to the number of variants;
+            # should not be taken into consideration, and local_warehouse_2 should
+            # not be returned
+            Stock(warehouse=local_warehouse_2, product_variant=variant, quantity=3),
+        ]
+    )
+
+    lines = checkout_with_items_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_USD.id)
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == all_warehouse.id
+
+
+def test_applicable_for_click_and_collect_no_quantity_check_stock_available(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure that when the stock exists in the warehouse, the warehouse is returned."""
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 10
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse = warehouses_for_cc[2]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line.variant, quantity=0),
+            Stock(warehouse=local_warehouse, product_variant=line.variant, quantity=1),
+        ]
+    )
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect_no_quantity_check(
+        lines, channel_USD.id
+    )
+
+    # then
+    assert len(result) == 2
+    assert set(result.values_list("id", flat=True)) == {
+        all_warehouse.id,
+        local_warehouse.id,
+    }
+
+
+def test_applicable_for_click_and_collect_no_quantity_check_stock_available_in_local(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure that the stock for `ALL` warehouse can be collected from local one.
+
+    When the stock is available in the local warehouse, also
+    the warehouse with `ALL_WAREHOUSES` option is returned.
+    """
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 10
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse = warehouses_for_cc[2]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=local_warehouse, product_variant=line.variant, quantity=1),
+        ]
+    )
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect_no_quantity_check(
+        lines, channel_USD.id
+    )
+
+    # then
+    assert len(result) == 2
+    assert set(result.values_list("id", flat=True)) == {
+        all_warehouse.id,
+        local_warehouse.id,
+    }
+
+
+def test_applicable_for_click_and_collect_no_quantity_check_stock_available_in_disabled(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure that the stock for `ALL` warehouse can be collected from disabled one.
+
+    When the stock is available in the warehouse with `DISABLED`
+    click and collect option, also the warehouse with `ALL_WAREHOUSES`
+    option is returned.
+    """
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 10
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    disabled_warehouse = warehouses_for_cc[0]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(
+                warehouse=disabled_warehouse, product_variant=line.variant, quantity=1
+            ),
+        ]
+    )
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect_no_quantity_check(
+        lines, channel_USD.id
+    )
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == all_warehouse.id
+
+
+def test_applicable_for_click_and_collect_no_quantity_check_no_stocks(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure that when there are no stocks, no warehouse is returned."""
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 10
+    line.save(update_fields=["quantity"])
+
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect_no_quantity_check(
+        lines, channel_USD.id
+    )
+
+    # then
+    assert len(result) == 0
+
+
+def test_applicable_for_click_and_collect_no_quantity_check_one_line_without_stock(
+    warehouses_for_cc, checkout_with_items_for_cc, channel_USD
+):
+    """Ensure that when there are no stocks for all lines, no warehouse is returned."""
+    # given
+    line_1, line_2, line_3 = checkout_with_items_for_cc.lines.all()
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse = warehouses_for_cc[2]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(
+                warehouse=local_warehouse,
+                product_variant=line_1.variant,
+                quantity=0,
+            ),
+            Stock(warehouse=all_warehouse, product_variant=line_2.variant, quantity=0),
+        ]
+    )
+    lines = checkout_with_items_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect_no_quantity_check(
+        lines, channel_USD.id
+    )
+
+    # then
+    assert len(result) == 0
+
+
+def test_applicable_for_click_and_collect_no_quantity_check_no_channels(
+    warehouses_for_cc, checkout_with_item_for_cc, channel_USD
+):
+    """Ensure the warehouse isn't returned when it's not available in the given channel."""
+    # given
+    line = checkout_with_item_for_cc.lines.first()
+    line.quantity = 10
+    line.save(update_fields=["quantity"])
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse = warehouses_for_cc[2]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=local_warehouse, product_variant=line.variant, quantity=1),
+        ]
+    )
+
+    all_warehouse.channels.remove(channel_USD)
+    lines = checkout_with_item_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect_no_quantity_check(
+        lines, channel_USD.id
+    )
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == local_warehouse.id
+
+
+def test_applicable_for_click_and_collect_no_quantity_check_additional_stock(
+    warehouses_for_cc, checkout_with_items_for_cc, channel_USD, variant
+):
+    """Ensure that stock of another variant will be not taken into account.
+
+    When the warehouse has additional stock for another variant, and the warehouse stock
+    number is equal to the number of variants, the warehouse is not returned.
+    """
+    # given
+    line_1, line_2, line_3 = checkout_with_items_for_cc.lines.all()
+
+    all_warehouse = warehouses_for_cc[1]
+    local_warehouse_1 = warehouses_for_cc[2]
+    local_warehouse_2 = warehouses_for_cc[3]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=all_warehouse, product_variant=line_1.variant, quantity=1),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line_1.variant, quantity=1
+            ),
+            Stock(
+                warehouse=local_warehouse_1, product_variant=line_2.variant, quantity=1
+            ),
+            Stock(
+                warehouse=local_warehouse_2, product_variant=line_3.variant, quantity=1
+            ),
+            # stock for different variant, causes that the number of stocks for
+            # local_warehouse_1 is equal to the number of variants;
+            # should not be taken into consideration, and local_warehouse_2 should
+            # not be returned
+            Stock(warehouse=local_warehouse_1, product_variant=variant, quantity=1),
+        ]
+    )
+
+    lines = checkout_with_items_for_cc.lines.all()
+
+    # when
+    result = Warehouse.objects.applicable_for_click_and_collect_no_quantity_check(
+        lines, channel_USD.id
+    )
+
+    # then
+    assert len(result) == 1
+    assert result.first().id == all_warehouse.id


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/16624

Fix fetching available collection points for warehouses with `ALL` option.
For such warehouses, the stock can be collected from any warehouses, but there must be enough stocks in other warehouses to cover the whole order.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
