### PR TITLE
Bump `memray` package from `1.13.0` to `1.13.4`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2665,7 +2665,7 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "memray"
-version = "1.13.0"
+version = "1.13.4"
 description = "A memory profiler for Python applications"
 optional = false
 python-versions = ">=3.7.0"


### PR DESCRIPTION
I want to merge this change because it bumps `memray` package from `1.13.0` to `1.13.4`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
