### PR TITLE
Make `amount` optional in `transactionEventReport` for `REFUND_REVERSE`, `CHARGEBACK`, `INFO`, and all `*_FAILURE` events

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -13,7 +13,7 @@ from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....order import OrderStatus
-from .....payment import TransactionEventType
+from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment.models import TransactionEvent
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from ....core.enums import TransactionEventReportErrorCode
@@ -2244,3 +2244,224 @@ def test_transaction_event_report_assign_transaction_psp_reference_if_missing(
         == expected_transaction_psp_reference
     )
     assert transaction.psp_reference == expected_transaction_psp_reference
+
+
+@pytest.mark.parametrize(
+    "event_type", [event_type for event_type in OPTIONAL_AMOUNT_EVENTS]
+)
+def test_transaction_event_report_missing_amount(
+    event_type,
+    transaction_item_generator,
+    transaction_events_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    expected_amount = 10
+    event_types = [
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_SUCCESS,
+        TransactionEventType.REFUND_SUCCESS,
+    ]
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[
+            psp_reference,
+        ]
+        * len(event_types),
+        types=event_types,
+        amounts=[
+            expected_amount,
+        ]
+        * len(event_types),
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": event_type.upper(),
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["errors"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    event = TransactionEvent.objects.last()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == event_type
+    expected_amount = (
+        expected_amount if event_type != TransactionEventType.INFO else Decimal("0")
+    )
+    assert event.amount_value == expected_amount
+    assert event.currency == transaction.currency
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        event_type
+        for event_type in OPTIONAL_AMOUNT_EVENTS
+        if event_type != TransactionEventType.INFO
+    ],
+)
+def test_transaction_event_report_missing_amount_not_deduced_error_raised(
+    event_type,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": event_type.upper(),
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["transactionEvent"]
+    errors = transaction_report_data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "amount"
+    assert errors[0]["code"] == TransactionEventReportErrorCode.REQUIRED.name
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        event_type[0]
+        for event_type in TransactionEventType.CHOICES
+        if event_type[0] not in OPTIONAL_AMOUNT_EVENTS
+    ],
+)
+def test_transaction_event_report_missing_amount_error_raised(
+    event_type,
+    transaction_item_generator,
+    transaction_events_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    amount = 10
+    event_types = [
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_SUCCESS,
+        TransactionEventType.REFUND_SUCCESS,
+    ]
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[
+            psp_reference,
+        ]
+        * len(event_types),
+        types=event_types,
+        amounts=[
+            amount,
+        ]
+        * len(event_types),
+    )
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": event_type.upper(),
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["transactionEvent"]
+    errors = transaction_report_data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "amount"
+    assert errors[0]["code"] == TransactionEventReportErrorCode.REQUIRED.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16909,8 +16909,12 @@ type Mutation {
   Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionEventReport(
-    """The amount of the event to report."""
-    amount: PositiveDecimal!
+    """
+    The amount of the event to report. 
+    
+    Required for all `REQUEST`, `SUCCESS`, `ACTION_REQUIRED`, and `ADJUSTMENT` events. For other events, the amount will be calculated based on the previous events with the same pspReference. If not possible to calculate, the mutation will return an error.
+    """
+    amount: PositiveDecimal
 
     """List of all possible actions for the transaction"""
     availableActions: [TransactionActionEnum!]
@@ -24821,6 +24825,7 @@ enum TransactionEventReportErrorCode @doc(category: "Payments") {
   NOT_FOUND
   INCORRECT_DETAILS
   ALREADY_EXISTS
+  REQUIRED
 }
 
 """

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -257,6 +257,13 @@ OPTIONAL_PSP_REFERENCE_EVENTS = [
     TransactionEventType.CANCEL_FAILURE,
 ]
 
+OPTIONAL_AMOUNT_EVENTS = [
+    *FAILED_TRANSACTION_EVENTS,
+    TransactionEventType.REFUND_REVERSE,
+    TransactionEventType.CHARGE_BACK,
+    TransactionEventType.INFO,
+]
+
 
 class TokenizedPaymentFlow:
     """Represents possible tokenized payment flows that can be used to process payment.

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -64,6 +64,7 @@ class TransactionEventReportErrorCode(Enum):
     NOT_FOUND = "not_found"
     INCORRECT_DETAILS = "incorrect_details"
     ALREADY_EXISTS = "already_exists"
+    REQUIRED = "required"
 
 
 class PaymentGatewayConfigErrorCode(Enum):


### PR DESCRIPTION
Make `amount` optional in `transactionEventReport` for all following events:
- `REFUND_REVERSE`
- `CHARGE_BACK`
- `INFO`
- `AUTHORIZATION_FAILURE`
- `CHARGE_FAILURE`
- `REFUND_FAILURE`
- `CANCEL_FAILURE`


Port of https://github.com/saleor/saleor/pull/16688

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
