### PR TITLE
Only allow Int and Float literals to be passed to the Decimal scalar

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -22,10 +22,11 @@ class Decimal(graphene.Float):
 
     @staticmethod
     def parse_literal(node):
-        try:
-            return decimal.Decimal(node.value)
-        except decimal.DecimalException:
-            return None
+        if isinstance(node, (ast.FloatValue, ast.IntValue)):
+            try:
+                return decimal.Decimal(node.value)
+            except decimal.DecimalException:
+                return None
 
     @staticmethod
     def parse_value(value):

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -1,6 +1,8 @@
+import decimal
 from unittest import mock
 
 import pytest
+from graphql.language.ast import FloatValue, IntValue, ObjectValue, StringValue
 
 from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
@@ -431,4 +433,28 @@ def test_decimal_scalar_invalid_value(invalid_value):
 @pytest.mark.parametrize("invalid_value", ["NaN", "-Infinity", "1e-9999999", "-1"])
 def test_positive_decimal_scalar_invalid_value(invalid_value):
     result = PositiveDecimal.parse_value(invalid_value)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "valid_node",
+    [
+        FloatValue(value="1.0"),
+        IntValue(value="1"),
+    ],
+)
+def test_decimal_scalar_valid_literal(valid_node):
+    result = Decimal.parse_literal(valid_node)
+    assert result == decimal.Decimal(1)
+
+
+@pytest.mark.parametrize(
+    "invalid_node",
+    [
+        StringValue(value="1.0"),
+        ObjectValue(fields=[]),
+    ],
+)
+def test_decimal_scalar_invalid_literal(invalid_node):
+    result = Decimal.parse_literal(invalid_node)
     assert result is None


### PR DESCRIPTION
Saleor did not check what type of AST nodes were passed to Decimal.parse_literal, which meant you could pass all types of literals. Some, like Strings, had a chance of working despite being undocumented. Others, like Objects, would crash Saleor.

⚠️  This change is technically unsafe to backport as-is because it disallows String literals from being passed as Decimal scalars despite them never being officially supported as such.

Examples:

```graphql
mutation {
  example(
    amount1: 10 # ok
    amount2: 10.0 # ok
    amount3: "10.0" # used to work, now disallowed
    amount4: { foo: "bar" } # used to crash, now disallowed
  ) { __typename }
}
```

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
