### PR TITLE
Fix restoring voucher usage limit when the voucher is removed from draft order

### DIFF
--- a/saleor/graphql/discount/mutations/voucher/voucher_update.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_update.py
@@ -92,9 +92,15 @@ class VoucherUpdate(VoucherCreate):
     def is_voucher_used(cls, instance) -> bool:
         voucher_codes = instance.codes.all()
         used_codes = voucher_codes.filter(
-            Exists(order_models.Order.objects.filter(voucher_code=OuterRef("code")))
+            Exists(
+                order_models.Order.objects.filter(
+                    voucher_code=OuterRef("code"), voucher_id=OuterRef("voucher_id")
+                )
+            )
             | Exists(
-                order_models.OrderLine.objects.filter(voucher_code=OuterRef("code"))
+                order_models.OrderLine.objects.filter(
+                    voucher_code=OuterRef("code"),
+                )
             )
             | Exists(
                 checkout_models.Checkout.objects.filter(voucher_code=OuterRef("code"))

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -14,6 +14,7 @@ from ....discount.utils.voucher import (
     get_active_voucher_code,
     get_voucher_code_instance,
     increase_voucher_usage,
+    release_voucher_code_usage,
 )
 from ....order import OrderOrigin, OrderStatus, events, models
 from ....order.actions import call_order_event
@@ -528,6 +529,8 @@ class DraftOrderCreate(
         is_new_instance,
         app,
         manager,
+        old_voucher=None,
+        old_voucher_code=None,
     ):
         updated_fields = []
         with traced_atomic_transaction():
@@ -568,11 +571,17 @@ class DraftOrderCreate(
                 )
                 updated_fields.append("undiscounted_base_shipping_price_amount")
 
+            if "voucher" in cleaned_input:
+                cls.handle_order_voucher(
+                    cleaned_input,
+                    instance,
+                    is_new_instance,
+                    old_voucher,
+                    old_voucher_code,
+                )
+
             # Save any changes create/update the draft
             cls._commit_changes(info, instance, cleaned_input, is_new_instance, app)
-
-            if voucher := cleaned_input.get("voucher"):
-                cls.handle_order_voucher(cleaned_input, instance, voucher)
 
             update_order_display_gross_prices(instance)
 
@@ -606,13 +615,23 @@ class DraftOrderCreate(
                 )
 
     @classmethod
-    def handle_order_voucher(cls, cleaned_input, instance, voucher):
-        code_instance = cleaned_input.pop("voucher_code_instance", None)
+    def handle_order_voucher(
+        cls, cleaned_input, instance, is_new_instance, old_voucher, old_voucher_code
+    ):
+        user_email = instance.user_email or instance.user and instance.user.email
         channel = instance.channel
-        if channel.include_draft_order_in_voucher_usage:
+        if not channel.include_draft_order_in_voucher_usage:
+            return
+
+        if voucher := cleaned_input["voucher"]:
+            code_instance = cleaned_input.pop("voucher_code_instance", None)
             increase_voucher_usage(
                 voucher,
                 code_instance,
-                instance.user_email or instance.user and instance.user.email,
+                user_email,
                 increase_voucher_customer_usage=False,
             )
+        elif not is_new_instance and old_voucher:
+            # handle removing voucher
+            voucher_code = VoucherCode.objects.filter(code=old_voucher_code).first()
+            release_voucher_code_usage(voucher_code, old_voucher, user_email)

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -74,3 +74,37 @@ class DraftOrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
             app=app,
             manager=manager,
         )
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        instance = cls.get_instance(info, **data)
+        channel_id = cls.get_instance_channel_id(instance, **data)
+        cls.check_channel_permissions(info, [channel_id])
+        old_voucher = instance.voucher
+        old_voucher_code = instance.voucher_code
+        data = data.get("input")
+        cleaned_input = cls.clean_input(info, instance, data)
+        instance = cls.construct_instance(instance, cleaned_input)
+        cls.clean_instance(info, instance)
+        cls.save_draft_order(
+            info, instance, cleaned_input, old_voucher, old_voucher_code
+        )
+        cls._save_m2m(info, instance, cleaned_input)
+        return cls.success_response(instance)
+
+    @classmethod
+    def save_draft_order(
+        cls, info: ResolveInfo, instance, cleaned_input, old_voucher, old_voucher_code
+    ):
+        manager = get_plugin_manager_promise(info.context).get()
+        app = get_app_promise(info.context).get()
+        return cls._save_draft_order(
+            info,
+            instance,
+            cleaned_input,
+            is_new_instance=False,
+            app=app,
+            manager=manager,
+            old_voucher=old_voucher,
+            old_voucher_code=old_voucher_code,
+        )

--- a/saleor/tests/e2e/orders/discounts/test_order_voucher_usage_is_released_when_voucher_is_removed.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_voucher_usage_is_released_when_voucher_is_removed.py
@@ -1,0 +1,145 @@
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_shop
+from ...utils import assign_permissions
+from ...vouchers.utils import (
+    create_voucher,
+    create_voucher_channel_listing,
+    get_voucher,
+)
+from ..utils import draft_order_create, draft_order_update
+
+
+def prepare_voucher(
+    e2e_staff_api_client,
+    channel_id,
+    voucher_code,
+    voucher_discount_type,
+    voucher_discount_value,
+    voucher_type,
+    usage_limit,
+):
+    input = {
+        "code": voucher_code,
+        "discountValueType": voucher_discount_type,
+        "type": voucher_type,
+        "usageLimit": usage_limit,
+        "singleUse": False,
+        "applyOncePerOrder": False,
+    }
+    voucher_data = create_voucher(e2e_staff_api_client, input)
+
+    voucher_id = voucher_data["id"]
+    channel_listing = [
+        {
+            "channelId": channel_id,
+            "discountValue": voucher_discount_value,
+        },
+    ]
+    create_voucher_channel_listing(
+        e2e_staff_api_client,
+        voucher_id,
+        channel_listing,
+    )
+
+    return (
+        voucher_code,
+        voucher_id,
+    )
+
+
+@pytest.mark.e2e
+def test_order_voucher_usage_is_released_when_voucher_is_removed_CORE_0939(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+    permission_manage_checkouts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+        permission_manage_checkouts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {"includeDraftOrderInVoucherUsage": True},
+            }
+        ],
+    )
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
+    )
+
+    usage_limit = 10
+    voucher_code, voucher_id = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        voucher_code="voucher",
+        voucher_discount_type="PERCENTAGE",
+        voucher_discount_value=15,
+        voucher_type="ENTIRE_ORDER",
+        usage_limit=usage_limit,
+    )
+
+    # Step 1 - Create draft order with the voucher
+    input = {
+        "channelId": channel_id,
+        "userEmail": "test_user@test.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "shippingMethod": shipping_method_id,
+        "lines": [{"variantId": product_variant_id, "quantity": 2}],
+        "voucherCode": voucher_code,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert order_id is not None
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert data["order"]["lines"] is not None
+    assert data["order"]["voucher"]["id"] == voucher_id
+    assert data["order"]["voucherCode"] == voucher_code
+
+    voucher_data = get_voucher(e2e_staff_api_client, voucher_id)
+    assert voucher_data["voucher"]["id"] == voucher_id
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 1
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["isActive"] is True
+
+    # Step 2 - Remove the voucher from draft order and verify the voucher usage
+    input = {"voucherCode": None}
+    data = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    assert data["order"]["voucherCode"] is None
+    assert data["order"]["voucher"] is None
+
+    voucher_data = get_voucher(e2e_staff_api_client, voucher_id)
+    assert voucher_data["voucher"]["id"] == voucher_id
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 0
+    assert voucher_data["voucher"]["codes"]["edges"][0]["node"]["isActive"] is True

--- a/saleor/tests/e2e/orders/utils/draft_order_create.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_create.py
@@ -20,6 +20,7 @@ mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
         code
         id
       }
+      voucherCode
       billingAddress {
         streetAddress1
       }


### PR DESCRIPTION
- Fix decreasing voucher usage when the voucher is removed from draft order
- Add e2e for such case
- Fix restriction regarding updating voucher `usage_limit` - do not block the voucher update when exist an order that has a matching `voucher_code`, but an empty `voucher` instance. This might happened when the voucher code was applied to the order, but the corresponding voucher has been deleted. Nest the new voucher has been created with the same code value as the previous voucher code.

Port of https://github.com/saleor/saleor/pull/16664

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
