### PR TITLE
Add `TaxableObjectDiscountType` to inform tax apps how to distribute discounts.

### DIFF
--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -27,6 +27,7 @@ from ..utils import (
     increase_voucher_code_usage_value,
     is_order_level_voucher,
     remove_voucher_usage_by_customer,
+    split_manual_discount,
     validate_voucher,
 )
 
@@ -670,3 +671,55 @@ def test_get_the_cheapest_line(checkout_with_items, channel_USD):
     line_info = _get_the_cheapest_line(lines)
     # then
     assert line_info == lines[0]
+
+
+@pytest.mark.parametrize(
+    (
+        "value",
+        "value_type",
+        "subtotal",
+        "shipping_price",
+        "subtotal_portion",
+        "shipping_portion",
+    ),
+    [
+        (20, DiscountValueType.FIXED, 30, 10, 15, 5),
+        (100, DiscountValueType.FIXED, 30, 10, 30, 10),
+        (13.77, DiscountValueType.FIXED, 30, 10, Decimal("10.33"), Decimal("3.44")),
+        (0, DiscountValueType.FIXED, 30, 10, 0, 0),
+        (20, DiscountValueType.FIXED, 0, 10, 0, 10),
+        (50, DiscountValueType.FIXED, 30, 0, 30, 0),
+        (50, DiscountValueType.FIXED, 0, 0, 0, 0),
+        (0, DiscountValueType.PERCENTAGE, 30, 10, 0, 0),
+        (50, DiscountValueType.PERCENTAGE, 30, 10, 15, 5),
+        (33.33, DiscountValueType.PERCENTAGE, 30, 10, 10, Decimal("3.33")),
+        (100, DiscountValueType.PERCENTAGE, 30, 10, 30, 10),
+        (50, DiscountValueType.PERCENTAGE, 0, 10, 0, 5),
+        (50, DiscountValueType.PERCENTAGE, 30, 0, 15, 0),
+        (50, DiscountValueType.PERCENTAGE, 0, 0, 0, 0),
+    ],
+)
+def test_split_manual_discount(
+    value,
+    value_type,
+    subtotal,
+    shipping_price,
+    subtotal_portion,
+    shipping_portion,
+    draft_order_with_fixed_discount_order,
+):
+    # given
+    subtotal = Money(subtotal, currency="USD")
+    shipping = Money(shipping_price, currency="USD")
+    discount = draft_order_with_fixed_discount_order.discounts.first()
+    discount.value = value
+    discount.value_type = value_type
+
+    # when
+    subtotal_discount, shipping_discount = split_manual_discount(
+        discount, subtotal, shipping
+    )
+
+    # then
+    assert subtotal_discount == Money(subtotal_portion, "USD")
+    assert shipping_discount == Money(shipping_portion, "USD")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -36110,6 +36110,19 @@ type TaxableObjectDiscount @doc(category: "Taxes") {
 
   """The amount of the discount."""
   amount: Money!
+
+  """
+  Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
+  """
+  type: TaxableObjectDiscountTypeEnum!
+}
+
+"""
+Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
+"""
+enum TaxableObjectDiscountTypeEnum @doc(category: "Taxes") {
+  SUBTOTAL
+  SHIPPING
 }
 
 type TaxableObjectLine @doc(category: "Taxes") {

--- a/saleor/graphql/tax/enums.py
+++ b/saleor/graphql/tax/enums.py
@@ -1,4 +1,9 @@
-from ...tax import TaxCalculationStrategy as InternalTaxCalculationStrategy
+from ...tax import (
+    TaxableObjectDiscountType,
+)
+from ...tax import (
+    TaxCalculationStrategy as InternalTaxCalculationStrategy,
+)
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.enums import to_enum
 
@@ -17,3 +22,10 @@ TaxCalculationStrategy = to_enum(
     type_name="TaxCalculationStrategy",
 )
 TaxCalculationStrategy.doc_category = DOC_CATEGORY_TAXES
+
+
+TaxableObjectDiscountTypeEnum = to_enum(
+    TaxableObjectDiscountType,
+    description="Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.",
+)
+TaxableObjectDiscountTypeEnum.doc_category = DOC_CATEGORY_TAXES

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -16,6 +16,7 @@ from .....order.calculations import fetch_order_prices_if_expired
 from .....order.models import Order
 from .....order.utils import update_discount_for_order_line
 from .....plugins.manager import get_plugins_manager
+from .....tax import TaxableObjectDiscountType
 from .....tests.fixtures import recalculate_order
 from .....webhook.event_types import WebhookEventSyncType
 from .....webhook.models import Webhook
@@ -45,6 +46,7 @@ subscription {
           amount {
             amount
           }
+          type
         }
 
         lines {
@@ -159,6 +161,7 @@ def test_checkout_calculate_taxes_with_free_shipping_voucher(
     checkout_with_voucher_free_shipping,
     webhook_app,
     permission_handle_taxes,
+    checkout_with_shipping_address,
 ):
     # given
     checkout = checkout_with_voucher_free_shipping
@@ -232,8 +235,16 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
     checkout_with_voucher,
     webhook_app,
     permission_handle_taxes,
+    address,
+    shipping_method,
 ):
     # given
+    checkout = checkout_with_voucher
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
     webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
@@ -246,16 +257,18 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
 
     # when
     deliveries = create_delivery_for_subscription_sync_event(
-        event_type, checkout_with_voucher, webhook
+        event_type, checkout, webhook
     )
 
     # then
     assert json.loads(deliveries.payload.payload) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
-            "address": None,
+            "address": {"id": to_global_id_or_none(address)},
             "currency": "USD",
-            "discounts": [{"amount": {"amount": 20.0}}],
+            "discounts": [
+                {"amount": {"amount": 20.0}, "type": TaxableObjectDiscountType.SUBTOTAL}
+            ],
             "channel": {"id": to_global_id_or_none(checkout_with_voucher.channel)},
             "lines": [
                 {
@@ -264,7 +277,7 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
                     "productSku": "123",
                     "quantity": 3,
                     "sourceLine": {
-                        "id": to_global_id_or_none(checkout_with_voucher.lines.first()),
+                        "id": to_global_id_or_none(checkout.lines.first()),
                         "__typename": "CheckoutLine",
                     },
                     "totalPrice": {"amount": 30.0},
@@ -273,9 +286,9 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
                 }
             ],
             "pricesEnteredWithTax": True,
-            "shippingPrice": {"amount": 0.0},
+            "shippingPrice": {"amount": 10.0},
             "sourceObject": {
-                "id": to_global_id_or_none(checkout_with_voucher),
+                "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
             },
         },
