### PR TITLE
Fix logging error objects

### DIFF
--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -213,7 +213,9 @@ def create_order(payment, checkout, manager):
         )
     except ValidationError as e:
         logger.info(
-            "Failed to create order from checkout %s.", checkout.pk, extra={"error": e}
+            "Failed to create order from checkout %s.",
+            checkout.pk,
+            extra={"error": str(e)},
         )
         return None
     # Refresh the payment to assign the newly created order
@@ -292,7 +294,9 @@ def handle_authorization(notification: dict[str, Any], gateway_config: GatewayCo
             amount.get("value"), amount.get("currency")
         )
     except TypeError as e:
-        logger.exception("Cannot convert amount from minor unit", extra={"error": e})
+        logger.exception(
+            "Cannot convert amount from minor unit", extra={"error": str(e)}
+        )
         return
 
     if notification_payment_amount < payment.total:
@@ -856,7 +860,7 @@ def handle_order_closed(notification: dict[str, Any], gateway_config: GatewayCon
             get_plugins_manager(allow_replica=False),
         )
     except Exception as e:
-        logger.exception("Exception during order creation", extra={"error": e})
+        logger.exception("Exception during order creation", extra={"error": str(e)})
         return
     finally:
         if not order and adyen_partial_payments:

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -72,12 +72,12 @@ def handle_webhook(
     except ValueError as e:
         # Invalid payload
         logger.warning(
-            "Received invalid payload for Stripe webhook", extra={"error": e}
+            "Received invalid payload for Stripe webhook", extra={"error": str(e)}
         )
         return HttpResponse(status=400)
     except SignatureVerificationError as e:
         # Invalid signature
-        logger.warning("Invalid signature for Stripe webhook", extra={"error": e})
+        logger.warning("Invalid signature for Stripe webhook", extra={"error": str(e)})
         return HttpResponse(status=400)
 
     webhook_handlers = {
@@ -218,7 +218,9 @@ def _finalize_checkout(
             app=None,
         )
     except ValidationError as e:
-        logger.info("Failed to complete checkout %s.", checkout.pk, extra={"error": e})
+        logger.info(
+            "Failed to complete checkout %s.", checkout.pk, extra={"error": str(e)}
+        )
         return None
 
 

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -132,19 +132,19 @@ def get_user_info(user_info_url, access_token) -> Optional[dict]:
     except requests.exceptions.HTTPError as e:
         logger.warning(
             "Fetching OIDC user info failed. HTTP error occurred",
-            extra={"user_info_url": user_info_url, "error": e},
+            extra={"user_info_url": user_info_url, "error": str(e)},
         )
         return None
     except requests.exceptions.RequestException as e:
         logger.warning(
             "Fetching OIDC user info failed",
-            extra={"user_info_url": user_info_url, "error": e},
+            extra={"user_info_url": user_info_url, "error": str(e)},
         )
         return None
     except json.JSONDecodeError as e:
         logger.warning(
             "Invalid OIDC user info response",
-            extra={"user_info_url": user_info_url, "error": e},
+            extra={"user_info_url": user_info_url, "error": str(e)},
         )
         return None
 
@@ -154,7 +154,8 @@ def decode_access_token(token, jwks_url):
         return get_decoded_token(token, jwks_url)
     except (JoseError, ValueError) as e:
         logger.info(
-            "Invalid OIDC access token format", extra={"error": e, "jwks_url": jwks_url}
+            "Invalid OIDC access token format",
+            extra={"error": str(e), "jwks_url": jwks_url},
         )
         return None
 
@@ -173,7 +174,7 @@ def get_user_from_oauth_access_token_in_jwt_format(
     except (JoseError, ValueError) as e:
         logger.info(
             "OIDC access token validation failed",
-            extra={"error": e, "user_info_url": user_info_url},
+            extra={"error": str(e), "user_info_url": user_info_url},
         )
         return None
 
@@ -196,7 +197,7 @@ def get_user_from_oauth_access_token_in_jwt_format(
             last_login=token_payload.get("iat"),
         )
     except AuthenticationError as e:
-        logger.info("Unable to create a user object", extra={"error": e})
+        logger.info("Unable to create a user object", extra={"error": str(e)})
         return None
 
     scope = token_payload.get("scope")

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -97,7 +97,7 @@ def put_event(generate_payload: Callable[[], bytes]):
             if get_buffer(get_buffer_name()).put_event(payload):
                 logger.warning("Observability buffer full, event dropped.")
     except TruncationError as err:
-        logger.warning("Observability event dropped. %s", err, extra=err.extra)
+        logger.warning("Observability event dropped. %s", str(err), extra=err.extra)
     except Exception:
         logger.error("Observability event dropped.", exc_info=True)
 


### PR DESCRIPTION
I want to merge this change because it stringifies error objects before logging them, which can prevent potential memory leaks.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
