### PR TITLE
Add resource names to common operations

### DIFF
--- a/saleor/graphql/core/dataloaders.py
+++ b/saleor/graphql/core/dataloaders.py
@@ -44,10 +44,10 @@ class DataLoader(BaseLoader, Generic[K, R]):
         self, keys: Iterable[K]
     ) -> Promise[list[R]]:
         with opentracing.global_tracer().start_active_span(
-            self.__class__.__name__
+            "dataloader.batch_load"
         ) as scope:
             span = scope.span
-            span.set_tag(opentracing.tags.COMPONENT, "dataloaders")
+            span.set_tag("resource.name", self.__class__.__name__)
 
             with allow_writer_in_context(self.context):
                 results = self.batch_load(keys)

--- a/saleor/graphql/core/tracing.py
+++ b/saleor/graphql/core/tracing.py
@@ -9,9 +9,9 @@ def traced_resolver(func):
     def wrapper(*args, **kwargs):
         info = next(arg for arg in args if isinstance(arg, ResolveInfo))
         operation = f"{info.parent_type.name}.{info.field_name}"
-        with opentracing.global_tracer().start_active_span(operation) as scope:
+        with opentracing.global_tracer().start_active_span("graphql.resolve") as scope:
             span = scope.span
-            span.set_tag(opentracing.tags.COMPONENT, "graphql")
+            span.set_tag("resource.name", operation)
             span.set_tag("graphql.parent_type", info.parent_type.name)
             span.set_tag("graphql.field_name", info.field_name)
             return func(*args, **kwargs)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -161,6 +161,7 @@ class GraphQLView(View):
         # Add `child_of=span_ontext` to `start_active_span`
         with tracer.start_active_span("http") as scope:
             span = scope.span
+            span.set_tag("resource.name", request.path)
             span.set_tag(opentracing.tags.COMPONENT, "http")
             span.set_tag(opentracing.tags.HTTP_METHOD, request.method)
             span.set_tag(
@@ -277,6 +278,7 @@ class GraphQLView(View):
             _query_identifier = query_identifier(document)
             self._query = _query_identifier
             raw_query_string = document.document_string
+            span.set_tag("resource.name", raw_query_string)
             span.set_tag("graphql.query", raw_query_string)
             span.set_tag("graphql.query_identifier", _query_identifier)
             span.set_tag("graphql.query_fingerprint", query_fingerprint(document))


### PR DESCRIPTION
This way, we can get a better first glance in the APM.

This is a port of #16670 

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
