### PR TITLE
Make `amount` optional in `transactionEventReport` for `REFUND_REVERSE`, `CHARGEBACK`, `INFO`, and all `*_FAILURE` events

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -13,7 +13,7 @@ from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....order import OrderStatus
-from .....payment import TransactionEventType
+from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment.models import TransactionEvent
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from ....core.enums import TransactionEventReportErrorCode
@@ -2244,3 +2244,224 @@ def test_transaction_event_report_assign_transaction_psp_reference_if_missing(
         == expected_transaction_psp_reference
     )
     assert transaction.psp_reference == expected_transaction_psp_reference
+
+
+@pytest.mark.parametrize(
+    "event_type", [event_type for event_type in OPTIONAL_AMOUNT_EVENTS]
+)
+def test_transaction_event_report_missing_amount(
+    event_type,
+    transaction_item_generator,
+    transaction_events_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    expected_amount = 10
+    event_types = [
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_SUCCESS,
+        TransactionEventType.REFUND_SUCCESS,
+    ]
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[
+            psp_reference,
+        ]
+        * len(event_types),
+        types=event_types,
+        amounts=[
+            expected_amount,
+        ]
+        * len(event_types),
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": event_type.upper(),
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["errors"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    event = TransactionEvent.objects.last()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == event_type
+    expected_amount = (
+        expected_amount if event_type != TransactionEventType.INFO else Decimal("0")
+    )
+    assert event.amount_value == expected_amount
+    assert event.currency == transaction.currency
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        event_type
+        for event_type in OPTIONAL_AMOUNT_EVENTS
+        if event_type != TransactionEventType.INFO
+    ],
+)
+def test_transaction_event_report_missing_amount_not_deduced_error_raised(
+    event_type,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": event_type.upper(),
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["transactionEvent"]
+    errors = transaction_report_data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "amount"
+    assert errors[0]["code"] == TransactionEventReportErrorCode.REQUIRED.name
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        event_type[0]
+        for event_type in TransactionEventType.CHOICES
+        if event_type[0] not in OPTIONAL_AMOUNT_EVENTS
+    ],
+)
+def test_transaction_event_report_missing_amount_error_raised(
+    event_type,
+    transaction_item_generator,
+    transaction_events_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    amount = 10
+    event_types = [
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_SUCCESS,
+        TransactionEventType.REFUND_SUCCESS,
+    ]
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[
+            psp_reference,
+        ]
+        * len(event_types),
+        types=event_types,
+        amounts=[
+            amount,
+        ]
+        * len(event_types),
+    )
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": event_type.upper(),
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["transactionEvent"]
+    errors = transaction_report_data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "amount"
+    assert errors[0]["code"] == TransactionEventReportErrorCode.REQUIRED.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16687,8 +16687,12 @@ type Mutation {
   Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionEventReport(
-    """The amount of the event to report."""
-    amount: PositiveDecimal!
+    """
+    The amount of the event to report. 
+    
+    Required for all `REQUEST`, `SUCCESS`, `ACTION_REQUIRED`, and `ADJUSTMENT` events. For other events, the amount will be calculated based on the previous events with the same pspReference. If not possible to calculate, the mutation will return an error.
+    """
+    amount: PositiveDecimal
 
     """List of all possible actions for the transaction"""
     availableActions: [TransactionActionEnum!]
@@ -24567,6 +24571,7 @@ enum TransactionEventReportErrorCode @doc(category: "Payments") {
   NOT_FOUND
   INCORRECT_DETAILS
   ALREADY_EXISTS
+  REQUIRED
 }
 
 """

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -257,6 +257,13 @@ OPTIONAL_PSP_REFERENCE_EVENTS = [
     TransactionEventType.CANCEL_FAILURE,
 ]
 
+OPTIONAL_AMOUNT_EVENTS = [
+    *FAILED_TRANSACTION_EVENTS,
+    TransactionEventType.REFUND_REVERSE,
+    TransactionEventType.CHARGE_BACK,
+    TransactionEventType.INFO,
+]
+
 
 class TokenizedPaymentFlow:
     """Represents possible tokenized payment flows that can be used to process payment.

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -64,6 +64,7 @@ class TransactionEventReportErrorCode(Enum):
     NOT_FOUND = "not_found"
     INCORRECT_DETAILS = "incorrect_details"
     ALREADY_EXISTS = "already_exists"
+    REQUIRED = "required"
 
 
 class PaymentGatewayConfigErrorCode(Enum):

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -27,6 +27,7 @@ from ..utils import (
     create_transaction_event_from_request_and_webhook_response,
     get_channel_slug_from_payment,
     get_correct_event_types_based_on_request_type,
+    get_transaction_event_amount,
     parse_transaction_action_data,
     recalculate_refundable_for_checkout,
     try_void_or_refund_inactive_payment,
@@ -2503,3 +2504,231 @@ def test_recalculate_refundable_for_checkout_update_missing_checkout(
     # then
     transaction_item.refresh_from_db()
     assert transaction_item.last_refund_success is False
+
+
+@pytest.mark.parametrize(
+    ("input_event_type", "event_type_to_create"),
+    [
+        (TransactionEventType.CHARGE_FAILURE, TransactionEventType.CHARGE_SUCCESS),
+        (TransactionEventType.CHARGE_FAILURE, TransactionEventType.CHARGE_REQUEST),
+        (
+            TransactionEventType.CHARGE_FAILURE,
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+        ),
+        (
+            TransactionEventType.CHARGE_FAILURE,
+            TransactionEventType.AUTHORIZATION_REQUEST,
+        ),
+        (
+            TransactionEventType.CHARGE_FAILURE,
+            TransactionEventType.AUTHORIZATION_FAILURE,
+        ),
+        (TransactionEventType.REFUND_FAILURE, TransactionEventType.REFUND_SUCCESS),
+        (TransactionEventType.REFUND_FAILURE, TransactionEventType.REFUND_REQUEST),
+        (TransactionEventType.REFUND_FAILURE, TransactionEventType.CHARGE_SUCCESS),
+        (TransactionEventType.REFUND_FAILURE, TransactionEventType.CHARGE_REQUEST),
+        (TransactionEventType.REFUND_FAILURE, TransactionEventType.CHARGE_FAILURE),
+        (TransactionEventType.CANCEL_FAILURE, TransactionEventType.CANCEL_SUCCESS),
+        (TransactionEventType.CANCEL_FAILURE, TransactionEventType.CANCEL_REQUEST),
+        (
+            TransactionEventType.CANCEL_FAILURE,
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+        ),
+        (
+            TransactionEventType.CANCEL_FAILURE,
+            TransactionEventType.AUTHORIZATION_REQUEST,
+        ),
+        (
+            TransactionEventType.CANCEL_FAILURE,
+            TransactionEventType.AUTHORIZATION_FAILURE,
+        ),
+        (
+            TransactionEventType.AUTHORIZATION_FAILURE,
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+        ),
+        (
+            TransactionEventType.AUTHORIZATION_FAILURE,
+            TransactionEventType.AUTHORIZATION_REQUEST,
+        ),
+        (TransactionEventType.REFUND_REVERSE, TransactionEventType.REFUND_SUCCESS),
+        (TransactionEventType.CHARGE_BACK, TransactionEventType.CHARGE_SUCCESS),
+    ],
+)
+def test_get_transaction_event_amount(
+    input_event_type,
+    event_type_to_create,
+    transaction_events_generator,
+    transaction_item,
+):
+    # given
+    expected_amount = 10
+    psp_reference = "xyz"
+    transaction_events_generator(
+        transaction=transaction_item,
+        psp_references=[
+            psp_reference,
+        ],
+        types=[
+            event_type_to_create,
+        ],
+        amounts=[
+            expected_amount,
+        ],
+    )
+
+    # when
+    amount = get_transaction_event_amount(input_event_type, psp_reference)
+
+    # then
+    assert amount == expected_amount
+
+
+def test_get_transaction_event_amount_match_the_newest_event(
+    transaction_events_generator, transaction_item
+):
+    # given
+    psp_reference = "xyz"
+    event_types = [
+        TransactionEventType.CHARGE_SUCCESS,
+        TransactionEventType.CHARGE_REQUEST,
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.AUTHORIZATION_FAILURE,
+    ]
+    events = transaction_events_generator(
+        transaction=transaction_item,
+        psp_references=[
+            psp_reference,
+        ]
+        * len(event_types),
+        types=event_types,
+        amounts=[10, 5, 4, 3, 2],
+    )
+    newest_event = events[-1]
+    for event in events[:-1]:
+        event.created_at = newest_event.created_at - timedelta(minutes=10)
+    TransactionEvent.objects.bulk_update(events[:-1], ["created_at"])
+
+    # when
+    amount = get_transaction_event_amount(
+        TransactionEventType.CHARGE_FAILURE, psp_reference
+    )
+
+    # then
+    assert amount == newest_event.amount_value
+
+
+@pytest.mark.parametrize(
+    ("input_event_type", "event_types_to_create"),
+    [
+        (TransactionEventType.CHARGE_FAILURE, [TransactionEventType.REFUND_FAILURE]),
+        (TransactionEventType.CHARGE_FAILURE, []),
+        (
+            TransactionEventType.REFUND_FAILURE,
+            [TransactionEventType.AUTHORIZATION_FAILURE],
+        ),
+        (TransactionEventType.REFUND_FAILURE, []),
+        (TransactionEventType.CANCEL_FAILURE, [TransactionEventType.CHARGE_FAILURE]),
+        (TransactionEventType.CANCEL_FAILURE, []),
+        (
+            TransactionEventType.AUTHORIZATION_FAILURE,
+            [TransactionEventType.CHARGE_SUCCESS],
+        ),
+        (TransactionEventType.AUTHORIZATION_FAILURE, []),
+        (TransactionEventType.REFUND_REVERSE, [TransactionEventType.REFUND_FAILURE]),
+        (TransactionEventType.REFUND_REVERSE, []),
+        (TransactionEventType.CHARGE_BACK, [TransactionEventType.CHARGE_FAILURE]),
+        (TransactionEventType.CHARGE_BACK, []),
+    ],
+)
+def test_get_transaction_event_amount_missing_matching_event(
+    input_event_type,
+    event_types_to_create,
+    transaction_events_generator,
+    transaction_item,
+):
+    # given
+    amount = 10
+    psp_reference = "xyz"
+    if event_types_to_create:
+        transaction_events_generator(
+            transaction=transaction_item,
+            psp_references=[
+                psp_reference,
+            ],
+            types=event_types_to_create,
+            amounts=[
+                amount,
+            ],
+        )
+
+    # when & then
+    with pytest.raises(
+        ValueError, match=f"Unable to deduce the amount for {input_event_type} event."
+    ):
+        get_transaction_event_amount(input_event_type, psp_reference)
+
+
+def test_get_transaction_event_amount_missing_matching_event_different_psp_reference(
+    transaction_events_generator, transaction_item
+):
+    # given
+    psp_reference = "xyz"
+    transaction_events_generator(
+        transaction=transaction_item,
+        psp_references=[
+            "123",
+        ],
+        types=[TransactionEventType.CHARGE_SUCCESS],
+        amounts=[10],
+    )
+    event_type = TransactionEventType.CHARGE_FAILURE
+
+    # when & then
+    with pytest.raises(
+        ValueError, match=f"Unable to deduce the amount for {event_type} event."
+    ):
+        get_transaction_event_amount(event_type, psp_reference)
+
+
+def test_get_transaction_event_amount_invalid_event_type(
+    transaction_events_generator, transaction_item
+):
+    # given
+    psp_reference = "xyz"
+    transaction_events_generator(
+        transaction=transaction_item,
+        psp_references=[
+            psp_reference,
+        ],
+        types=[TransactionEventType.CHARGE_FAILURE],
+        amounts=[10],
+    )
+    event_type = TransactionEventType.CHARGE_SUCCESS
+
+    # when & then
+    with pytest.raises(
+        ValueError, match=f"Unable to deduce the amount for {event_type} event."
+    ):
+        get_transaction_event_amount(event_type, psp_reference)
+
+
+def test_get_transaction_event_amount_for_info_event_type(
+    transaction_events_generator, transaction_item
+):
+    # given
+    psp_reference = "xyz"
+    transaction_events_generator(
+        transaction=transaction_item,
+        psp_references=[
+            "123",
+        ],
+        types=[TransactionEventType.CHARGE_SUCCESS],
+        amounts=[10],
+    )
+
+    # when
+    amount = get_transaction_event_amount(TransactionEventType.INFO, psp_reference)
+
+    # then
+    assert amount == 0


### PR DESCRIPTION
Make `amount` optional in `transactionEventReport` for all following events:
- `REFUND_REVERSE`
- `CHARGE_BACK`
- `INFO`
- `AUTHORIZATION_FAILURE`
- `CHARGE_FAILURE`
- `REFUND_FAILURE`
- `CANCEL_FAILURE`


Port of https://github.com/saleor/saleor/pull/16688


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
