### PR TITLE
Fix failing deprecated `send_webhook_request_async` task

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -22,7 +22,7 @@ task_logger = get_task_logger(__name__)
 def send_webhook_request_async(self, event_delivery_id):
     from ...webhook.transport.asynchronous.transport import send_webhook_request_async
 
-    send_webhook_request_async(self, event_delivery_id)
+    send_webhook_request_async(event_delivery_id)
 
 
 @app.task

--- a/saleor/plugins/webhook/tests/test_deprecated_webhook_tasks.py
+++ b/saleor/plugins/webhook/tests/test_deprecated_webhook_tasks.py
@@ -1,0 +1,51 @@
+import json
+from unittest import mock
+
+from ....core import EventDeliveryStatus
+from ....core.models import EventDelivery, EventDeliveryAttempt
+from ..tasks import send_webhook_request_async
+
+
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.observability.report_event_delivery_attempt"
+)
+@mock.patch("saleor.webhook.transport.asynchronous.transport.clear_successful_delivery")
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+def test_send_webhook_request_async(
+    mocked_send_response,
+    mocked_clear_delivery,
+    mocked_observability,
+    event_delivery,
+    webhook_response,
+):
+    # given
+    mocked_send_response.return_value = webhook_response
+
+    # when
+    send_webhook_request_async(event_delivery.pk)
+
+    # then
+    mocked_send_response.assert_called_once_with(
+        event_delivery.webhook.target_url,
+        "mirumee.com",
+        event_delivery.webhook.secret_key,
+        event_delivery.event_type,
+        event_delivery.payload.payload,
+        event_delivery.webhook.custom_headers,
+    )
+    mocked_clear_delivery.assert_called_once_with(event_delivery)
+    attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
+    delivery = EventDelivery.objects.get(id=event_delivery.pk)
+
+    assert attempt
+    assert delivery
+    assert attempt.status == EventDeliveryStatus.SUCCESS
+    assert attempt.response == webhook_response.content
+    assert attempt.response_headers == json.dumps(webhook_response.response_headers)
+    assert attempt.response_status_code == webhook_response.response_status_code
+    assert attempt.request_headers == json.dumps(webhook_response.request_headers)
+    assert attempt.duration == webhook_response.duration
+    assert delivery.status == EventDeliveryStatus.SUCCESS
+    mocked_observability.assert_called_once_with(attempt)


### PR DESCRIPTION
Fix failing deprecated `send_webhook_request_async` task from `saleor/plugins/webhook/tasks.py`

Port of https://github.com/saleor/saleor/pull/16679/commits

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
