### PR TITLE
Release 3.20.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.26",
+  "version": "3.20.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.26",
+      "version": "3.20.27",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.26",
+  "version": "3.20.27",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.26"
+version = "3.20.27"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.26"
+__version__ = "3.20.27"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Add `TaxableObjectDiscountType` to inform how to distribute discounts (#16655) (6593e6caa0)
* Test checkout complete with overridden prices (#16657) (8607bd57d3)
* Fix fetching available collection points (#16624) (ec8cf69c95)
* Use last-login threshold in external mutations (#16652) (396c11b1f0)