### PR TITLE
Add workflow to check patches

### DIFF
--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -39,4 +39,4 @@ jobs:
         id: apply_patches
         run: |
           cd workflows-test
-          git apply ../saleor-multitenant/patches/**.patch
+          git apply ../saleor-multitenant/patches/**.patch > /dev/null 2>&1

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -13,7 +13,7 @@ name: Test Patches
 
 on:
   pull_request:
-    types: [labeled, opened, synchronize, unlabeled]
+    types: [labeled, opened, synchronize]
 
 jobs:
   apply-patches:

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -1,0 +1,42 @@
+# The action fetches code from the PR's source branch, takes the target branch, and
+# tries to fetch and apply patches using PR's target branch.
+# Example: if a PR targets a version branch `3.20`, the action would checkout to `3.20`
+# branch in the patches repo and try to apply patches from that branch. If patches
+# apply, the action succeeds, otherwise it returns an error, and indicates that patches
+# need to be adjusted.
+#
+# - Action runs on all branches.
+# - Action runs only when label is applied: `check patches` (will be changed to all PRs
+# when workflow is more tested).
+
+name: Test Patches
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, unlabeled]
+
+jobs:
+  apply-patches:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'check patches') }}
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          path: saleor
+          ref: ${{ github.head_ref }}
+
+      - name: Checkout patches
+        id: checkout-patches
+        uses: actions/checkout@v4
+        with:
+          repository: saleor/saleor-multitenant
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: saleor-multitenant
+          ref: ${{ github.base_ref }}
+
+      - name: Apply patches
+        id: apply_patches
+        run: |
+          cd workflows-test
+          git apply ../saleor-multitenant/patches/**.patch


### PR DESCRIPTION
The action fetches code from the PR's source branch, takes the target branch, and tries to fetch and apply patches using PR's target branch. Example: if a PR targets a version branch `3.20`, the action would checkout to `3.20` branch in the patches repo and try to apply patches from that branch. If patches apply, the action succeeds, otherwise it returns an error, and indicates that patches need to be adjusted.

Other assumptions:
- Action runs on all branches.
- Action runs only when the label is applied: `check patches` (will be changed to all PRs when the workflow is more tested).

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
