### PR TITLE
Trigger workflow staging build in new release flow

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -48,14 +48,12 @@ jobs:
     steps:
       - name: Trigger staging deployment for tagged release
         run: |
-          set -x
-
-          export GITHUB_TOKEN=$( \
+          GITHUB_TOKEN=$( \
             curl --request GET --url ${{ secrets.VAULT_URL}} --header "Authorization: JWT ${{ secrets.VAULT_JWT }}" | jq -r .token \
           )
 
           curl -f -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
             https://api.github.com/repos/saleor/saleor-multitenant/dispatches \
             -d "{\"event_type\":\"deploy-staging\",\"client_payload\":{\"version\":\"${{ needs.publish.outputs.version }}\"}}"

--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -40,3 +40,22 @@ jobs:
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLOUD_CI_WEBHOOK_URL }}
       SLACK_MENTION_GROUP_ID: ${{ secrets.SLACK_CORE_SUPPORT_GROUP_ID }}
+
+  deploy:
+    runs-on: ubuntu-20.04
+    needs:
+      - publish
+    steps:
+      - name: Trigger staging deployment for tagged release
+        run: |
+          set -x
+
+          export GITHUB_TOKEN=$( \
+            curl --request GET --url ${{ secrets.VAULT_URL}} --header "Authorization: JWT ${{ secrets.VAULT_JWT }}" | jq -r .token \
+          )
+
+          curl -f -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/saleor/saleor-multitenant/dispatches \
+            -d "{\"event_type\":\"deploy-staging\",\"client_payload\":{\"version\":\"${{ needs.publish.outputs.version }}\"}}"


### PR DESCRIPTION
I want to merge this change because it trigers staging build on release tag creation

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