@@ -342,13 +355,20 @@ def test_checkout_calculate_taxes_with_entire_order_voucher_once_per_order(
 
 @freeze_time("2020-03-18 12:00:00")
 def test_checkout_calculate_taxes_with_shipping_voucher(
-    checkout_with_voucher,
-    voucher,
+    checkout_with_item,
+    voucher_free_shipping,
     webhook_app,
     permission_handle_taxes,
+    address,
+    shipping_method,
 ):
     # given
-    voucher.type = VoucherType.SHIPPING
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.voucher_code = voucher_free_shipping.codes.first()
+
     webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
@@ -361,17 +381,17 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
 
     # when
     deliveries = create_delivery_for_subscription_sync_event(
-        event_type, checkout_with_voucher, webhook
+        event_type, checkout, webhook
     )
 
     # then
     assert json.loads(deliveries.payload.payload) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
-            "address": None,
+            "address": {"id": to_global_id_or_none(address)},
             "currency": "USD",
-            "discounts": [{"amount": {"amount": 20.0}}],
-            "channel": {"id": to_global_id_or_none(checkout_with_voucher.channel)},
+            "discounts": [],
+            "channel": {"id": to_global_id_or_none(checkout.channel)},
             "lines": [
                 {
                     "chargeTaxes": True,
@@ -379,7 +399,7 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
                     "productSku": "123",
                     "quantity": 3,
                     "sourceLine": {
-                        "id": to_global_id_or_none(checkout_with_voucher.lines.first()),
+                        "id": to_global_id_or_none(checkout.lines.first()),
                         "__typename": "CheckoutLine",
                     },
                     "totalPrice": {"amount": 30.0},
@@ -390,7 +410,7 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
             "pricesEnteredWithTax": True,
             "shippingPrice": {"amount": 0.0},
             "sourceObject": {
-                "id": to_global_id_or_none(checkout_with_voucher),
+                "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
             },
         },
@@ -432,7 +452,12 @@ def test_checkout_calculate_taxes_with_order_promotion(
         "taxBase": {
             "address": None,
             "currency": "USD",
-            "discounts": [{"amount": {"amount": float(discount_amount)}}],
+            "discounts": [
+                {
+                    "amount": {"amount": float(discount_amount)},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                }
+            ],
             "channel": {"id": channel_id},
             "lines": [
                 {
@@ -722,7 +747,12 @@ def test_draft_order_calculate_taxes_entire_order_voucher(
         "taxBase": {
             "address": {"id": to_global_id_or_none(order.shipping_address)},
             "currency": "USD",
-            "discounts": [{"amount": {"amount": float(discount_amount)}}],
+            "discounts": [
+                {
+                    "amount": {"amount": float(discount_amount)},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                }
+            ],
             "channel": {"id": to_global_id_or_none(order.channel)},
             "lines": [
                 {
@@ -983,6 +1013,8 @@ def test_order_calculate_taxes_with_manual_discount(
 ):
     # given
     order = order_line.order
+    currency = order.currency
+
     order.total = order_line.total_price + order.shipping_price
     order.undiscounted_total = order.total
     order.save()
@@ -997,12 +1029,25 @@ def test_order_calculate_taxes_with_manual_discount(
         reason="Discount reason",
         amount=(order.undiscounted_total - order.total).gross,
     )
+
+    shipping_price = Money(Decimal("10"), currency)
+    order.base_shipping_price = shipping_price
+    order.shipping_price_net = shipping_price
+    order.shipping_price_gross = shipping_price
+
     recalculate_order(order)
     order.refresh_from_db()
 
     webhook = subscription_calculate_taxes_for_order
     webhook.subscription_query = TAXES_SUBSCRIPTION_QUERY
     webhook.save(update_fields=["subscription_query"])
+
+    # Manual discount applies both to subtotal and shipping. For tax calculation it
+    # requires to be split into subtotal and shipping portion.
+    subtotal = order.subtotal.net
+    total = subtotal + shipping_price
+    manual_discount_subtotal_portion = subtotal / total * value
+    manual_discount_shipping_portion = value - manual_discount_subtotal_portion
 
     # when
     deliveries = create_delivery_for_subscription_sync_event(
@@ -1015,7 +1060,16 @@ def test_order_calculate_taxes_with_manual_discount(
         "taxBase": {
             "address": {"id": to_global_id_or_none(order.shipping_address)},
             "currency": "USD",
-            "discounts": [{"amount": {"amount": 20.0}}],
+            "discounts": [
+                {
+                    "amount": {"amount": float(manual_discount_subtotal_portion)},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                },
+                {
+                    "amount": {"amount": float(manual_discount_shipping_portion)},
+                    "type": TaxableObjectDiscountType.SHIPPING,
+                },
+            ],
             "channel": {"id": to_global_id_or_none(order.channel)},
             "lines": [
                 {
@@ -1033,7 +1087,7 @@ def test_order_calculate_taxes_with_manual_discount(
                 }
             ],
             "pricesEnteredWithTax": True,
-            "shippingPrice": {"amount": 0.0},
+            "shippingPrice": {"amount": float(shipping_price.amount)},
             "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
         },
     }
@@ -1110,7 +1164,12 @@ def test_order_calculate_taxes_order_promotion(
         "taxBase": {
             "address": {"id": to_global_id_or_none(order.shipping_address)},
             "currency": "USD",
-            "discounts": [{"amount": {"amount": float(discount_amount)}}],
+            "discounts": [
+                {
+                    "amount": {"amount": float(discount_amount)},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                }
+            ],
             "channel": {"id": to_global_id_or_none(order.channel)},
             "lines": [
                 {

--- a/saleor/tax/__init__.py
+++ b/saleor/tax/__init__.py
@@ -3,3 +3,10 @@ class TaxCalculationStrategy:
     TAX_APP = "TAX_APP"
 
     CHOICES = [(FLAT_RATES, "Flat rates"), (TAX_APP, "Tax app")]
+
+
+class TaxableObjectDiscountType:
+    SUBTOTAL = "SUBTOTAL"
+    SHIPPING = "SHIPPING"
+
+    CHOICES = [(SUBTOTAL, "Subtotal"), (SHIPPING, "Shipping")]


### PR DESCRIPTION
I want to merge this change because the Avatax app does not have enough information on how to distribute order-level discounts over the lines, resulting in incorrect tax calculations.

RFC: https://github.com/saleor/saleor/issues/16613
Internal issue: https://linear.app/saleor/issue/SHOPX-1145/enrich-avatax-payload-with-info-how-to-distribute-order-level-discount
Port: https://github.com/saleor/saleor/pull/16630

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
