### PR TITLE
Fix release tool to trigger publishing containers

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -12,7 +12,9 @@ jobs:
       GH_REF: ${{ github.event.pull_request.head.ref }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - run: echo "PR_TAG_REF=$GH_REF" | sed "s/release-//" >> $GITHUB_ENV
+      - name: Prepare release tag version
+        id: prepare-tag
+        run: echo "PR_TAG_REF=$GH_REF" | sed "s/release-//" >> $GITHUB_OUTPUT
       - name: Create tag
         uses: actions/github-script@v5
         with:
@@ -20,8 +22,21 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: `refs/tags/${process.env.PR_TAG_REF}`,
+              ref: "refs/tags/${{ steps.prepare-tag.outputs.PR_TAG_REF }}",
               sha: context.sha
             })
-      - run: |
-          gh release create "$PR_TAG_REF" --repo="$GITHUB_REPOSITORY" --generate-notes --draft --verify-tag
+      - name: Create github release
+        run: |
+          gh release create "${{ steps.prepare-tag.outputs.PR_TAG_REF }}" --repo="$GITHUB_REPOSITORY" --generate-notes --draft --verify-tag
+    outputs:
+      version: ${{ steps.prepare-tag.outputs.PR_TAG_REF }}
+
+  publish:
+    needs:
+      - run-release-trigger
+    uses: ./.github/workflows/publish-containers.yml
+    with:
+      version: ${{ needs.run-release-trigger.outputs.version }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLOUD_CI_WEBHOOK_URL }}
+      SLACK_MENTION_GROUP_ID: ${{ secrets.SLACK_CORE_SUPPORT_GROUP_ID }}

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,13 +1,23 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      # Matches stable and pre-releases
-      - "[0-9]+.[0-9]+.[0-9]+*"
-    branches:
-      - main
-      - ci/**
+  workflow_call:
+    inputs:
+      prefix:
+        description: Optional image prefix for branch build
+        required: false
+        type: string
+      version:
+        description: Optional custom image version tag
+        required: false
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+      SLACK_MENTION_GROUP_ID:
+    outputs:
+      version:
+        description: Docker image version
+        value: ${{ jobs.docker.outputs.version }}
 
 jobs:
   docker:
@@ -16,6 +26,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Checkout
@@ -36,9 +49,10 @@ jobs:
           images: |
             ghcr.io/${{ steps.image.outputs.image_name }}
           tags: |
-            type=ref,event=branch,prefix=unstable-
+            type=ref,event=branch,prefix=${{ inputs.prefix }}
             type=pep440,pattern={{version}}
             type=pep440,pattern={{major}}.{{minor}}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != null }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -66,7 +80,7 @@ jobs:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Image digest
@@ -75,21 +89,12 @@ jobs:
             Digest: ${{ steps.docker_build.outputs.digest }}
             Tags: ${{ steps.meta.outputs.tags }}"
 
-      - name: Trigger staging deployment for tagged release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          curl -f -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.SALEOR_RELEASE_TOKEN }}" \
-            https://api.github.com/repos/saleor/saleor-multitenant/dispatches \
-            -d "{\"event_type\":\"deploy-staging\",\"client_payload\":{\"version\":\"${{ steps.meta.outputs.version }}\"}}"
-
       - name: Notify Slack
         if: ${{ failure() }}
         env:
           JOB_STATUS: ${{ job.status }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLOUD_CI_WEBHOOK_URL }}
-          SLACK_MENTION_GROUP_ID: ${{ secrets.SLACK_CORE_SUPPORT_GROUP_ID }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_MENTION_GROUP_ID: ${{ secrets.SLACK_MENTION_GROUP_ID }}
           JOB_TITLE: "Build of Saleor Core ${{ steps.meta.outputs.version }}"
         run: |
           python3 ./.github/workflows/notify/notify-slack.py

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,0 +1,16 @@
+name: Publish main
+
+on:
+  push:
+    branches:
+      - main
+      - ci/**
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-containers.yml
+    with:
+      prefix: unstable-
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLOUD_CI_WEBHOOK_URL }}
+      SLACK_MENTION_GROUP_ID: ${{ secrets.SLACK_CORE_SUPPORT_GROUP_ID }}


### PR DESCRIPTION
I want to merge this change because it fixes new release tool workflow not triggering image build

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
