### PR TITLE
[DO NOT MERGE] PoC: Add new `TransactonEventTypeOutputEnum` to add new REFUND_OR_CANCEL event

### DIFF
--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -5,6 +5,7 @@ from ...payment import (
     StorePaymentMethod,
     TokenizedPaymentFlow,
     TransactionAction,
+    TransactionEventOutputType,
     TransactionEventType,
     TransactionKind,
 )
@@ -34,6 +35,14 @@ TransactionEventTypeEnum = to_enum(
     TransactionEventType, description=TransactionEventType.__doc__
 )
 TransactionEventTypeEnum.doc_category = DOC_CATEGORY_PAYMENTS
+
+TransactionEventTypeOutputEnum = to_enum(
+    TransactionEventOutputType,
+    type_name="TransactionEventTypeOutputEnum",
+    description=TransactionEventOutputType.__doc__,
+)
+
+TransactionEventTypeOutputEnum.doc_category = DOC_CATEGORY_PAYMENTS
 
 
 class OrderAction(BaseEnum):

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -43,7 +43,7 @@ from .enums import (
     PaymentChargeStatusEnum,
     TokenizedPaymentFlowEnum,
     TransactionActionEnum,
-    TransactionEventTypeEnum,
+    TransactionEventTypeOutputEnum,
     TransactionKindEnum,
 )
 
@@ -335,7 +335,7 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
         description="The amount related to this event." + ADDED_IN_313,
     )
     type = graphene.Field(
-        TransactionEventTypeEnum,
+        TransactionEventTypeOutputEnum,
         description="The type of action related to this event." + ADDED_IN_313,
     )
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -30,7 +30,7 @@ type Query {
 
   """
   List of all available webhook events.
-  
+
   Requires one of the following permissions: MANAGE_APPS.
   """
   webhookEvents: [WebhookEvent!] @doc(category: "Webhooks") @deprecated(reason: "This field will be removed in Saleor 4.0. Use `WebhookEventTypeAsyncEnum` and `WebhookEventTypeSyncEnum` to get available event types.")
@@ -45,7 +45,7 @@ type Query {
 
   """
   Look up a warehouse by ID.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS, MANAGE_SHIPPING.
   """
   warehouse(
@@ -53,8 +53,8 @@ type Query {
     id: ID
 
     """
-    External ID of a warehouse. 
-    
+    External ID of a warehouse.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -62,7 +62,7 @@ type Query {
 
   """
   List of warehouses.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS, MANAGE_SHIPPING.
   """
   warehouses(
@@ -88,7 +88,7 @@ type Query {
 
   """
   Returns a list of all translatable items of a given kind.
-  
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   translations(
@@ -114,7 +114,7 @@ type Query {
 
   """
   Lookup a translatable item by ID.
-  
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   translation(
@@ -127,9 +127,9 @@ type Query {
 
   """
   Look up a tax configuration.
-  
+
   Added in Saleor 3.9.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfiguration(
@@ -139,9 +139,9 @@ type Query {
 
   """
   List of tax configurations.
-  
+
   Added in Saleor 3.9.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfigurations(
@@ -167,9 +167,9 @@ type Query {
 
   """
   Look up a tax class.
-  
+
   Added in Saleor 3.9.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass(
@@ -179,9 +179,9 @@ type Query {
 
   """
   List of tax classes.
-  
+
   Added in Saleor 3.9.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClasses(
@@ -210,7 +210,7 @@ type Query {
 
   """
   Tax class rates grouped by country.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxCountryConfiguration(
@@ -223,7 +223,7 @@ type Query {
 
   """
   Look up a stock by ID
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   stock(
@@ -233,7 +233,7 @@ type Query {
 
   """
   List of stocks.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   stocks(
@@ -261,21 +261,21 @@ type Query {
 
   """
   Order related settings from site settings. Returns `orderSettings` for the first `channel` in alphabetical order.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderSettings: OrderSettings @doc(category: "Orders") @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `channel` query to fetch the `orderSettings` field instead.")
 
   """
   Gift card related settings from site settings.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardSettings: GiftCardSettings! @doc(category: "Gift cards")
 
   """
   Look up a shipping zone by ID.
-  
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingZone(
@@ -288,7 +288,7 @@ type Query {
 
   """
   List of the shop's shipping zones.
-  
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingZones(
@@ -317,7 +317,7 @@ type Query {
 
   """
   Look up digital content by ID.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   digitalContent(
@@ -327,7 +327,7 @@ type Query {
 
   """
   List of digital content.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   digitalContents(
@@ -355,9 +355,9 @@ type Query {
 
     """
     Where filtering options.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     where: CategoryWhereInput
@@ -395,7 +395,7 @@ type Query {
 
     """
     Language code of the category slug, omit to use primary slug.
-    
+
     Added in Saleor 3.21.
     """
     slugLanguageCode: LanguageCodeEnum
@@ -413,7 +413,7 @@ type Query {
 
     """
     Language code of the collection slug, omit to use primary slug.
-    
+
     Added in Saleor 3.21.
     """
     slugLanguageCode: LanguageCodeEnum
@@ -431,9 +431,9 @@ type Query {
 
     """
     Where filtering options.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     where: CollectionWhereInput
@@ -473,14 +473,14 @@ type Query {
 
     """
     Language code of the product slug, omit to use primary slug.
-    
+
     Added in Saleor 3.21.
     """
     slugLanguageCode: LanguageCodeEnum
 
     """
-    External ID of the product. 
-    
+    External ID of the product.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -498,9 +498,9 @@ type Query {
 
     """
     Where filtering options.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     where: ProductWhereInput
@@ -510,7 +510,7 @@ type Query {
 
     """
     Search products.
-    
+
     Added in Saleor 3.14.
     """
     search: String
@@ -577,8 +577,8 @@ type Query {
     sku: String
 
     """
-    External ID of the product. 
-    
+    External ID of the product.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -602,9 +602,9 @@ type Query {
 
     """
     Where filtering options.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     where: ProductVariantWhereInput
@@ -631,7 +631,7 @@ type Query {
 
   """
   List of top selling products.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   reportProductSales(
@@ -660,7 +660,7 @@ type Query {
 
   """
   Look up a payment by ID.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   payment(
@@ -670,7 +670,7 @@ type Query {
 
   """
   List of payments.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   payments(
@@ -696,11 +696,11 @@ type Query {
 
   """
   Look up a transaction by ID.
-  
+
   Added in Saleor 3.6.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transaction(
@@ -725,7 +725,7 @@ type Query {
 
     """
     Language code of the page slug, omit to use primary slug.
-    
+
     Added in Saleor 3.21.
     """
     slugLanguageCode: LanguageCodeEnum
@@ -789,7 +789,7 @@ type Query {
 
   """
   List of activity events to display on homepage (at the moment it only contains order-events).
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   homepageEvents(
@@ -816,10 +816,10 @@ type Query {
     id: ID
 
     """
-    External ID of an order. 
-    
+    External ID of an order.
+
     Added in Saleor 3.10..
-    
+
     Requires one of the following permissions: MANAGE_ORDERS.
     """
     externalReference: String
@@ -827,7 +827,7 @@ type Query {
 
   """
   List of orders.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orders(
@@ -859,7 +859,7 @@ type Query {
 
   """
   List of draft orders.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrders(
@@ -888,7 +888,7 @@ type Query {
 
   """
   Return the total sales amount from a specific period.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   ordersTotal(
@@ -929,8 +929,8 @@ type Query {
     sortBy: MenuSortingInput
 
     """
-    Filtering options for menus. 
-    
+    Filtering options for menus.
+
     `slug`: This field will be removed in Saleor 4.0. Use `slugs` instead.
     """
     filter: MenuFilterInput
@@ -991,7 +991,7 @@ type Query {
 
   """
   Look up a gift card by ID.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCard(
@@ -1001,29 +1001,29 @@ type Query {
 
   """
   List of gift cards.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCards(
     """
     Sort gift cards.
-    
+
     Added in Saleor 3.1.
     """
     sortBy: GiftCardSortingInput
 
     """
     Filtering options for gift cards.
-    
+
     Added in Saleor 3.1.
     """
     filter: GiftCardFilterInput
 
     """
     Search gift cards by email and name of user, who created or used the gift card, and by code.
-    
+
     Added in Saleor 3.15.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     search: String
@@ -1047,18 +1047,18 @@ type Query {
 
   """
   List of gift card currencies.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardCurrencies: [String!]! @doc(category: "Gift cards")
 
   """
   List of gift card tags.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardTags(
@@ -1084,7 +1084,7 @@ type Query {
 
   """
   Look up a plugin by ID.
-  
+
   Requires one of the following permissions: MANAGE_PLUGINS.
   """
   plugin(
@@ -1094,7 +1094,7 @@ type Query {
 
   """
   List of plugins.
-  
+
   Requires one of the following permissions: MANAGE_PLUGINS.
   """
   plugins(
@@ -1123,7 +1123,7 @@ type Query {
 
   """
   Look up a sale by ID.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   sale(
@@ -1136,7 +1136,7 @@ type Query {
 
   """
   List of the shop's sales.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   sales(
@@ -1147,8 +1147,8 @@ type Query {
     sortBy: SaleSortingInput
 
     """
-    Search sales by name, value or type. 
-    
+    Search sales by name, value or type.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `filter.search` input instead.
     """
     query: String
@@ -1175,7 +1175,7 @@ type Query {
 
   """
   Look up a voucher by ID.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   voucher(
@@ -1188,7 +1188,7 @@ type Query {
 
   """
   List of the shop's vouchers.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   vouchers(
@@ -1199,8 +1199,8 @@ type Query {
     sortBy: VoucherSortingInput
 
     """
-    Search vouchers by name or code. 
-    
+    Search vouchers by name or code.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `filter.search` input instead.
     """
     query: String
@@ -1227,11 +1227,11 @@ type Query {
 
   """
   Look up a promotion by ID.
-  
+
   Added in Saleor 3.17.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   promotion(
@@ -1241,11 +1241,11 @@ type Query {
 
   """
   List of the promotions.
-  
+
   Added in Saleor 3.17.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   promotions(
@@ -1274,7 +1274,7 @@ type Query {
 
   """
   Look up a export file by ID.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   exportFile(
@@ -1284,7 +1284,7 @@ type Query {
 
   """
   List of export files.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   exportFiles(
@@ -1316,20 +1316,20 @@ type Query {
 
   """
   Look up a checkout by id.
-  
+
   Requires one of the following permissions to query a checkout, if a checkout is in inactive channel: MANAGE_CHECKOUTS, IMPERSONATE_USER, HANDLE_PAYMENTS.
   """
   checkout(
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
 
     """
     The checkout's token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -1337,20 +1337,20 @@ type Query {
 
   """
   List of checkouts.
-  
+
   Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   """
   checkouts(
     """
     Sort checkouts.
-    
+
     Added in Saleor 3.1.
     """
     sortBy: CheckoutSortingInput
 
     """
     Filtering options for checkouts.
-    
+
     Added in Saleor 3.1.
     """
     filter: CheckoutFilterInput
@@ -1377,7 +1377,7 @@ type Query {
 
   """
   List of checkout lines.
-  
+
   Requires one of the following permissions: MANAGE_CHECKOUTS.
   """
   checkoutLines(
@@ -1405,7 +1405,7 @@ type Query {
 
     """
     Slug of the channel.
-    
+
     Added in Saleor 3.6.
     """
     slug: String
@@ -1413,7 +1413,7 @@ type Query {
 
   """
   List of all channels.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   channels: [Channel!] @doc(category: "Channels")
@@ -1425,16 +1425,16 @@ type Query {
 
     """
     Filtering options for attributes.
-    
+
     Added in Saleor 3.11.
     """
     where: AttributeWhereInput
 
     """
     Search attributes.
-    
+
     Added in Saleor 3.11.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     search: String
@@ -1471,8 +1471,8 @@ type Query {
     slug: String
 
     """
-    External ID of the attribute. 
-    
+    External ID of the attribute.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -1480,14 +1480,14 @@ type Query {
 
   """
   List of all apps installations
-  
+
   Requires one of the following permissions: MANAGE_APPS.
   """
   appsInstallations: [AppInstallation!]! @doc(category: "Apps")
 
   """
   List of the apps.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, MANAGE_APPS.
   """
   apps(
@@ -1516,7 +1516,7 @@ type Query {
 
   """
   Look up an app by ID. If ID is not provided, return the currently authenticated app.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER AUTHENTICATED_APP. The authenticated app has access to its resources. Fetching different apps requires MANAGE_APPS permission.
   """
   app(
@@ -1526,9 +1526,9 @@ type Query {
 
   """
   List of all extensions.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   appExtensions(
@@ -1554,9 +1554,9 @@ type Query {
 
   """
   Look up an app extension by ID.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   appExtension(
@@ -1581,7 +1581,7 @@ type Query {
 
   """
   Look up an address by ID.
-  
+
   Requires one of the following permissions: MANAGE_USERS, OWNER.
   """
   address(
@@ -1591,7 +1591,7 @@ type Query {
 
   """
   List of the shop's customers. This list includes all users who registered through the accountRegister mutation. Additionally, staff users who have placed an order using their account will also appear in this list.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS, MANAGE_USERS.
   """
   customers(
@@ -1620,7 +1620,7 @@ type Query {
 
   """
   List of permission groups.
-  
+
   Requires one of the following permissions: MANAGE_STAFF.
   """
   permissionGroups(
@@ -1649,7 +1649,7 @@ type Query {
 
   """
   Look up permission group by ID.
-  
+
   Requires one of the following permissions: MANAGE_STAFF.
   """
   permissionGroup(
@@ -1662,7 +1662,7 @@ type Query {
 
   """
   List of the shop's staff users.
-  
+
   Requires one of the following permissions: MANAGE_STAFF.
   """
   staffUsers(
@@ -1691,7 +1691,7 @@ type Query {
 
   """
   Look up a user by ID or email address.
-  
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_USERS, MANAGE_ORDERS.
   """
   user(
@@ -1702,8 +1702,8 @@ type Query {
     email: String
 
     """
-    External ID of the user. 
-    
+    External ID of the user.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -1771,9 +1771,9 @@ type Webhook implements Node @doc(category: "Webhooks") {
 
   """
   Custom headers, which will be added to HTTP request.
-  
+
   Added in Saleor 3.12.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   customHeaders: JSONString
@@ -1798,7 +1798,7 @@ type WebhookEvent @doc(category: "Webhooks") {
 enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """
   All the events.
-  
+
   DEPRECATED: this value will be removed in Saleor 4.0.
   """
   ANY_EVENTS
@@ -1898,9 +1898,9 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A gift card has been sent.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   GIFT_CARD_SENT
@@ -1910,14 +1910,14 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A gift card metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   GIFT_CARD_METADATA_UPDATED
 
   """
   A gift card export is completed.
-  
+
   Added in Saleor 3.16.
   """
   GIFT_CARD_EXPORT_COMPLETED
@@ -1950,9 +1950,9 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   Payment has been made. The order may be partially or fully paid.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_PAID
@@ -1962,18 +1962,18 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   The order received a refund. The order may be partially or fully refunded.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_REFUNDED
 
   """
   The order is fully refunded.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_FULLY_REFUNDED
@@ -1994,16 +1994,16 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   An order metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   ORDER_METADATA_UPDATED
 
   """
   Orders are imported.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_BULK_CREATED
@@ -2019,7 +2019,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A fulfillment metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   FULFILLMENT_METADATA_UPDATED
@@ -2090,7 +2090,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A customer account metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   CUSTOMER_METADATA_UPDATED
@@ -2106,7 +2106,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A collection metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   COLLECTION_METADATA_UPDATED
@@ -2122,35 +2122,35 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A product metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   PRODUCT_METADATA_UPDATED
 
   """
   A product export is completed.
-  
+
   Added in Saleor 3.16.
   """
   PRODUCT_EXPORT_COMPLETED
 
   """
   A new product media is created.
-  
+
   Added in Saleor 3.12.
   """
   PRODUCT_MEDIA_CREATED
 
   """
   A product media is updated.
-  
+
   Added in Saleor 3.12.
   """
   PRODUCT_MEDIA_UPDATED
 
   """
   A product media is deleted.
-  
+
   Added in Saleor 3.12.
   """
   PRODUCT_MEDIA_DELETED
@@ -2168,7 +2168,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A product variant metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   PRODUCT_VARIANT_METADATA_UPDATED
@@ -2193,14 +2193,14 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A checkout metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   CHECKOUT_METADATA_UPDATED
 
   """
   User notification triggered.
-  
+
   DEPRECATED: this value will be removed in Saleor 4.0. See the docs for more details about migrating from NOTIFY_USER to other events: https://docs.saleor.io/docs/next/upgrade-guides/notify-user-deprecation
   """
   NOTIFY_USER
@@ -2252,7 +2252,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A shipping zone metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   SHIPPING_ZONE_METADATA_UPDATED
@@ -2271,7 +2271,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   Transaction item metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   TRANSACTION_ITEM_METADATA_UPDATED
@@ -2293,7 +2293,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A warehouse metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   WAREHOUSE_METADATA_UPDATED
@@ -2311,14 +2311,14 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A voucher metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   VOUCHER_METADATA_UPDATED
 
   """
   A voucher code export is completed.
-  
+
   Added in Saleor 3.18.
   """
   VOUCHER_CODE_EXPORT_COMPLETED
@@ -2328,14 +2328,14 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   A thumbnail is created.
-  
+
   Added in Saleor 3.12.
   """
   THUMBNAIL_CREATED
 
   """
   Shop metadata is updated.
-  
+
   Added in Saleor 3.15.
   """
   SHOP_METADATA_UPDATED
@@ -2363,41 +2363,41 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """
   Event called for checkout tax calculation.
-  
+
   Added in Saleor 3.6.
   """
   CHECKOUT_CALCULATE_TAXES
 
   """
   Event called for order tax calculation.
-  
+
   Added in Saleor 3.6.
   """
   ORDER_CALCULATE_TAXES
 
   """
   Event called when charge has been requested for transaction.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_CHARGE_REQUESTED
 
   """
   Event called when refund has been requested for transaction.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_REFUND_REQUESTED
 
   """
   Event called when cancel has been requested for transaction.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_CANCELATION_REQUESTED
@@ -2454,41 +2454,41 @@ enum WebhookEventTypeSyncEnum @doc(category: "Webhooks") {
 
   """
   Event called for checkout tax calculation.
-  
+
   Added in Saleor 3.6.
   """
   CHECKOUT_CALCULATE_TAXES
 
   """
   Event called for order tax calculation.
-  
+
   Added in Saleor 3.6.
   """
   ORDER_CALCULATE_TAXES
 
   """
   Event called when charge has been requested for transaction.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_CHARGE_REQUESTED
 
   """
   Event called when refund has been requested for transaction.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_REFUND_REQUESTED
 
   """
   Event called when cancel has been requested for transaction.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_CANCELATION_REQUESTED
@@ -2524,7 +2524,7 @@ type WebhookEventAsync @doc(category: "Webhooks") {
 enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   """
   All the events.
-  
+
   DEPRECATED: this value will be removed in Saleor 4.0.
   """
   ANY_EVENTS
@@ -2624,9 +2624,9 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A gift card has been sent.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   GIFT_CARD_SENT
@@ -2636,14 +2636,14 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A gift card metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   GIFT_CARD_METADATA_UPDATED
 
   """
   A gift card export is completed.
-  
+
   Added in Saleor 3.16.
   """
   GIFT_CARD_EXPORT_COMPLETED
@@ -2676,9 +2676,9 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   Payment has been made. The order may be partially or fully paid.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_PAID
@@ -2688,18 +2688,18 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   The order received a refund. The order may be partially or fully refunded.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_REFUNDED
 
   """
   The order is fully refunded.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_FULLY_REFUNDED
@@ -2720,16 +2720,16 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   An order metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   ORDER_METADATA_UPDATED
 
   """
   Orders are imported.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_BULK_CREATED
@@ -2745,7 +2745,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A fulfillment metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   FULFILLMENT_METADATA_UPDATED
@@ -2816,7 +2816,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A customer account metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   CUSTOMER_METADATA_UPDATED
@@ -2832,7 +2832,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A collection metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   COLLECTION_METADATA_UPDATED
@@ -2848,35 +2848,35 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A product metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   PRODUCT_METADATA_UPDATED
 
   """
   A product export is completed.
-  
+
   Added in Saleor 3.16.
   """
   PRODUCT_EXPORT_COMPLETED
 
   """
   A new product media is created.
-  
+
   Added in Saleor 3.12.
   """
   PRODUCT_MEDIA_CREATED
 
   """
   A product media is updated.
-  
+
   Added in Saleor 3.12.
   """
   PRODUCT_MEDIA_UPDATED
 
   """
   A product media is deleted.
-  
+
   Added in Saleor 3.12.
   """
   PRODUCT_MEDIA_DELETED
@@ -2894,7 +2894,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A product variant metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   PRODUCT_VARIANT_METADATA_UPDATED
@@ -2919,14 +2919,14 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A checkout metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   CHECKOUT_METADATA_UPDATED
 
   """
   User notification triggered.
-  
+
   DEPRECATED: this value will be removed in Saleor 4.0. See the docs for more details about migrating from NOTIFY_USER to other events: https://docs.saleor.io/docs/next/upgrade-guides/notify-user-deprecation
   """
   NOTIFY_USER
@@ -2978,7 +2978,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A shipping zone metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   SHIPPING_ZONE_METADATA_UPDATED
@@ -2997,7 +2997,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   Transaction item metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   TRANSACTION_ITEM_METADATA_UPDATED
@@ -3019,7 +3019,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A warehouse metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   WAREHOUSE_METADATA_UPDATED
@@ -3037,14 +3037,14 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A voucher metadata is updated.
-  
+
   Added in Saleor 3.8.
   """
   VOUCHER_METADATA_UPDATED
 
   """
   A voucher code export is completed.
-  
+
   Added in Saleor 3.18.
   """
   VOUCHER_CODE_EXPORT_COMPLETED
@@ -3054,14 +3054,14 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """
   A thumbnail is created.
-  
+
   Added in Saleor 3.12.
   """
   THUMBNAIL_CREATED
 
   """
   Shop metadata is updated.
-  
+
   Added in Saleor 3.15.
   """
   SHOP_METADATA_UPDATED
@@ -3077,16 +3077,16 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -3096,23 +3096,23 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
 
   """
   Canonical app ID from the manifest
-  
+
   Added in Saleor 3.19.
   """
   identifier: String
@@ -3134,14 +3134,14 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
 
   """
   Last 4 characters of the tokens.
-  
+
   Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   tokens: [AppToken!]
 
   """
   List of webhooks assigned to this app.
-  
+
   Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   webhooks: [Webhook!]
@@ -3169,7 +3169,7 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
 
   """
   URL to manifest used during app's installation.
-  
+
   Added in Saleor 3.5.
   """
   manifestUrl: String
@@ -3182,25 +3182,25 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
 
   """
   The App's author name.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   author: String
 
   """
   App's dashboard extensions.
-  
+
   Added in Saleor 3.1.
   """
   extensions: [AppExtension!]!
 
   """
   App's brand data.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   brand: AppBrand
@@ -3212,7 +3212,7 @@ interface ObjectWithMetadata {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
   """
   privateMetafield(key: String!): String
@@ -3227,7 +3227,7 @@ interface ObjectWithMetadata {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
   """
   metafield(key: String!): String
@@ -3394,9 +3394,9 @@ Note: this API is currently in Feature Preview and can be subject to changes at 
 type AppBrand @doc(category: "Apps") {
   """
   App's logos details.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   logo: AppBrandLogo!
@@ -3412,9 +3412,9 @@ Note: this API is currently in Feature Preview and can be subject to changes at 
 type AppBrandLogo @doc(category: "Apps") {
   """
   URL to the default logo image.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   default(
@@ -3425,9 +3425,9 @@ type AppBrandLogo @doc(category: "Apps") {
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: IconThumbnailFormatEnum = ORIGINAL
@@ -3762,16 +3762,16 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -3781,16 +3781,16 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -3815,7 +3815,7 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Click and collect options: local, all or disabled.
-  
+
   Added in Saleor 3.1.
   """
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum!
@@ -3841,9 +3841,9 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Stocks that belong to this warehouse.
-  
+
   Added in Saleor 3.20.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   stocks(
@@ -3865,8 +3865,8 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
   ): StockCountableConnection
 
   """
-  External ID of this warehouse. 
-  
+  External ID of this warehouse.
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -3879,46 +3879,46 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   List of private metadata items. Requires staff permissions to access.
-  
+
   Added in Saleor 3.10.
   """
   privateMetadata: [MetadataItem!]!
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.10.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.10.
   """
   privateMetafields(keys: [String!]): Metadata
 
   """
   List of public metadata items. Can be accessed without permissions.
-  
+
   Added in Saleor 3.10.
   """
   metadata: [MetadataItem!]!
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.10.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.10.
   """
   metafields(keys: [String!]): Metadata
@@ -4030,16 +4030,16 @@ type ShippingZone implements Node & ObjectWithMetadata @doc(category: "Shipping"
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -4049,16 +4049,16 @@ type ShippingZone implements Node & ObjectWithMetadata @doc(category: "Shipping"
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -4120,16 +4120,16 @@ type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shi
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -4139,16 +4139,16 @@ type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shi
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -4158,7 +4158,7 @@ type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shi
 
   """
   Shipping method description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -4174,7 +4174,7 @@ type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shi
 
   """
   List of channels available for the method.
-  
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   channelListings: [ShippingMethodChannelListing!]
@@ -4192,7 +4192,7 @@ type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shi
 
   """
   List of excluded products for the shipping method.
-  
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   excludedProducts(
@@ -4227,7 +4227,7 @@ type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shi
 
   """
   Tax class assigned to this shipping method.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
@@ -4251,14 +4251,14 @@ type ShippingMethodTranslation implements Node @doc(category: "Shipping") {
 
   """
   Translated description of the shipping method.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Represents the shipping method fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: ShippingMethodTranslatableContent
@@ -5063,7 +5063,7 @@ type ShippingMethodTranslatableContent implements Node @doc(category: "Shipping"
 
   """
   The ID of the shipping method to translate.
-  
+
   Added in Saleor 3.14.
   """
   shippingMethodId: ID!
@@ -5073,7 +5073,7 @@ type ShippingMethodTranslatableContent implements Node @doc(category: "Shipping"
 
   """
   Shipping method description to translate.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -5086,7 +5086,7 @@ type ShippingMethodTranslatableContent implements Node @doc(category: "Shipping"
 
   """
   Shipping method are the methods you'll use to get customer's orders  to them. They are directly exposed to the customers.
-  
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingMethod: ShippingMethodType @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
@@ -5117,46 +5117,46 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
 
   """
   List of private metadata items. Requires staff permissions to access.
-  
+
   Added in Saleor 3.15.
   """
   privateMetadata: [MetadataItem!]!
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.15.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.15.
   """
   privateMetafields(keys: [String!]): Metadata
 
   """
   List of public metadata items. Can be accessed without permissions.
-  
+
   Added in Saleor 3.15.
   """
   metadata: [MetadataItem!]!
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.15.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.15.
   """
   metafields(keys: [String!]): Metadata
@@ -5166,109 +5166,109 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
 
   """
   Name of the channel.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   name: String!
 
   """
   Whether the channel is active.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   isActive: Boolean!
 
   """
   A currency that is assigned to the channel.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   currencyCode: String!
 
   """
   Whether a channel has associated orders.
-  
+
   Requires one of the following permissions: MANAGE_CHANNELS.
   """
   hasOrders: Boolean!
 
   """
   Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   defaultCountry: CountryDisplay!
 
   """
   List of warehouses assigned to this channel.
-  
+
   Added in Saleor 3.5.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   warehouses: [Warehouse!]!
 
   """
   List of shippable countries for the channel.
-  
+
   Added in Saleor 3.6.
   """
   countries: [CountryDisplay!]
 
   """
   Shipping methods that are available for the channel.
-  
+
   Added in Saleor 3.6.
   """
   availableShippingMethodsPerCountry(countries: [CountryCode!]): [ShippingMethodsPerCountry!]
 
   """
   Define the stock setting for this channel.
-  
+
   Added in Saleor 3.7.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   stockSettings: StockSettings!
 
   """
   Channel-specific order settings.
-  
+
   Added in Saleor 3.12.
-  
+
   Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_ORDERS.
   """
   orderSettings: OrderSettings!
 
   """
   Channel-specific checkout settings.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_CHECKOUTS.
   """
   checkoutSettings: CheckoutSettings!
 
   """
   Channel-specific payment settings.
-  
+
   Added in Saleor 3.16.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_CHANNELS, HANDLE_PAYMENTS.
   """
   paymentSettings: PaymentSettings!
 
   """
   Channel specific tax configuration.
-  
+
   Added in Saleor 3.20.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfiguration: TaxConfiguration!
@@ -5557,7 +5557,7 @@ type ShippingMethod implements Node & ObjectWithMetadata @doc(category: "Shippin
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
   """
   privateMetafield(key: String!): String
@@ -5572,7 +5572,7 @@ type ShippingMethod implements Node & ObjectWithMetadata @doc(category: "Shippin
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
   """
   metafield(key: String!): String
@@ -5590,7 +5590,7 @@ type ShippingMethod implements Node & ObjectWithMetadata @doc(category: "Shippin
 
   """
   Shipping method description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -5685,9 +5685,9 @@ type OrderSettings {
 
   """
   Expiration time in minutes. Default null - means do not expire any orders.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   expireOrdersAfter: Minute
@@ -5696,36 +5696,36 @@ type OrderSettings {
   Determine what strategy will be used to mark the order as paid. Based on the chosen option, the proper object will be created and attached to the order when it's manually marked as paid.
   `PAYMENT_FLOW` - [default option] creates the `Payment` object.
   `TRANSACTION_FLOW` - creates the `TransactionItem` object.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   markAsPaidStrategy: MarkAsPaidStrategyEnum!
 
   """
   The time in days after expired orders will be deleted.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   deleteExpiredOrdersAfter: Day!
 
   """
   Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   allowUnpaidOrders: Boolean!
 
   """
   Determine if voucher applied on draft order should be count toward voucher usage.
-  
+
   Added in Saleor 3.18.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   includeDraftOrderInVoucherUsage: Boolean!
@@ -5763,7 +5763,7 @@ Note: this API is currently in Feature Preview and can be subject to changes at 
 type CheckoutSettings {
   """
   Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one.
-  
+
   Added in Saleor 3.15.This field will be removed in Saleor 4.0.
   """
   useLegacyErrorFlow: Boolean!
@@ -5773,9 +5773,9 @@ type CheckoutSettings {
 type PaymentSettings {
   """
   Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
-  
+
   Added in Saleor 3.16.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   defaultTransactionFlowStrategy: TransactionFlowStrategyEnum!
@@ -5806,16 +5806,16 @@ type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -5825,16 +5825,16 @@ type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -5861,7 +5861,7 @@ type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
-  
+
   Added in Saleor 3.19.
   """
   taxAppId: String
@@ -5896,7 +5896,7 @@ type TaxConfigurationPerCountry @doc(category: "Taxes") {
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
-  
+
   Added in Saleor 3.19.
   """
   taxAppId: String
@@ -5949,16 +5949,16 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -5968,16 +5968,16 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -5993,7 +5993,7 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Description of the product.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -6028,7 +6028,7 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Description of the product.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
@@ -6042,7 +6042,7 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.6.
     """
     format: ThumbnailFormatEnum = ORIGINAL
@@ -6073,7 +6073,7 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Get a single attribute attached to product by attribute slug.
-  
+
   Added in Saleor 3.9.
   """
   attribute(
@@ -6086,7 +6086,7 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   List of availability in channels for the product.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   channelListings: [ProductChannelListing!]
@@ -6104,8 +6104,8 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
   ): ProductImage @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `mediaById` field instead.")
 
   """
-  Get a single variant by SKU or ID. 
-  
+  Get a single variant by SKU or ID.
+
   Added in Saleor 3.9.
   """
   variant(
@@ -6124,8 +6124,8 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
   """List of media for the product."""
   media(
     """
-    Sort media. 
-    
+    Sort media.
+
     Added in Saleor 3.9.
     """
     sortBy: MediaSortingInput
@@ -6158,14 +6158,14 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
 
   """
-  External ID of this product. 
-  
+  External ID of this product.
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -6183,16 +6183,16 @@ type ProductType implements Node & ObjectWithMetadata @doc(category: "Products")
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -6202,16 +6202,16 @@ type ProductType implements Node & ObjectWithMetadata @doc(category: "Products")
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -6264,7 +6264,7 @@ type ProductType implements Node & ObjectWithMetadata @doc(category: "Products")
 
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
@@ -6277,7 +6277,7 @@ type ProductType implements Node & ObjectWithMetadata @doc(category: "Products")
 
   """
   Variant attributes of that product type with attached variant selection.
-  
+
   Added in Saleor 3.1.
   """
   assignedVariantAttributes(
@@ -6290,7 +6290,7 @@ type ProductType implements Node & ObjectWithMetadata @doc(category: "Products")
 
   """
   List of attributes which can be assigned to this product type.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   availableAttributes(
@@ -6343,16 +6343,16 @@ type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -6362,16 +6362,16 @@ type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -6411,16 +6411,16 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -6430,16 +6430,16 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -6569,8 +6569,8 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
   ): ProductTypeCountableConnection!
 
   """
-  External ID of this attribute. 
-  
+  External ID of this attribute.
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -6688,7 +6688,7 @@ type AttributeValue implements Node @doc(category: "Attributes") {
 
   """
   Represents the text of the attribute value, includes formatting.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   richText: JSONString
@@ -6708,8 +6708,8 @@ type AttributeValue implements Node @doc(category: "Attributes") {
   dateTime: DateTime
 
   """
-  External ID of this attribute value. 
-  
+  External ID of this attribute value.
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -6728,7 +6728,7 @@ type AttributeValueTranslation implements Node @doc(category: "Attributes") {
 
   """
   Translated rich-text attribute value.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   richText: JSONString
@@ -6738,7 +6738,7 @@ type AttributeValueTranslation implements Node @doc(category: "Attributes") {
 
   """
   Represents the attribute value fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: AttributeValueTranslatableContent
@@ -6753,7 +6753,7 @@ type AttributeValueTranslatableContent implements Node @doc(category: "Attribute
 
   """
   The ID of the attribute value to translate.
-  
+
   Added in Saleor 3.14.
   """
   attributeValueId: ID!
@@ -6763,7 +6763,7 @@ type AttributeValueTranslatableContent implements Node @doc(category: "Attribute
 
   """
   Attribute value.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   richText: JSONString
@@ -6782,7 +6782,7 @@ type AttributeValueTranslatableContent implements Node @doc(category: "Attribute
 
   """
   Associated attribute that can be translated.
-  
+
   Added in Saleor 3.9.
   """
   attribute: AttributeTranslatableContent
@@ -6797,7 +6797,7 @@ type AttributeTranslatableContent implements Node @doc(category: "Attributes") {
 
   """
   The ID of the attribute to translate.
-  
+
   Added in Saleor 3.14.
   """
   attributeId: ID!
@@ -6828,7 +6828,7 @@ type AttributeTranslation implements Node @doc(category: "Attributes") {
 
   """
   Represents the attribute fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: AttributeTranslatableContent
@@ -6942,8 +6942,8 @@ input AttributeFilterInput @doc(category: "Attributes") {
   slugs: [String!]
 
   """
-  Specifies the channel by which the data should be filtered. 
-  
+  Specifies the channel by which the data should be filtered.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -7046,16 +7046,16 @@ type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -7065,16 +7065,16 @@ type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -7090,7 +7090,7 @@ type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Description of the category.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -7106,14 +7106,14 @@ type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Description of the category.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
   """
   The date and time when the category was last updated.
-  
+
   Added in Saleor 3.17.
   """
   updatedAt: DateTime!
@@ -7143,23 +7143,23 @@ type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
   products(
     """
     Filtering options for products.
-    
+
     Added in Saleor 3.10.
     """
     filter: ProductFilterInput
 
     """
     Filtering options for products.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     where: ProductWhereInput
 
     """
     Sort products.
-    
+
     Added in Saleor 3.10.
     """
     sortBy: ProductOrder
@@ -7212,7 +7212,7 @@ type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.6.
     """
     format: ThumbnailFormatEnum = ORIGINAL
@@ -7256,29 +7256,29 @@ input ProductFilterInput @doc(category: "Products") {
   metadata: [MetadataFilter!]
 
   """
-  Filter by the publication date. 
-  
+  Filter by the publication date.
+
   Added in Saleor 3.8.
   """
   publishedFrom: DateTime
 
   """
-  Filter by availability for purchase. 
-  
+  Filter by availability for purchase.
+
   Added in Saleor 3.8.
   """
   isAvailable: Boolean
 
   """
-  Filter by the date of availability for purchase. 
-  
+  Filter by the date of availability for purchase.
+
   Added in Saleor 3.8.
   """
   availableFrom: DateTime
 
   """
-  Filter by visibility in product listings. 
-  
+  Filter by visibility in product listings.
+
   Added in Saleor 3.8.
   """
   isVisibleInListing: Boolean
@@ -7298,8 +7298,8 @@ input ProductFilterInput @doc(category: "Products") {
   slugs: [String!]
 
   """
-  Specifies the channel by which the data should be filtered. 
-  
+  Specifies the channel by which the data should be filtered.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -7510,7 +7510,7 @@ input ProductOrder @doc(category: "Products") {
 
   """
   Specifies the channel in which to sort the data.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -7536,14 +7536,14 @@ enum ProductOrderField @doc(category: "Products") {
 
   """
   Sort products by price.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   PRICE
 
   """
   Sort products by a minimal price of a product's variant.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   MINIMAL_PRICE
@@ -7559,21 +7559,21 @@ enum ProductOrderField @doc(category: "Products") {
 
   """
   Sort products by publication status.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   PUBLISHED
 
   """
   Sort products by publication date.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   PUBLICATION_DATE
 
   """
   Sort products by publication date.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   PUBLISHED_AT
@@ -7583,7 +7583,7 @@ enum ProductOrderField @doc(category: "Products") {
 
   """
   Sort products by collection. Note: This option is available only for the `Collection.products` query.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   COLLECTION
@@ -7593,7 +7593,7 @@ enum ProductOrderField @doc(category: "Products") {
 
   """
   Sort products by creation date.
-  
+
   Added in Saleor 3.8.
   """
   CREATED_AT
@@ -7630,7 +7630,7 @@ type CategoryTranslation implements Node @doc(category: "Products") {
 
   """
   Translated category slug.
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -7640,21 +7640,21 @@ type CategoryTranslation implements Node @doc(category: "Products") {
 
   """
   Translated description of the category.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Translated description of the category.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
   """
   Represents the category fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: CategoryTranslatableContent
@@ -7669,7 +7669,7 @@ type CategoryTranslatableContent implements Node @doc(category: "Products") {
 
   """
   The ID of the category to translate.
-  
+
   Added in Saleor 3.14.
   """
   categoryId: ID!
@@ -7682,7 +7682,7 @@ type CategoryTranslatableContent implements Node @doc(category: "Products") {
 
   """
   Slug to translate.
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -7692,14 +7692,14 @@ type CategoryTranslatableContent implements Node @doc(category: "Products") {
 
   """
   Category description to translate.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Description of the category.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
@@ -7724,16 +7724,16 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -7743,16 +7743,16 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -7784,7 +7784,7 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   List of price information in channels for the product.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   channelListings: [ProductVariantChannelListing!]
@@ -7810,14 +7810,14 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   Total quantity ordered.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   quantityOrdered: Int
 
   """
   Total revenue generated by a variant in given period of time. Note: this field should be queried using `reportProductSales` query as it uses optimizations suitable for such calculations.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   revenue(period: ReportingPeriod): TaxedMoney
@@ -7836,14 +7836,14 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   Digital content for the product variant.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   digitalContent: DigitalContent
 
   """
   Stocks for the product variant.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   stocks(
@@ -7853,8 +7853,8 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
     address: AddressInput
 
     """
-    Two-letter ISO 3166-1 country code. 
-    
+    Two-letter ISO 3166-1 country code.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `address` argument instead.
     """
     countryCode: CountryCode
@@ -7870,8 +7870,8 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
     address: AddressInput
 
     """
-    Two-letter ISO 3166-1 country code. When provided, the exact quantity from a warehouse operating in shipping zones that contain this country will be returned. Otherwise, it will return the maximum quantity from all shipping zones. 
-    
+    Two-letter ISO 3166-1 country code. When provided, the exact quantity from a warehouse operating in shipping zones that contain this country will be returned. Otherwise, it will return the maximum quantity from all shipping zones.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `address` argument instead.
     """
     countryCode: CountryCode
@@ -7879,7 +7879,7 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   Preorder data for product variant.
-  
+
   Added in Saleor 3.1.
   """
   preorder: PreorderData
@@ -7891,8 +7891,8 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
   updatedAt: DateTime!
 
   """
-  External ID of this product. 
-  
+  External ID of this product.
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -7914,14 +7914,14 @@ type ProductVariantChannelListing implements Node @doc(category: "Products") {
 
   """
   Gross margin percentage value.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   margin: Int
 
   """
   Preorder variant data.
-  
+
   Added in Saleor 3.1.
   """
   preorderThreshold: PreorderThreshold
@@ -8007,23 +8007,23 @@ input AddressInput {
 
   """
   Phone number.
-  
+
   Phone numbers are validated with Google's [libphonenumber](https://github.com/google/libphonenumber) library.
   """
   phone: String
 
   """
   Address public metadata.
-  
+
   Added in Saleor 3.15.
   """
   metadata: [MetadataInput!]
 
   """
   Determine if the address should be validated. By default, Saleor accepts only address inputs matching ruleset from [Google Address Data]{https://chromium-i18n.appspot.com/ssl-address), using [i18naddress](https://github.com/mirumee/google-i18n-address) library. Some mutations may require additional permissions to use the the field. More info about permissions can be found in relevant mutation.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   skipValidation: Boolean = false
@@ -8073,7 +8073,7 @@ type ProductImage @doc(category: "Products") {
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.6.
     """
     format: ThumbnailFormatEnum = ORIGINAL
@@ -8087,46 +8087,46 @@ type ProductMedia implements Node & ObjectWithMetadata @doc(category: "Products"
 
   """
   List of private metadata items. Requires staff permissions to access.
-  
+
   Added in Saleor 3.12.
   """
   privateMetadata: [MetadataItem!]!
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.12.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.12.
   """
   privateMetafields(keys: [String!]): Metadata
 
   """
   List of public metadata items. Can be accessed without permissions.
-  
+
   Added in Saleor 3.12.
   """
   metadata: [MetadataItem!]!
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.12.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.12.
   """
   metafields(keys: [String!]): Metadata
@@ -8152,7 +8152,7 @@ type ProductMedia implements Node & ObjectWithMetadata @doc(category: "Products"
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.6.
     """
     format: ThumbnailFormatEnum = ORIGINAL
@@ -8160,7 +8160,7 @@ type ProductMedia implements Node & ObjectWithMetadata @doc(category: "Products"
 
   """
   Product id the media refers to.
-  
+
   Added in Saleor 3.12.
   """
   productId: ID
@@ -8184,7 +8184,7 @@ type ProductVariantTranslation implements Node @doc(category: "Products") {
 
   """
   Represents the product variant fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: ProductVariantTranslatableContent
@@ -8199,7 +8199,7 @@ type ProductVariantTranslatableContent implements Node @doc(category: "Products"
 
   """
   The ID of the product variant to translate.
-  
+
   Added in Saleor 3.14.
   """
   productVariantId: ID!
@@ -8230,16 +8230,16 @@ type DigitalContent implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -8249,16 +8249,16 @@ type DigitalContent implements Node & ObjectWithMetadata @doc(category: "Product
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -8321,21 +8321,21 @@ type Stock implements Node @doc(category: "Products") {
 
   """
   Quantity of a product in the warehouse's possession, including the allocated stock that is waiting for shipment.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   quantity: Int!
 
   """
   Quantity allocated for orders.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   quantityAllocated: Int!
 
   """
   Quantity reserved for checkouts.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   quantityReserved: Int!
@@ -8345,14 +8345,14 @@ type Stock implements Node @doc(category: "Products") {
 type PreorderData @doc(category: "Products") {
   """
   The global preorder threshold for product variant.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   globalThreshold: Int
 
   """
   Total number of sold product variant during preorder.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   globalSoldUnits: Int!
@@ -8374,7 +8374,7 @@ type ProductPricingInfo @doc(category: "Products") {
 
   """
   Determines whether displayed prices should include taxes.
-  
+
   Added in Saleor 3.9.
   """
   displayGrossPrices: Boolean!
@@ -8408,7 +8408,7 @@ type ProductChannelListing implements Node @doc(category: "Products") {
 
   """
   The product publication date time.
-  
+
   Added in Saleor 3.3.
   """
   publishedAt: DateTime
@@ -8425,7 +8425,7 @@ type ProductChannelListing implements Node @doc(category: "Products") {
 
   """
   The product available for purchase date time.
-  
+
   Added in Saleor 3.3.
   """
   availableForPurchaseAt: DateTime
@@ -8435,14 +8435,14 @@ type ProductChannelListing implements Node @doc(category: "Products") {
 
   """
   Purchase cost of product.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   purchaseCost: MoneyRange
 
   """
   Range of margin percentage value.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   margin: Margin
@@ -8495,16 +8495,16 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -8514,16 +8514,16 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -8539,7 +8539,7 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
 
   """
   Description of the collection.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -8554,7 +8554,7 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
 
   """
   Description of the collection.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
@@ -8566,9 +8566,9 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
 
     """
     Filtering options for products.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     where: ProductWhereInput
@@ -8602,7 +8602,7 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.6.
     """
     format: ThumbnailFormatEnum = ORIGINAL
@@ -8616,7 +8616,7 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
 
   """
   List of channels in which the collection is available.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   channelListings: [CollectionChannelListing!]
@@ -8638,7 +8638,7 @@ type CollectionTranslation implements Node @doc(category: "Products") {
 
   """
   Translated collection slug.
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -8648,21 +8648,21 @@ type CollectionTranslation implements Node @doc(category: "Products") {
 
   """
   Translated description of the collection.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Translated description of the collection.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
   """
   Represents the collection fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: CollectionTranslatableContent
@@ -8677,7 +8677,7 @@ type CollectionTranslatableContent implements Node @doc(category: "Products") {
 
   """
   The ID of the collection to translate.
-  
+
   Added in Saleor 3.14.
   """
   collectionId: ID!
@@ -8690,7 +8690,7 @@ type CollectionTranslatableContent implements Node @doc(category: "Products") {
 
   """
   Slug to translate
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -8700,14 +8700,14 @@ type CollectionTranslatableContent implements Node @doc(category: "Products") {
 
   """
   Collection's description to translate.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Description of the collection.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
@@ -8730,7 +8730,7 @@ type CollectionChannelListing implements Node @doc(category: "Products") {
 
   """
   The collection publication date.
-  
+
   Added in Saleor 3.3.
   """
   publishedAt: DateTime
@@ -8758,7 +8758,7 @@ type ProductTranslation implements Node @doc(category: "Products") {
 
   """
   Translated product slug.
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -8768,21 +8768,21 @@ type ProductTranslation implements Node @doc(category: "Products") {
 
   """
   Translated description of the product.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Translated description of the product.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
   """
   Represents the product fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: ProductTranslatableContent
@@ -8797,7 +8797,7 @@ type ProductTranslatableContent implements Node @doc(category: "Products") {
 
   """
   The ID of the product to translate.
-  
+
   Added in Saleor 3.14.
   """
   productId: ID!
@@ -8810,7 +8810,7 @@ type ProductTranslatableContent implements Node @doc(category: "Products") {
 
   """
   Slug to translate.
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -8820,14 +8820,14 @@ type ProductTranslatableContent implements Node @doc(category: "Products") {
 
   """
   Product's description to translate.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Description of the product.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
@@ -8930,7 +8930,7 @@ type PageTranslatableContent implements Node @doc(category: "Pages") {
 
   """
   The ID of the page to translate.
-  
+
   Added in Saleor 3.14.
   """
   pageId: ID!
@@ -8943,7 +8943,7 @@ type PageTranslatableContent implements Node @doc(category: "Pages") {
 
   """
   Slug to translate.
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -8953,14 +8953,14 @@ type PageTranslatableContent implements Node @doc(category: "Pages") {
 
   """
   Content of the page to translate.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   content: JSONString
 
   """
   Content of the page.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   contentJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `content` field instead.")
@@ -8996,7 +8996,7 @@ type PageTranslation implements Node @doc(category: "Pages") {
 
   """
   Translated page slug.
-  
+
   Added in Saleor 3.21.
   """
   slug: String
@@ -9006,21 +9006,21 @@ type PageTranslation implements Node @doc(category: "Pages") {
 
   """
   Translated content of the page.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   content: JSONString
 
   """
   Translated description of the page.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   contentJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `content` field instead.")
 
   """
   Represents the page fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: PageTranslatableContent
@@ -9038,16 +9038,16 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -9057,16 +9057,16 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -9082,7 +9082,7 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   Content of the page.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   content: JSONString
@@ -9090,7 +9090,7 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   The page publication date.
-  
+
   Added in Saleor 3.3.
   """
   publishedAt: DateTime
@@ -9109,7 +9109,7 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   Content of the page.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   contentJson: JSONString! @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `content` field instead.")
@@ -9136,16 +9136,16 @@ type PageType implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -9155,16 +9155,16 @@ type PageType implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -9180,7 +9180,7 @@ type PageType implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   Attributes that can be assigned to the page type.
-  
+
   Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   availableAttributes(
@@ -9206,7 +9206,7 @@ type PageType implements Node & ObjectWithMetadata @doc(category: "Pages") {
 
   """
   Whether page type has pages assigned.
-  
+
   Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   hasPages: Boolean
@@ -9221,7 +9221,7 @@ type VoucherTranslatableContent implements Node @doc(category: "Discounts") {
 
   """
   The ID of the voucher to translate.
-  
+
   Added in Saleor 3.14.
   """
   voucherId: ID!
@@ -9237,7 +9237,7 @@ type VoucherTranslatableContent implements Node @doc(category: "Discounts") {
 
   """
   Vouchers allow giving discounts to particular customers on categories, collections or specific products. They can be used during checkout by providing valid voucher codes.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   voucher: Voucher @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
@@ -9256,7 +9256,7 @@ type VoucherTranslation implements Node @doc(category: "Discounts") {
 
   """
   Represents the voucher fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: VoucherTranslatableContent
@@ -9274,16 +9274,16 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -9293,16 +9293,16 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -9312,7 +9312,7 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of codes available for this voucher.
-  
+
   Added in Saleor 3.18.
   """
   codes(
@@ -9360,9 +9360,9 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   Determine if the voucher codes can be used once or multiple times.
-  
+
   Added in Saleor 3.18.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   singleUse: Boolean!
@@ -9394,7 +9394,7 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of collections this voucher applies to.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   collections(
@@ -9417,7 +9417,7 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of products this voucher applies to.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   products(
@@ -9440,9 +9440,9 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of product variants this voucher applies to.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   variants(
@@ -9489,7 +9489,7 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of availability in channels for the voucher.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   channelListings: [VoucherChannelListing!]
@@ -9609,7 +9609,7 @@ type MenuItemTranslatableContent implements Node @doc(category: "Menu") {
 
   """
   The ID of the menu item to translate.
-  
+
   Added in Saleor 3.14.
   """
   menuItemId: ID!
@@ -9642,7 +9642,7 @@ type MenuItemTranslation implements Node @doc(category: "Menu") {
 
   """
   Represents the menu item fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: MenuItemTranslatableContent
@@ -9660,16 +9660,16 @@ type MenuItem implements Node & ObjectWithMetadata @doc(category: "Menu") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -9679,16 +9679,16 @@ type MenuItem implements Node & ObjectWithMetadata @doc(category: "Menu") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -9743,16 +9743,16 @@ type Menu implements Node & ObjectWithMetadata @doc(category: "Menu") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -9762,16 +9762,16 @@ type Menu implements Node & ObjectWithMetadata @doc(category: "Menu") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -9803,7 +9803,7 @@ type PromotionTranslatableContent implements Node @doc(category: "Discounts") {
 
   """
   Description of the promotion.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -9832,14 +9832,14 @@ type PromotionTranslation implements Node @doc(category: "Discounts") {
 
   """
   Translated description of the promotion.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Represents the promotion fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: PromotionTranslatableContent
@@ -9856,7 +9856,7 @@ type PromotionRuleTranslatableContent implements Node @doc(category: "Discounts"
 
   """
   ID of the promotion rule to translate.
-  
+
   Added in Saleor 3.14.
   """
   promotionRuleId: ID!
@@ -9866,7 +9866,7 @@ type PromotionRuleTranslatableContent implements Node @doc(category: "Discounts"
 
   """
   Description of the promotion rule.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -9895,14 +9895,14 @@ type PromotionRuleTranslation implements Node @doc(category: "Discounts") {
 
   """
   Translated description of the promotion rule.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
   """
   Represents the promotion rule fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: PromotionRuleTranslatableContent
@@ -9919,7 +9919,7 @@ type SaleTranslatableContent implements Node @doc(category: "Discounts") {
 
   """
   The ID of the sale to translate.
-  
+
   Added in Saleor 3.14.
   """
   saleId: ID!
@@ -9935,7 +9935,7 @@ type SaleTranslatableContent implements Node @doc(category: "Discounts") {
 
   """
   Sales allow creating discounts for categories, collections or products and are visible to all the customers.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   sale: Sale @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
@@ -9958,7 +9958,7 @@ type SaleTranslation implements Node @doc(category: "Discounts") {
 
   """
   Represents the sale fields to translate.
-  
+
   Added in Saleor 3.14.
   """
   translatableContent: SaleTranslatableContent
@@ -9978,16 +9978,16 @@ type Sale implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -9997,16 +9997,16 @@ type Sale implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -10050,7 +10050,7 @@ type Sale implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of collections this sale applies to.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   collections(
@@ -10073,7 +10073,7 @@ type Sale implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of products this sale applies to.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   products(
@@ -10096,9 +10096,9 @@ type Sale implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of product variants this sale applies to.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   variants(
@@ -10127,7 +10127,7 @@ type Sale implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of channels available for the sale.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   channelListings: [SaleChannelListing!]
@@ -10264,7 +10264,7 @@ type Shop implements ObjectWithMetadata {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
   """
   privateMetafield(key: String!): String
@@ -10279,7 +10279,7 @@ type Shop implements ObjectWithMetadata {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
   """
   metafield(key: String!): String
@@ -10295,8 +10295,8 @@ type Shop implements ObjectWithMetadata {
   """List of available payment gateways."""
   availablePaymentGateways(
     """
-    A currency for which gateways will be returned. 
-    
+    A currency for which gateways will be returned.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `channel` argument instead.
     """
     currency: String
@@ -10319,9 +10319,9 @@ type Shop implements ObjectWithMetadata {
 
   """
   List of all currencies supported by shop's channels.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   channelCurrencies: [String!]!
@@ -10329,8 +10329,8 @@ type Shop implements ObjectWithMetadata {
   """List of countries available in the shop."""
   countries(
     """
-    A language code to return the translation for. 
-    
+    A language code to return the translation for.
+
     DEPRECATED: this field will be removed in Saleor 4.0.
     """
     languageCode: LanguageCodeEnum
@@ -10344,14 +10344,14 @@ type Shop implements ObjectWithMetadata {
 
   """
   Default shop's email sender's name.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   defaultMailSenderName: String
 
   """
   Default shop's email sender's address.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   defaultMailSenderAddress: String
@@ -10379,14 +10379,14 @@ type Shop implements ObjectWithMetadata {
 
   """
   Automatically approve all new fulfillments.
-  
+
   Added in Saleor 3.1.
   """
   fulfillmentAutoApprove: Boolean!
 
   """
   Allow to approve fulfillments which are unpaid.
-  
+
   Added in Saleor 3.1.
   """
   fulfillmentAllowUnpaid: Boolean!
@@ -10407,48 +10407,48 @@ type Shop implements ObjectWithMetadata {
 
   """
   Enable automatic fulfillment for all digital products.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   automaticFulfillmentDigitalProducts: Boolean
 
   """
   Default number of minutes stock will be reserved for anonymous checkout or null when stock reservation is disabled.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   reserveStockDurationAnonymousUser: Int
 
   """
   Default number of minutes stock will be reserved for authenticated checkout or null when stock reservation is disabled.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   reserveStockDurationAuthenticatedUser: Int
 
   """
   Default number of maximum line quantity in single checkout (per single checkout line).
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   limitQuantityPerCheckout: Int
 
   """
   Default number of max downloads per digital content URL.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   defaultDigitalMaxDownloads: Int
 
   """
   Default number of days which digital content URL will be valid.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   defaultDigitalUrlValidDays: Int
@@ -10461,55 +10461,55 @@ type Shop implements ObjectWithMetadata {
 
   """
   List of staff notification recipients.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   staffNotificationRecipients: [StaffNotificationRecipient!]
 
   """
   Determines if account confirmation by email is enabled.
-  
+
   Added in Saleor 3.14.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   enableAccountConfirmationByEmail: Boolean
 
   """
   Determines if user can login without confirmation when `enableAccountConfirmation` is enabled.
-  
+
   Added in Saleor 3.15.
-  
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   allowLoginWithoutConfirmation: Boolean
 
   """
   Resource limitations and current usage if any set for a shop
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   limits: LimitInfo! @deprecated(reason: "This field will be removed in Saleor 4.0.")
 
   """
   Saleor API version.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   version: String!
 
   """
   Minor Saleor API version.
-  
+
   Added in Saleor 3.5.
   """
   schemaVersion: String!
 
   """
   List of tax apps that can be assigned to the channel. The list will be calculated by Saleor based on the apps that are subscribed to webhooks related to tax calculations: CHECKOUT_CALCULATE_TAXES
-  
+
   Added in Saleor 3.19.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, MANAGE_APPS.
   """
   availableTaxApps: [App!]!
@@ -10620,16 +10620,16 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -10639,16 +10639,16 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -10670,7 +10670,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   Determines if user has confirmed email.
-  
+
   Added in Saleor 3.15.
   """
   isConfirmed: Boolean!
@@ -10695,7 +10695,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   Returns checkouts assigned to this user.
-  
+
   Added in Saleor 3.8.
   """
   checkouts(
@@ -10740,7 +10740,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   A note about the customer.
-  
+
   Requires one of the following permissions: MANAGE_USERS, MANAGE_STAFF.
   """
   note: String
@@ -10777,18 +10777,18 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   List of channels the user has access to. The sum of channels from all user groups. If at least one group has `restrictedAccessToChannels` set to False - all channels are returned.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   accessibleChannels: [Channel!]
 
   """
   Determine if user have restricted access to channels. False if at least one user group has `restrictedAccessToChannels` set to False.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   restrictedAccessToChannels: Boolean!
@@ -10802,7 +10802,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.6.
     """
     format: ThumbnailFormatEnum = ORIGINAL
@@ -10810,7 +10810,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   List of events associated with the user.
-  
+
   Requires one of the following permissions: MANAGE_USERS, MANAGE_STAFF.
   """
   events: [CustomerEvent!]
@@ -10833,8 +10833,8 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   defaultBillingAddress: Address
 
   """
-  External ID of this user. 
-  
+  External ID of this user.
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -10850,9 +10850,9 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   Returns a list of user's stored payment methods that can be used in provided channel. The field returns a list of stored payment methods by payment apps. When `amount` is not provided, 0 will be used as default value.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   storedPaymentMethods(
@@ -10871,16 +10871,16 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -10890,16 +10890,16 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -10909,7 +10909,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   Time of last modification of the given checkout.
-  
+
   Added in Saleor 3.13.
   """
   updatedAt: DateTime!
@@ -10930,8 +10930,8 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   shippingAddress: Address
 
   """
-  The customer note for the checkout. 
-  
+  The customer note for the checkout.
+
   Added in Saleor 3.21.
   """
   customerNote: String!
@@ -10954,9 +10954,9 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The voucher assigned to the checkout.
-  
+
   Added in Saleor 3.18.
-  
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   voucher: Voucher
@@ -10966,7 +10966,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   Shipping methods that can be used with this checkout.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
   - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
@@ -10975,7 +10975,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   Shipping methods that can be used with this checkout.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
   - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
@@ -10984,14 +10984,14 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   Collection points that can be used for this order.
-  
+
   Added in Saleor 3.1.
   """
   availableCollectionPoints: [Warehouse!]!
 
   """
   List of available payment gateways.
-  
+
   Triggers the following webhook events:
   - PAYMENT_LIST_GATEWAYS (sync): Fetch payment gateways available for checkout.
   """
@@ -11011,7 +11011,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   Date when oldest stock reservation for this checkout expires or null if no stock is reserved.
-  
+
   Added in Saleor 3.1.
   """
   stockReservationExpires: DateTime
@@ -11023,7 +11023,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The price of the shipping, with all the taxes included. Set to 0 when no delivery method is selected.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11031,7 +11031,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The shipping method related with checkout.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
   - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
@@ -11040,9 +11040,9 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The delivery method selected for this checkout.
-  
+
   Added in Saleor 3.1.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
   - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
@@ -11051,7 +11051,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The price of the checkout before shipping, with taxes included.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11059,7 +11059,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   Returns True if checkout has to be exempt from taxes.
-  
+
   Added in Saleor 3.8.
   """
   taxExemption: Boolean!
@@ -11069,7 +11069,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The sum of the checkout line prices, with all the taxes,shipping costs, and discounts included.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11077,11 +11077,11 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The difference between the paid and the checkout total amount.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11092,27 +11092,27 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
-  
+
   Added in Saleor 3.4.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactions: [TransactionItem!]
 
   """
   Determines whether displayed prices should include taxes.
-  
+
   Added in Saleor 3.9.
   """
   displayGrossPrices: Boolean!
 
   """
   The authorize status of the checkout.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11120,11 +11120,11 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The charge status of the checkout.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11132,9 +11132,9 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   List of user's stored payment methods that can be used in this checkout session. It uses the channel that the checkout was created in. When `amount` is not provided, `checkout.total` will be used as a default value.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   storedPaymentMethods(
@@ -11144,9 +11144,9 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   List of problems with the checkout.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   problems: [CheckoutProblem!]
@@ -11164,16 +11164,16 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -11183,16 +11183,16 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -11205,7 +11205,7 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
 
   """
   Gift card code. It can be fetched both by a staff member with 'MANAGE_GIFT_CARD' when gift card hasn't been used yet or a user who bought or issued the gift card.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD, OWNER.
   """
   code: String!
@@ -11215,30 +11215,30 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
 
   """
   The user who bought or issued a gift card.
-  
+
   Added in Saleor 3.1.
   """
   createdBy: User
 
   """
   The customer who used a gift card.
-  
+
   Added in Saleor 3.1.
   """
   usedBy: User @deprecated(reason: "This field will be removed in Saleor 4.0.")
 
   """
   Email address of the user who bought or issued gift card.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_USERS, OWNER.
   """
   createdByEmail: String
 
   """
   Email address of the customer who used a gift card.
-  
+
   Added in Saleor 3.1.
   """
   usedByEmail: String @deprecated(reason: "This field will be removed in Saleor 4.0.")
@@ -11251,25 +11251,25 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
 
   """
   App which created the gift card.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   app: App
 
   """
   Related gift card product.
-  
+
   Added in Saleor 3.1.
   """
   product: Product
 
   """
   List of events associated with the gift card.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   events(
@@ -11279,16 +11279,16 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
 
   """
   The gift card tag.
-  
+
   Added in Saleor 3.1.
-  
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   tags: [GiftCardTag!]!
 
   """
   Slug of the channel where the gift card was bought.
-  
+
   Added in Saleor 3.1.
   """
   boughtInChannel: String
@@ -11413,46 +11413,46 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
 
   """
   List of private metadata items. Requires staff permissions to access.
-  
+
   Added in Saleor 3.5.
   """
   privateMetadata: [MetadataItem!]!
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.5.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.5.
   """
   privateMetafields(keys: [String!]): Metadata
 
   """
   List of public metadata items. Can be accessed without permissions.
-  
+
   Added in Saleor 3.5.
   """
   metadata: [MetadataItem!]!
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.5.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.5.
   """
   metafields(keys: [String!]): Metadata
@@ -11465,7 +11465,7 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
 
   """
   The unit price of the checkout line, with taxes and discounts.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11476,7 +11476,7 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
 
   """
   The sum of the checkout line price, taxes and discounts.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11490,18 +11490,18 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
 
   """
   List of problems with the checkout line.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   problems: [CheckoutLineProblem!]
 
   """
   Determine if the line is a gift.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   isGift: Boolean
@@ -11569,16 +11569,16 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -11588,23 +11588,23 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
 
   """
   The transaction token.
-  
+
   Added in Saleor 3.14.
   """
   token: UUID!
@@ -11625,7 +11625,7 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
 
   """
   Total amount of ongoing authorization requests for the transaction.
-  
+
   Added in Saleor 3.13.
   """
   authorizePendingAmount: Money!
@@ -11635,21 +11635,21 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
 
   """
   Total amount of ongoing refund requests for the transaction.
-  
+
   Added in Saleor 3.13.
   """
   refundPendingAmount: Money!
 
   """
   Total amount canceled for this payment.
-  
+
   Added in Saleor 3.13.
   """
   canceledAmount: Money!
 
   """
   Total amount of ongoing cancel requests for the transaction.
-  
+
   Added in Saleor 3.13.
   """
   cancelPendingAmount: Money!
@@ -11659,42 +11659,42 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
 
   """
   Total amount of ongoing charge requests for the transaction.
-  
+
   Added in Saleor 3.13.
   """
   chargePendingAmount: Money!
 
   """
   Name of the transaction.
-  
+
   Added in Saleor 3.13.
   """
   name: String!
 
   """
   Message related to the transaction.
-  
+
   Added in Saleor 3.13.
   """
   message: String!
 
   """
   PSP reference of transaction.
-  
+
   Added in Saleor 3.13.
   """
   pspReference: String!
 
   """
   The related order.
-  
+
   Added in Saleor 3.6.
   """
   order: Order
 
   """
   The related checkout.
-  
+
   Added in Saleor 3.14.
   """
   checkout: Checkout
@@ -11704,14 +11704,14 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
 
   """
   User or App that created the transaction.
-  
+
   Added in Saleor 3.13.
   """
   createdBy: UserOrApp
 
   """
   The url that will allow to redirect user to payment provider page with transaction details.
-  
+
   Added in Saleor 3.13.
   """
   externalUrl: String!
@@ -11741,16 +11741,16 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -11760,16 +11760,16 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -11833,7 +11833,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Collection points that can be used for this order.
-  
+
   Added in Saleor 3.1.
   """
   availableCollectionPoints: [Warehouse!]!
@@ -11863,28 +11863,28 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   The authorize status of the order.
-  
+
   Added in Saleor 3.4.
   """
   authorizeStatus: OrderAuthorizeStatusEnum!
 
   """
   The charge status of the order.
-  
+
   Added in Saleor 3.4.
   """
   chargeStatus: OrderChargeStatusEnum!
 
   """
   Returns True if order has to be exempt from taxes.
-  
+
   Added in Saleor 3.8.
   """
   taxExemption: Boolean!
 
   """
   List of transactions for the order. Requires one of the following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS.
-  
+
   Added in Saleor 3.4.
   """
   transactions: [TransactionItem!]!
@@ -11903,7 +11903,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Undiscounted total price of shipping.
-  
+
   Added in Saleor 3.19.
   """
   undiscountedShippingPrice: Money!
@@ -11916,30 +11916,30 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Denormalized tax class assigned to the shipping method.
-  
+
   Added in Saleor 3.9.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   shippingTaxClass: TaxClass
 
   """
   Denormalized name of the tax class assigned to the shipping method.
-  
+
   Added in Saleor 3.9.
   """
   shippingTaxClassName: String
 
   """
   Denormalized public metadata of the shipping method's tax class.
-  
+
   Added in Saleor 3.9.
   """
   shippingTaxClassMetadata: [MetadataItem!]!
 
   """
   Denormalized private metadata of the shipping method's tax class. Requires staff permissions to access.
-  
+
   Added in Saleor 3.9.
   """
   shippingTaxClassPrivateMetadata: [MetadataItem!]!
@@ -11950,7 +11950,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Voucher code that was used for Order.
-  
+
   Added in Saleor 3.18.
   """
   voucherCode: String
@@ -11986,21 +11986,21 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Amount charged for the order.
-  
+
   Added in Saleor 3.13.
   """
   totalCharged: Money!
 
   """
   Amount canceled for the order.
-  
+
   Added in Saleor 3.13.
   """
   totalCanceled: Money!
 
   """
   List of events associated with the order.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   events: [OrderEvent!]!
@@ -12018,7 +12018,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   The delivery method selected for this order.
-  
+
   Added in Saleor 3.1.
   """
   deliveryMethod: DeliveryMethod
@@ -12044,107 +12044,107 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Determines whether displayed prices should include taxes.
-  
+
   Added in Saleor 3.9.
   """
   displayGrossPrices: Boolean!
 
   """
-  External ID of this order. 
-  
+  External ID of this order.
+
   Added in Saleor 3.10.
   """
   externalReference: String
 
   """
-  ID of the checkout that the order was created from. 
-  
+  ID of the checkout that the order was created from.
+
   Added in Saleor 3.11.
   """
   checkoutId: ID
 
   """
   List of granted refunds.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   grantedRefunds: [OrderGrantedRefund!]!
 
   """
   Total amount of granted refund.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalGrantedRefund: Money!
 
   """
   Total refund amount for the order.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   totalRefunded: Money!
 
   """
   Total amount of ongoing refund requests for the order's transactions.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalRefundPending: Money!
 
   """
   Total amount of ongoing authorize requests for the order's transactions.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalAuthorizePending: Money!
 
   """
   Total amount of ongoing charge requests for the order's transactions.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalChargePending: Money!
 
   """
   Total amount of ongoing cancel requests for the order's transactions.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalCancelPending: Money!
 
   """
   The difference amount between granted refund and the amounts that are pending and refunded.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalRemainingGrant: Money!
@@ -12172,16 +12172,16 @@ type Fulfillment implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -12191,16 +12191,16 @@ type Fulfillment implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -12228,14 +12228,14 @@ type Fulfillment implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Amount of refunded shipping price.
-  
+
   Added in Saleor 3.14.
   """
   shippingRefundedAmount: Money
 
   """
   Total refunded amount assigned to this fulfillment.
-  
+
   Added in Saleor 3.14.
   """
   totalRefundedAmount: Money
@@ -12270,46 +12270,46 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   List of private metadata items. Requires staff permissions to access.
-  
+
   Added in Saleor 3.5.
   """
   privateMetadata: [MetadataItem!]!
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.5.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.5.
   """
   privateMetafields(keys: [String!]): Metadata
 
   """
   List of public metadata items. Can be accessed without permissions.
-  
+
   Added in Saleor 3.5.
   """
   metadata: [MetadataItem!]!
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.5.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.5.
   """
   metafields(keys: [String!]): Metadata
@@ -12349,7 +12349,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.6.
     """
     format: ThumbnailFormatEnum = ORIGINAL
@@ -12377,7 +12377,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Returns True, if the line unit price was overridden.
-  
+
   Added in Saleor 3.14.
   """
   isPriceOverridden: Boolean
@@ -12395,21 +12395,21 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   List of allocations across warehouses.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   allocations: [Allocation!]
 
   """
   Denormalized sale ID, set when order line is created for a product variant that is on sale.
-  
+
   Added in Saleor 3.14.
   """
   saleId: ID
 
   """
   A quantity of items remaining to be fulfilled.
-  
+
   Added in Saleor 3.1.
   """
   quantityToFulfill: Int!
@@ -12419,46 +12419,46 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Denormalized tax class of the product in this order line.
-  
+
   Added in Saleor 3.9.
-  
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
 
   """
   Denormalized name of the tax class.
-  
+
   Added in Saleor 3.9.
   """
   taxClassName: String
 
   """
   Denormalized public metadata of the tax class.
-  
+
   Added in Saleor 3.9.
   """
   taxClassMetadata: [MetadataItem!]!
 
   """
   Denormalized private metadata of the tax class. Requires staff permissions to access.
-  
+
   Added in Saleor 3.9.
   """
   taxClassPrivateMetadata: [MetadataItem!]!
 
   """
   Voucher code that was used for this order line.
-  
+
   Added in Saleor 3.14.
   """
   voucherCode: String
 
   """
   Determine if the line is a gift.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   isGift: Boolean
@@ -12478,14 +12478,14 @@ type Allocation implements Node @doc(category: "Products") {
 
   """
   Quantity allocated for orders.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   quantity: Int!
 
   """
   The warehouse were items were allocated.
-  
+
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
   warehouse: Warehouse!
@@ -12512,16 +12512,16 @@ type Invoice implements ObjectWithMetadata & Job & Node @doc(category: "Orders")
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -12531,16 +12531,16 @@ type Invoice implements ObjectWithMetadata & Job & Node @doc(category: "Orders")
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -12571,7 +12571,7 @@ type Invoice implements ObjectWithMetadata & Job & Node @doc(category: "Orders")
 
   """
   Order related to the invoice.
-  
+
   Added in Saleor 3.10.
   """
   order: Order
@@ -12675,16 +12675,16 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -12694,16 +12694,16 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -12734,7 +12734,7 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
 
   """
   IP address of the user who created the payment.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   customerIpAddress: String
@@ -12744,7 +12744,7 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
 
   """
   List of actions that can be performed in the current state of a payment.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   actions: [OrderAction!]!
@@ -12757,21 +12757,21 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
 
   """
   List of all transactions within this payment.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   transactions: [Transaction!]
 
   """
   Maximum amount of money that can be captured.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   availableCaptureAmount: Money
 
   """
   Maximum amount of money that can be refunded.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   availableRefundAmount: Money
@@ -12781,14 +12781,14 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
 
   """
   Informs whether this is a partial payment.
-  
+
   Added in Saleor 3.14.
   """
   partial: Boolean!
 
   """
   PSP reference of the payment.
-  
+
   Added in Saleor 3.14.
   """
   pspReference: String
@@ -12926,9 +12926,9 @@ type OrderEvent implements Node @doc(category: "Orders") {
 
   """
   The order event which is related to this event.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   related: OrderEvent
@@ -13064,7 +13064,7 @@ type OrderDiscount implements Node @doc(category: "Discounts") {
 
   """
   Explanation for the applied discount.
-  
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   reason: String
@@ -13182,39 +13182,39 @@ type OrderGrantedRefund @doc(category: "Orders") {
 
   """
   If true, the refunded amount includes the shipping price.If false, the refunded amount does not include the shipping price.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingCostsIncluded: Boolean!
 
   """
   Lines assigned to the granted refund.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   lines: [OrderGrantedRefundLine!]
 
   """
   Status of the granted refund calculated based on transactionItem assigned to granted refund.
-  
+
   Added in Saleor 3.20.
   """
   status: OrderGrantedRefundStatusEnum!
 
   """
   List of refund events associated with the granted refund.
-  
+
   Added in Saleor 3.20.
   """
   transactionEvents: [TransactionEvent!]
 
   """
   The transaction assigned to the granted refund.
-  
+
   Added in Saleor 3.20.
   """
   transaction: TransactionItem
@@ -13265,49 +13265,49 @@ type TransactionEvent implements Node @doc(category: "Payments") {
 
   """
   PSP reference of transaction.
-  
+
   Added in Saleor 3.13.
   """
   pspReference: String!
 
   """
   Message related to the transaction's event.
-  
+
   Added in Saleor 3.13.
   """
   message: String!
 
   """
   The url that will allow to redirect user to payment provider page with transaction details.
-  
+
   Added in Saleor 3.13.
   """
   externalUrl: String!
 
   """
   The amount related to this event.
-  
+
   Added in Saleor 3.13.
   """
   amount: Money!
 
   """
   The type of action related to this event.
-  
+
   Added in Saleor 3.13.
   """
   type: TransactionEventTypeEnum
 
   """
   User or App that created the transaction event.
-  
+
   Added in Saleor 3.13.
   """
   createdBy: UserOrApp
 
   """
   Idempotency key assigned to the event.
-  
+
   Added in Saleor 3.14.
   """
   idempotencyKey: String
@@ -13339,8 +13339,65 @@ Represents possible event types.
     CANCEL_FAILURE - represents failure cancel.
     CANCEL_REQUEST - represents cancel request.
     INFO - represents info event.
+
+    Added in Saleor 3.xx
+
+    REFUND_OR_CANCEL_REQUEST - represents refund or cancel request
+    REFUND_OR_CANCEL_SUCCESS - represents refund or cancel
+    REFUND_OR_CANCEL_FAILURE - represents failed refund or cancel
 """
 enum TransactionEventTypeEnum @doc(category: "Payments") {
+  AUTHORIZATION_SUCCESS
+  AUTHORIZATION_FAILURE
+  AUTHORIZATION_ADJUSTMENT
+  AUTHORIZATION_REQUEST
+  AUTHORIZATION_ACTION_REQUIRED
+  CHARGE_ACTION_REQUIRED
+  CHARGE_SUCCESS
+  CHARGE_FAILURE
+  CHARGE_BACK
+  CHARGE_REQUEST
+  REFUND_SUCCESS
+  REFUND_FAILURE
+  REFUND_REVERSE
+  REFUND_REQUEST
+  CANCEL_SUCCESS
+  CANCEL_FAILURE
+  CANCEL_REQUEST
+  INFO
+  REFUND_OR_CANCEL_REQUEST
+  REFUND_OR_CANCEL_SUCCESS
+  REFUND_OR_CANCEL_FAILURE
+}
+
+"""
+Represents possible event types on requested TransactionEvent.
+
+    Added in Saleor 3.xx.
+
+    The following types are possible:
+    AUTHORIZATION_SUCCESS - represents success authorization.
+    AUTHORIZATION_FAILURE - represents failure authorization.
+    AUTHORIZATION_ADJUSTMENT - represents authorization adjustment.
+    AUTHORIZATION_REQUEST - represents authorization request.
+    AUTHORIZATION_ACTION_REQUIRED - represents authorization that needs
+    additional actions from the customer.
+    CHARGE_ACTION_REQUIRED - represents charge that needs
+    additional actions from the customer.
+    CHARGE_SUCCESS - represents success charge.
+    CHARGE_FAILURE - represents failure charge.
+    CHARGE_BACK - represents chargeback.
+    CHARGE_REQUEST - represents charge request.
+    REFUND_SUCCESS - represents success refund.
+    REFUND_FAILURE - represents failure refund.
+    REFUND_REVERSE - represents reverse refund.
+    REFUND_REQUEST - represents refund request.
+    CANCEL_SUCCESS - represents success cancel.
+    CANCEL_FAILURE - represents failure cancel.
+    CANCEL_REQUEST - represents cancel request.
+    INFO - represents info event.
+"""
+enum TransactionEventTypeEnumOutput @doc(category: "Payments") {
   AUTHORIZATION_SUCCESS
   AUTHORIZATION_FAILURE
   AUTHORIZATION_ADJUSTMENT
@@ -13539,7 +13596,7 @@ type Group implements Node @doc(category: "Users") {
 
   """
   List of group users
-  
+
   Requires one of the following permissions: MANAGE_STAFF.
   """
   users: [User!]
@@ -13554,18 +13611,18 @@ type Group implements Node @doc(category: "Users") {
 
   """
   List of channels the group has access to.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   accessibleChannels: [Channel!]
 
   """
   Determine if the group have restricted access to channels.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   restrictedAccessToChannels: Boolean!
@@ -13634,9 +13691,9 @@ type PaymentSource @doc(category: "Payments") {
 
   """
   List of public metadata items.
-  
+
   Added in Saleor 3.1.
-  
+
   Can be accessed without permissions.
   """
   metadata: [MetadataItem!]!
@@ -13727,8 +13784,8 @@ input CategoryFilterInput @doc(category: "Products") {
   slugs: [String!]
 
   """
-  Filter by when was the most recent update. 
-  
+  Filter by when was the most recent update.
+
   Added in Saleor 3.17.
   """
   updatedAt: DateTimeRangeInput
@@ -13751,7 +13808,7 @@ input CategorySortingInput @doc(category: "Products") {
 
   """
   Specifies the channel in which to sort the data.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -13779,8 +13836,8 @@ input CollectionFilterInput @doc(category: "Products") {
   slugs: [String!]
 
   """
-  Specifies the channel by which the data should be filtered. 
-  
+  Specifies the channel by which the data should be filtered.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -13808,7 +13865,7 @@ input CollectionSortingInput @doc(category: "Products") {
 
   """
   Specifies the channel in which to sort the data.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -13823,7 +13880,7 @@ enum CollectionSortField @doc(category: "Products") {
 
   """
   Sort collections by availability.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   AVAILABILITY
@@ -13833,14 +13890,14 @@ enum CollectionSortField @doc(category: "Products") {
 
   """
   Sort collections by publication date.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   PUBLICATION_DATE
 
   """
   Sort collections by publication date.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   PUBLISHED_AT
@@ -13936,8 +13993,8 @@ type PaymentCountableEdge @doc(category: "Payments") {
 
 input PaymentFilterInput @doc(category: "Payments") {
   """
-  Filter by ids. 
-  
+  Filter by ids.
+
   Added in Saleor 3.8.
   """
   ids: [ID!]
@@ -13981,28 +14038,28 @@ enum PageSortField @doc(category: "Pages") {
 
   """
   Sort pages by creation date.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   CREATION_DATE
 
   """
   Sort pages by publication date.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   PUBLICATION_DATE
 
   """
   Sort pages by publication date.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   PUBLISHED_AT
 
   """
   Sort pages by creation date.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   CREATED_AT
@@ -14089,15 +14146,15 @@ enum OrderSortField @doc(category: "Orders") {
   RANK
 
   """
-  Sort orders by creation date. 
-  
+  Sort orders by creation date.
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   CREATION_DATE
 
   """
-  Sort orders by creation date. 
-  
+  Sort orders by creation date.
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   CREATED_AT
@@ -14249,7 +14306,7 @@ enum GiftCardSortField @doc(category: "Gift cards") {
 
   """
   Sort gift cards by created at.
-  
+
   Added in Saleor 3.8.
   """
   CREATED_AT
@@ -14432,7 +14489,7 @@ input SaleSortingInput @doc(category: "Discounts") {
 
   """
   Specifies the channel in which to sort the data.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -14453,7 +14510,7 @@ enum SaleSortField @doc(category: "Discounts") {
 
   """
   Sort sales by value.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   VALUE
@@ -14507,7 +14564,7 @@ input VoucherSortingInput @doc(category: "Discounts") {
 
   """
   Specifies the channel in which to sort the data.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
   """
   channel: String
@@ -14519,14 +14576,14 @@ input VoucherSortingInput @doc(category: "Discounts") {
 enum VoucherSortField {
   """
   Sort vouchers by code.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   CODE
 
   """
   Sort vouchers by name.
-  
+
   Added in Saleor 3.18.
   """
   NAME
@@ -14539,7 +14596,7 @@ enum VoucherSortField {
 
   """
   Sort vouchers by value.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   VALUE
@@ -14552,7 +14609,7 @@ enum VoucherSortField {
 
   """
   Sort vouchers by minimum spent amount.
-  
+
   This option requires a channel filter to work as the values can vary between channels.
   """
   MINIMUM_SPENT_AMOUNT
@@ -14573,16 +14630,16 @@ type Promotion implements Node & ObjectWithMetadata @doc(category: "Discounts") 
 
   """
   A single key from private metadata. Requires staff permissions to access.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
@@ -14592,16 +14649,16 @@ type Promotion implements Node & ObjectWithMetadata @doc(category: "Discounts") 
 
   """
   A single key from public metadata.
-  
+
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
+
   Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
+
   Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
@@ -14611,9 +14668,9 @@ type Promotion implements Node & ObjectWithMetadata @doc(category: "Discounts") 
 
   """
   The type of the promotion. Implicate if the discount is applied on catalogue or order level.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   type: PromotionTypeEnum
@@ -14672,16 +14729,16 @@ type PromotionRule implements Node @doc(category: "Discounts") {
 
   """
   List of channels where the rule applies.
-  
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   channels: [Channel!]
 
   """
   The reward value of the promotion rule. Defines the discount value applied when the rule conditions are met.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardValue: PositiveDecimal
@@ -14691,9 +14748,9 @@ type PromotionRule implements Node @doc(category: "Discounts") {
 
   """
   The type of the predicate that must be met to apply the reward.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   predicateType: PromotionTypeEnum
@@ -14703,18 +14760,18 @@ type PromotionRule implements Node @doc(category: "Discounts") {
 
   """
   The checkout/order predicate that must be met to apply the rule reward.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: JSON
 
   """
   The reward type of the promotion rule.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardType: RewardTypeEnum
@@ -14727,18 +14784,18 @@ type PromotionRule implements Node @doc(category: "Discounts") {
 
   """
   Product variant IDs available as a gift to choose.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   giftIds: [ID!]
 
   """
   Defines the maximum number of gifts to choose from the gifts list.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   giftsLimit: Int
@@ -14773,8 +14830,8 @@ type PromotionCreatedEvent implements Node & PromotionEventInterface @doc(catego
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -14790,8 +14847,8 @@ interface PromotionEventInterface {
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -14824,8 +14881,8 @@ type PromotionUpdatedEvent implements Node & PromotionEventInterface @doc(catego
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -14848,8 +14905,8 @@ type PromotionStartedEvent implements Node & PromotionEventInterface @doc(catego
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -14872,8 +14929,8 @@ type PromotionEndedEvent implements Node & PromotionEventInterface @doc(category
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -14896,8 +14953,8 @@ type PromotionRuleCreatedEvent implements Node & PromotionEventInterface & Promo
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -14935,8 +14992,8 @@ type PromotionRuleUpdatedEvent implements Node & PromotionEventInterface & Promo
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -14962,8 +15019,8 @@ type PromotionRuleDeletedEvent implements Node & PromotionEventInterface & Promo
   type: PromotionEventsEnum!
 
   """
-  User or App that created the promotion event. 
-  
+  User or App that created the promotion event.
+
   Requires one of the following permissions: MANAGE_STAFF, MANAGE_APPS, OWNER.
   """
   createdBy: UserOrApp
@@ -15256,9 +15313,9 @@ type AppInstallation implements Node & Job @doc(category: "Apps") {
 
   """
   App's brand data.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   brand: AppBrand
@@ -15335,9 +15392,9 @@ type AddressValidationData @doc(category: "Users") {
 
   """
   The address format of the address validation rule.
-  
+
   Many fields in the JSON refer to address fields by one-letter abbreviations. These are defined as follows:
-  
+
   - `N`: Name
   - `O`: Organization
   - `A`: Street Address Line(s)
@@ -15346,16 +15403,16 @@ type AddressValidationData @doc(category: "Users") {
   - `S`: Administrative area such as a state, province, island etc
   - `Z`: Zip or postal code
   - `X`: Sorting code
-  
+
   [Click here for more information.](https://github.com/google/libaddressinput/wiki/AddressValidationMetadata)
   """
   addressFormat: String!
 
   """
   The latin address format of the address validation rule.
-  
+
   Many fields in the JSON refer to address fields by one-letter abbreviations. These are defined as follows:
-  
+
   - `N`: Name
   - `O`: Organization
   - `A`: Street Address Line(s)
@@ -15364,7 +15421,7 @@ type AddressValidationData @doc(category: "Users") {
   - `S`: Administrative area such as a state, province, island etc
   - `Z`: Zip or postal code
   - `X`: Sorting code
-  
+
   [Click here for more information.](https://github.com/google/libaddressinput/wiki/AddressValidationMetadata)
   """
   addressLatinFormat: String!
@@ -15448,8 +15505,8 @@ input CustomerFilterInput @doc(category: "Users") {
   metadata: [MetadataFilter!]
 
   """
-  Filter by ids. 
-  
+  Filter by ids.
+
   Added in Saleor 3.8.
   """
   ids: [ID!]
@@ -15537,8 +15594,8 @@ enum StaffMemberStatus @doc(category: "Users") {
 
 type Mutation {
   """
-  Creates a new webhook subscription. 
-  
+  Creates a new webhook subscription.
+
   Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
   """
   webhookCreate(
@@ -15547,8 +15604,8 @@ type Mutation {
   ): WebhookCreate @doc(category: "Webhooks")
 
   """
-  Delete a webhook. Before the deletion, the webhook is deactivated to pause any deliveries that are already scheduled. The deletion might fail if delivery is in progress. In such a case, the webhook is not deleted but remains deactivated. 
-  
+  Delete a webhook. Before the deletion, the webhook is deactivated to pause any deliveries that are already scheduled. The deletion might fail if delivery is in progress. In such a case, the webhook is not deleted but remains deactivated.
+
   Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
   """
   webhookDelete(
@@ -15557,8 +15614,8 @@ type Mutation {
   ): WebhookDelete @doc(category: "Webhooks")
 
   """
-  Updates a webhook subscription. 
-  
+  Updates a webhook subscription.
+
   Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
   """
   webhookUpdate(
@@ -15570,8 +15627,8 @@ type Mutation {
   ): WebhookUpdate @doc(category: "Webhooks")
 
   """
-  Retries event delivery. 
-  
+  Retries event delivery.
+
   Requires one of the following permissions: MANAGE_APPS.
   """
   eventDeliveryRetry(
@@ -15581,11 +15638,11 @@ type Mutation {
 
   """
   Performs a dry run of a webhook event. Supports a single event (the first, if multiple provided in the `query`). Requires permission relevant to processed event.
-  
+
   Added in Saleor 3.11.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   webhookDryRun(
@@ -15598,11 +15655,11 @@ type Mutation {
 
   """
   Trigger a webhook event. Supports a single event (the first, if multiple provided in the `webhook.subscription_query`). Requires permission relevant to processed event. Successfully delivered webhook returns `delivery` with status='PENDING' and empty payload.
-  
+
   Added in Saleor 3.11.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   webhookTrigger(
@@ -15614,8 +15671,8 @@ type Mutation {
   ): WebhookTrigger @doc(category: "Webhooks")
 
   """
-  Creates new warehouse. 
-  
+  Creates new warehouse.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   createWarehouse(
@@ -15624,14 +15681,14 @@ type Mutation {
   ): WarehouseCreate @doc(category: "Products")
 
   """
-  Updates given warehouse. 
-  
+  Updates given warehouse.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   updateWarehouse(
     """
     External reference of a warehouse.
-    
+
     Added in Saleor 3.16.
     """
     externalReference: String
@@ -15644,8 +15701,8 @@ type Mutation {
   ): WarehouseUpdate @doc(category: "Products")
 
   """
-  Deletes selected warehouse. 
-  
+  Deletes selected warehouse.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   deleteWarehouse(
@@ -15654,8 +15711,8 @@ type Mutation {
   ): WarehouseDelete @doc(category: "Products")
 
   """
-  Add shipping zone to given warehouse. 
-  
+  Add shipping zone to given warehouse.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   assignWarehouseShippingZone(
@@ -15667,8 +15724,8 @@ type Mutation {
   ): WarehouseShippingZoneAssign @doc(category: "Products")
 
   """
-  Remove shipping zone from given warehouse. 
-  
+  Remove shipping zone from given warehouse.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   unassignWarehouseShippingZone(
@@ -15681,9 +15738,9 @@ type Mutation {
 
   """
   Create a tax class.
-  
-  Added in Saleor 3.9. 
-  
+
+  Added in Saleor 3.9.
+
   Requires one of the following permissions: MANAGE_TAXES.
   """
   taxClassCreate(
@@ -15693,9 +15750,9 @@ type Mutation {
 
   """
   Delete a tax class. After deleting the tax class any products, product types or shipping methods using it are updated to use the default tax class.
-  
-  Added in Saleor 3.9. 
-  
+
+  Added in Saleor 3.9.
+
   Requires one of the following permissions: MANAGE_TAXES.
   """
   taxClassDelete(
@@ -15705,9 +15762,9 @@ type Mutation {
 
   """
   Update a tax class.
-  
-  Added in Saleor 3.9. 
-  
+
+  Added in Saleor 3.9.
+
   Requires one of the following permissions: MANAGE_TAXES.
   """
   taxClassUpdate(
@@ -15720,9 +15777,9 @@ type Mutation {
 
   """
   Update tax configuration for a channel.
-  
-  Added in Saleor 3.9. 
-  
+
+  Added in Saleor 3.9.
+
   Requires one of the following permissions: MANAGE_TAXES.
   """
   taxConfigurationUpdate(
@@ -15735,9 +15792,9 @@ type Mutation {
 
   """
   Update tax class rates for a specific country.
-  
-  Added in Saleor 3.9. 
-  
+
+  Added in Saleor 3.9.
+
   Requires one of the following permissions: MANAGE_TAXES.
   """
   taxCountryConfigurationUpdate(
@@ -15752,9 +15809,9 @@ type Mutation {
 
   """
   Remove all tax class rates for a specific country.
-  
-  Added in Saleor 3.9. 
-  
+
+  Added in Saleor 3.9.
+
   Requires one of the following permissions: MANAGE_TAXES.
   """
   taxCountryConfigurationDelete(
@@ -15764,9 +15821,9 @@ type Mutation {
 
   """
   Exempt checkout or order from charging the taxes. When tax exemption is enabled, taxes won't be charged for the checkout or order. Taxes may still be calculated in cases when product prices are entered with the tax included and the net price needs to be known.
-  
-  Added in Saleor 3.8. 
-  
+
+  Added in Saleor 3.8.
+
   Requires one of the following permissions: MANAGE_TAXES.
   """
   taxExemptionManage(
@@ -15779,13 +15836,13 @@ type Mutation {
 
   """
   Updates stocks for a given variant and warehouse. Variant and warehouse selectors have to be the same for all stock inputs. Is not allowed to use 'variantId' in one input and 'variantExternalReference' in another.
-  
+
   Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
-  
+
   Triggers the following webhook events:
   - PRODUCT_VARIANT_STOCK_UPDATED (async): A product variant stock details were updated.
   """
@@ -15798,8 +15855,8 @@ type Mutation {
   ): StockBulkUpdate @doc(category: "Products") @webhookEventsInfo(asyncEvents: [PRODUCT_VARIANT_STOCK_UPDATED], syncEvents: [])
 
   """
-  Creates a new staff notification recipient. 
-  
+  Creates a new staff notification recipient.
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   staffNotificationRecipientCreate(
@@ -15808,8 +15865,8 @@ type Mutation {
   ): StaffNotificationRecipientCreate @doc(category: "Users")
 
   """
-  Updates a staff notification recipient. 
-  
+  Updates a staff notification recipient.
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   staffNotificationRecipientUpdate(
@@ -15821,8 +15878,8 @@ type Mutation {
   ): StaffNotificationRecipientUpdate @doc(category: "Users")
 
   """
-  Delete staff notification recipient. 
-  
+  Delete staff notification recipient.
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   staffNotificationRecipientDelete(
@@ -15832,9 +15889,9 @@ type Mutation {
 
   """
   Updates site domain of the shop.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead.
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   shopDomainUpdate(
@@ -15843,10 +15900,10 @@ type Mutation {
   ): ShopDomainUpdate @doc(category: "Shop") @deprecated(reason: "\\n\\nDEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead.")
 
   """
-  Updates shop settings. 
-  
+  Updates shop settings.
+
   Requires one of the following permissions: MANAGE_SETTINGS.
-  
+
   Triggers the following webhook events:
   - SHOP_METADATA_UPDATED (async): Optionally triggered when public or private metadata is updated.
   """
@@ -15856,15 +15913,15 @@ type Mutation {
   ): ShopSettingsUpdate @doc(category: "Shop") @webhookEventsInfo(asyncEvents: [SHOP_METADATA_UPDATED], syncEvents: [])
 
   """
-  Fetch tax rates. 
-  
+  Fetch tax rates.
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   shopFetchTaxRates: ShopFetchTaxRates @doc(category: "Shop") @deprecated(reason: "\\n\\nDEPRECATED: this mutation will be removed in Saleor 4.0.")
 
   """
-  Creates/updates translations for shop settings. 
-  
+  Creates/updates translations for shop settings.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   shopSettingsTranslate(
@@ -15876,8 +15933,8 @@ type Mutation {
   ): ShopSettingsTranslate @doc(category: "Shop")
 
   """
-  Update the shop's address. If the `null` value is passed, the currently selected address will be deleted. 
-  
+  Update the shop's address. If the `null` value is passed, the currently selected address will be deleted.
+
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   shopAddressUpdate(
@@ -15886,8 +15943,8 @@ type Mutation {
   ): ShopAddressUpdate @doc(category: "Shop")
 
   """
-  Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order.  
-  
+  Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderSettingsUpdate(
@@ -15896,8 +15953,8 @@ type Mutation {
   ): OrderSettingsUpdate @doc(category: "Orders") @deprecated(reason: "\\n\\nDEPRECATED: this mutation will be removed in Saleor 4.0. Use `channelUpdate` mutation instead.")
 
   """
-  Update gift card settings. 
-  
+  Update gift card settings.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardSettingsUpdate(
@@ -15906,8 +15963,8 @@ type Mutation {
   ): GiftCardSettingsUpdate @doc(category: "Gift cards")
 
   """
-  Manage shipping method's availability in channels. 
-  
+  Manage shipping method's availability in channels.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingMethodChannelListingUpdate(
@@ -15919,8 +15976,8 @@ type Mutation {
   ): ShippingMethodChannelListingUpdate @doc(category: "Shipping")
 
   """
-  Creates a new shipping price. 
-  
+  Creates a new shipping price.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingPriceCreate(
@@ -15929,8 +15986,8 @@ type Mutation {
   ): ShippingPriceCreate @doc(category: "Shipping")
 
   """
-  Deletes a shipping price. 
-  
+  Deletes a shipping price.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingPriceDelete(
@@ -15939,8 +15996,8 @@ type Mutation {
   ): ShippingPriceDelete @doc(category: "Shipping")
 
   """
-  Deletes shipping prices. 
-  
+  Deletes shipping prices.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingPriceBulkDelete(
@@ -15949,8 +16006,8 @@ type Mutation {
   ): ShippingPriceBulkDelete @doc(category: "Shipping")
 
   """
-  Updates a new shipping price. 
-  
+  Updates a new shipping price.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingPriceUpdate(
@@ -15962,8 +16019,8 @@ type Mutation {
   ): ShippingPriceUpdate @doc(category: "Shipping")
 
   """
-  Creates/updates translations for a shipping method. 
-  
+  Creates/updates translations for a shipping method.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   shippingPriceTranslate(
@@ -15978,8 +16035,8 @@ type Mutation {
   ): ShippingPriceTranslate @doc(category: "Shipping")
 
   """
-  Exclude products from shipping price. 
-  
+  Exclude products from shipping price.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingPriceExcludeProducts(
@@ -15991,8 +16048,8 @@ type Mutation {
   ): ShippingPriceExcludeProducts @doc(category: "Shipping")
 
   """
-  Remove product from excluded list for shipping price. 
-  
+  Remove product from excluded list for shipping price.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingPriceRemoveProductFromExclude(
@@ -16004,8 +16061,8 @@ type Mutation {
   ): ShippingPriceRemoveProductFromExclude @doc(category: "Shipping")
 
   """
-  Creates a new shipping zone. 
-  
+  Creates a new shipping zone.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingZoneCreate(
@@ -16014,8 +16071,8 @@ type Mutation {
   ): ShippingZoneCreate @doc(category: "Shipping")
 
   """
-  Deletes a shipping zone. 
-  
+  Deletes a shipping zone.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingZoneDelete(
@@ -16024,8 +16081,8 @@ type Mutation {
   ): ShippingZoneDelete @doc(category: "Shipping")
 
   """
-  Deletes shipping zones. 
-  
+  Deletes shipping zones.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingZoneBulkDelete(
@@ -16034,8 +16091,8 @@ type Mutation {
   ): ShippingZoneBulkDelete @doc(category: "Shipping")
 
   """
-  Updates a new shipping zone. 
-  
+  Updates a new shipping zone.
+
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingZoneUpdate(
@@ -16047,8 +16104,8 @@ type Mutation {
   ): ShippingZoneUpdate @doc(category: "Shipping")
 
   """
-  Assign attributes to a given product type. 
-  
+  Assign attributes to a given product type.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productAttributeAssign(
@@ -16061,9 +16118,9 @@ type Mutation {
 
   """
   Update attributes assigned to product variant for given product type.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productAttributeAssignmentUpdate(
@@ -16075,8 +16132,8 @@ type Mutation {
   ): ProductAttributeAssignmentUpdate @doc(category: "Products")
 
   """
-  Un-assign attributes from a given product type. 
-  
+  Un-assign attributes from a given product type.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productAttributeUnassign(
@@ -16088,8 +16145,8 @@ type Mutation {
   ): ProductAttributeUnassign @doc(category: "Products")
 
   """
-  Creates a new category. 
-  
+  Creates a new category.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   categoryCreate(
@@ -16103,8 +16160,8 @@ type Mutation {
   ): CategoryCreate @doc(category: "Products")
 
   """
-  Deletes a category. 
-  
+  Deletes a category.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   categoryDelete(
@@ -16113,8 +16170,8 @@ type Mutation {
   ): CategoryDelete @doc(category: "Products")
 
   """
-  Deletes categories. 
-  
+  Deletes categories.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   categoryBulkDelete(
@@ -16123,8 +16180,8 @@ type Mutation {
   ): CategoryBulkDelete @doc(category: "Products")
 
   """
-  Updates a category. 
-  
+  Updates a category.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   categoryUpdate(
@@ -16136,8 +16193,8 @@ type Mutation {
   ): CategoryUpdate @doc(category: "Products")
 
   """
-  Creates/updates translations for a category. 
-  
+  Creates/updates translations for a category.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   categoryTranslate(
@@ -16152,8 +16209,8 @@ type Mutation {
   ): CategoryTranslate @doc(category: "Products")
 
   """
-  Adds products to a collection. 
-  
+  Adds products to a collection.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionAddProducts(
@@ -16165,8 +16222,8 @@ type Mutation {
   ): CollectionAddProducts @doc(category: "Products")
 
   """
-  Creates a new collection. 
-  
+  Creates a new collection.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionCreate(
@@ -16175,8 +16232,8 @@ type Mutation {
   ): CollectionCreate @doc(category: "Products")
 
   """
-  Deletes a collection. 
-  
+  Deletes a collection.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionDelete(
@@ -16185,8 +16242,8 @@ type Mutation {
   ): CollectionDelete @doc(category: "Products")
 
   """
-  Reorder the products of a collection. 
-  
+  Reorder the products of a collection.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionReorderProducts(
@@ -16198,8 +16255,8 @@ type Mutation {
   ): CollectionReorderProducts @doc(category: "Products")
 
   """
-  Deletes collections. 
-  
+  Deletes collections.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionBulkDelete(
@@ -16208,8 +16265,8 @@ type Mutation {
   ): CollectionBulkDelete @doc(category: "Products")
 
   """
-  Remove products from a collection. 
-  
+  Remove products from a collection.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionRemoveProducts(
@@ -16221,8 +16278,8 @@ type Mutation {
   ): CollectionRemoveProducts @doc(category: "Products")
 
   """
-  Updates a collection. 
-  
+  Updates a collection.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionUpdate(
@@ -16234,8 +16291,8 @@ type Mutation {
   ): CollectionUpdate @doc(category: "Products")
 
   """
-  Creates/updates translations for a collection. 
-  
+  Creates/updates translations for a collection.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   collectionTranslate(
@@ -16250,8 +16307,8 @@ type Mutation {
   ): CollectionTranslate @doc(category: "Products")
 
   """
-  Manage collection's availability in channels. 
-  
+  Manage collection's availability in channels.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionChannelListingUpdate(
@@ -16263,8 +16320,8 @@ type Mutation {
   ): CollectionChannelListingUpdate @doc(category: "Products")
 
   """
-  Creates a new product. 
-  
+  Creates a new product.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productCreate(
@@ -16273,14 +16330,14 @@ type Mutation {
   ): ProductCreate @doc(category: "Products")
 
   """
-  Deletes a product. 
-  
+  Deletes a product.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productDelete(
     """
-    External ID of a product to delete. 
-    
+    External ID of a product to delete.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -16291,11 +16348,11 @@ type Mutation {
 
   """
   Creates products.
-  
+
   Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productBulkCreate(
@@ -16307,8 +16364,8 @@ type Mutation {
   ): ProductBulkCreate @doc(category: "Products")
 
   """
-  Deletes products. 
-  
+  Deletes products.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productBulkDelete(
@@ -16317,14 +16374,14 @@ type Mutation {
   ): ProductBulkDelete @doc(category: "Products")
 
   """
-  Updates an existing product. 
-  
+  Updates an existing product.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productUpdate(
     """
-    External ID of a product to update. 
-    
+    External ID of a product to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -16338,13 +16395,13 @@ type Mutation {
 
   """
   Creates/updates translations for products.
-  
+
   Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
-  
+
   Triggers the following webhook events:
   - TRANSLATION_CREATED (async): Called when a translation was created.
   - TRANSLATION_UPDATED (async): Called when a translation was updated.
@@ -16358,8 +16415,8 @@ type Mutation {
   ): ProductBulkTranslate @doc(category: "Products") @webhookEventsInfo(asyncEvents: [TRANSLATION_CREATED, TRANSLATION_UPDATED], syncEvents: [])
 
   """
-  Creates/updates translations for a product. 
-  
+  Creates/updates translations for a product.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   productTranslate(
@@ -16374,8 +16431,8 @@ type Mutation {
   ): ProductTranslate @doc(category: "Products")
 
   """
-  Manage product's availability in channels. 
-  
+  Manage product's availability in channels.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productChannelListingUpdate(
@@ -16387,8 +16444,8 @@ type Mutation {
   ): ProductChannelListingUpdate @doc(category: "Products")
 
   """
-  Create a media object (image or video URL) associated with product. For image, this mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
-  
+  Create a media object (image or video URL) associated with product. For image, this mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productMediaCreate(
@@ -16397,8 +16454,8 @@ type Mutation {
   ): ProductMediaCreate @doc(category: "Products")
 
   """
-  Reorder the variants of a product. Mutation updates updated_at on product and triggers PRODUCT_UPDATED webhook. 
-  
+  Reorder the variants of a product. Mutation updates updated_at on product and triggers PRODUCT_UPDATED webhook.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantReorder(
@@ -16410,8 +16467,8 @@ type Mutation {
   ): ProductVariantReorder @doc(category: "Products")
 
   """
-  Deletes a product media. 
-  
+  Deletes a product media.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productMediaDelete(
@@ -16420,8 +16477,8 @@ type Mutation {
   ): ProductMediaDelete @doc(category: "Products")
 
   """
-  Deletes product media. 
-  
+  Deletes product media.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productMediaBulkDelete(
@@ -16430,8 +16487,8 @@ type Mutation {
   ): ProductMediaBulkDelete @doc(category: "Products")
 
   """
-  Changes ordering of the product media. 
-  
+  Changes ordering of the product media.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productMediaReorder(
@@ -16443,8 +16500,8 @@ type Mutation {
   ): ProductMediaReorder @doc(category: "Products")
 
   """
-  Updates a product media. 
-  
+  Updates a product media.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productMediaUpdate(
@@ -16456,8 +16513,8 @@ type Mutation {
   ): ProductMediaUpdate @doc(category: "Products")
 
   """
-  Creates a new product type. 
-  
+  Creates a new product type.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productTypeCreate(
@@ -16466,8 +16523,8 @@ type Mutation {
   ): ProductTypeCreate @doc(category: "Products")
 
   """
-  Deletes a product type. 
-  
+  Deletes a product type.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productTypeDelete(
@@ -16476,8 +16533,8 @@ type Mutation {
   ): ProductTypeDelete @doc(category: "Products")
 
   """
-  Deletes product types. 
-  
+  Deletes product types.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productTypeBulkDelete(
@@ -16486,8 +16543,8 @@ type Mutation {
   ): ProductTypeBulkDelete @doc(category: "Products")
 
   """
-  Updates an existing product type. 
-  
+  Updates an existing product type.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productTypeUpdate(
@@ -16499,8 +16556,8 @@ type Mutation {
   ): ProductTypeUpdate @doc(category: "Products")
 
   """
-  Reorder the attributes of a product type. 
-  
+  Reorder the attributes of a product type.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productTypeReorderAttributes(
@@ -16515,8 +16572,8 @@ type Mutation {
   ): ProductTypeReorderAttributes @doc(category: "Products")
 
   """
-  Reorder product attribute values. 
-  
+  Reorder product attribute values.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productReorderAttributeValues(
@@ -16531,8 +16588,8 @@ type Mutation {
   ): ProductReorderAttributeValues @doc(category: "Products")
 
   """
-  Create new digital content. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
-  
+  Create new digital content. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   digitalContentCreate(
@@ -16544,8 +16601,8 @@ type Mutation {
   ): DigitalContentCreate @doc(category: "Products")
 
   """
-  Remove digital content assigned to given variant. 
-  
+  Remove digital content assigned to given variant.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   digitalContentDelete(
@@ -16554,8 +16611,8 @@ type Mutation {
   ): DigitalContentDelete @doc(category: "Products")
 
   """
-  Update digital content. 
-  
+  Update digital content.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   digitalContentUpdate(
@@ -16567,8 +16624,8 @@ type Mutation {
   ): DigitalContentUpdate @doc(category: "Products")
 
   """
-  Generate new URL to digital content. 
-  
+  Generate new URL to digital content.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   digitalContentUrlCreate(
@@ -16577,8 +16634,8 @@ type Mutation {
   ): DigitalContentUrlCreate @doc(category: "Products")
 
   """
-  Creates a new variant for a product. 
-  
+  Creates a new variant for a product.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantCreate(
@@ -16587,14 +16644,14 @@ type Mutation {
   ): ProductVariantCreate @doc(category: "Products")
 
   """
-  Deletes a product variant. 
-  
+  Deletes a product variant.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantDelete(
     """
-    External ID of a product variant to update. 
-    
+    External ID of a product variant to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -16604,23 +16661,23 @@ type Mutation {
 
     """
     SKU of a product variant to delete.
-    
+
     Added in Saleor 3.8.
     """
     sku: String
   ): ProductVariantDelete @doc(category: "Products")
 
   """
-  Creates product variants for a given product. 
-  
+  Creates product variants for a given product.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantBulkCreate(
     """
     Policies of error handling. DEFAULT: REJECT_EVERYTHING
-    
+
     Added in Saleor 3.11.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     errorPolicy: ErrorPolicyEnum
@@ -16634,11 +16691,11 @@ type Mutation {
 
   """
   Update multiple product variants.
-  
+
   Added in Saleor 3.11.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantBulkUpdate(
@@ -16653,8 +16710,8 @@ type Mutation {
   ): ProductVariantBulkUpdate @doc(category: "Products")
 
   """
-  Deletes product variants. 
-  
+  Deletes product variants.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantBulkDelete(
@@ -16663,15 +16720,15 @@ type Mutation {
 
     """
     List of product variant SKUs to delete.
-    
+
     Added in Saleor 3.8.
     """
     skus: [String!]
   ): ProductVariantBulkDelete @doc(category: "Products")
 
   """
-  Creates stocks for product variant. 
-  
+  Creates stocks for product variant.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantStocksCreate(
@@ -16683,8 +16740,8 @@ type Mutation {
   ): ProductVariantStocksCreate @doc(category: "Products")
 
   """
-  Delete stocks from product variant. 
-  
+  Delete stocks from product variant.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantStocksDelete(
@@ -16699,8 +16756,8 @@ type Mutation {
   ): ProductVariantStocksDelete @doc(category: "Products")
 
   """
-  Update stocks for product variant. 
-  
+  Update stocks for product variant.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantStocksUpdate(
@@ -16715,14 +16772,14 @@ type Mutation {
   ): ProductVariantStocksUpdate @doc(category: "Products")
 
   """
-  Updates an existing variant for product. 
-  
+  Updates an existing variant for product.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantUpdate(
     """
-    External ID of a product variant to update. 
-    
+    External ID of a product variant to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -16735,15 +16792,15 @@ type Mutation {
 
     """
     SKU of a product variant to update.
-    
+
     Added in Saleor 3.8.
     """
     sku: String
   ): ProductVariantUpdate @doc(category: "Products")
 
   """
-  Set default variant for a product. Mutation triggers PRODUCT_UPDATED webhook. 
-  
+  Set default variant for a product. Mutation triggers PRODUCT_UPDATED webhook.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantSetDefault(
@@ -16755,8 +16812,8 @@ type Mutation {
   ): ProductVariantSetDefault @doc(category: "Products")
 
   """
-  Creates/updates translations for a product variant. 
-  
+  Creates/updates translations for a product variant.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   productVariantTranslate(
@@ -16772,13 +16829,13 @@ type Mutation {
 
   """
   Creates/updates translations for products variants.
-  
+
   Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
-  
+
   Triggers the following webhook events:
   - TRANSLATION_CREATED (async): A translation was created.
   - TRANSLATION_UPDATED (async): A translation was updated.
@@ -16792,8 +16849,8 @@ type Mutation {
   ): ProductVariantBulkTranslate @doc(category: "Products") @webhookEventsInfo(asyncEvents: [TRANSLATION_CREATED, TRANSLATION_UPDATED], syncEvents: [])
 
   """
-  Manage product variant prices in channels. 
-  
+  Manage product variant prices in channels.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantChannelListingUpdate(
@@ -16807,15 +16864,15 @@ type Mutation {
 
     """
     SKU of a product variant to update.
-    
+
     Added in Saleor 3.8.
     """
     sku: String
   ): ProductVariantChannelListingUpdate @doc(category: "Products")
 
   """
-  Reorder product variant attribute values. 
-  
+  Reorder product variant attribute values.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantReorderAttributeValues(
@@ -16831,9 +16888,9 @@ type Mutation {
 
   """
   Deactivates product variant preorder. It changes all preorder allocation into regular allocation.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantPreorderDeactivate(
@@ -16842,8 +16899,8 @@ type Mutation {
   ): ProductVariantPreorderDeactivate @doc(category: "Products")
 
   """
-  Assign an media to a product variant. 
-  
+  Assign an media to a product variant.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   variantMediaAssign(
@@ -16855,8 +16912,8 @@ type Mutation {
   ): VariantMediaAssign @doc(category: "Products")
 
   """
-  Unassign an media from a product variant. 
-  
+  Unassign an media from a product variant.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   variantMediaUnassign(
@@ -16868,8 +16925,8 @@ type Mutation {
   ): VariantMediaUnassign @doc(category: "Products")
 
   """
-  Captures the authorized payment amount. 
-  
+  Captures the authorized payment amount.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   paymentCapture(
@@ -16881,8 +16938,8 @@ type Mutation {
   ): PaymentCapture @doc(category: "Payments")
 
   """
-  Refunds the captured payment amount. 
-  
+  Refunds the captured payment amount.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   paymentRefund(
@@ -16894,8 +16951,8 @@ type Mutation {
   ): PaymentRefund @doc(category: "Payments")
 
   """
-  Voids the authorized payment. 
-  
+  Voids the authorized payment.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   paymentVoid(
@@ -16923,11 +16980,11 @@ type Mutation {
 
   """
   Create transaction for checkout or order.
-  
+
   Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transactionCreate(
@@ -16943,11 +17000,11 @@ type Mutation {
 
   """
   Update transaction.
-  
+
   Added in Saleor 3.4.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionUpdate(
@@ -16956,7 +17013,7 @@ type Mutation {
 
     """
     The token of the transaction. One of field id or token is required.
-    
+
     Added in Saleor 3.14.
     """
     token: UUID
@@ -16970,11 +17027,11 @@ type Mutation {
 
   """
   Request an action for payment transaction.
-  
+
   Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transactionRequestAction(
@@ -16991,7 +17048,7 @@ type Mutation {
 
     """
     The token of the transaction. One of field id or token is required.
-    
+
     Added in Saleor 3.14.
     """
     token: UUID
@@ -16999,11 +17056,11 @@ type Mutation {
 
   """
   Request a refund for payment transaction based on granted refund.
-  
+
   Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transactionRequestRefundForGrantedRefund(
@@ -17023,17 +17080,17 @@ type Mutation {
 
   """
   Report the event for the transaction.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionEventReport(
     """
-    The amount of the event to report. 
-    
+    The amount of the event to report.
+
     Required for all `REQUEST`, `SUCCESS`, `ACTION_REQUIRED`, and `ADJUSTMENT` events. For other events, the amount will be calculated based on the previous events with the same pspReference. If not possible to calculate, the mutation will return an error.
     """
     amount: PositiveDecimal
@@ -17062,7 +17119,7 @@ type Mutation {
 
     """
     The token of the transaction. One of field id or token is required.
-    
+
     Added in Saleor 3.14.
     """
     token: UUID
@@ -17073,9 +17130,9 @@ type Mutation {
 
   """
   Initializes a payment gateway session. It triggers the webhook `PAYMENT_GATEWAY_INITIALIZE_SESSION`, to the requested `paymentGateways`. If `paymentGateways` is not provided, the webhook will be send to all subscribed payment gateways. There is a limit of 100 transaction items per checkout / order.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   paymentGatewayInitialize(
@@ -17093,9 +17150,9 @@ type Mutation {
 
   """
   Initializes a transaction session. It triggers the webhook `TRANSACTION_INITIALIZE_SESSION`, to the requested `paymentGateways`. There is a limit of 100 transaction items per checkout / order.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactionInitialize(
@@ -17111,7 +17168,7 @@ type Mutation {
 
     """
     The customer's IP address. If not provided Saleor will try to determine the customer's IP address on its own. The customer's IP address will be passed to the payment app. The IP should be in ipv4 or ipv6 format. The field can be used only by an app that has `HANDLE_PAYMENTS` permission.
-    
+
     Added in Saleor 3.16.
     """
     customerIpAddress: String
@@ -17121,7 +17178,7 @@ type Mutation {
 
     """
     The idempotency key assigned to the action. It will be passed to the payment app to discover potential duplicate actions. If not provided, the default one will be generated. If empty string provided, INVALID error code will be raised.
-    
+
     Added in Saleor 3.14.
     """
     idempotencyKey: String
@@ -17131,16 +17188,16 @@ type Mutation {
   ): TransactionInitialize @doc(category: "Payments")
 
   """
-  Processes a transaction session. It triggers the webhook `TRANSACTION_PROCESS_SESSION`, to the assigned `paymentGateways`. 
-  
+  Processes a transaction session. It triggers the webhook `TRANSACTION_PROCESS_SESSION`, to the assigned `paymentGateways`.
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactionProcess(
     """
     The customer's IP address. If not provided Saleor will try to determine the customer's IP address on its own. The customer's IP address will be passed to the payment app. The IP should be in ipv4 or ipv6 format. The field can be used only by an app that has `HANDLE_PAYMENTS` permission.
-    
+
     Added in Saleor 3.16.
     """
     customerIpAddress: String
@@ -17155,7 +17212,7 @@ type Mutation {
 
     """
     The token of the transaction to process. One of field id or token is required.
-    
+
     Added in Saleor 3.14.
     """
     token: UUID
@@ -17163,13 +17220,13 @@ type Mutation {
 
   """
   Request to delete a stored payment method on payment provider side.
-  
+
   Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - STORED_PAYMENT_METHOD_DELETE_REQUESTED (sync): The customer requested to delete a payment method.
   """
@@ -17183,13 +17240,13 @@ type Mutation {
 
   """
   Initializes payment gateway for tokenizing payment method session.
-  
+
   Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION (sync): The customer requested to initialize payment gateway for tokenization.
   """
@@ -17206,13 +17263,13 @@ type Mutation {
 
   """
   Tokenize payment method.
-  
+
   Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION (sync): The customer requested to tokenize payment method.
   """
@@ -17234,13 +17291,13 @@ type Mutation {
 
   """
   Tokenize payment method.
-  
+
   Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION (sync): The customer continues payment method tokenization.
   """
@@ -17258,8 +17315,8 @@ type Mutation {
   ): PaymentMethodProcessTokenization @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION])
 
   """
-  Creates a new page. 
-  
+  Creates a new page.
+
   Requires one of the following permissions: MANAGE_PAGES.
   """
   pageCreate(
@@ -17268,8 +17325,8 @@ type Mutation {
   ): PageCreate @doc(category: "Pages")
 
   """
-  Deletes a page. 
-  
+  Deletes a page.
+
   Requires one of the following permissions: MANAGE_PAGES.
   """
   pageDelete(
@@ -17278,8 +17335,8 @@ type Mutation {
   ): PageDelete @doc(category: "Pages")
 
   """
-  Deletes pages. 
-  
+  Deletes pages.
+
   Requires one of the following permissions: MANAGE_PAGES.
   """
   pageBulkDelete(
@@ -17288,8 +17345,8 @@ type Mutation {
   ): PageBulkDelete @doc(category: "Pages")
 
   """
-  Publish pages. 
-  
+  Publish pages.
+
   Requires one of the following permissions: MANAGE_PAGES.
   """
   pageBulkPublish(
@@ -17301,8 +17358,8 @@ type Mutation {
   ): PageBulkPublish @doc(category: "Pages")
 
   """
-  Updates an existing page. 
-  
+  Updates an existing page.
+
   Requires one of the following permissions: MANAGE_PAGES.
   """
   pageUpdate(
@@ -17314,8 +17371,8 @@ type Mutation {
   ): PageUpdate @doc(category: "Pages")
 
   """
-  Creates/updates translations for a page. 
-  
+  Creates/updates translations for a page.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   pageTranslate(
@@ -17330,8 +17387,8 @@ type Mutation {
   ): PageTranslate @doc(category: "Pages")
 
   """
-  Create a new page type. 
-  
+  Create a new page type.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageTypeCreate(
@@ -17340,8 +17397,8 @@ type Mutation {
   ): PageTypeCreate @doc(category: "Pages")
 
   """
-  Update page type. 
-  
+  Update page type.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageTypeUpdate(
@@ -17353,8 +17410,8 @@ type Mutation {
   ): PageTypeUpdate @doc(category: "Pages")
 
   """
-  Delete a page type. 
-  
+  Delete a page type.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageTypeDelete(
@@ -17363,8 +17420,8 @@ type Mutation {
   ): PageTypeDelete @doc(category: "Pages")
 
   """
-  Delete page types. 
-  
+  Delete page types.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageTypeBulkDelete(
@@ -17373,8 +17430,8 @@ type Mutation {
   ): PageTypeBulkDelete @doc(category: "Pages")
 
   """
-  Assign attributes to a given page type. 
-  
+  Assign attributes to a given page type.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageAttributeAssign(
@@ -17386,8 +17443,8 @@ type Mutation {
   ): PageAttributeAssign @doc(category: "Pages")
 
   """
-  Unassign attributes from a given page type. 
-  
+  Unassign attributes from a given page type.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageAttributeUnassign(
@@ -17399,8 +17456,8 @@ type Mutation {
   ): PageAttributeUnassign @doc(category: "Pages")
 
   """
-  Reorder the attributes of a page type. 
-  
+  Reorder the attributes of a page type.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageTypeReorderAttributes(
@@ -17412,8 +17469,8 @@ type Mutation {
   ): PageTypeReorderAttributes @doc(category: "Pages")
 
   """
-  Reorder page attribute values. 
-  
+  Reorder page attribute values.
+
   Requires one of the following permissions: MANAGE_PAGES.
   """
   pageReorderAttributeValues(
@@ -17428,8 +17485,8 @@ type Mutation {
   ): PageReorderAttributeValues @doc(category: "Pages")
 
   """
-  Completes creating an order. 
-  
+  Completes creating an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderComplete(
@@ -17438,8 +17495,8 @@ type Mutation {
   ): DraftOrderComplete @doc(category: "Orders")
 
   """
-  Creates a new draft order. 
-  
+  Creates a new draft order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderCreate(
@@ -17448,14 +17505,14 @@ type Mutation {
   ): DraftOrderCreate @doc(category: "Orders")
 
   """
-  Deletes a draft order. 
-  
+  Deletes a draft order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderDelete(
     """
-    External ID of a product to delete. 
-    
+    External ID of a product to delete.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -17465,8 +17522,8 @@ type Mutation {
   ): DraftOrderDelete @doc(category: "Orders")
 
   """
-  Deletes draft orders. 
-  
+  Deletes draft orders.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderBulkDelete(
@@ -17475,8 +17532,8 @@ type Mutation {
   ): DraftOrderBulkDelete @doc(category: "Orders")
 
   """
-  Deletes order lines. 
-  
+  Deletes order lines.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderLinesBulkDelete(
@@ -17485,14 +17542,14 @@ type Mutation {
   ): DraftOrderLinesBulkDelete @doc(category: "Orders") @deprecated(reason: "This field will be removed in Saleor 4.0.")
 
   """
-  Updates a draft order. 
-  
+  Updates a draft order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderUpdate(
     """
-    External ID of a draft order to update. 
-    
+    External ID of a draft order to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -17506,9 +17563,9 @@ type Mutation {
 
   """
   Adds note to the order.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderAddNote(
@@ -17520,8 +17577,8 @@ type Mutation {
   ): OrderAddNote @doc(category: "Orders") @deprecated(reason: "This field will be removed in Saleor 4.0. Use `orderNoteAdd` instead.")
 
   """
-  Cancel an order. 
-  
+  Cancel an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderCancel(
@@ -17530,8 +17587,8 @@ type Mutation {
   ): OrderCancel @doc(category: "Orders")
 
   """
-  Capture an order. 
-  
+  Capture an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderCapture(
@@ -17543,8 +17600,8 @@ type Mutation {
   ): OrderCapture @doc(category: "Orders")
 
   """
-  Confirms an unconfirmed order by changing status to unfulfilled. 
-  
+  Confirms an unconfirmed order by changing status to unfulfilled.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderConfirm(
@@ -17553,10 +17610,10 @@ type Mutation {
   ): OrderConfirm @doc(category: "Orders")
 
   """
-  Creates new fulfillments for an order. 
-  
+  Creates new fulfillments for an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
-  
+
   Triggers the following webhook events:
   - FULFILLMENT_CREATED (async): A new fulfillment is created.
   - ORDER_FULFILLED (async): Order is fulfilled.
@@ -17572,8 +17629,8 @@ type Mutation {
   ): OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED, FULFILLMENT_TRACKING_NUMBER_UPDATED, FULFILLMENT_APPROVED], syncEvents: [])
 
   """
-  Cancels existing fulfillment and optionally restocks items. 
-  
+  Cancels existing fulfillment and optionally restocks items.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderFulfillmentCancel(
@@ -17586,11 +17643,11 @@ type Mutation {
 
   """
   Approve existing fulfillment.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_ORDERS.
-  
+
   Triggers the following webhook events:
   - FULFILLMENT_APPROVED (async): Fulfillment is approved.
   """
@@ -17606,10 +17663,10 @@ type Mutation {
   ): FulfillmentApprove @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_APPROVED], syncEvents: [])
 
   """
-  Updates a fulfillment for an order. 
-  
+  Updates a fulfillment for an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
-  
+
   Triggers the following webhook events:
   - FULFILLMENT_TRACKING_NUMBER_UPDATED (async): Fulfillment tracking number is updated.
   """
@@ -17622,8 +17679,8 @@ type Mutation {
   ): FulfillmentUpdateTracking @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_TRACKING_NUMBER_UPDATED], syncEvents: [])
 
   """
-  Refund products. 
-  
+  Refund products.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderFulfillmentRefundProducts(
@@ -17635,8 +17692,8 @@ type Mutation {
   ): FulfillmentRefundProducts @doc(category: "Orders")
 
   """
-  Return products. 
-  
+  Return products.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderFulfillmentReturnProducts(
@@ -17649,11 +17706,11 @@ type Mutation {
 
   """
   Adds granted refund to the order.
-  
+
   Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderGrantRefundCreate(
@@ -17666,11 +17723,11 @@ type Mutation {
 
   """
   Updates granted refund.
-  
+
   Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderGrantRefundUpdate(
@@ -17682,8 +17739,8 @@ type Mutation {
   ): OrderGrantRefundUpdate @doc(category: "Orders")
 
   """
-  Create order lines for an order. 
-  
+  Create order lines for an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderLinesCreate(
@@ -17695,8 +17752,8 @@ type Mutation {
   ): OrderLinesCreate @doc(category: "Orders")
 
   """
-  Deletes an order line from an order. 
-  
+  Deletes an order line from an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderLineDelete(
@@ -17705,8 +17762,8 @@ type Mutation {
   ): OrderLineDelete @doc(category: "Orders")
 
   """
-  Updates an order line of an order. 
-  
+  Updates an order line of an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderLineUpdate(
@@ -17718,8 +17775,8 @@ type Mutation {
   ): OrderLineUpdate @doc(category: "Orders")
 
   """
-  Adds discount to the order. 
-  
+  Adds discount to the order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderDiscountAdd(
@@ -17731,8 +17788,8 @@ type Mutation {
   ): OrderDiscountAdd @doc(category: "Orders")
 
   """
-  Update discount for the order. 
-  
+  Update discount for the order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderDiscountUpdate(
@@ -17744,8 +17801,8 @@ type Mutation {
   ): OrderDiscountUpdate @doc(category: "Orders")
 
   """
-  Remove discount from the order. 
-  
+  Remove discount from the order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderDiscountDelete(
@@ -17754,8 +17811,8 @@ type Mutation {
   ): OrderDiscountDelete @doc(category: "Orders")
 
   """
-  Update discount for the order line. 
-  
+  Update discount for the order line.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderLineDiscountUpdate(
@@ -17767,8 +17824,8 @@ type Mutation {
   ): OrderLineDiscountUpdate @doc(category: "Orders")
 
   """
-  Remove discount applied to the order line. 
-  
+  Remove discount applied to the order line.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderLineDiscountRemove(
@@ -17778,11 +17835,11 @@ type Mutation {
 
   """
   Adds note to the order.
-  
+
   Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderNoteAdd(
@@ -17795,11 +17852,11 @@ type Mutation {
 
   """
   Updates note of an order.
-  
+
   Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderNoteUpdate(
@@ -17811,8 +17868,8 @@ type Mutation {
   ): OrderNoteUpdate @doc(category: "Orders")
 
   """
-  Mark order as manually paid. 
-  
+  Mark order as manually paid.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderMarkAsPaid(
@@ -17824,8 +17881,8 @@ type Mutation {
   ): OrderMarkAsPaid @doc(category: "Orders")
 
   """
-  Refund an order. 
-  
+  Refund an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderRefund(
@@ -17837,14 +17894,14 @@ type Mutation {
   ): OrderRefund @doc(category: "Orders")
 
   """
-  Updates an order. 
-  
+  Updates an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderUpdate(
     """
-    External ID of an order to update. 
-    
+    External ID of an order to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -17857,8 +17914,8 @@ type Mutation {
   ): OrderUpdate @doc(category: "Orders")
 
   """
-  Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed. 
-  
+  Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderUpdateShipping(
@@ -17870,8 +17927,8 @@ type Mutation {
   ): OrderUpdateShipping @doc(category: "Orders")
 
   """
-  Void an order. 
-  
+  Void an order.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderVoid(
@@ -17880,8 +17937,8 @@ type Mutation {
   ): OrderVoid @doc(category: "Orders")
 
   """
-  Cancels orders. 
-  
+  Cancels orders.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderBulkCancel(
@@ -17891,11 +17948,11 @@ type Mutation {
 
   """
   Creates multiple orders.
-  
+
   Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_ORDERS_IMPORT.
   """
   orderBulkCreate(
@@ -17956,8 +18013,8 @@ type Mutation {
   ): UpdatePrivateMetadata
 
   """
-  Assigns storefront's navigation menus. 
-  
+  Assigns storefront's navigation menus.
+
   Requires one of the following permissions: MANAGE_MENUS, MANAGE_SETTINGS.
   """
   assignNavigation(
@@ -17969,10 +18026,10 @@ type Mutation {
   ): AssignNavigation @doc(category: "Menu")
 
   """
-  Creates a new Menu. 
-  
+  Creates a new Menu.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_CREATED (async): A menu was created.
   """
@@ -17982,10 +18039,10 @@ type Mutation {
   ): MenuCreate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_CREATED], syncEvents: [])
 
   """
-  Deletes a menu. 
-  
+  Deletes a menu.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_DELETED (async): A menu was deleted.
   """
@@ -17995,10 +18052,10 @@ type Mutation {
   ): MenuDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: [])
 
   """
-  Deletes menus. 
-  
+  Deletes menus.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_DELETED (async): A menu was deleted.
   """
@@ -18008,10 +18065,10 @@ type Mutation {
   ): MenuBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: [])
 
   """
-  Updates a menu. 
-  
+  Updates a menu.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_UPDATED (async): A menu was updated.
   """
@@ -18024,10 +18081,10 @@ type Mutation {
   ): MenuUpdate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_UPDATED], syncEvents: [])
 
   """
-  Creates a new menu item. 
-  
+  Creates a new menu item.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_ITEM_CREATED (async): A menu item was created.
   """
@@ -18039,10 +18096,10 @@ type Mutation {
   ): MenuItemCreate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_CREATED], syncEvents: [])
 
   """
-  Deletes a menu item. 
-  
+  Deletes a menu item.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_ITEM_DELETED (async): A menu item was deleted.
   """
@@ -18052,10 +18109,10 @@ type Mutation {
   ): MenuItemDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: [])
 
   """
-  Deletes menu items. 
-  
+  Deletes menu items.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_ITEM_DELETED (async): A menu item was deleted.
   """
@@ -18065,10 +18122,10 @@ type Mutation {
   ): MenuItemBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: [])
 
   """
-  Updates a menu item. 
-  
+  Updates a menu item.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_ITEM_UPDATED (async): A menu item was updated.
   """
@@ -18083,8 +18140,8 @@ type Mutation {
   ): MenuItemUpdate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_UPDATED], syncEvents: [])
 
   """
-  Creates/updates translations for a menu item. 
-  
+  Creates/updates translations for a menu item.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   menuItemTranslate(
@@ -18099,10 +18156,10 @@ type Mutation {
   ): MenuItemTranslate @doc(category: "Menu")
 
   """
-  Moves items of menus. 
-  
+  Moves items of menus.
+
   Requires one of the following permissions: MANAGE_MENUS.
-  
+
   Triggers the following webhook events:
   - MENU_ITEM_UPDATED (async): Optionally triggered when sort order or parent changed for menu item.
   """
@@ -18115,10 +18172,10 @@ type Mutation {
   ): MenuItemMove @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_UPDATED], syncEvents: [])
 
   """
-  Request an invoice for the order using plugin. 
-  
+  Request an invoice for the order using plugin.
+
   Requires one of the following permissions: MANAGE_ORDERS.
-  
+
   Triggers the following webhook events:
   - INVOICE_REQUESTED (async): An invoice was requested.
   """
@@ -18131,10 +18188,10 @@ type Mutation {
   ): InvoiceRequest @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [INVOICE_REQUESTED], syncEvents: [])
 
   """
-  Requests deletion of an invoice. 
-  
+  Requests deletion of an invoice.
+
   Requires one of the following permissions: MANAGE_ORDERS.
-  
+
   Triggers the following webhook events:
   - INVOICE_DELETED (async): An invoice was requested to delete.
   """
@@ -18144,8 +18201,8 @@ type Mutation {
   ): InvoiceRequestDelete @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [INVOICE_DELETED], syncEvents: [])
 
   """
-  Creates a ready to send invoice. 
-  
+  Creates a ready to send invoice.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   invoiceCreate(
@@ -18157,8 +18214,8 @@ type Mutation {
   ): InvoiceCreate @doc(category: "Orders")
 
   """
-  Deletes an invoice. 
-  
+  Deletes an invoice.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   invoiceDelete(
@@ -18167,8 +18224,8 @@ type Mutation {
   ): InvoiceDelete @doc(category: "Orders")
 
   """
-  Updates an invoice. 
-  
+  Updates an invoice.
+
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   invoiceUpdate(
@@ -18180,10 +18237,10 @@ type Mutation {
   ): InvoiceUpdate @doc(category: "Orders")
 
   """
-  Send an invoice notification to the customer. 
-  
+  Send an invoice notification to the customer.
+
   Requires one of the following permissions: MANAGE_ORDERS.
-  
+
   Triggers the following webhook events:
   - INVOICE_SENT (async): A notification for invoice send
   - NOTIFY_USER (async): A notification for invoice send
@@ -18194,10 +18251,10 @@ type Mutation {
   ): InvoiceSendNotification @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [INVOICE_SENT, NOTIFY_USER], syncEvents: [])
 
   """
-  Activate a gift card. 
-  
+  Activate a gift card.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_STATUS_CHANGED (async): A gift card was activated.
   """
@@ -18207,10 +18264,10 @@ type Mutation {
   ): GiftCardActivate @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [GIFT_CARD_STATUS_CHANGED], syncEvents: [])
 
   """
-  Creates a new gift card. 
-  
+  Creates a new gift card.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_CREATED (async): A gift card was created.
   - NOTIFY_USER (async): A notification for created gift card.
@@ -18222,11 +18279,11 @@ type Mutation {
 
   """
   Delete gift card.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_DELETED (async): A gift card was deleted.
   """
@@ -18236,10 +18293,10 @@ type Mutation {
   ): GiftCardDelete @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [GIFT_CARD_DELETED], syncEvents: [])
 
   """
-  Deactivate a gift card. 
-  
+  Deactivate a gift card.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_STATUS_CHANGED (async): A gift card was deactivated.
   """
@@ -18249,10 +18306,10 @@ type Mutation {
   ): GiftCardDeactivate @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [GIFT_CARD_STATUS_CHANGED], syncEvents: [])
 
   """
-  Update a gift card. 
-  
+  Update a gift card.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_UPDATED (async): A gift card was updated.
   """
@@ -18266,11 +18323,11 @@ type Mutation {
 
   """
   Resend a gift card.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for gift card resend.
   """
@@ -18281,11 +18338,11 @@ type Mutation {
 
   """
   Adds note to the gift card.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_UPDATED (async): A gift card was updated.
   """
@@ -18299,11 +18356,11 @@ type Mutation {
 
   """
   Create gift cards.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_CREATED (async): A gift card was created.
   - NOTIFY_USER (async): A notification for created gift card.
@@ -18315,11 +18372,11 @@ type Mutation {
 
   """
   Delete gift cards.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_DELETED (async): A gift card was deleted.
   """
@@ -18330,11 +18387,11 @@ type Mutation {
 
   """
   Activate gift cards.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_STATUS_CHANGED (async): A gift card was activated.
   """
@@ -18345,11 +18402,11 @@ type Mutation {
 
   """
   Deactivate gift cards.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - GIFT_CARD_STATUS_CHANGED (async): A gift card was deactivated.
   """
@@ -18359,8 +18416,8 @@ type Mutation {
   ): GiftCardBulkDeactivate @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [GIFT_CARD_STATUS_CHANGED], syncEvents: [])
 
   """
-  Update plugin configuration. 
-  
+  Update plugin configuration.
+
   Requires one of the following permissions: MANAGE_PLUGINS.
   """
   pluginUpdate(
@@ -18376,7 +18433,7 @@ type Mutation {
 
   """
   Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload.
-  
+
   Added in Saleor 3.1.
   """
   externalNotificationTrigger(
@@ -18394,13 +18451,13 @@ type Mutation {
 
   """
   Creates a new promotion.
-  
+
   Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - PROMOTION_CREATED (async): A promotion was created.
   - PROMOTION_STARTED (async): Optionally called if promotion was started.
@@ -18412,13 +18469,13 @@ type Mutation {
 
   """
   Updates an existing promotion.
-  
+
   Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - PROMOTION_UPDATED (async): A promotion was updated.
   - PROMOTION_STARTED (async): Optionally called if promotion was started.
@@ -18434,13 +18491,13 @@ type Mutation {
 
   """
   Deletes a promotion.
-  
+
   Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - PROMOTION_DELETED (async): A promotion was deleted.
   """
@@ -18451,13 +18508,13 @@ type Mutation {
 
   """
   Creates a new promotion rule.
-  
+
   Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - PROMOTION_RULE_CREATED (async): A promotion rule was created.
   """
@@ -18468,13 +18525,13 @@ type Mutation {
 
   """
   Updates an existing promotion rule.
-  
+
   Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - PROMOTION_RULE_UPDATED (async): A promotion rule was updated.
   """
@@ -18488,13 +18545,13 @@ type Mutation {
 
   """
   Deletes a promotion rule.
-  
+
   Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - PROMOTION_RULE_DELETED (async): A promotion rule was deleted.
   """
@@ -18505,9 +18562,9 @@ type Mutation {
 
   """
   Creates/updates translations for a promotion.
-  
-  Added in Saleor 3.17. 
-  
+
+  Added in Saleor 3.17.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   promotionTranslate(
@@ -18523,9 +18580,9 @@ type Mutation {
 
   """
   Creates/updates translations for a promotion rule.
-  
-  Added in Saleor 3.17. 
-  
+
+  Added in Saleor 3.17.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   promotionRuleTranslate(
@@ -18541,13 +18598,13 @@ type Mutation {
 
   """
   Deletes promotions.
-  
+
   Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - PROMOTION_DELETED (async): A promotion was deleted.
   """
@@ -18558,11 +18615,11 @@ type Mutation {
 
   """
   Creates a new sale.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionCreate` mutation instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionCreate` mutation instead.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - SALE_CREATED (async): A sale was created.
   """
@@ -18573,11 +18630,11 @@ type Mutation {
 
   """
   Deletes a sale.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionDelete` mutation instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionDelete` mutation instead.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - SALE_DELETED (async): A sale was deleted.
   """
@@ -18587,10 +18644,10 @@ type Mutation {
   ): SaleDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [SALE_DELETED], syncEvents: [])
 
   """
-  Deletes sales. 
-  
+  Deletes sales.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - SALE_DELETED (async): A sale was deleted.
   """
@@ -18601,11 +18658,11 @@ type Mutation {
 
   """
   Updates a sale.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionUpdate` mutation instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionUpdate` mutation instead.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - SALE_UPDATED (async): A sale was updated.
   - SALE_TOGGLE (async): Optionally triggered when a sale is started or stopped.
@@ -18620,11 +18677,11 @@ type Mutation {
 
   """
   Adds products, categories, collections to a sale.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` mutation instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` mutation instead.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - SALE_UPDATED (async): A sale was updated.
   """
@@ -18638,11 +18695,11 @@ type Mutation {
 
   """
   Removes products, categories, collections from a sale.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleUpdate` or `promotionRuleDelete` mutations instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleUpdate` or `promotionRuleDelete` mutations instead.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - SALE_UPDATED (async): A sale was updated.
   """
@@ -18656,9 +18713,9 @@ type Mutation {
 
   """
   Creates/updates translations for a sale.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PromotionTranslate` mutation instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PromotionTranslate` mutation instead.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   saleTranslate(
@@ -18674,9 +18731,9 @@ type Mutation {
 
   """
   Manage sale's availability in channels.
-  
-  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` or `promotionRuleUpdate` mutations instead. 
-  
+
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` or `promotionRuleUpdate` mutations instead.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   saleChannelListingUpdate(
@@ -18688,10 +18745,10 @@ type Mutation {
   ): SaleChannelListingUpdate @doc(category: "Discounts")
 
   """
-  Creates a new voucher. 
-  
+  Creates a new voucher.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_CREATED (async): A voucher was created.
   - VOUCHER_CODES_CREATED (async): A voucher codes were created.
@@ -18702,10 +18759,10 @@ type Mutation {
   ): VoucherCreate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_CREATED, VOUCHER_CODES_CREATED], syncEvents: [])
 
   """
-  Deletes a voucher. 
-  
+  Deletes a voucher.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_DELETED (async): A voucher was deleted.
   """
@@ -18715,10 +18772,10 @@ type Mutation {
   ): VoucherDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_DELETED], syncEvents: [])
 
   """
-  Deletes vouchers. 
-  
+  Deletes vouchers.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_DELETED (async): A voucher was deleted.
   """
@@ -18728,10 +18785,10 @@ type Mutation {
   ): VoucherBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_DELETED], syncEvents: [])
 
   """
-  Updates a voucher. 
-  
+  Updates a voucher.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_UPDATED (async): A voucher was updated.
   - VOUCHER_CODES_CREATED (async): A voucher code was created.
@@ -18745,10 +18802,10 @@ type Mutation {
   ): VoucherUpdate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED, VOUCHER_CODES_CREATED], syncEvents: [])
 
   """
-  Adds products, categories, collections to a voucher. 
-  
+  Adds products, categories, collections to a voucher.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_UPDATED (async): A voucher was updated.
   """
@@ -18761,10 +18818,10 @@ type Mutation {
   ): VoucherAddCatalogues @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED], syncEvents: [])
 
   """
-  Removes products, categories, collections from a voucher. 
-  
+  Removes products, categories, collections from a voucher.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_UPDATED (async): A voucher was updated.
   """
@@ -18777,8 +18834,8 @@ type Mutation {
   ): VoucherRemoveCatalogues @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED], syncEvents: [])
 
   """
-  Creates/updates translations for a voucher. 
-  
+  Creates/updates translations for a voucher.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   voucherTranslate(
@@ -18793,10 +18850,10 @@ type Mutation {
   ): VoucherTranslate @doc(category: "Discounts")
 
   """
-  Manage voucher's availability in channels. 
-  
+  Manage voucher's availability in channels.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_UPDATED (async): A voucher was updated.
   """
@@ -18810,11 +18867,11 @@ type Mutation {
 
   """
   Deletes voucher codes.
-  
-  Added in Saleor 3.18. 
-  
+
+  Added in Saleor 3.18.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_CODES_DELETED (async): A voucher codes were deleted.
   """
@@ -18824,10 +18881,10 @@ type Mutation {
   ): VoucherCodeBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_CODES_DELETED], syncEvents: [])
 
   """
-  Export products to csv file. 
-  
+  Export products to csv file.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
-  
+
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for the exported file.
   - PRODUCT_EXPORT_COMPLETED (async): A notification for the exported file.
@@ -18839,11 +18896,11 @@ type Mutation {
 
   """
   Export gift cards to csv file.
-  
-  Added in Saleor 3.1. 
-  
+
+  Added in Saleor 3.1.
+
   Requires one of the following permissions: MANAGE_GIFT_CARD.
-  
+
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for the exported file.
   - GIFT_CARD_EXPORT_COMPLETED (async): A notification for the exported file.
@@ -18855,13 +18912,13 @@ type Mutation {
 
   """
   Export voucher codes to csv/xlsx file.
-  
+
   Added in Saleor 3.18.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_DISCOUNTS.
-  
+
   Triggers the following webhook events:
   - VOUCHER_CODE_EXPORT_COMPLETED (async): A notification for the exported file.
   """
@@ -18871,8 +18928,8 @@ type Mutation {
   ): ExportVoucherCodes @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_CODE_EXPORT_COMPLETED], syncEvents: [])
 
   """
-  Upload a file. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
-  
+  Upload a file. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   fileUpload(
@@ -18882,21 +18939,21 @@ type Mutation {
 
   """
   Adds a gift card or a voucher to a checkout.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutAddPromoCode(
     """
     The ID of the checkout.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -18906,7 +18963,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -18914,7 +18971,7 @@ type Mutation {
 
   """
   Update billing address in the existing checkout.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
@@ -18923,29 +18980,29 @@ type Mutation {
     billingAddress: AddressInput!
 
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
 
     """
     The rules for changing validation for received billing address data.
-    
+
     Added in Saleor 3.5.
     """
     validationRules: CheckoutAddressValidationRules
@@ -18953,7 +19010,7 @@ type Mutation {
 
   """
   Completes the checkout. As a result a new order is created. The mutation allows to create the unpaid order when setting `orderSettings.allowUnpaidOrders` for given `Channel` is set to `true`. When `orderSettings.allowUnpaidOrders` is set to `false`, checkout can be completed only when attached `Payment`/`TransactionItem`s fully cover the checkout's total. When processing the checkout with `Payment`, in case of required additional confirmation step like 3D secure, the `confirmationNeeded` flag will be set to True and no order will be created until payment is confirmed with second call of this mutation.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
   - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
@@ -18968,22 +19025,22 @@ type Mutation {
   """
   checkoutComplete(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
 
     """
     Fields required to update the checkout metadata.
-    
+
     Added in Saleor 3.8.
     """
     metadata: [MetadataInput!]
@@ -18997,15 +19054,15 @@ type Mutation {
     redirectUrl: String
 
     """
-    Determines whether to store the payment source for future usage. 
-    
+    Determines whether to store the payment source for future usage.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use checkoutPaymentCreate for this action.
     """
     storeSource: Boolean = false
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19013,9 +19070,9 @@ type Mutation {
 
   """
   Create a new checkout.
-  
+
   `skipValidation` field requires HANDLE_CHECKOUTS and AUTHENTICATED_APP permissions.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_CREATED (async): A checkout was created.
   """
@@ -19026,9 +19083,9 @@ type Mutation {
 
   """
   Create new checkout from existing order.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   checkoutCreateFromOrder(
@@ -19037,17 +19094,17 @@ type Mutation {
   ): CheckoutCreateFromOrder @doc(category: "Checkout")
 
   """
-  Sets the customer as the owner of the checkout. 
-  
+  Sets the customer as the owner of the checkout.
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutCustomerAttach(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
@@ -19059,45 +19116,45 @@ type Mutation {
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
   ): CheckoutCustomerAttach @doc(category: "Checkout") @webhookEventsInfo(asyncEvents: [CHECKOUT_UPDATED], syncEvents: [])
 
   """
-  Removes the user assigned as the owner of the checkout. 
-  
+  Removes the user assigned as the owner of the checkout.
+
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutCustomerDetach(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19105,9 +19162,9 @@ type Mutation {
 
   """
   Updates customer note in the existing checkout object.
-  
+
   Added in Saleor 3.21.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
@@ -19121,14 +19178,14 @@ type Mutation {
 
   """
   Updates email address in the existing checkout object.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutEmailUpdate(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
@@ -19138,14 +19195,14 @@ type Mutation {
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19153,21 +19210,21 @@ type Mutation {
 
   """
   Deletes a CheckoutLine.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutLineDelete(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19177,7 +19234,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19185,14 +19242,14 @@ type Mutation {
 
   """
   Deletes checkout lines.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutLinesDelete(
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19202,7 +19259,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19210,21 +19267,21 @@ type Mutation {
 
   """
   Adds a checkout line to the existing checkout.If line was already in checkout, its quantity will be increased.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutLinesAdd(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19236,7 +19293,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19244,21 +19301,21 @@ type Mutation {
 
   """
   Updates checkout line in the existing checkout.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutLinesUpdate(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19270,7 +19327,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19278,21 +19335,21 @@ type Mutation {
 
   """
   Remove a gift card or a voucher from a checkout.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutRemovePromoCode(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19305,7 +19362,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19314,15 +19371,15 @@ type Mutation {
   """Create a new payment for given checkout."""
   checkoutPaymentCreate(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19332,7 +19389,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19340,21 +19397,21 @@ type Mutation {
 
   """
   Update shipping address in the existing checkout.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutShippingAddressUpdate(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19364,14 +19421,14 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
 
     """
     The rules for changing validation for received shipping address data.
-    
+
     Added in Saleor 3.5.
     """
     validationRules: CheckoutAddressValidationRules
@@ -19379,22 +19436,22 @@ type Mutation {
 
   """
   Updates the shipping method of the checkout.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Triggered when updating the checkout shipping method with the external one.
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutShippingMethodUpdate(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19404,17 +19461,17 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
   ): CheckoutShippingMethodUpdate @doc(category: "Checkout") @webhookEventsInfo(asyncEvents: [CHECKOUT_UPDATED], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT]) @deprecated(reason: "This field will be removed in Saleor 4.0. Use `checkoutDeliveryMethodUpdate` instead.")
 
   """
-  Updates the delivery method (shipping method or pick up point) of the checkout. Updates the checkout shipping_address for click and collect delivery for a warehouse address. 
-  
+  Updates the delivery method (shipping method or pick up point) of the checkout. Updates the checkout shipping_address for click and collect delivery for a warehouse address.
+
   Added in Saleor 3.1.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Triggered when updating the checkout delivery method with the external one.
   - CHECKOUT_UPDATED (async): A checkout was updated.
@@ -19425,14 +19482,14 @@ type Mutation {
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19440,21 +19497,21 @@ type Mutation {
 
   """
   Update language code in the existing checkout.
-  
+
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutLanguageCodeUpdate(
     """
-    The ID of the checkout. 
-    
+    The ID of the checkout.
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     checkoutId: ID
 
     """
     The checkout's ID.
-    
+
     Added in Saleor 3.4.
     """
     id: ID
@@ -19464,7 +19521,7 @@ type Mutation {
 
     """
     Checkout token.
-    
+
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
@@ -19472,9 +19529,9 @@ type Mutation {
 
   """
   Create new order from existing checkout. Requires the following permissions: AUTHENTICATED_APP and HANDLE_CHECKOUTS.
-  
+
   Added in Saleor 3.2.
-  
+
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
   - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
@@ -19493,14 +19550,14 @@ type Mutation {
 
     """
     Fields required to update the checkout metadata.
-    
+
     Added in Saleor 3.8.
     """
     metadata: [MetadataInput!]
 
     """
     Fields required to update the checkout private metadata.
-    
+
     Added in Saleor 3.8.
     """
     privateMetadata: [MetadataInput!]
@@ -19512,10 +19569,10 @@ type Mutation {
   ): OrderCreateFromCheckout @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [ORDER_CREATED, NOTIFY_USER, NOTIFY_USER, ORDER_UPDATED, ORDER_PAID, ORDER_FULLY_PAID, ORDER_CONFIRMED], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS, CHECKOUT_CALCULATE_TAXES])
 
   """
-  Creates new channel. 
-  
+  Creates new channel.
+
   Requires one of the following permissions: MANAGE_CHANNELS.
-  
+
   Triggers the following webhook events:
   - CHANNEL_CREATED (async): A channel was created.
   """
@@ -19526,12 +19583,12 @@ type Mutation {
 
   """
   Update a channel.
-  
+
   Requires one of the following permissions: MANAGE_CHANNELS.
   Requires one of the following permissions when updating only `orderSettings` field: `MANAGE_CHANNELS`, `MANAGE_ORDERS`.
   Requires one of the following permissions when updating only `checkoutSettings` field: `MANAGE_CHANNELS`, `MANAGE_CHECKOUTS`.
   Requires one of the following permissions when updating only `paymentSettings` field: `MANAGE_CHANNELS`, `HANDLE_PAYMENTS`.
-  
+
   Triggers the following webhook events:
   - CHANNEL_UPDATED (async): A channel was updated.
   - CHANNEL_METADATA_UPDATED (async): Optionally triggered when public or private metadata is updated.
@@ -19545,10 +19602,10 @@ type Mutation {
   ): ChannelUpdate @doc(category: "Channels") @webhookEventsInfo(asyncEvents: [CHANNEL_UPDATED, CHANNEL_METADATA_UPDATED], syncEvents: [])
 
   """
-  Delete a channel. Orders associated with the deleted channel will be moved to the target channel. Checkouts, product availability, and pricing will be removed. 
-  
+  Delete a channel. Orders associated with the deleted channel will be moved to the target channel. Checkouts, product availability, and pricing will be removed.
+
   Requires one of the following permissions: MANAGE_CHANNELS.
-  
+
   Triggers the following webhook events:
   - CHANNEL_DELETED (async): A channel was deleted.
   """
@@ -19561,10 +19618,10 @@ type Mutation {
   ): ChannelDelete @doc(category: "Channels") @webhookEventsInfo(asyncEvents: [CHANNEL_DELETED], syncEvents: [])
 
   """
-  Activate a channel. 
-  
+  Activate a channel.
+
   Requires one of the following permissions: MANAGE_CHANNELS.
-  
+
   Triggers the following webhook events:
   - CHANNEL_STATUS_CHANGED (async): A channel was activated.
   """
@@ -19574,10 +19631,10 @@ type Mutation {
   ): ChannelActivate @doc(category: "Channels") @webhookEventsInfo(asyncEvents: [CHANNEL_STATUS_CHANGED], syncEvents: [])
 
   """
-  Deactivate a channel. 
-  
+  Deactivate a channel.
+
   Requires one of the following permissions: MANAGE_CHANNELS.
-  
+
   Triggers the following webhook events:
   - CHANNEL_STATUS_CHANGED (async): A channel was deactivated.
   """
@@ -19588,9 +19645,9 @@ type Mutation {
 
   """
   Reorder the warehouses of a channel.
-  
-  Added in Saleor 3.7. 
-  
+
+  Added in Saleor 3.7.
+
   Requires one of the following permissions: MANAGE_CHANNELS.
   """
   channelReorderWarehouses(
@@ -19603,7 +19660,7 @@ type Mutation {
 
   """
   Creates an attribute.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_CREATED (async): An attribute was created.
   """
@@ -19613,17 +19670,17 @@ type Mutation {
   ): AttributeCreate @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_CREATED], syncEvents: [])
 
   """
-  Deletes an attribute. 
-  
+  Deletes an attribute.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_DELETED (async): An attribute was deleted.
   """
   attributeDelete(
     """
-    External ID of an attribute to delete. 
-    
+    External ID of an attribute to delete.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -19633,17 +19690,17 @@ type Mutation {
   ): AttributeDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_DELETED], syncEvents: [])
 
   """
-  Updates attribute. 
-  
+  Updates attribute.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_UPDATED (async): An attribute was updated.
   """
   attributeUpdate(
     """
-    External ID of an attribute to update. 
-    
+    External ID of an attribute to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -19657,11 +19714,11 @@ type Mutation {
 
   """
   Creates attributes.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_CREATED (async): An attribute was created.
   """
@@ -19675,11 +19732,11 @@ type Mutation {
 
   """
   Updates attributes.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_UPDATED (async): An attribute was updated. Optionally called when new attribute value was created or deleted.
   - ATTRIBUTE_VALUE_CREATED (async): Called optionally when an attribute value was created.
@@ -19694,8 +19751,8 @@ type Mutation {
   ): AttributeBulkUpdate @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_UPDATED, ATTRIBUTE_VALUE_CREATED, ATTRIBUTE_VALUE_DELETED], syncEvents: [])
 
   """
-  Creates/updates translations for an attribute. 
-  
+  Creates/updates translations for an attribute.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   attributeTranslate(
@@ -19711,11 +19768,11 @@ type Mutation {
 
   """
   Creates/updates translations for attributes.
-  
+
   Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   attributeBulkTranslate(
@@ -19727,10 +19784,10 @@ type Mutation {
   ): AttributeBulkTranslate @doc(category: "Attributes")
 
   """
-  Deletes attributes. 
-  
+  Deletes attributes.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_DELETED (async): An attribute was deleted.
   """
@@ -19740,10 +19797,10 @@ type Mutation {
   ): AttributeBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_DELETED], syncEvents: [])
 
   """
-  Deletes values of attributes. 
-  
+  Deletes values of attributes.
+
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_DELETED (async): An attribute value was deleted.
   - ATTRIBUTE_UPDATED (async): An attribute was updated.
@@ -19754,10 +19811,10 @@ type Mutation {
   ): AttributeValueBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_DELETED, ATTRIBUTE_UPDATED], syncEvents: [])
 
   """
-  Creates a value for an attribute. 
-  
+  Creates a value for an attribute.
+
   Requires one of the following permissions: MANAGE_PRODUCTS.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_CREATED (async): An attribute value was created.
   - ATTRIBUTE_UPDATED (async): An attribute was updated.
@@ -19771,18 +19828,18 @@ type Mutation {
   ): AttributeValueCreate @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_CREATED, ATTRIBUTE_UPDATED], syncEvents: [])
 
   """
-  Deletes a value of an attribute. 
-  
+  Deletes a value of an attribute.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_DELETED (async): An attribute value was deleted.
   - ATTRIBUTE_UPDATED (async): An attribute was updated.
   """
   attributeValueDelete(
     """
-    External ID of a value to delete. 
-    
+    External ID of a value to delete.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -19792,18 +19849,18 @@ type Mutation {
   ): AttributeValueDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_DELETED, ATTRIBUTE_UPDATED], syncEvents: [])
 
   """
-  Updates value of an attribute. 
-  
+  Updates value of an attribute.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_UPDATED (async): An attribute value was updated.
   - ATTRIBUTE_UPDATED (async): An attribute was updated.
   """
   attributeValueUpdate(
     """
-    External ID of an AttributeValue to update. 
-    
+    External ID of an AttributeValue to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -19817,11 +19874,11 @@ type Mutation {
 
   """
   Creates/updates translations for attributes values.
-  
+
   Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   attributeValueBulkTranslate(
@@ -19833,8 +19890,8 @@ type Mutation {
   ): AttributeValueBulkTranslate @doc(category: "Attributes")
 
   """
-  Creates/updates translations for an attribute value. 
-  
+  Creates/updates translations for an attribute value.
+
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
   attributeValueTranslate(
@@ -19849,10 +19906,10 @@ type Mutation {
   ): AttributeValueTranslate @doc(category: "Attributes")
 
   """
-  Reorder the values of an attribute. 
-  
+  Reorder the values of an attribute.
+
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  
+
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_UPDATED (async): An attribute value was updated.
   - ATTRIBUTE_UPDATED (async): An attribute was updated.
@@ -19867,7 +19924,7 @@ type Mutation {
 
   """
   Creates a new app. Requires the following permissions: AUTHENTICATED_STAFF_USER and MANAGE_APPS.
-  
+
   Triggers the following webhook events:
   - APP_INSTALLED (async): An app was installed.
   """
@@ -19877,10 +19934,10 @@ type Mutation {
   ): AppCreate @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_INSTALLED], syncEvents: [])
 
   """
-  Updates an existing app. 
-  
+  Updates an existing app.
+
   Requires one of the following permissions: MANAGE_APPS.
-  
+
   Triggers the following webhook events:
   - APP_UPDATED (async): An app was updated.
   """
@@ -19893,10 +19950,10 @@ type Mutation {
   ): AppUpdate @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_UPDATED], syncEvents: [])
 
   """
-  Deletes an app. 
-  
+  Deletes an app.
+
   Requires one of the following permissions: MANAGE_APPS.
-  
+
   Triggers the following webhook events:
   - APP_DELETED (async): An app was deleted.
   """
@@ -19906,8 +19963,8 @@ type Mutation {
   ): AppDelete @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_DELETED], syncEvents: [])
 
   """
-  Creates a new token. 
-  
+  Creates a new token.
+
   Requires one of the following permissions: MANAGE_APPS.
   """
   appTokenCreate(
@@ -19916,8 +19973,8 @@ type Mutation {
   ): AppTokenCreate @doc(category: "Apps")
 
   """
-  Deletes an authentication token assigned to app. 
-  
+  Deletes an authentication token assigned to app.
+
   Requires one of the following permissions: MANAGE_APPS.
   """
   appTokenDelete(
@@ -19940,10 +19997,10 @@ type Mutation {
   ): AppInstall @doc(category: "Apps")
 
   """
-  Retry failed installation of new app. 
-  
+  Retry failed installation of new app.
+
   Requires one of the following permissions: MANAGE_APPS.
-  
+
   Triggers the following webhook events:
   - APP_INSTALLED (async): An app was installed.
   """
@@ -19956,8 +20013,8 @@ type Mutation {
   ): AppRetryInstall @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_INSTALLED], syncEvents: [])
 
   """
-  Delete failed installation. 
-  
+  Delete failed installation.
+
   Requires one of the following permissions: MANAGE_APPS.
   """
   appDeleteFailedInstallation(
@@ -19966,8 +20023,8 @@ type Mutation {
   ): AppDeleteFailedInstallation @doc(category: "Apps")
 
   """
-  Fetch and validate manifest. 
-  
+  Fetch and validate manifest.
+
   Requires one of the following permissions: MANAGE_APPS.
   """
   appFetchManifest(
@@ -19976,10 +20033,10 @@ type Mutation {
   ): AppFetchManifest @doc(category: "Apps")
 
   """
-  Activate the app. 
-  
+  Activate the app.
+
   Requires one of the following permissions: MANAGE_APPS.
-  
+
   Triggers the following webhook events:
   - APP_STATUS_CHANGED (async): An app was activated.
   """
@@ -19989,10 +20046,10 @@ type Mutation {
   ): AppActivate @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_STATUS_CHANGED], syncEvents: [])
 
   """
-  Deactivate the app. 
-  
+  Deactivate the app.
+
   Requires one of the following permissions: MANAGE_APPS.
-  
+
   Triggers the following webhook events:
   - APP_STATUS_CHANGED (async): An app was deactivated.
   """
@@ -20005,7 +20062,7 @@ type Mutation {
   tokenCreate(
     """
     The audience that will be included to JWT tokens with prefix `custom:`.
-    
+
     Added in Saleor 3.8.
     """
     audience: String
@@ -20037,8 +20094,8 @@ type Mutation {
   ): VerifyToken @doc(category: "Authentication")
 
   """
-  Deactivate all JWT tokens of the currently authenticated user. 
-  
+  Deactivate all JWT tokens of the currently authenticated user.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
   """
   tokensDeactivateAll: DeactivateAllUserTokens @doc(category: "Authentication")
@@ -20090,7 +20147,7 @@ type Mutation {
 
   """
   Sends an email with the account password modification link.
-  
+
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for password reset.
   - ACCOUNT_SET_PASSWORD_REQUESTED (async): Setting a new password for the account is requested.
@@ -20113,13 +20170,13 @@ type Mutation {
 
   """
   Sends a notification confirmation.
-  
+
   Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for account confirmation.
   - ACCOUNT_CONFIRMATION_REQUESTED (async): An account confirmation was requested. This event is always sent regardless of settings.
@@ -20134,7 +20191,7 @@ type Mutation {
 
   """
   Confirm user account with token sent by email during registration.
-  
+
   Triggers the following webhook events:
   - ACCOUNT_CONFIRMED (async): Account was confirmed.
   """
@@ -20161,8 +20218,8 @@ type Mutation {
   ): SetPassword @doc(category: "Users")
 
   """
-  Change the password of the logged in user. 
-  
+  Change the password of the logged in user.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
   """
   passwordChange(
@@ -20174,10 +20231,10 @@ type Mutation {
   ): PasswordChange @doc(category: "Users")
 
   """
-  Request email change of the logged in user. 
-  
+  Request email change of the logged in user.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for account email change.
   - ACCOUNT_CHANGE_EMAIL_REQUESTED (async): An account email change was requested.
@@ -20201,10 +20258,10 @@ type Mutation {
   ): RequestEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_CHANGE_EMAIL_REQUESTED], syncEvents: [])
 
   """
-  Confirm the email change of the logged-in user. 
-  
+  Confirm the email change of the logged-in user.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - NOTIFY_USER (async): A notification that account email change was confirmed.
@@ -20222,9 +20279,9 @@ type Mutation {
 
   """
   Create a new address for the customer.
-  
+
   Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - ADDRESS_CREATED (async): An address was created.
@@ -20232,7 +20289,7 @@ type Mutation {
   accountAddressCreate(
     """
     ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
-    
+
     Added in Saleor 3.19.
     """
     customerId: ID
@@ -20248,7 +20305,7 @@ type Mutation {
 
   """
   Updates an address of the logged-in user. Requires one of the following permissions: MANAGE_USERS, IS_OWNER.
-  
+
   Triggers the following webhook events:
   - ADDRESS_UPDATED (async): An address was updated.
   """
@@ -20262,7 +20319,7 @@ type Mutation {
 
   """
   Delete an address of the logged-in user. Requires one of the following permissions: MANAGE_USERS, IS_OWNER.
-  
+
   Triggers the following webhook events:
   - ADDRESS_DELETED (async): An address was deleted.
   """
@@ -20272,10 +20329,10 @@ type Mutation {
   ): AccountAddressDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ADDRESS_DELETED], syncEvents: [])
 
   """
-  Sets a default address for the authenticated user. 
-  
+  Sets a default address for the authenticated user.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer's address was updated.
   """
@@ -20289,7 +20346,7 @@ type Mutation {
 
   """
   Register a new user.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_CREATED (async): A new customer account was created.
   - NOTIFY_USER (async): A notification for account confirmation.
@@ -20302,9 +20359,9 @@ type Mutation {
 
   """
   Updates the account of the logged-in user.
-  
+
   Requires one of following set of permissions: AUTHENTICATED_USER or AUTHENTICATED_APP + IMPERSONATE_USER.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
@@ -20312,7 +20369,7 @@ type Mutation {
   accountUpdate(
     """
     ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
-    
+
     Added in Saleor 3.19.
     """
     customerId: ID
@@ -20322,10 +20379,10 @@ type Mutation {
   ): AccountUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, CUSTOMER_METADATA_UPDATED], syncEvents: [])
 
   """
-  Sends an email with the account removal link for the logged-in user. 
-  
+  Sends an email with the account removal link for the logged-in user.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for account delete request.
   - ACCOUNT_DELETE_REQUESTED (async): An account delete requested.
@@ -20343,10 +20400,10 @@ type Mutation {
   ): AccountRequestDeletion @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_DELETE_REQUESTED], syncEvents: [])
 
   """
-  Remove user account. 
-  
+  Remove user account.
+
   Requires one of the following permissions: AUTHENTICATED_USER.
-  
+
   Triggers the following webhook events:
   - ACCOUNT_DELETED (async): Account was deleted.
   """
@@ -20358,10 +20415,10 @@ type Mutation {
   ): AccountDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ACCOUNT_DELETED], syncEvents: [])
 
   """
-  Creates user address. 
-  
+  Creates user address.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - ADDRESS_CREATED (async): A new address was created.
   """
@@ -20374,10 +20431,10 @@ type Mutation {
   ): AddressCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ADDRESS_CREATED], syncEvents: [])
 
   """
-  Updates an address. 
-  
+  Updates an address.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - ADDRESS_UPDATED (async): An address was updated.
   """
@@ -20390,10 +20447,10 @@ type Mutation {
   ): AddressUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ADDRESS_UPDATED], syncEvents: [])
 
   """
-  Deletes an address. 
-  
+  Deletes an address.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - ADDRESS_DELETED (async): An address was deleted.
   """
@@ -20403,10 +20460,10 @@ type Mutation {
   ): AddressDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ADDRESS_DELETED], syncEvents: [])
 
   """
-  Sets a default address for the given user. 
-  
+  Sets a default address for the given user.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer was updated.
   """
@@ -20422,10 +20479,10 @@ type Mutation {
   ): AddressSetDefault @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED], syncEvents: [])
 
   """
-  Creates a new customer. 
-  
+  Creates a new customer.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_CREATED (async): A new customer account was created.
   - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
@@ -20438,18 +20495,18 @@ type Mutation {
   ): CustomerCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, CUSTOMER_METADATA_UPDATED, NOTIFY_USER, ACCOUNT_SET_PASSWORD_REQUESTED], syncEvents: [])
 
   """
-  Updates an existing customer. 
-  
+  Updates an existing customer.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A new customer account was updated.
   - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
   """
   customerUpdate(
     """
-    External ID of a customer to update. 
-    
+    External ID of a customer to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -20462,17 +20519,17 @@ type Mutation {
   ): CustomerUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, CUSTOMER_METADATA_UPDATED], syncEvents: [])
 
   """
-  Deletes a customer. 
-  
+  Deletes a customer.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_DELETED (async): A customer account was deleted.
   """
   customerDelete(
     """
-    External ID of a customer to update. 
-    
+    External ID of a customer to update.
+
     Added in Saleor 3.10.
     """
     externalReference: String
@@ -20482,10 +20539,10 @@ type Mutation {
   ): CustomerDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_DELETED], syncEvents: [])
 
   """
-  Deletes customers. 
-  
+  Deletes customers.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_DELETED (async): A customer account was deleted.
   """
@@ -20496,13 +20553,13 @@ type Mutation {
 
   """
   Updates customers.
-  
+
   Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
+
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
   Requires one of the following permissions: MANAGE_USERS.
-  
+
   Triggers the following webhook events:
   - CUSTOMER_UPDATED (async): A customer account was updated.
   - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
@@ -20516,10 +20573,10 @@ type Mutation {
   ): CustomerBulkUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, CUSTOMER_METADATA_UPDATED], syncEvents: [])
 
   """
-  Creates a new staff user. Apps are not allowed to perform this mutation. 
-  
+  Creates a new staff user. Apps are not allowed to perform this mutation.
+
   Requires one of the following permissions: MANAGE_STAFF.
-  
+
   Triggers the following webhook events:
   - STAFF_CREATED (async): A new staff account was created.
   - NOTIFY_USER (async): A notification for setting the password.
@@ -20531,10 +20588,10 @@ type Mutation {
   ): StaffCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [STAFF_CREATED, NOTIFY_USER, STAFF_SET_PASSWORD_REQUESTED], syncEvents: [])
 
   """
-  Updates an existing staff user. Apps are not allowed to perform this mutation. 
-  
+  Updates an existing staff user. Apps are not allowed to perform this mutation.
+
   Requires one of the following permissions: MANAGE_STAFF.
-  
+
   Triggers the following webhook events:
   - STAFF_UPDATED (async): A staff account was updated.
   """
@@ -20547,10 +20604,10 @@ type Mutation {
   ): StaffUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [STAFF_UPDATED], syncEvents: [])
 
   """
-  Deletes a staff user. Apps are not allowed to perform this mutation. 
-  
+  Deletes a staff user. Apps are not allowed to perform this mutation.
+
   Requires one of the following permissions: MANAGE_STAFF.
-  
+
   Triggers the following webhook events:
   - STAFF_DELETED (async): A staff account was deleted.
   """
@@ -20560,10 +20617,10 @@ type Mutation {
   ): StaffDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [STAFF_DELETED], syncEvents: [])
 
   """
-  Deletes staff users. Apps are not allowed to perform this mutation. 
-  
+  Deletes staff users. Apps are not allowed to perform this mutation.
+
   Requires one of the following permissions: MANAGE_STAFF.
-  
+
   Triggers the following webhook events:
   - STAFF_DELETED (async): A staff account was deleted.
   """
@@ -20573,8 +20630,8 @@ type Mutation {
   ): StaffBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [STAFF_DELETED], syncEvents: [])
 
   """
-  Create a user avatar. Only for staff members. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
-  
+  Create a user avatar. Only for staff members. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   userAvatarUpdate(
@@ -20583,15 +20640,15 @@ type Mutation {
   ): UserAvatarUpdate @doc(category: "Users")
 
   """
-  Deletes a user avatar. Only for staff members. 
-  
+  Deletes a user avatar. Only for staff members.
+
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   userAvatarDelete: UserAvatarDelete @doc(category: "Users")
 
   """
-  Activate or deactivate users. 
-  
+  Activate or deactivate users.
+
   Requires one of the following permissions: MANAGE_USERS.
   """
   userBulkSetActive(
@@ -20603,10 +20660,10 @@ type Mutation {
   ): UserBulkSetActive @doc(category: "Users")
 
   """
-  Create new permission group. Apps are not allowed to perform this mutation. 
-  
+  Create new permission group. Apps are not allowed to perform this mutation.
+
   Requires one of the following permissions: MANAGE_STAFF.
-  
+
   Triggers the following webhook events:
   - PERMISSION_GROUP_CREATED (async)
   """
@@ -20616,10 +20673,10 @@ type Mutation {
   ): PermissionGroupCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [PERMISSION_GROUP_CREATED], syncEvents: [])
 
   """
-  Update permission group. Apps are not allowed to perform this mutation. 
-  
+  Update permission group. Apps are not allowed to perform this mutation.
+
   Requires one of the following permissions: MANAGE_STAFF.
-  
+
   Triggers the following webhook events:
   - PERMISSION_GROUP_UPDATED (async)
   """
@@ -20632,10 +20689,10 @@ type Mutation {
   ): PermissionGroupUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [PERMISSION_GROUP_UPDATED], syncEvents: [])
 
   """
-  Delete permission group. Apps are not allowed to perform this mutation. 
-  
+  Delete permission group. Apps are not allowed to perform this mutation.
+
   Requires one of the following permissions: MANAGE_STAFF.
-  
+
   Triggers the following webhook events:
   - PERMISSION_GROUP_DELETED (async)
   """
@@ -20646,7 +20703,7 @@ type Mutation {
 }
 
 """
-Creates a new webhook subscription. 
+Creates a new webhook subscription.
 
 Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
 """
@@ -20692,8 +20749,8 @@ input WebhookCreateInput @doc(category: "Webhooks") {
   targetUrl: String
 
   """
-  The events that webhook wants to subscribe. 
-  
+  The events that webhook wants to subscribe.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.
   """
   events: [WebhookEventTypeEnum!]
@@ -20712,30 +20769,30 @@ input WebhookCreateInput @doc(category: "Webhooks") {
 
   """
   The secret key used to create a hash signature with each payload.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.
   """
   secretKey: String
 
   """
   Subscription query used to define a webhook payload.
-  
+
   Added in Saleor 3.2.
   """
   query: String
 
   """
   Custom headers, which will be added to HTTP request. There is a limitation of 5 headers per webhook and 998 characters per header.Only `X-*`, `Authorization*`, and `BrokerProperties` keys are allowed.
-  
+
   Added in Saleor 3.12.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   customHeaders: JSONString
 }
 
 """
-Delete a webhook. Before the deletion, the webhook is deactivated to pause any deliveries that are already scheduled. The deletion might fail if delivery is in progress. In such a case, the webhook is not deleted but remains deactivated. 
+Delete a webhook. Before the deletion, the webhook is deactivated to pause any deliveries that are already scheduled. The deletion might fail if delivery is in progress. In such a case, the webhook is not deleted but remains deactivated.
 
 Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
 """
@@ -20746,7 +20803,7 @@ type WebhookDelete @doc(category: "Webhooks") {
 }
 
 """
-Updates a webhook subscription. 
+Updates a webhook subscription.
 
 Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
 """
@@ -20764,8 +20821,8 @@ input WebhookUpdateInput @doc(category: "Webhooks") {
   targetUrl: String
 
   """
-  The events that webhook wants to subscribe. 
-  
+  The events that webhook wants to subscribe.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.
   """
   events: [WebhookEventTypeEnum!]
@@ -20784,30 +20841,30 @@ input WebhookUpdateInput @doc(category: "Webhooks") {
 
   """
   Use to create a hash signature with each payload.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.
   """
   secretKey: String
 
   """
   Subscription query used to define a webhook payload.
-  
+
   Added in Saleor 3.2.
   """
   query: String
 
   """
   Custom headers, which will be added to HTTP request. There is a limitation of 5 headers per webhook and 998 characters per header.Only `X-*`, `Authorization*`, and `BrokerProperties` keys are allowed.
-  
+
   Added in Saleor 3.12.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   customHeaders: JSONString
 }
 
 """
-Retries event delivery. 
+Retries event delivery.
 
 Requires one of the following permissions: MANAGE_APPS.
 """
@@ -20822,7 +20879,7 @@ Performs a dry run of a webhook event. Supports a single event (the first, if mu
 
 Added in Saleor 3.11.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
 """
@@ -20862,7 +20919,7 @@ Trigger a webhook event. Supports a single event (the first, if multiple provide
 
 Added in Saleor 3.11.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
 """
@@ -20898,7 +20955,7 @@ enum WebhookTriggerErrorCode @doc(category: "Webhooks") {
 }
 
 """
-Creates new warehouse. 
+Creates new warehouse.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -20942,7 +20999,7 @@ input WarehouseCreateInput @doc(category: "Products") {
 
   """
   External ID of the warehouse.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -20955,14 +21012,14 @@ input WarehouseCreateInput @doc(category: "Products") {
 
   """
   Shipping zones supported by the warehouse.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0. Providing the zone ids will raise a ValidationError.
   """
   shippingZones: [ID!]
 }
 
 """
-Updates given warehouse. 
+Updates given warehouse.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -20981,7 +21038,7 @@ input WarehouseUpdateInput @doc(category: "Products") {
 
   """
   External ID of the warehouse.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -20994,21 +21051,21 @@ input WarehouseUpdateInput @doc(category: "Products") {
 
   """
   Click and collect options: local, all or disabled.
-  
+
   Added in Saleor 3.1.
   """
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum
 
   """
   Visibility of warehouse stocks.
-  
+
   Added in Saleor 3.1.
   """
   isPrivate: Boolean
 }
 
 """
-Deletes selected warehouse. 
+Deletes selected warehouse.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -21019,7 +21076,7 @@ type WarehouseDelete @doc(category: "Products") {
 }
 
 """
-Add shipping zone to given warehouse. 
+Add shipping zone to given warehouse.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -21030,7 +21087,7 @@ type WarehouseShippingZoneAssign @doc(category: "Products") {
 }
 
 """
-Remove shipping zone from given warehouse. 
+Remove shipping zone from given warehouse.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -21043,7 +21100,7 @@ type WarehouseShippingZoneUnassign @doc(category: "Products") {
 """
 Create a tax class.
 
-Added in Saleor 3.9. 
+Added in Saleor 3.9.
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -21095,7 +21152,7 @@ input CountryRateInput @doc(category: "Taxes") {
 """
 Delete a tax class. After deleting the tax class any products, product types or shipping methods using it are updated to use the default tax class.
 
-Added in Saleor 3.9. 
+Added in Saleor 3.9.
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -21126,7 +21183,7 @@ enum TaxClassDeleteErrorCode @doc(category: "Taxes") {
 """
 Update a tax class.
 
-Added in Saleor 3.9. 
+Added in Saleor 3.9.
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -21186,7 +21243,7 @@ input CountryRateUpdateInput @doc(category: "Taxes") {
 """
 Update tax configuration for a channel.
 
-Added in Saleor 3.9. 
+Added in Saleor 3.9.
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -21243,7 +21300,7 @@ input TaxConfigurationUpdateInput @doc(category: "Taxes") {
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. It's possible to set plugin by using prefix `plugin:` with `PLUGIN_ID` e.g. with Avalara `plugin:mirumee.taxes.avalara`.Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
-  
+
   Added in Saleor 3.19.
   """
   taxAppId: String
@@ -21268,7 +21325,7 @@ input TaxConfigurationPerCountryInput @doc(category: "Taxes") {
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
-  
+
   Added in Saleor 3.19.
   """
   taxAppId: String
@@ -21277,7 +21334,7 @@ input TaxConfigurationPerCountryInput @doc(category: "Taxes") {
 """
 Update tax class rates for a specific country.
 
-Added in Saleor 3.9. 
+Added in Saleor 3.9.
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -21322,7 +21379,7 @@ input TaxClassRateInput @doc(category: "Taxes") {
 """
 Remove all tax class rates for a specific country.
 
-Added in Saleor 3.9. 
+Added in Saleor 3.9.
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -21354,7 +21411,7 @@ enum TaxCountryConfigurationDeleteErrorCode @doc(category: "Taxes") {
 """
 Exempt checkout or order from charging the taxes. When tax exemption is enabled, taxes won't be charged for the checkout or order. Taxes may still be calculated in cases when product prices are entered with the tax included and the net price needs to be known.
 
-Added in Saleor 3.8. 
+Added in Saleor 3.8.
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -21390,7 +21447,7 @@ Updates stocks for a given variant and warehouse. Variant and warehouse selector
 
 Added in Saleor 3.13.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 
@@ -21465,7 +21522,7 @@ input StockBulkUpdateInput @doc(category: "Products") {
 }
 
 """
-Creates a new staff notification recipient. 
+Creates a new staff notification recipient.
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """
@@ -21510,7 +21567,7 @@ input StaffNotificationRecipientInput {
 }
 
 """
-Updates a staff notification recipient. 
+Updates a staff notification recipient.
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """
@@ -21521,7 +21578,7 @@ type StaffNotificationRecipientUpdate @doc(category: "Users") {
 }
 
 """
-Delete staff notification recipient. 
+Delete staff notification recipient.
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """
@@ -21534,7 +21591,7 @@ type StaffNotificationRecipientDelete @doc(category: "Users") {
 """
 Updates site domain of the shop.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead.
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """
@@ -21554,7 +21611,7 @@ input SiteDomainInput {
 }
 
 """
-Updates shop settings. 
+Updates shop settings.
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 
@@ -21588,14 +21645,14 @@ input ShopSettingsInput {
 
   """
   Enable automatic approval of all new fulfillments.
-  
+
   Added in Saleor 3.1.
   """
   fulfillmentAutoApprove: Boolean
 
   """
   Enable ability to approve fulfillments which are unpaid.
-  
+
   Added in Saleor 3.1.
   """
   fulfillmentAllowUnpaid: Boolean
@@ -21617,77 +21674,77 @@ input ShopSettingsInput {
 
   """
   Default number of minutes stock will be reserved for anonymous checkout. Enter 0 or null to disable.
-  
+
   Added in Saleor 3.1.
   """
   reserveStockDurationAnonymousUser: Int
 
   """
   Default number of minutes stock will be reserved for authenticated checkout. Enter 0 or null to disable.
-  
+
   Added in Saleor 3.1.
   """
   reserveStockDurationAuthenticatedUser: Int
 
   """
   Default number of maximum line quantity in single checkout. Minimum possible value is 1, default value is 50.
-  
+
   Added in Saleor 3.1.
   """
   limitQuantityPerCheckout: Int
 
   """
   Enable automatic account confirmation by email.
-  
+
   Added in Saleor 3.14.
   """
   enableAccountConfirmationByEmail: Boolean
 
   """
   Enable possibility to login without account confirmation.
-  
+
   Added in Saleor 3.15.
   """
   allowLoginWithoutConfirmation: Boolean
 
   """
   Shop public metadata.
-  
+
   Added in Saleor 3.15.
   """
   metadata: [MetadataInput!]
 
   """
   Shop private metadata.
-  
+
   Added in Saleor 3.15.
   """
   privateMetadata: [MetadataInput!]
 
   """
-  Include taxes in prices. 
-  
+  Include taxes in prices.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `taxConfigurationUpdate` mutation to configure this setting per channel or country.
   """
   includeTaxesInPrices: Boolean
 
   """
-  Display prices with tax in store. 
-  
+  Display prices with tax in store.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `taxConfigurationUpdate` mutation to configure this setting per channel or country.
   """
   displayGrossPrices: Boolean
 
   """
-  Charge taxes on shipping. 
-  
+  Charge taxes on shipping.
+
   DEPRECATED: this field will be removed in Saleor 4.0. To enable taxes for a shipping method, assign a tax class to the shipping method with `shippingPriceCreate` or `shippingPriceUpdate` mutations.
   """
   chargeTaxesOnShipping: Boolean
 }
 
 """
-Fetch tax rates. 
+Fetch tax rates.
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """
@@ -21699,7 +21756,7 @@ type ShopFetchTaxRates @doc(category: "Shop") {
 }
 
 """
-Creates/updates translations for shop settings. 
+Creates/updates translations for shop settings.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -21737,7 +21794,7 @@ input ShopSettingsTranslationInput {
 }
 
 """
-Update the shop's address. If the `null` value is passed, the currently selected address will be deleted. 
+Update the shop's address. If the `null` value is passed, the currently selected address will be deleted.
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """
@@ -21749,7 +21806,7 @@ type ShopAddressUpdate @doc(category: "Shop") {
 }
 
 """
-Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order.  
+Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -21790,7 +21847,7 @@ input OrderSettingsUpdateInput @doc(category: "Orders") {
 }
 
 """
-Update gift card settings. 
+Update gift card settings.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -21836,7 +21893,7 @@ input TimePeriodInputType {
 }
 
 """
-Manage shipping method's availability in channels. 
+Manage shipping method's availability in channels.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -21900,7 +21957,7 @@ input ShippingMethodChannelListingAddInput @doc(category: "Shipping") {
 }
 
 """
-Creates a new shipping price. 
+Creates a new shipping price.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -21963,7 +22020,7 @@ input ShippingPostalCodeRulesCreateInputRange @doc(category: "Shipping") {
 }
 
 """
-Deletes a shipping price. 
+Deletes a shipping price.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -21978,7 +22035,7 @@ type ShippingPriceDelete @doc(category: "Shipping") {
 }
 
 """
-Deletes shipping prices. 
+Deletes shipping prices.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -21990,7 +22047,7 @@ type ShippingPriceBulkDelete @doc(category: "Shipping") {
 }
 
 """
-Updates a new shipping price. 
+Updates a new shipping price.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -22003,7 +22060,7 @@ type ShippingPriceUpdate @doc(category: "Shipping") {
 }
 
 """
-Creates/updates translations for a shipping method. 
+Creates/updates translations for a shipping method.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -22018,14 +22075,14 @@ input ShippingPriceTranslationInput {
 
   """
   Translated shipping method description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 }
 
 """
-Exclude products from shipping price. 
+Exclude products from shipping price.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -22042,7 +22099,7 @@ input ShippingPriceExcludeProductsInput @doc(category: "Shipping") {
 }
 
 """
-Remove product from excluded list for shipping price. 
+Remove product from excluded list for shipping price.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -22054,7 +22111,7 @@ type ShippingPriceRemoveProductFromExclude @doc(category: "Shipping") {
 }
 
 """
-Creates a new shipping zone. 
+Creates a new shipping zone.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -22087,7 +22144,7 @@ input ShippingZoneCreateInput @doc(category: "Shipping") {
 }
 
 """
-Deletes a shipping zone. 
+Deletes a shipping zone.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -22098,7 +22155,7 @@ type ShippingZoneDelete @doc(category: "Shipping") {
 }
 
 """
-Deletes shipping zones. 
+Deletes shipping zones.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -22110,7 +22167,7 @@ type ShippingZoneBulkDelete @doc(category: "Shipping") {
 }
 
 """
-Updates a new shipping zone. 
+Updates a new shipping zone.
 
 Requires one of the following permissions: MANAGE_SHIPPING.
 """
@@ -22149,7 +22206,7 @@ input ShippingZoneUpdateInput @doc(category: "Shipping") {
 }
 
 """
-Assign attributes to a given product type. 
+Assign attributes to a given product type.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -22211,7 +22268,7 @@ input ProductAttributeAssignInput @doc(category: "Products") {
 
   """
   Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].
-  
+
   Added in Saleor 3.1.
   """
   variantSelection: Boolean
@@ -22225,7 +22282,7 @@ enum ProductAttributeType @doc(category: "Products") {
 """
 Update attributes assigned to product variant for given product type.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -22242,14 +22299,14 @@ input ProductAttributeAssignmentUpdateInput @doc(category: "Products") {
 
   """
   Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].
-  
+
   Added in Saleor 3.1.
   """
   variantSelection: Boolean!
 }
 
 """
-Un-assign attributes from a given product type. 
+Un-assign attributes from a given product type.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -22261,7 +22318,7 @@ type ProductAttributeUnassign @doc(category: "Products") {
 }
 
 """
-Creates a new category. 
+Creates a new category.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22274,7 +22331,7 @@ type CategoryCreate @doc(category: "Products") {
 input CategoryInput @doc(category: "Products") {
   """
   Category description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -22296,14 +22353,14 @@ input CategoryInput @doc(category: "Products") {
 
   """
   Fields required to update the category metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the category private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
@@ -22323,7 +22380,7 @@ Variables of this type must be set to null in mutations. They will be replaced w
 scalar Upload
 
 """
-Deletes a category. 
+Deletes a category.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22334,7 +22391,7 @@ type CategoryDelete @doc(category: "Products") {
 }
 
 """
-Deletes categories. 
+Deletes categories.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22346,7 +22403,7 @@ type CategoryBulkDelete @doc(category: "Products") {
 }
 
 """
-Updates a category. 
+Updates a category.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22357,7 +22414,7 @@ type CategoryUpdate @doc(category: "Products") {
 }
 
 """
-Creates/updates translations for a category. 
+Creates/updates translations for a category.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -22375,14 +22432,14 @@ input TranslationInput {
 
   """
   Translated description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 }
 
 """
-Adds products to a collection. 
+Adds products to a collection.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22420,7 +22477,7 @@ enum CollectionErrorCode @doc(category: "Products") {
 }
 
 """
-Creates a new collection. 
+Creates a new collection.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22442,7 +22499,7 @@ input CollectionCreateInput @doc(category: "Products") {
 
   """
   Description of the collection.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -22457,22 +22514,22 @@ input CollectionCreateInput @doc(category: "Products") {
   seo: SeoInput
 
   """
-  Publication date. ISO 8601 standard. 
-  
+  Publication date. ISO 8601 standard.
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   publicationDate: Date
 
   """
   Fields required to update the collection metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the collection private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
@@ -22482,7 +22539,7 @@ input CollectionCreateInput @doc(category: "Products") {
 }
 
 """
-Deletes a collection. 
+Deletes a collection.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22493,7 +22550,7 @@ type CollectionDelete @doc(category: "Products") {
 }
 
 """
-Reorder the products of a collection. 
+Reorder the products of a collection.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22515,7 +22572,7 @@ input MoveProductInput @doc(category: "Products") {
 }
 
 """
-Deletes collections. 
+Deletes collections.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22527,7 +22584,7 @@ type CollectionBulkDelete @doc(category: "Products") {
 }
 
 """
-Remove products from a collection. 
+Remove products from a collection.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22539,7 +22596,7 @@ type CollectionRemoveProducts @doc(category: "Products") {
 }
 
 """
-Updates a collection. 
+Updates a collection.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22561,7 +22618,7 @@ input CollectionInput @doc(category: "Products") {
 
   """
   Description of the collection.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -22576,29 +22633,29 @@ input CollectionInput @doc(category: "Products") {
   seo: SeoInput
 
   """
-  Publication date. ISO 8601 standard. 
-  
+  Publication date. ISO 8601 standard.
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   publicationDate: Date
 
   """
   Fields required to update the collection metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the collection private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 }
 
 """
-Creates/updates translations for a collection. 
+Creates/updates translations for a collection.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -22609,7 +22666,7 @@ type CollectionTranslate @doc(category: "Products") {
 }
 
 """
-Manage collection's availability in channels. 
+Manage collection's availability in channels.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22658,22 +22715,22 @@ input PublishableChannelListingInput @doc(category: "Products") {
   isPublished: Boolean
 
   """
-  Publication date. ISO 8601 standard. 
-  
+  Publication date. ISO 8601 standard.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `publishedAt` field instead.
   """
   publicationDate: Date
 
   """
   Publication date time. ISO 8601 standard.
-  
+
   Added in Saleor 3.3.
   """
   publishedAt: DateTime
 }
 
 """
-Creates a new product. 
+Creates a new product.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22691,8 +22748,8 @@ input ProductCreateInput @doc(category: "Products") {
   category: ID
 
   """
-  Determine if taxes are being charged for the product. 
-  
+  Determine if taxes are being charged for the product.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `Channel.taxConfiguration` to configure whether tax collection is enabled.
   """
   chargeTaxes: Boolean
@@ -22702,7 +22759,7 @@ input ProductCreateInput @doc(category: "Products") {
 
   """
   Product description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -22719,8 +22776,8 @@ input ProductCreateInput @doc(category: "Products") {
   taxClass: ID
 
   """
-  Tax rate for enabled tax gateway. 
-  
+  Tax rate for enabled tax gateway.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
   """
   taxCode: String
@@ -22736,21 +22793,21 @@ input ProductCreateInput @doc(category: "Products") {
 
   """
   Fields required to update the product metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the product private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 
   """
   External ID of this product.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -22765,7 +22822,7 @@ input AttributeValueInput @doc(category: "Attributes") {
 
   """
   External ID of this attribute.
-  
+
   Added in Saleor 3.14.
   """
   externalReference: String
@@ -22777,28 +22834,28 @@ input AttributeValueInput @doc(category: "Attributes") {
 
   """
   Attribute value ID or external reference.
-  
+
   Added in Saleor 3.9.
   """
   dropdown: AttributeValueSelectableTypeInput
 
   """
   Attribute value ID or external reference.
-  
+
   Added in Saleor 3.9.
   """
   swatch: AttributeValueSelectableTypeInput
 
   """
   List of attribute value IDs or external references.
-  
+
   Added in Saleor 3.9.
   """
   multiselect: [AttributeValueSelectableTypeInput!]
 
   """
   Numeric value of an attribute.
-  
+
   Added in Saleor 3.9.
   """
   numeric: String
@@ -22843,7 +22900,7 @@ input AttributeValueSelectableTypeInput @doc(category: "Attributes") {
 
   """
   External reference of an attribute value.
-  
+
   Added in Saleor 3.14.
   """
   externalReference: String
@@ -22855,7 +22912,7 @@ input AttributeValueSelectableTypeInput @doc(category: "Attributes") {
 }
 
 """
-Deletes a product. 
+Deletes a product.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22870,7 +22927,7 @@ Creates products.
 
 Added in Saleor 3.13.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -22942,8 +22999,8 @@ input ProductBulkCreateInput @doc(category: "Products") {
   category: ID
 
   """
-  Determine if taxes are being charged for the product. 
-  
+  Determine if taxes are being charged for the product.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `Channel.taxConfiguration` to configure whether tax collection is enabled.
   """
   chargeTaxes: Boolean
@@ -22953,7 +23010,7 @@ input ProductBulkCreateInput @doc(category: "Products") {
 
   """
   Product description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -22970,8 +23027,8 @@ input ProductBulkCreateInput @doc(category: "Products") {
   taxClass: ID
 
   """
-  Tax rate for enabled tax gateway. 
-  
+  Tax rate for enabled tax gateway.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
   """
   taxCode: String
@@ -23064,35 +23121,35 @@ input ProductVariantBulkCreateInput @doc(category: "Products") {
 
   """
   Determines if variant is in preorder.
-  
+
   Added in Saleor 3.1.
   """
   preorder: PreorderSettingsInput
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
-  
+
   Added in Saleor 3.1.
   """
   quantityLimitPerCustomer: Int
 
   """
   Fields required to update the product variant metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the product variant private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 
   """
   External ID of this product variant.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -23110,7 +23167,7 @@ input BulkAttributeValueInput @doc(category: "Products") {
 
   """
   External ID of this attribute.
-  
+
   Added in Saleor 3.14.
   """
   externalReference: String
@@ -23122,63 +23179,63 @@ input BulkAttributeValueInput @doc(category: "Products") {
 
   """
   Attribute value ID.
-  
+
   Added in Saleor 3.12.
   """
   dropdown: AttributeValueSelectableTypeInput
 
   """
   Attribute value ID.
-  
+
   Added in Saleor 3.12.
   """
   swatch: AttributeValueSelectableTypeInput
 
   """
   List of attribute value IDs.
-  
+
   Added in Saleor 3.12.
   """
   multiselect: [AttributeValueSelectableTypeInput!]
 
   """
   Numeric value of an attribute.
-  
+
   Added in Saleor 3.12.
   """
   numeric: String
 
   """
   URL of the file attribute. Every time, a new value is created.
-  
+
   Added in Saleor 3.12.
   """
   file: String
 
   """
   File content type.
-  
+
   Added in Saleor 3.12.
   """
   contentType: String
 
   """
   List of entity IDs that will be used as references.
-  
+
   Added in Saleor 3.12.
   """
   references: [ID!]
 
   """
   Text content in JSON format.
-  
+
   Added in Saleor 3.12.
   """
   richText: JSONString
 
   """
   Plain text content.
-  
+
   Added in Saleor 3.12.
   """
   plainText: String
@@ -23190,14 +23247,14 @@ input BulkAttributeValueInput @doc(category: "Products") {
 
   """
   Represents the date value of the attribute value.
-  
+
   Added in Saleor 3.12.
   """
   date: Date
 
   """
   Represents the date/time value of the attribute value.
-  
+
   Added in Saleor 3.12.
   """
   dateTime: DateTime
@@ -23231,14 +23288,14 @@ input ProductVariantChannelListingAddInput @doc(category: "Products") {
 
   """
   The threshold for preorder variant in channel.
-  
+
   Added in Saleor 3.1.
   """
   preorderThreshold: Int
 }
 
 """
-Deletes products. 
+Deletes products.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23250,7 +23307,7 @@ type ProductBulkDelete @doc(category: "Products") {
 }
 
 """
-Updates an existing product. 
+Updates an existing product.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23268,8 +23325,8 @@ input ProductInput @doc(category: "Products") {
   category: ID
 
   """
-  Determine if taxes are being charged for the product. 
-  
+  Determine if taxes are being charged for the product.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `Channel.taxConfiguration` to configure whether tax collection is enabled.
   """
   chargeTaxes: Boolean
@@ -23279,7 +23336,7 @@ input ProductInput @doc(category: "Products") {
 
   """
   Product description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
@@ -23296,8 +23353,8 @@ input ProductInput @doc(category: "Products") {
   taxClass: ID
 
   """
-  Tax rate for enabled tax gateway. 
-  
+  Tax rate for enabled tax gateway.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
   """
   taxCode: String
@@ -23313,21 +23370,21 @@ input ProductInput @doc(category: "Products") {
 
   """
   Fields required to update the product metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the product private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 
   """
   External ID of this product.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -23338,7 +23395,7 @@ Creates/updates translations for products.
 
 Added in Saleor 3.15.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 
@@ -23398,7 +23455,7 @@ input ProductBulkTranslateInput @doc(category: "Products") {
 }
 
 """
-Creates/updates translations for a product. 
+Creates/updates translations for a product.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -23409,7 +23466,7 @@ type ProductTranslate @doc(category: "Products") {
 }
 
 """
-Manage product's availability in channels. 
+Manage product's availability in channels.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23461,15 +23518,15 @@ input ProductChannelListingAddInput @doc(category: "Products") {
   isPublished: Boolean
 
   """
-  Publication date. ISO 8601 standard. 
-  
+  Publication date. ISO 8601 standard.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `publishedAt` field instead.
   """
   publicationDate: Date
 
   """
   Publication date time. ISO 8601 standard.
-  
+
   Added in Saleor 3.3.
   """
   publishedAt: DateTime
@@ -23485,15 +23542,15 @@ input ProductChannelListingAddInput @doc(category: "Products") {
   isAvailableForPurchase: Boolean
 
   """
-  A start date from which a product will be available for purchase. When not set and isAvailable is set to True, the current day is assumed. 
-  
+  A start date from which a product will be available for purchase. When not set and isAvailable is set to True, the current day is assumed.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `availableForPurchaseAt` field instead.
   """
   availableForPurchaseDate: Date
 
   """
   A start date time from which a product will be available for purchase. When not set and `isAvailable` is set to True, the current day is assumed.
-  
+
   Added in Saleor 3.3.
   """
   availableForPurchaseAt: DateTime
@@ -23506,7 +23563,7 @@ input ProductChannelListingAddInput @doc(category: "Products") {
 }
 
 """
-Create a media object (image or video URL) associated with product. For image, this mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
+Create a media object (image or video URL) associated with product. For image, this mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23532,7 +23589,7 @@ input ProductMediaCreateInput @doc(category: "Products") {
 }
 
 """
-Reorder the variants of a product. Mutation updates updated_at on product and triggers PRODUCT_UPDATED webhook. 
+Reorder the variants of a product. Mutation updates updated_at on product and triggers PRODUCT_UPDATED webhook.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23553,7 +23610,7 @@ input ReorderInput {
 }
 
 """
-Deletes a product media. 
+Deletes a product media.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23565,7 +23622,7 @@ type ProductMediaDelete @doc(category: "Products") {
 }
 
 """
-Deletes product media. 
+Deletes product media.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23577,7 +23634,7 @@ type ProductMediaBulkDelete @doc(category: "Products") {
 }
 
 """
-Changes ordering of the product media. 
+Changes ordering of the product media.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23589,7 +23646,7 @@ type ProductMediaReorder @doc(category: "Products") {
 }
 
 """
-Updates a product media. 
+Updates a product media.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23606,7 +23663,7 @@ input ProductMediaUpdateInput @doc(category: "Products") {
 }
 
 """
-Creates a new product type. 
+Creates a new product type.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -23649,8 +23706,8 @@ input ProductTypeInput @doc(category: "Products") {
   weight: WeightScalar
 
   """
-  Tax rate for enabled tax gateway. 
-  
+  Tax rate for enabled tax gateway.
+
   DEPRECATED: this field will be removed in Saleor 4.0.. Use tax classes to control the tax calculation for a product type. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
   """
   taxCode: String
@@ -23662,7 +23719,7 @@ input ProductTypeInput @doc(category: "Products") {
 }
 
 """
-Deletes a product type. 
+Deletes a product type.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -23673,7 +23730,7 @@ type ProductTypeDelete @doc(category: "Products") {
 }
 
 """
-Deletes product types. 
+Deletes product types.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -23685,7 +23742,7 @@ type ProductTypeBulkDelete @doc(category: "Products") {
 }
 
 """
-Updates an existing product type. 
+Updates an existing product type.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -23696,7 +23753,7 @@ type ProductTypeUpdate @doc(category: "Products") {
 }
 
 """
-Reorder the attributes of a product type. 
+Reorder the attributes of a product type.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
@@ -23708,7 +23765,7 @@ type ProductTypeReorderAttributes @doc(category: "Products") {
 }
 
 """
-Reorder product attribute values. 
+Reorder product attribute values.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23720,7 +23777,7 @@ type ProductReorderAttributeValues @doc(category: "Products") {
 }
 
 """
-Create new digital content. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
+Create new digital content. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23750,14 +23807,14 @@ input DigitalContentUploadInput @doc(category: "Products") {
 
   """
   Fields required to update the digital content metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the digital content private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
@@ -23767,7 +23824,7 @@ input DigitalContentUploadInput @doc(category: "Products") {
 }
 
 """
-Remove digital content assigned to given variant. 
+Remove digital content assigned to given variant.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23778,7 +23835,7 @@ type DigitalContentDelete @doc(category: "Products") {
 }
 
 """
-Update digital content. 
+Update digital content.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23808,21 +23865,21 @@ input DigitalContentInput @doc(category: "Products") {
 
   """
   Fields required to update the digital content metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the digital content private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 }
 
 """
-Generate new URL to digital content. 
+Generate new URL to digital content.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23838,7 +23895,7 @@ input DigitalContentUrlCreateInput @doc(category: "Products") {
 }
 
 """
-Creates a new variant for a product. 
+Creates a new variant for a product.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23868,35 +23925,35 @@ input ProductVariantCreateInput @doc(category: "Products") {
 
   """
   Determines if variant is in preorder.
-  
+
   Added in Saleor 3.1.
   """
   preorder: PreorderSettingsInput
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
-  
+
   Added in Saleor 3.1.
   """
   quantityLimitPerCustomer: Int
 
   """
   Fields required to update the product variant metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the product variant private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 
   """
   External ID of this product variant.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -23909,7 +23966,7 @@ input ProductVariantCreateInput @doc(category: "Products") {
 }
 
 """
-Deletes a product variant. 
+Deletes a product variant.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23920,7 +23977,7 @@ type ProductVariantDelete @doc(category: "Products") {
 }
 
 """
-Creates product variants for a given product. 
+Creates product variants for a given product.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -23933,7 +23990,7 @@ type ProductVariantBulkCreate @doc(category: "Products") {
 
   """
   List of the created variants.
-  
+
   Added in Saleor 3.11.
   """
   results: [ProductVariantBulkResult!]!
@@ -23963,7 +24020,7 @@ type ProductVariantBulkError @doc(category: "Products") {
 
   """
   Path to field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
-  
+
   Added in Saleor 3.14.
   """
   path: String
@@ -23979,14 +24036,14 @@ type ProductVariantBulkError @doc(category: "Products") {
 
   """
   List of stocks IDs which causes the error.
-  
+
   Added in Saleor 3.12.
   """
   stocks: [ID!]
 
   """
   List of channel IDs which causes the error.
-  
+
   Added in Saleor 3.12.
   """
   channels: [ID!]
@@ -24044,7 +24101,7 @@ Update multiple product variants.
 
 Added in Saleor 3.11.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24082,53 +24139,53 @@ input ProductVariantBulkUpdateInput @doc(category: "Products") {
 
   """
   Determines if variant is in preorder.
-  
+
   Added in Saleor 3.1.
   """
   preorder: PreorderSettingsInput
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
-  
+
   Added in Saleor 3.1.
   """
   quantityLimitPerCustomer: Int
 
   """
   Fields required to update the product variant metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the product variant private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 
   """
   External ID of this product variant.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
 
   """
   Stocks input.
-  
+
   Added in Saleor 3.12.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   stocks: ProductVariantStocksUpdateInput
 
   """
   Channel listings input.
-  
+
   Added in Saleor 3.12.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   channelListings: ProductVariantChannelListingUpdateInput
@@ -24182,7 +24239,7 @@ input ChannelListingUpdateInput @doc(category: "Products") {
 }
 
 """
-Deletes product variants. 
+Deletes product variants.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24194,7 +24251,7 @@ type ProductVariantBulkDelete @doc(category: "Products") {
 }
 
 """
-Creates stocks for product variant. 
+Creates stocks for product variant.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24228,7 +24285,7 @@ type BulkStockError @doc(category: "Products") {
 }
 
 """
-Delete stocks from product variant. 
+Delete stocks from product variant.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24262,7 +24319,7 @@ enum StockErrorCode @doc(category: "Products") {
 }
 
 """
-Update stocks for product variant. 
+Update stocks for product variant.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24274,7 +24331,7 @@ type ProductVariantStocksUpdate @doc(category: "Products") {
 }
 
 """
-Updates an existing variant for product. 
+Updates an existing variant for product.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24304,42 +24361,42 @@ input ProductVariantInput @doc(category: "Products") {
 
   """
   Determines if variant is in preorder.
-  
+
   Added in Saleor 3.1.
   """
   preorder: PreorderSettingsInput
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
-  
+
   Added in Saleor 3.1.
   """
   quantityLimitPerCustomer: Int
 
   """
   Fields required to update the product variant metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the product variant private metadata.
-  
+
   Added in Saleor 3.8.
   """
   privateMetadata: [MetadataInput!]
 
   """
   External ID of this product variant.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
 }
 
 """
-Set default variant for a product. Mutation triggers PRODUCT_UPDATED webhook. 
+Set default variant for a product. Mutation triggers PRODUCT_UPDATED webhook.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24350,7 +24407,7 @@ type ProductVariantSetDefault @doc(category: "Products") {
 }
 
 """
-Creates/updates translations for a product variant. 
+Creates/updates translations for a product variant.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -24369,7 +24426,7 @@ Creates/updates translations for products variants.
 
 Added in Saleor 3.15.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 
@@ -24429,7 +24486,7 @@ input ProductVariantBulkTranslateInput @doc(category: "Products") {
 }
 
 """
-Manage product variant prices in channels. 
+Manage product variant prices in channels.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24441,7 +24498,7 @@ type ProductVariantChannelListingUpdate @doc(category: "Products") {
 }
 
 """
-Reorder product variant attribute values. 
+Reorder product variant attribute values.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24455,7 +24512,7 @@ type ProductVariantReorderAttributeValues @doc(category: "Products") {
 """
 Deactivates product variant preorder. It changes all preorder allocation into regular allocation.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24466,7 +24523,7 @@ type ProductVariantPreorderDeactivate @doc(category: "Products") {
 }
 
 """
-Assign an media to a product variant. 
+Assign an media to a product variant.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24478,7 +24535,7 @@ type VariantMediaAssign @doc(category: "Products") {
 }
 
 """
-Unassign an media from a product variant. 
+Unassign an media from a product variant.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -24490,7 +24547,7 @@ type VariantMediaUnassign @doc(category: "Products") {
 }
 
 """
-Captures the authorized payment amount. 
+Captures the authorized payment amount.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -24539,7 +24596,7 @@ enum PaymentErrorCode @doc(category: "Payments") {
 }
 
 """
-Refunds the captured payment amount. 
+Refunds the captured payment amount.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -24551,7 +24608,7 @@ type PaymentRefund @doc(category: "Payments") {
 }
 
 """
-Voids the authorized payment. 
+Voids the authorized payment.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -24632,7 +24689,7 @@ Create transaction for checkout or order.
 
 Added in Saleor 3.4.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: HANDLE_PAYMENTS.
 """
@@ -24666,21 +24723,21 @@ enum TransactionCreateErrorCode @doc(category: "Payments") {
 input TransactionCreateInput @doc(category: "Payments") {
   """
   Payment name of the transaction.
-  
+
   Added in Saleor 3.13.
   """
   name: String
 
   """
   The message of the transaction.
-  
+
   Added in Saleor 3.13.
   """
   message: String
 
   """
-  PSP Reference of the transaction. 
-  
+  PSP Reference of the transaction.
+
   Added in Saleor 3.13.
   """
   pspReference: String
@@ -24699,7 +24756,7 @@ input TransactionCreateInput @doc(category: "Payments") {
 
   """
   Amount canceled by this transaction.
-  
+
   Added in Saleor 3.13.
   """
   amountCanceled: MoneyInput
@@ -24712,7 +24769,7 @@ input TransactionCreateInput @doc(category: "Payments") {
 
   """
   The url that will allow to redirect user to payment provider page with transaction event details.
-  
+
   Added in Saleor 3.13.
   """
   externalUrl: String
@@ -24721,14 +24778,14 @@ input TransactionCreateInput @doc(category: "Payments") {
 input TransactionEventInput @doc(category: "Payments") {
   """
   PSP Reference related to this action.
-  
+
   Added in Saleor 3.13.
   """
   pspReference: String
 
   """
   The message related to the event.
-  
+
   Added in Saleor 3.13.
   """
   message: String
@@ -24773,21 +24830,21 @@ enum TransactionUpdateErrorCode @doc(category: "Payments") {
 input TransactionUpdateInput @doc(category: "Payments") {
   """
   Payment name of the transaction.
-  
+
   Added in Saleor 3.13.
   """
   name: String
 
   """
   The message of the transaction.
-  
+
   Added in Saleor 3.13.
   """
   message: String
 
   """
-  PSP Reference of the transaction. 
-  
+  PSP Reference of the transaction.
+
   Added in Saleor 3.13.
   """
   pspReference: String
@@ -24806,7 +24863,7 @@ input TransactionUpdateInput @doc(category: "Payments") {
 
   """
   Amount canceled by this transaction.
-  
+
   Added in Saleor 3.13.
   """
   amountCanceled: MoneyInput
@@ -24819,7 +24876,7 @@ input TransactionUpdateInput @doc(category: "Payments") {
 
   """
   The url that will allow to redirect user to payment provider page with transaction event details.
-  
+
   Added in Saleor 3.13.
   """
   externalUrl: String
@@ -24830,7 +24887,7 @@ Request an action for payment transaction.
 
 Added in Saleor 3.4.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: HANDLE_PAYMENTS.
 """
@@ -24864,7 +24921,7 @@ Request a refund for payment transaction based on granted refund.
 
 Added in Saleor 3.15.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: HANDLE_PAYMENTS.
 """
@@ -25050,7 +25107,7 @@ enum TransactionInitializeErrorCode @doc(category: "Payments") {
 }
 
 """
-Processes a transaction session. It triggers the webhook `TRANSACTION_PROCESS_SESSION`, to the assigned `paymentGateways`. 
+Processes a transaction session. It triggers the webhook `TRANSACTION_PROCESS_SESSION`, to the assigned `paymentGateways`.
 
 Added in Saleor 3.13.
 
@@ -25096,7 +25153,7 @@ Request to delete a stored payment method on payment provider side.
 
 Added in Saleor 3.16.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -25150,7 +25207,7 @@ Initializes payment gateway for tokenizing payment method session.
 
 Added in Saleor 3.16.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -25206,7 +25263,7 @@ Tokenize payment method.
 
 Added in Saleor 3.16.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -25269,7 +25326,7 @@ Tokenize payment method.
 
 Added in Saleor 3.16.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -25310,7 +25367,7 @@ enum PaymentMethodProcessTokenizationErrorCode @doc(category: "Payments") {
 }
 
 """
-Creates a new page. 
+Creates a new page.
 
 Requires one of the following permissions: MANAGE_PAGES.
 """
@@ -25358,7 +25415,7 @@ input PageCreateInput @doc(category: "Pages") {
 
   """
   Page content.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   content: JSONString
@@ -25370,15 +25427,15 @@ input PageCreateInput @doc(category: "Pages") {
   isPublished: Boolean
 
   """
-  Publication date. ISO 8601 standard. 
-  
+  Publication date. ISO 8601 standard.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `publishedAt` field instead.
   """
   publicationDate: String
 
   """
   Publication date time. ISO 8601 standard.
-  
+
   Added in Saleor 3.3.
   """
   publishedAt: DateTime
@@ -25391,7 +25448,7 @@ input PageCreateInput @doc(category: "Pages") {
 }
 
 """
-Deletes a page. 
+Deletes a page.
 
 Requires one of the following permissions: MANAGE_PAGES.
 """
@@ -25402,7 +25459,7 @@ type PageDelete @doc(category: "Pages") {
 }
 
 """
-Deletes pages. 
+Deletes pages.
 
 Requires one of the following permissions: MANAGE_PAGES.
 """
@@ -25414,7 +25471,7 @@ type PageBulkDelete @doc(category: "Pages") {
 }
 
 """
-Publish pages. 
+Publish pages.
 
 Requires one of the following permissions: MANAGE_PAGES.
 """
@@ -25426,7 +25483,7 @@ type PageBulkPublish @doc(category: "Pages") {
 }
 
 """
-Updates an existing page. 
+Updates an existing page.
 
 Requires one of the following permissions: MANAGE_PAGES.
 """
@@ -25445,7 +25502,7 @@ input PageInput @doc(category: "Pages") {
 
   """
   Page content.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   content: JSONString
@@ -25457,15 +25514,15 @@ input PageInput @doc(category: "Pages") {
   isPublished: Boolean
 
   """
-  Publication date. ISO 8601 standard. 
-  
+  Publication date. ISO 8601 standard.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `publishedAt` field instead.
   """
   publicationDate: String
 
   """
   Publication date time. ISO 8601 standard.
-  
+
   Added in Saleor 3.3.
   """
   publishedAt: DateTime
@@ -25475,7 +25532,7 @@ input PageInput @doc(category: "Pages") {
 }
 
 """
-Creates/updates translations for a page. 
+Creates/updates translations for a page.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -25493,14 +25550,14 @@ input PageTranslationInput {
 
   """
   Translated page content.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   content: JSONString
 }
 
 """
-Create a new page type. 
+Create a new page type.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 """
@@ -25522,7 +25579,7 @@ input PageTypeCreateInput @doc(category: "Pages") {
 }
 
 """
-Update page type. 
+Update page type.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 """
@@ -25547,7 +25604,7 @@ input PageTypeUpdateInput @doc(category: "Pages") {
 }
 
 """
-Delete a page type. 
+Delete a page type.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 """
@@ -25558,7 +25615,7 @@ type PageTypeDelete @doc(category: "Pages") {
 }
 
 """
-Delete page types. 
+Delete page types.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 """
@@ -25570,7 +25627,7 @@ type PageTypeBulkDelete @doc(category: "Pages") {
 }
 
 """
-Assign attributes to a given page type. 
+Assign attributes to a given page type.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 """
@@ -25582,7 +25639,7 @@ type PageAttributeAssign @doc(category: "Pages") {
 }
 
 """
-Unassign attributes from a given page type. 
+Unassign attributes from a given page type.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 """
@@ -25594,7 +25651,7 @@ type PageAttributeUnassign @doc(category: "Pages") {
 }
 
 """
-Reorder the attributes of a page type. 
+Reorder the attributes of a page type.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 """
@@ -25606,7 +25663,7 @@ type PageTypeReorderAttributes @doc(category: "Pages") {
 }
 
 """
-Reorder page attribute values. 
+Reorder page attribute values.
 
 Requires one of the following permissions: MANAGE_PAGES.
 """
@@ -25618,7 +25675,7 @@ type PageReorderAttributeValues @doc(category: "Pages") {
 }
 
 """
-Completes creating an order. 
+Completes creating an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25630,7 +25687,7 @@ type DraftOrderComplete @doc(category: "Orders") {
 }
 
 """
-Creates a new draft order. 
+Creates a new draft order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25664,7 +25721,7 @@ input DraftOrderCreateInput @doc(category: "Orders") {
 
   """
   A code of the voucher associated with the order.
-  
+
   Added in Saleor 3.18.
   """
   voucherCode: String
@@ -25682,7 +25739,7 @@ input DraftOrderCreateInput @doc(category: "Orders") {
 
   """
   External ID of this order.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -25699,24 +25756,24 @@ input OrderLineCreateInput @doc(category: "Orders") {
   variantId: ID!
 
   """
-  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. 
-  
+  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic.
+
   Added in Saleor 3.6.
   """
   forceNewLine: Boolean = false
 
   """
   Custom price of the item.When the line with the same variant will be provided multiple times, the last price will be used.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   price: PositiveDecimal
 }
 
 """
-Deletes a draft order. 
+Deletes a draft order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25727,7 +25784,7 @@ type DraftOrderDelete @doc(category: "Orders") {
 }
 
 """
-Deletes draft orders. 
+Deletes draft orders.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25739,7 +25796,7 @@ type DraftOrderBulkDelete @doc(category: "Orders") {
 }
 
 """
-Deletes order lines. 
+Deletes order lines.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25751,7 +25808,7 @@ type DraftOrderLinesBulkDelete @doc(category: "Orders") {
 }
 
 """
-Updates a draft order. 
+Updates a draft order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25785,7 +25842,7 @@ input DraftOrderInput @doc(category: "Orders") {
 
   """
   A code of the voucher associated with the order.
-  
+
   Added in Saleor 3.18.
   """
   voucherCode: String
@@ -25803,7 +25860,7 @@ input DraftOrderInput @doc(category: "Orders") {
 
   """
   External ID of this order.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -25812,7 +25869,7 @@ input DraftOrderInput @doc(category: "Orders") {
 """
 Adds note to the order.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. 
+DEPRECATED: this mutation will be removed in Saleor 4.0.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25829,14 +25886,14 @@ type OrderAddNote @doc(category: "Orders") {
 input OrderAddNoteInput @doc(category: "Orders") {
   """
   Note message.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   message: String!
 }
 
 """
-Cancel an order. 
+Cancel an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25848,7 +25905,7 @@ type OrderCancel @doc(category: "Orders") {
 }
 
 """
-Capture an order. 
+Capture an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25860,7 +25917,7 @@ type OrderCapture @doc(category: "Orders") {
 }
 
 """
-Confirms an unconfirmed order by changing status to unfulfilled. 
+Confirms an unconfirmed order by changing status to unfulfilled.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25871,7 +25928,7 @@ type OrderConfirm @doc(category: "Orders") {
 }
 
 """
-Creates new fulfillments for an order. 
+Creates new fulfillments for an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 
@@ -25903,7 +25960,7 @@ input OrderFulfillInput @doc(category: "Orders") {
 
   """
   Fulfillment tracking number.
-  
+
   Added in Saleor 3.6.
   """
   trackingNumber: String
@@ -25926,7 +25983,7 @@ input OrderFulfillStockInput @doc(category: "Orders") {
 }
 
 """
-Cancels existing fulfillment and optionally restocks items. 
+Cancels existing fulfillment and optionally restocks items.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -25950,7 +26007,7 @@ input FulfillmentCancelInput @doc(category: "Orders") {
 """
 Approve existing fulfillment.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 
@@ -25968,7 +26025,7 @@ type FulfillmentApprove @doc(category: "Orders") @webhookEventsInfo(asyncEvents:
 }
 
 """
-Updates a fulfillment for an order. 
+Updates a fulfillment for an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 
@@ -25994,7 +26051,7 @@ input FulfillmentUpdateTrackingInput @doc(category: "Orders") {
 }
 
 """
-Refund products. 
+Refund products.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26041,7 +26098,7 @@ input OrderRefundFulfillmentLineInput @doc(category: "Orders") {
 }
 
 """
-Return products. 
+Return products.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26107,7 +26164,7 @@ Adds granted refund to the order.
 
 Added in Saleor 3.13.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26134,9 +26191,9 @@ type OrderGrantRefundCreateError @doc(category: "Orders") {
 
   """
   List of lines which cause the error.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   lines: [OrderGrantRefundCreateLineError!]
@@ -26184,27 +26241,27 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
 
   """
   Lines to assign to granted refund.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   lines: [OrderGrantRefundCreateLineInput!]
 
   """
   Determine if granted refund should include shipping costs.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   grantRefundForShipping: Boolean
 
   """
   The ID of the transaction item related to the granted refund. If `amount` provided in the input, the transaction.chargedAmount needs to be equal or greater than provided `amount`.If `amount` is not provided in the input and calculated automatically by Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be used.Field will be required starting from Saleor 3.21.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactionId: ID
@@ -26226,7 +26283,7 @@ Updates granted refund.
 
 Added in Saleor 3.13.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26253,18 +26310,18 @@ type OrderGrantRefundUpdateError @doc(category: "Orders") {
 
   """
   List of lines to add which cause the error.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addLines: [OrderGrantRefundUpdateLineError!]
 
   """
   List of lines to remove which cause the error.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   removeLines: [OrderGrantRefundUpdateLineError!]
@@ -26312,36 +26369,36 @@ input OrderGrantRefundUpdateInput @doc(category: "Orders") {
 
   """
   Lines to assign to granted refund.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addLines: [OrderGrantRefundUpdateLineAddInput!]
 
   """
   Lines to remove from granted refund.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   removeLines: [ID!]
 
   """
   Determine if granted refund should include shipping costs.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   grantRefundForShipping: Boolean
 
   """
   The ID of the transaction item related to the granted refund. If `amount` provided in the input, the transaction.chargedAmount needs to be equal or greater than provided `amount`.If `amount` is not provided in the input and calculated automatically by Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be used.Field will be required starting from Saleor 3.21.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactionId: ID
@@ -26359,7 +26416,7 @@ input OrderGrantRefundUpdateLineAddInput @doc(category: "Orders") {
 }
 
 """
-Create order lines for an order. 
+Create order lines for an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26374,7 +26431,7 @@ type OrderLinesCreate @doc(category: "Orders") {
 }
 
 """
-Deletes an order line from an order. 
+Deletes an order line from an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26389,7 +26446,7 @@ type OrderLineDelete @doc(category: "Orders") {
 }
 
 """
-Updates an order line of an order. 
+Updates an order line of an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26407,7 +26464,7 @@ input OrderLineInput @doc(category: "Orders") {
 }
 
 """
-Adds discount to the order. 
+Adds discount to the order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26430,7 +26487,7 @@ input OrderDiscountCommonInput @doc(category: "Orders") {
 }
 
 """
-Update discount for the order. 
+Update discount for the order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26442,7 +26499,7 @@ type OrderDiscountUpdate @doc(category: "Orders") {
 }
 
 """
-Remove discount from the order. 
+Remove discount from the order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26454,7 +26511,7 @@ type OrderDiscountDelete @doc(category: "Orders") {
 }
 
 """
-Update discount for the order line. 
+Update discount for the order line.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26469,7 +26526,7 @@ type OrderLineDiscountUpdate @doc(category: "Orders") {
 }
 
 """
-Remove discount applied to the order line. 
+Remove discount applied to the order line.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26488,7 +26545,7 @@ Adds note to the order.
 
 Added in Saleor 3.15.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26529,7 +26586,7 @@ Updates note of an order.
 
 Added in Saleor 3.15.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26562,7 +26619,7 @@ enum OrderNoteUpdateErrorCode @doc(category: "Orders") {
 }
 
 """
-Mark order as manually paid. 
+Mark order as manually paid.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26574,7 +26631,7 @@ type OrderMarkAsPaid @doc(category: "Orders") {
 }
 
 """
-Refund an order. 
+Refund an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26586,7 +26643,7 @@ type OrderRefund @doc(category: "Orders") {
 }
 
 """
-Updates an order. 
+Updates an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26608,14 +26665,14 @@ input OrderUpdateInput @doc(category: "Orders") {
 
   """
   External ID of this order.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
 }
 
 """
-Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed. 
+Updates a shipping method of the order. Requires shipping method ID to update, when null is passed then currently assigned shipping method is removed.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26634,7 +26691,7 @@ input OrderUpdateShippingInput @doc(category: "Orders") {
 }
 
 """
-Void an order. 
+Void an order.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26646,7 +26703,7 @@ type OrderVoid @doc(category: "Orders") {
 }
 
 """
-Cancels orders. 
+Cancels orders.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -26662,7 +26719,7 @@ Creates multiple orders.
 
 Added in Saleor 3.14.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_ORDERS_IMPORT.
 """
@@ -26779,7 +26836,7 @@ input OrderBulkCreateInput @doc(category: "Orders") {
 
   """
   Code of a voucher associated with the order.
-  
+
   Added in Saleor 3.18.
   """
   voucherCode: String
@@ -27049,7 +27106,7 @@ type UpdatePrivateMetadata {
 }
 
 """
-Assigns storefront's navigation menus. 
+Assigns storefront's navigation menus.
 
 Requires one of the following permissions: MANAGE_MENUS, MANAGE_SETTINGS.
 """
@@ -27094,7 +27151,7 @@ enum NavigationType {
 }
 
 """
-Creates a new Menu. 
+Creates a new Menu.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27136,7 +27193,7 @@ input MenuItemInput {
 }
 
 """
-Deletes a menu. 
+Deletes a menu.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27150,7 +27207,7 @@ type MenuDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DEL
 }
 
 """
-Deletes menus. 
+Deletes menus.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27165,7 +27222,7 @@ type MenuBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU
 }
 
 """
-Updates a menu. 
+Updates a menu.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27187,7 +27244,7 @@ input MenuInput {
 }
 
 """
-Creates a new menu item. 
+Creates a new menu item.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27224,7 +27281,7 @@ input MenuItemCreateInput {
 }
 
 """
-Deletes a menu item. 
+Deletes a menu item.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27238,7 +27295,7 @@ type MenuItemDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU
 }
 
 """
-Deletes menu items. 
+Deletes menu items.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27253,7 +27310,7 @@ type MenuItemBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [
 }
 
 """
-Updates a menu item. 
+Updates a menu item.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27267,7 +27324,7 @@ type MenuItemUpdate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU
 }
 
 """
-Creates/updates translations for a menu item. 
+Creates/updates translations for a menu item.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -27278,7 +27335,7 @@ type MenuItemTranslate @doc(category: "Menu") {
 }
 
 """
-Moves items of menus. 
+Moves items of menus.
 
 Requires one of the following permissions: MANAGE_MENUS.
 
@@ -27306,7 +27363,7 @@ input MenuItemMoveInput {
 }
 
 """
-Request an invoice for the order using plugin. 
+Request an invoice for the order using plugin.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 
@@ -27346,7 +27403,7 @@ enum InvoiceErrorCode @doc(category: "Orders") {
 }
 
 """
-Requests deletion of an invoice. 
+Requests deletion of an invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 
@@ -27360,7 +27417,7 @@ type InvoiceRequestDelete @doc(category: "Orders") @webhookEventsInfo(asyncEvent
 }
 
 """
-Creates a ready to send invoice. 
+Creates a ready to send invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -27379,21 +27436,21 @@ input InvoiceCreateInput @doc(category: "Orders") {
 
   """
   Fields required to update the invoice metadata.
-  
+
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the invoice private metadata.
-  
+
   Added in Saleor 3.14.
   """
   privateMetadata: [MetadataInput!]
 }
 
 """
-Deletes an invoice. 
+Deletes an invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -27404,7 +27461,7 @@ type InvoiceDelete @doc(category: "Orders") {
 }
 
 """
-Updates an invoice. 
+Updates an invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -27423,21 +27480,21 @@ input UpdateInvoiceInput @doc(category: "Orders") {
 
   """
   Fields required to update the invoice metadata.
-  
+
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the invoice private metadata.
-  
+
   Added in Saleor 3.14.
   """
   privateMetadata: [MetadataInput!]
 }
 
 """
-Send an invoice notification to the customer. 
+Send an invoice notification to the customer.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 
@@ -27452,7 +27509,7 @@ type InvoiceSendNotification @doc(category: "Orders") @webhookEventsInfo(asyncEv
 }
 
 """
-Activate a gift card. 
+Activate a gift card.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27494,7 +27551,7 @@ enum GiftCardErrorCode @doc(category: "Gift cards") {
 }
 
 """
-Creates a new gift card. 
+Creates a new gift card.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27511,28 +27568,28 @@ type GiftCardCreate @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents:
 input GiftCardCreateInput @doc(category: "Gift cards") {
   """
   The gift card tags to add.
-  
+
   Added in Saleor 3.1.
   """
   addTags: [String!]
 
   """
   The gift card expiry date.
-  
+
   Added in Saleor 3.1.
   """
   expiryDate: Date
 
   """
-  Start date of the gift card in ISO 8601 format. 
-  
+  Start date of the gift card in ISO 8601 format.
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   startDate: Date
 
   """
-  End date of the gift card in ISO 8601 format. 
-  
+  End date of the gift card in ISO 8601 format.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` from `expirySettings` instead.
   """
   endDate: Date
@@ -27545,28 +27602,28 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
 
   """
   Slug of a channel from which the email should be sent.
-  
+
   Added in Saleor 3.1.
   """
   channel: String
 
   """
   Determine if gift card is active.
-  
+
   Added in Saleor 3.1.
   """
   isActive: Boolean!
 
   """
-  Code to use the gift card. 
-  
+  Code to use the gift card.
+
   DEPRECATED: this field will be removed in Saleor 4.0. The code is now auto generated.
   """
   code: String
 
   """
   The gift card note from the staff member.
-  
+
   Added in Saleor 3.1.
   """
   note: String
@@ -27583,7 +27640,7 @@ input PriceInput {
 """
 Delete gift card.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27597,7 +27654,7 @@ type GiftCardDelete @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents:
 }
 
 """
-Deactivate a gift card. 
+Deactivate a gift card.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27612,7 +27669,7 @@ type GiftCardDeactivate @doc(category: "Gift cards") @webhookEventsInfo(asyncEve
 }
 
 """
-Update a gift card. 
+Update a gift card.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27628,42 +27685,42 @@ type GiftCardUpdate @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents:
 input GiftCardUpdateInput @doc(category: "Gift cards") {
   """
   The gift card tags to add.
-  
+
   Added in Saleor 3.1.
   """
   addTags: [String!]
 
   """
   The gift card expiry date.
-  
+
   Added in Saleor 3.1.
   """
   expiryDate: Date
 
   """
-  Start date of the gift card in ISO 8601 format. 
-  
+  Start date of the gift card in ISO 8601 format.
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   startDate: Date
 
   """
-  End date of the gift card in ISO 8601 format. 
-  
+  End date of the gift card in ISO 8601 format.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` from `expirySettings` instead.
   """
   endDate: Date
 
   """
   The gift card tags to remove.
-  
+
   Added in Saleor 3.1.
   """
   removeTags: [String!]
 
   """
   The gift card balance amount.
-  
+
   Added in Saleor 3.1.
   """
   balanceAmount: PositiveDecimal
@@ -27672,7 +27729,7 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
 """
 Resend a gift card.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27699,7 +27756,7 @@ input GiftCardResendInput @doc(category: "Gift cards") {
 """
 Adds note to the gift card.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27723,7 +27780,7 @@ input GiftCardAddNoteInput @doc(category: "Gift cards") {
 """
 Create gift cards.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27760,7 +27817,7 @@ input GiftCardBulkCreateInput @doc(category: "Gift cards") {
 """
 Delete gift cards.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27776,7 +27833,7 @@ type GiftCardBulkDelete @doc(category: "Gift cards") @webhookEventsInfo(asyncEve
 """
 Activate gift cards.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27792,7 +27849,7 @@ type GiftCardBulkActivate @doc(category: "Gift cards") @webhookEventsInfo(asyncE
 """
 Deactivate gift cards.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -27806,7 +27863,7 @@ type GiftCardBulkDeactivate @doc(category: "Gift cards") @webhookEventsInfo(asyn
 }
 
 """
-Update plugin configuration. 
+Update plugin configuration.
 
 Requires one of the following permissions: MANAGE_PLUGINS.
 """
@@ -27905,7 +27962,7 @@ Creates a new promotion.
 
 Added in Saleor 3.17.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -27973,8 +28030,8 @@ input PromotionCreateInput @doc(category: "Discounts") {
   name: String!
 
   """
-  Defines the promotion type. Implicate the required promotion rules predicate type and whether the promotion rules will give the catalogue or order discount. 
-  
+  Defines the promotion type. Implicate the required promotion rules predicate type and whether the promotion rules will give the catalogue or order discount.
+
   Added in Saleor 3.19.
   """
   type: PromotionTypeEnum!
@@ -27997,9 +28054,9 @@ input PromotionRuleInput @doc(category: "Discounts") {
 
   """
   Defines the conditions on the checkout/draft order level that must be met for the reward to be applied.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: OrderPredicateInput
@@ -28016,9 +28073,9 @@ input PromotionRuleInput @doc(category: "Discounts") {
 
   """
   Defines the reward type of the promotion rule.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardType: RewardTypeEnum
@@ -28028,9 +28085,9 @@ input PromotionRuleInput @doc(category: "Discounts") {
 
   """
   Product variant IDs available as a gift to choose.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   gifts: [ID!]
@@ -28086,7 +28143,7 @@ Updates an existing promotion.
 
 Added in Saleor 3.17.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28139,7 +28196,7 @@ Deletes a promotion.
 
 Added in Saleor 3.17.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28174,7 +28231,7 @@ Creates a new promotion rule.
 
 Added in Saleor 3.17.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28238,9 +28295,9 @@ input PromotionRuleCreateInput {
 
   """
   Defines the conditions on the checkout/draft order level that must be met for the reward to be applied.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: OrderPredicateInput
@@ -28257,9 +28314,9 @@ input PromotionRuleCreateInput {
 
   """
   Defines the reward type of the promotion rule.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardType: RewardTypeEnum
@@ -28269,9 +28326,9 @@ input PromotionRuleCreateInput {
 
   """
   Product variant IDs available as a gift to choose.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   gifts: [ID!]
@@ -28285,7 +28342,7 @@ Updates an existing promotion rule.
 
 Added in Saleor 3.17.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28346,9 +28403,9 @@ input PromotionRuleUpdateInput {
 
   """
   Defines the conditions on the checkout/draft order level that must be met for the reward to be applied.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: OrderPredicateInput
@@ -28365,9 +28422,9 @@ input PromotionRuleUpdateInput {
 
   """
   Defines the reward type of the promotion rule.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardType: RewardTypeEnum
@@ -28380,18 +28437,18 @@ input PromotionRuleUpdateInput {
 
   """
   List of variant IDs available as a gift to add.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addGifts: [ID!]
 
   """
   List of variant IDs available as a gift to remove.
-  
+
   Added in Saleor 3.19.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   removeGifts: [ID!]
@@ -28402,7 +28459,7 @@ Deletes a promotion rule.
 
 Added in Saleor 3.17.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28435,7 +28492,7 @@ enum PromotionRuleDeleteErrorCode {
 """
 Creates/updates translations for a promotion.
 
-Added in Saleor 3.17. 
+Added in Saleor 3.17.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -28449,7 +28506,7 @@ input PromotionTranslationInput {
 
   """
   Translated promotion description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSON
@@ -28458,7 +28515,7 @@ input PromotionTranslationInput {
 """
 Creates/updates translations for a promotion rule.
 
-Added in Saleor 3.17. 
+Added in Saleor 3.17.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -28472,7 +28529,7 @@ input PromotionRuleTranslationInput {
 
   """
   Translated promotion description.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSON
@@ -28483,7 +28540,7 @@ Deletes promotions.
 
 Added in Saleor 3.17.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28516,7 +28573,7 @@ type DiscountError @doc(category: "Discounts") {
 
   """
   List of voucher codes which causes the error.
-  
+
   Added in Saleor 3.18.
   """
   voucherCodes: [String!]
@@ -28537,7 +28594,7 @@ enum DiscountErrorCode @doc(category: "Discounts") {
 """
 Creates a new sale.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionCreate` mutation instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionCreate` mutation instead.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28580,7 +28637,7 @@ input SaleInput @doc(category: "Discounts") {
 """
 Deletes a sale.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionDelete` mutation instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionDelete` mutation instead.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28594,7 +28651,7 @@ type SaleDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [SAL
 }
 
 """
-Deletes sales. 
+Deletes sales.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28611,7 +28668,7 @@ type SaleBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: 
 """
 Updates a sale.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionUpdate` mutation instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionUpdate` mutation instead.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28628,7 +28685,7 @@ type SaleUpdate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [SAL
 """
 Adds products, categories, collections to a sale.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` mutation instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` mutation instead.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28654,7 +28711,7 @@ input CatalogueInput @doc(category: "Discounts") {
 
   """
   Product variant related to the discount.
-  
+
   Added in Saleor 3.1.
   """
   variants: [ID!]
@@ -28663,7 +28720,7 @@ input CatalogueInput @doc(category: "Discounts") {
 """
 Removes products, categories, collections from a sale.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleUpdate` or `promotionRuleDelete` mutations instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleUpdate` or `promotionRuleDelete` mutations instead.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28680,7 +28737,7 @@ type SaleRemoveCatalogues @doc(category: "Discounts") @webhookEventsInfo(asyncEv
 """
 Creates/updates translations for a sale.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PromotionTranslate` mutation instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PromotionTranslate` mutation instead.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -28693,7 +28750,7 @@ type SaleTranslate @doc(category: "Discounts") {
 """
 Manage sale's availability in channels.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` or `promotionRuleUpdate` mutations instead. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionRuleCreate` or `promotionRuleUpdate` mutations instead.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 """
@@ -28721,7 +28778,7 @@ input SaleChannelListingAddInput @doc(category: "Discounts") {
 }
 
 """
-Creates a new voucher. 
+Creates a new voucher.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28749,9 +28806,9 @@ input VoucherInput @doc(category: "Discounts") {
 
   """
   List of codes to add.
-  
+
   Added in Saleor 3.18.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addCodes: [String!]
@@ -28770,7 +28827,7 @@ input VoucherInput @doc(category: "Discounts") {
 
   """
   Variants discounted by the voucher.
-  
+
   Added in Saleor 3.1.
   """
   variants: [ID!]
@@ -28798,11 +28855,11 @@ input VoucherInput @doc(category: "Discounts") {
 
   """
   When set to 'True', each voucher code can be used only once; otherwise, codes can be used multiple times depending on `usageLimit`.
-  
+
   The option can only be changed if none of the voucher codes have been used.
-  
+
   Added in Saleor 3.18.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   singleUse: Boolean
@@ -28812,7 +28869,7 @@ input VoucherInput @doc(category: "Discounts") {
 }
 
 """
-Deletes a voucher. 
+Deletes a voucher.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28826,7 +28883,7 @@ type VoucherDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [
 }
 
 """
-Deletes vouchers. 
+Deletes vouchers.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28841,7 +28898,7 @@ type VoucherBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvent
 }
 
 """
-Updates a voucher. 
+Updates a voucher.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28856,7 +28913,7 @@ type VoucherUpdate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [
 }
 
 """
-Adds products, categories, collections to a voucher. 
+Adds products, categories, collections to a voucher.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28871,7 +28928,7 @@ type VoucherAddCatalogues @doc(category: "Discounts") @webhookEventsInfo(asyncEv
 }
 
 """
-Removes products, categories, collections from a voucher. 
+Removes products, categories, collections from a voucher.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28886,7 +28943,7 @@ type VoucherRemoveCatalogues @doc(category: "Discounts") @webhookEventsInfo(asyn
 }
 
 """
-Creates/updates translations for a voucher. 
+Creates/updates translations for a voucher.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -28897,7 +28954,7 @@ type VoucherTranslate @doc(category: "Discounts") {
 }
 
 """
-Manage voucher's availability in channels. 
+Manage voucher's availability in channels.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28933,7 +28990,7 @@ input VoucherChannelListingAddInput @doc(category: "Discounts") {
 """
 Deletes voucher codes.
 
-Added in Saleor 3.18. 
+Added in Saleor 3.18.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28969,7 +29026,7 @@ enum VoucherCodeBulkDeleteErrorCode @doc(category: "Discounts") {
 }
 
 """
-Export products to csv file. 
+Export products to csv file.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 
@@ -29071,7 +29128,7 @@ enum FileTypesEnum {
 """
 Export gift cards to csv file.
 
-Added in Saleor 3.1. 
+Added in Saleor 3.1.
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 
@@ -29106,7 +29163,7 @@ Export voucher codes to csv/xlsx file.
 
 Added in Saleor 3.18.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -29135,7 +29192,7 @@ input ExportVoucherCodesInput @doc(category: "Discounts") {
 }
 
 """
-Upload a file. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
+Upload a file. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
 
 Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
 """
@@ -29336,7 +29393,7 @@ input CheckoutCreateInput @doc(category: "Checkout") {
 
   """
   The checkout validation rules that can be changed.
-  
+
   Added in Saleor 3.5.
   """
   validationRules: CheckoutValidationRules
@@ -29351,21 +29408,21 @@ input CheckoutLineInput @doc(category: "Checkout") {
 
   """
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
-  
+
   Added in Saleor 3.1.
   """
   price: PositiveDecimal
 
   """
-  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. 
-  
+  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic.
+
   Added in Saleor 3.6.
   """
   forceNewLine: Boolean = false
 
   """
   Fields required to update the object's metadata.
-  
+
   Added in Saleor 3.8.
   """
   metadata: [MetadataInput!]
@@ -29444,7 +29501,7 @@ enum CheckoutCreateFromOrderErrorCode @doc(category: "Checkout") {
 }
 
 """
-Sets the customer as the owner of the checkout. 
+Sets the customer as the owner of the checkout.
 
 Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_USER.
 
@@ -29459,7 +29516,7 @@ type CheckoutCustomerAttach @doc(category: "Checkout") @webhookEventsInfo(asyncE
 }
 
 """
-Removes the user assigned as the owner of the checkout. 
+Removes the user assigned as the owner of the checkout.
 
 Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_USER.
 
@@ -29554,8 +29611,8 @@ type CheckoutLinesUpdate @doc(category: "Checkout") @webhookEventsInfo(asyncEven
 
 input CheckoutLineUpdateInput @doc(category: "Checkout") {
   """
-  ID of the product variant. 
-  
+  ID of the product variant.
+
   DEPRECATED: this field will be removed in Saleor 4.0. Use `lineId` instead.
   """
   variantId: ID
@@ -29567,14 +29624,14 @@ input CheckoutLineUpdateInput @doc(category: "Checkout") {
 
   """
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
-  
+
   Added in Saleor 3.1.
   """
   price: PositiveDecimal
 
   """
   ID of the line.
-  
+
   Added in Saleor 3.6.
   """
   lineId: ID
@@ -29625,14 +29682,14 @@ input PaymentInput @doc(category: "Payments") {
 
   """
   Payment store type.
-  
+
   Added in Saleor 3.1.
   """
   storePaymentMethod: StorePaymentMethodEnum = NONE
 
   """
   User public metadata.
-  
+
   Added in Saleor 3.1.
   """
   metadata: [MetadataInput!]
@@ -29682,7 +29739,7 @@ type CheckoutShippingMethodUpdate @doc(category: "Checkout") @webhookEventsInfo(
 }
 
 """
-Updates the delivery method (shipping method or pick up point) of the checkout. Updates the checkout shipping_address for click and collect delivery for a warehouse address. 
+Updates the delivery method (shipping method or pick up point) of the checkout. Updates the checkout shipping_address for click and collect delivery for a warehouse address.
 
 Added in Saleor 3.1.
 
@@ -29769,7 +29826,7 @@ enum OrderCreateFromCheckoutErrorCode @doc(category: "Orders") {
 }
 
 """
-Creates new channel. 
+Creates new channel.
 
 Requires one of the following permissions: MANAGE_CHANNELS.
 
@@ -29819,7 +29876,7 @@ input ChannelCreateInput @doc(category: "Channels") {
 
   """
   The channel stock settings.
-  
+
   Added in Saleor 3.7.
   """
   stockSettings: StockSettingsInput
@@ -29829,46 +29886,46 @@ input ChannelCreateInput @doc(category: "Channels") {
 
   """
   List of warehouses to assign to the channel.
-  
+
   Added in Saleor 3.5.
   """
   addWarehouses: [ID!]
 
   """
   The channel order settings
-  
+
   Added in Saleor 3.12.
   """
   orderSettings: OrderSettingsInput
 
   """
   Channel public metadata.
-  
+
   Added in Saleor 3.15.
   """
   metadata: [MetadataInput!]
 
   """
   Channel private metadata.
-  
+
   Added in Saleor 3.15.
   """
   privateMetadata: [MetadataInput!]
 
   """
   The channel checkout settings
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   checkoutSettings: CheckoutSettingsInput
 
   """
   The channel payment settings
-  
+
   Added in Saleor 3.16.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   paymentSettings: PaymentSettingsInput
@@ -29884,7 +29941,7 @@ input ChannelCreateInput @doc(category: "Channels") {
 
   """
   Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
-  
+
   Added in Saleor 3.1.
   """
   defaultCountry: CountryCode!
@@ -29910,18 +29967,18 @@ input OrderSettingsInput @doc(category: "Orders") {
 
   """
   Expiration time in minutes. Default null - means do not expire any orders. Enter 0 or null to disable.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   expireOrdersAfter: Minute
 
   """
   The time in days after expired orders will be deleted.Allowed range is from 1 to 120.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   deleteExpiredOrdersAfter: Day
@@ -29930,29 +29987,29 @@ input OrderSettingsInput @doc(category: "Orders") {
   Determine what strategy will be used to mark the order as paid. Based on the chosen option, the proper object will be created and attached to the order when it's manually marked as paid.
   `PAYMENT_FLOW` - [default option] creates the `Payment` object.
   `TRANSACTION_FLOW` - creates the `TransactionItem` object.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   markAsPaidStrategy: MarkAsPaidStrategyEnum
 
   """
   Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   allowUnpaidOrders: Boolean
 
   """
   Specify whether a coupon applied to draft orders will count toward voucher usage.
-  
+
   Warning:  when switching this setting from `false` to `true`, the vouchers will be disconnected from all draft orders.
-  
+
   Added in Saleor 3.18.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   includeDraftOrderInVoucherUsage: Boolean
@@ -29960,10 +30017,10 @@ input OrderSettingsInput @doc(category: "Orders") {
 
 input CheckoutSettingsInput @doc(category: "Checkout") {
   """
-  Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one. 
-  
+  Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one.
+
   Added in Saleor 3.15.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   useLegacyErrorFlow: Boolean
@@ -29972,9 +30029,9 @@ input CheckoutSettingsInput @doc(category: "Checkout") {
 input PaymentSettingsInput @doc(category: "Payments") {
   """
   Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
-  
+
   Added in Saleor 3.16.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   defaultTransactionFlowStrategy: TransactionFlowStrategyEnum
@@ -30004,7 +30061,7 @@ input ChannelUpdateInput @doc(category: "Channels") {
 
   """
   The channel stock settings.
-  
+
   Added in Saleor 3.7.
   """
   stockSettings: StockSettingsInput
@@ -30014,46 +30071,46 @@ input ChannelUpdateInput @doc(category: "Channels") {
 
   """
   List of warehouses to assign to the channel.
-  
+
   Added in Saleor 3.5.
   """
   addWarehouses: [ID!]
 
   """
   The channel order settings
-  
+
   Added in Saleor 3.12.
   """
   orderSettings: OrderSettingsInput
 
   """
   Channel public metadata.
-  
+
   Added in Saleor 3.15.
   """
   metadata: [MetadataInput!]
 
   """
   Channel private metadata.
-  
+
   Added in Saleor 3.15.
   """
   privateMetadata: [MetadataInput!]
 
   """
   The channel checkout settings
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   checkoutSettings: CheckoutSettingsInput
 
   """
   The channel payment settings
-  
+
   Added in Saleor 3.16.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   paymentSettings: PaymentSettingsInput
@@ -30066,7 +30123,7 @@ input ChannelUpdateInput @doc(category: "Channels") {
 
   """
   Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
-  
+
   Added in Saleor 3.1.
   """
   defaultCountry: CountryCode
@@ -30076,14 +30133,14 @@ input ChannelUpdateInput @doc(category: "Channels") {
 
   """
   List of warehouses to unassign from the channel.
-  
+
   Added in Saleor 3.5.
   """
   removeWarehouses: [ID!]
 }
 
 """
-Delete a channel. Orders associated with the deleted channel will be moved to the target channel. Checkouts, product availability, and pricing will be removed. 
+Delete a channel. Orders associated with the deleted channel will be moved to the target channel. Checkouts, product availability, and pricing will be removed.
 
 Requires one of the following permissions: MANAGE_CHANNELS.
 
@@ -30104,7 +30161,7 @@ input ChannelDeleteInput @doc(category: "Channels") {
 }
 
 """
-Activate a channel. 
+Activate a channel.
 
 Requires one of the following permissions: MANAGE_CHANNELS.
 
@@ -30119,7 +30176,7 @@ type ChannelActivate @doc(category: "Channels") @webhookEventsInfo(asyncEvents: 
 }
 
 """
-Deactivate a channel. 
+Deactivate a channel.
 
 Requires one of the following permissions: MANAGE_CHANNELS.
 
@@ -30136,7 +30193,7 @@ type ChannelDeactivate @doc(category: "Channels") @webhookEventsInfo(asyncEvents
 """
 Reorder the warehouses of a channel.
 
-Added in Saleor 3.7. 
+Added in Saleor 3.7.
 
 Requires one of the following permissions: MANAGE_CHANNELS.
 """
@@ -30218,7 +30275,7 @@ input AttributeCreateInput @doc(category: "Attributes") {
 
   """
   Whether the attribute can be filtered in storefront.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   filterableInStorefront: Boolean
@@ -30228,21 +30285,21 @@ input AttributeCreateInput @doc(category: "Attributes") {
 
   """
   The position of the attribute in the storefront navigation (0 by default).
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   storefrontSearchPosition: Int
 
   """
   Whether the attribute can be displayed in the admin product list.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   availableInGrid: Boolean
 
   """
   External ID of this attribute.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -30256,16 +30313,16 @@ input AttributeValueCreateInput @doc(category: "Attributes") {
 
   """
   Represents the text of the attribute value, includes formatting.
-  
+
   Rich text format. For reference see https://editorjs.io/
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   richText: JSONString
 
   """
   Represents the text of the attribute value, plain text without formatting.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   plainText: String
@@ -30278,7 +30335,7 @@ input AttributeValueCreateInput @doc(category: "Attributes") {
 
   """
   External ID of this attribute value.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -30288,7 +30345,7 @@ input AttributeValueCreateInput @doc(category: "Attributes") {
 }
 
 """
-Deletes an attribute. 
+Deletes an attribute.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 
@@ -30302,7 +30359,7 @@ type AttributeDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents
 }
 
 """
-Updates attribute. 
+Updates attribute.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 
@@ -30347,7 +30404,7 @@ input AttributeUpdateInput @doc(category: "Attributes") {
 
   """
   Whether the attribute can be filtered in storefront.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   filterableInStorefront: Boolean
@@ -30357,21 +30414,21 @@ input AttributeUpdateInput @doc(category: "Attributes") {
 
   """
   The position of the attribute in the storefront navigation (0 by default).
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   storefrontSearchPosition: Int
 
   """
   Whether the attribute can be displayed in the admin product list.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   availableInGrid: Boolean
 
   """
   External ID of this product.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -30385,16 +30442,16 @@ input AttributeValueUpdateInput @doc(category: "Attributes") {
 
   """
   Represents the text of the attribute value, includes formatting.
-  
+
   Rich text format. For reference see https://editorjs.io/
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   richText: JSONString
 
   """
   Represents the text of the attribute value, plain text without formatting.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   plainText: String
@@ -30407,7 +30464,7 @@ input AttributeValueUpdateInput @doc(category: "Attributes") {
 
   """
   External ID of this attribute value.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
@@ -30534,7 +30591,7 @@ input AttributeBulkUpdateInput @doc(category: "Attributes") {
 }
 
 """
-Creates/updates translations for an attribute. 
+Creates/updates translations for an attribute.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -30549,7 +30606,7 @@ Creates/updates translations for attributes.
 
 Added in Saleor 3.14.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -30605,7 +30662,7 @@ input AttributeBulkTranslateInput @doc(category: "Attributes") {
 }
 
 """
-Deletes attributes. 
+Deletes attributes.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 
@@ -30620,7 +30677,7 @@ type AttributeBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEv
 }
 
 """
-Deletes values of attributes. 
+Deletes values of attributes.
 
 Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
 
@@ -30636,7 +30693,7 @@ type AttributeValueBulkDelete @doc(category: "Attributes") @webhookEventsInfo(as
 }
 
 """
-Creates a value for an attribute. 
+Creates a value for an attribute.
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 
@@ -30653,7 +30710,7 @@ type AttributeValueCreate @doc(category: "Attributes") @webhookEventsInfo(asyncE
 }
 
 """
-Deletes a value of an attribute. 
+Deletes a value of an attribute.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 
@@ -30670,7 +30727,7 @@ type AttributeValueDelete @doc(category: "Attributes") @webhookEventsInfo(asyncE
 }
 
 """
-Updates value of an attribute. 
+Updates value of an attribute.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 
@@ -30691,7 +30748,7 @@ Creates/updates translations for attributes values.
 
 Added in Saleor 3.14.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -30751,7 +30808,7 @@ input AttributeValueTranslationInput {
 
   """
   Translated text.
-  
+
   Rich text format. For reference see https://editorjs.io/
   """
   richText: JSONString
@@ -30761,7 +30818,7 @@ input AttributeValueTranslationInput {
 }
 
 """
-Creates/updates translations for an attribute value. 
+Creates/updates translations for an attribute value.
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -30772,7 +30829,7 @@ type AttributeValueTranslate @doc(category: "Attributes") {
 }
 
 """
-Reorder the values of an attribute. 
+Reorder the values of an attribute.
 
 Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 
@@ -30841,7 +30898,7 @@ input AppInput @doc(category: "Apps") {
 
   """
   Canonical app ID. If not provided, the identifier will be generated based on app.id.
-  
+
   Added in Saleor 3.19.
   """
   identifier: String
@@ -30851,7 +30908,7 @@ input AppInput @doc(category: "Apps") {
 }
 
 """
-Updates an existing app. 
+Updates an existing app.
 
 Requires one of the following permissions: MANAGE_APPS.
 
@@ -30865,7 +30922,7 @@ type AppUpdate @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_UPDAT
 }
 
 """
-Deletes an app. 
+Deletes an app.
 
 Requires one of the following permissions: MANAGE_APPS.
 
@@ -30879,7 +30936,7 @@ type AppDelete @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_DELET
 }
 
 """
-Creates a new token. 
+Creates a new token.
 
 Requires one of the following permissions: MANAGE_APPS.
 """
@@ -30900,7 +30957,7 @@ input AppTokenInput @doc(category: "Apps") {
 }
 
 """
-Deletes an authentication token assigned to app. 
+Deletes an authentication token assigned to app.
 
 Requires one of the following permissions: MANAGE_APPS.
 """
@@ -30942,7 +30999,7 @@ input AppInstallInput @doc(category: "Apps") {
 }
 
 """
-Retry failed installation of new app. 
+Retry failed installation of new app.
 
 Requires one of the following permissions: MANAGE_APPS.
 
@@ -30956,7 +31013,7 @@ type AppRetryInstall @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP
 }
 
 """
-Delete failed installation. 
+Delete failed installation.
 
 Requires one of the following permissions: MANAGE_APPS.
 """
@@ -30967,7 +31024,7 @@ type AppDeleteFailedInstallation @doc(category: "Apps") {
 }
 
 """
-Fetch and validate manifest. 
+Fetch and validate manifest.
 
 Requires one of the following permissions: MANAGE_APPS.
 """
@@ -31025,41 +31082,41 @@ type Manifest @doc(category: "Apps") {
 
   """
   List of the app's webhooks.
-  
+
   Added in Saleor 3.5.
   """
   webhooks: [AppManifestWebhook!]!
 
   """
   The audience that will be included in all JWT tokens for the app.
-  
+
   Added in Saleor 3.8.
   """
   audience: String
 
   """
   Determines the app's required Saleor version as semver range.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   requiredSaleorVersion: AppManifestRequiredSaleorVersion
 
   """
   The App's author name.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   author: String
 
   """
   App's brand data.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   brand: AppManifestBrand
@@ -31102,18 +31159,18 @@ type AppManifestWebhook @doc(category: "Apps") {
 type AppManifestRequiredSaleorVersion @doc(category: "Apps") {
   """
   Required Saleor version as semver range.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   constraint: String!
 
   """
   Informs if the Saleor version matches the required one.
-  
+
   Added in Saleor 3.13.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   satisfied: Boolean!
@@ -31129,9 +31186,9 @@ Note: this API is currently in Feature Preview and can be subject to changes at 
 type AppManifestBrand @doc(category: "Apps") {
   """
   App's logos details.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   logo: AppManifestBrandLogo!
@@ -31147,9 +31204,9 @@ Note: this API is currently in Feature Preview and can be subject to changes at 
 type AppManifestBrandLogo @doc(category: "Apps") {
   """
   Data URL with a base64 encoded logo image.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   default(
@@ -31160,9 +31217,9 @@ type AppManifestBrandLogo @doc(category: "Apps") {
 
     """
     The format of the image. When not provided, format of the original image will be used.
-    
+
     Added in Saleor 3.14.
-    
+
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: IconThumbnailFormatEnum = ORIGINAL
@@ -31170,7 +31227,7 @@ type AppManifestBrandLogo @doc(category: "Apps") {
 }
 
 """
-Activate the app. 
+Activate the app.
 
 Requires one of the following permissions: MANAGE_APPS.
 
@@ -31184,7 +31241,7 @@ type AppActivate @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_STA
 }
 
 """
-Deactivate the app. 
+Deactivate the app.
 
 Requires one of the following permissions: MANAGE_APPS.
 
@@ -31305,7 +31362,7 @@ String, Boolean, Int, Float, List or Object.
 scalar GenericScalar
 
 """
-Deactivate all JWT tokens of the currently authenticated user. 
+Deactivate all JWT tokens of the currently authenticated user.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 """
@@ -31396,7 +31453,7 @@ Sends a notification confirmation.
 
 Added in Saleor 3.15.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -31461,7 +31518,7 @@ type SetPassword @doc(category: "Users") {
 }
 
 """
-Change the password of the logged in user. 
+Change the password of the logged in user.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 """
@@ -31473,7 +31530,7 @@ type PasswordChange @doc(category: "Users") {
 }
 
 """
-Request email change of the logged in user. 
+Request email change of the logged in user.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -31489,7 +31546,7 @@ type RequestEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: 
 }
 
 """
-Confirm the email change of the logged-in user. 
+Confirm the email change of the logged-in user.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -31551,7 +31608,7 @@ type AccountAddressDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents
 }
 
 """
-Sets a default address for the authenticated user. 
+Sets a default address for the authenticated user.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -31646,14 +31703,14 @@ input AccountInput @doc(category: "Users") {
 
   """
   Fields required to update the user metadata.
-  
+
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
 }
 
 """
-Sends an email with the account removal link for the logged-in user. 
+Sends an email with the account removal link for the logged-in user.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -31667,7 +31724,7 @@ type AccountRequestDeletion @doc(category: "Users") @webhookEventsInfo(asyncEven
 }
 
 """
-Remove user account. 
+Remove user account.
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -31681,7 +31738,7 @@ type AccountDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ACCO
 }
 
 """
-Creates user address. 
+Creates user address.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31697,7 +31754,7 @@ type AddressCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ADDR
 }
 
 """
-Updates an address. 
+Updates an address.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31713,7 +31770,7 @@ type AddressUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ADDR
 }
 
 """
-Deletes an address. 
+Deletes an address.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31729,7 +31786,7 @@ type AddressDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ADDR
 }
 
 """
-Sets a default address for the given user. 
+Sets a default address for the given user.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31744,7 +31801,7 @@ type AddressSetDefault @doc(category: "Users") @webhookEventsInfo(asyncEvents: [
 }
 
 """
-Creates a new customer. 
+Creates a new customer.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31784,14 +31841,14 @@ input UserCreateInput @doc(category: "Users") {
 
   """
   Fields required to update the user metadata.
-  
+
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the user private metadata.
-  
+
   Added in Saleor 3.14.
   """
   privateMetadata: [MetadataInput!]
@@ -31801,18 +31858,18 @@ input UserCreateInput @doc(category: "Users") {
 
   """
   External ID of the customer.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
 
   """
   User account is confirmed.
-  
+
   Added in Saleor 3.15.
-  
+
   DEPRECATED: this field will be removed in Saleor 4.0.
-  
+
   The user will be always set as unconfirmed. The confirmation will take place when the user sets the password.
   """
   isConfirmed: Boolean
@@ -31829,7 +31886,7 @@ input UserCreateInput @doc(category: "Users") {
 }
 
 """
-Updates an existing customer. 
+Updates an existing customer.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31867,14 +31924,14 @@ input CustomerInput @doc(category: "Users") {
 
   """
   Fields required to update the user metadata.
-  
+
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the user private metadata.
-  
+
   Added in Saleor 3.14.
   """
   privateMetadata: [MetadataInput!]
@@ -31884,21 +31941,21 @@ input CustomerInput @doc(category: "Users") {
 
   """
   External ID of the customer.
-  
+
   Added in Saleor 3.10.
   """
   externalReference: String
 
   """
   User account is confirmed.
-  
+
   Added in Saleor 3.15.
   """
   isConfirmed: Boolean
 }
 
 """
-Deletes a customer. 
+Deletes a customer.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31912,7 +31969,7 @@ type CustomerDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUS
 }
 
 """
-Deletes customers. 
+Deletes customers.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31931,7 +31988,7 @@ Updates customers.
 
 Added in Saleor 3.13.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31992,7 +32049,7 @@ input CustomerBulkUpdateInput @doc(category: "Users") {
 }
 
 """
-Creates a new staff user. Apps are not allowed to perform this mutation. 
+Creates a new staff user. Apps are not allowed to perform this mutation.
 
 Requires one of the following permissions: MANAGE_STAFF.
 
@@ -32051,14 +32108,14 @@ input StaffCreateInput @doc(category: "Users") {
 
   """
   Fields required to update the user metadata.
-  
+
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the user private metadata.
-  
+
   Added in Saleor 3.14.
   """
   privateMetadata: [MetadataInput!]
@@ -32073,7 +32130,7 @@ input StaffCreateInput @doc(category: "Users") {
 }
 
 """
-Updates an existing staff user. Apps are not allowed to perform this mutation. 
+Updates an existing staff user. Apps are not allowed to perform this mutation.
 
 Requires one of the following permissions: MANAGE_STAFF.
 
@@ -32105,14 +32162,14 @@ input StaffUpdateInput @doc(category: "Users") {
 
   """
   Fields required to update the user metadata.
-  
+
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
 
   """
   Fields required to update the user private metadata.
-  
+
   Added in Saleor 3.14.
   """
   privateMetadata: [MetadataInput!]
@@ -32125,7 +32182,7 @@ input StaffUpdateInput @doc(category: "Users") {
 }
 
 """
-Deletes a staff user. Apps are not allowed to perform this mutation. 
+Deletes a staff user. Apps are not allowed to perform this mutation.
 
 Requires one of the following permissions: MANAGE_STAFF.
 
@@ -32139,7 +32196,7 @@ type StaffDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [STAFF_
 }
 
 """
-Deletes staff users. Apps are not allowed to perform this mutation. 
+Deletes staff users. Apps are not allowed to perform this mutation.
 
 Requires one of the following permissions: MANAGE_STAFF.
 
@@ -32154,7 +32211,7 @@ type StaffBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ST
 }
 
 """
-Create a user avatar. Only for staff members. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
+Create a user avatar. Only for staff members. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec
 
 Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
 """
@@ -32166,7 +32223,7 @@ type UserAvatarUpdate @doc(category: "Users") {
 }
 
 """
-Deletes a user avatar. Only for staff members. 
+Deletes a user avatar. Only for staff members.
 
 Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
 """
@@ -32178,7 +32235,7 @@ type UserAvatarDelete @doc(category: "Users") {
 }
 
 """
-Activate or deactivate users. 
+Activate or deactivate users.
 
 Requires one of the following permissions: MANAGE_USERS.
 """
@@ -32190,7 +32247,7 @@ type UserBulkSetActive @doc(category: "Users") {
 }
 
 """
-Create new permission group. Apps are not allowed to perform this mutation. 
+Create new permission group. Apps are not allowed to perform this mutation.
 
 Requires one of the following permissions: MANAGE_STAFF.
 
@@ -32246,9 +32303,9 @@ input PermissionGroupCreateInput @doc(category: "Users") {
 
   """
   List of channels to assign to this group.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addChannels: [ID!]
@@ -32258,16 +32315,16 @@ input PermissionGroupCreateInput @doc(category: "Users") {
 
   """
   Determine if the group has restricted access to channels.  DEFAULT: False
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   restrictedAccessToChannels: Boolean = false
 }
 
 """
-Update permission group. Apps are not allowed to perform this mutation. 
+Update permission group. Apps are not allowed to perform this mutation.
 
 Requires one of the following permissions: MANAGE_STAFF.
 
@@ -32289,9 +32346,9 @@ input PermissionGroupUpdateInput @doc(category: "Users") {
 
   """
   List of channels to assign to this group.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addChannels: [ID!]
@@ -32307,25 +32364,25 @@ input PermissionGroupUpdateInput @doc(category: "Users") {
 
   """
   List of channels to unassign from this group.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   removeChannels: [ID!]
 
   """
   Determine if the group has restricted access to channels.
-  
+
   Added in Saleor 3.14.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   restrictedAccessToChannels: Boolean
 }
 
 """
-Delete permission group. Apps are not allowed to perform this mutation. 
+Delete permission group. Apps are not allowed to perform this mutation.
 
 Requires one of the following permissions: MANAGE_STAFF.
 
@@ -32341,16 +32398,16 @@ type PermissionGroupDelete @doc(category: "Users") @webhookEventsInfo(asyncEvent
 type Subscription @doc(category: "Miscellaneous") {
   """
   Look up subscription event.
-  
+
   Added in Saleor 3.2.
   """
   event: Event
 
   """
   Event sent when new draft order is created.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   draftOrderCreated(
@@ -32362,9 +32419,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when draft order is updated.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   draftOrderUpdated(
@@ -32376,9 +32433,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when draft order is deleted.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   draftOrderDeleted(
@@ -32390,9 +32447,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when new order is created.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderCreated(
@@ -32404,9 +32461,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is updated.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderUpdated(
@@ -32418,9 +32475,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is confirmed.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderConfirmed(
@@ -32432,9 +32489,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Payment has been made. The order may be partially or fully paid.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPaid(
@@ -32446,9 +32503,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is fully paid.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderFullyPaid(
@@ -32460,9 +32517,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   The order received a refund. The order may be partially or fully refunded.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderRefunded(
@@ -32474,9 +32531,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   The order is fully refunded.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderFullyRefunded(
@@ -32488,9 +32545,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is fulfilled.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderFulfilled(
@@ -32502,9 +32559,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is cancelled.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderCancelled(
@@ -32516,9 +32573,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order becomes expired.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderExpired(
@@ -32530,9 +32587,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order metadata is updated.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderMetadataUpdated(
@@ -32544,9 +32601,9 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when orders are imported.
-  
+
   Added in Saleor 3.20.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderBulkCreated(
@@ -34458,7 +34515,7 @@ type SaleToggle implements Event @doc(category: "Discounts") {
 
   """
   The sale the event relates to.
-  
+
   Added in Saleor 3.5.
   """
   sale(
@@ -34682,7 +34739,7 @@ type InvoiceRequested implements Event @doc(category: "Orders") {
 
   """
   Order related to the invoice.
-  
+
   Added in Saleor 3.10.
   """
   order: Order!
@@ -34711,7 +34768,7 @@ type InvoiceDeleted implements Event @doc(category: "Orders") {
 
   """
   Order related to the invoice.
-  
+
   Added in Saleor 3.10.
   """
   order: Order
@@ -34740,7 +34797,7 @@ type InvoiceSent implements Event @doc(category: "Orders") {
 
   """
   Order related to the invoice.
-  
+
   Added in Saleor 3.10.
   """
   order: Order
@@ -34772,7 +34829,7 @@ type FulfillmentCreated implements Event @doc(category: "Orders") {
 
   """
   If true, the app should send a notification to the customer.
-  
+
   Added in Saleor 3.16.
   """
   notifyCustomer: Boolean!
@@ -34854,7 +34911,7 @@ type FulfillmentApproved implements Event @doc(category: "Orders") {
 
   """
   If true, send a notification to the customer.
-  
+
   Added in Saleor 3.16.
   """
   notifyCustomer: Boolean!
@@ -35996,28 +36053,28 @@ type ThumbnailCreated implements Event @doc(category: "Miscellaneous") {
 
   """
   Thumbnail id.
-  
+
   Added in Saleor 3.12.
   """
   id: ID
 
   """
   Thumbnail url.
-  
+
   Added in Saleor 3.12.
   """
   url: String
 
   """
   Object the thumbnail refers to.
-  
+
   Added in Saleor 3.12.
   """
   objectId: ID
 
   """
   Original media url.
-  
+
   Added in Saleor 3.12.
   """
   mediaUrl: String
@@ -36213,7 +36270,7 @@ type TransactionAction @doc(category: "Payments") {
 
   """
   Currency code.
-  
+
   Added in Saleor 3.16.
   """
   currency: String!
@@ -36274,9 +36331,9 @@ type TransactionRefundRequested implements Event @doc(category: "Payments") {
 
   """
   Granted refund related to refund request.
-  
+
   Added in Saleor 3.15.
-  
+
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   grantedRefund: OrderGrantedRefund
@@ -36305,7 +36362,7 @@ type OrderFilterShippingMethods implements Event @doc(category: "Orders") {
 
   """
   Shipping methods that can be used with this checkout.
-  
+
   Added in Saleor 3.6.
   """
   shippingMethods: [ShippingMethod!]
@@ -36334,7 +36391,7 @@ type CheckoutFilterShippingMethods implements Event @doc(category: "Checkout") {
 
   """
   Shipping methods that can be used with this checkout.
-  
+
   Added in Saleor 3.6.
   """
   shippingMethods: [ShippingMethod!]
@@ -36363,7 +36420,7 @@ type ShippingListMethodsForCheckout implements Event @doc(category: "Checkout") 
 
   """
   Shipping methods that can be used with this checkout.
-  
+
   Added in Saleor 3.6.
   """
   shippingMethods: [ShippingMethod!]
@@ -36536,7 +36593,7 @@ type TransactionInitializeSession implements Event @doc(category: "Payments") {
 
   """
   The customer's IP address. If not provided as a parameter in the mutation, Saleor will try to determine the customer's IP address on its own.
-  
+
   Added in Saleor 3.16.
   """
   customerIpAddress: String
@@ -36546,7 +36603,7 @@ type TransactionInitializeSession implements Event @doc(category: "Payments") {
 
   """
   Idempotency key assigned to the transaction initialize.
-  
+
   Added in Saleor 3.14.
   """
   idempotencyKey: String!
@@ -36595,7 +36652,7 @@ type TransactionProcessSession implements Event @doc(category: "Payments") {
 
   """
   The customer's IP address. If not provided as a parameter in the mutation, Saleor will try to determine the customer's IP address on its own.
-  
+
   Added in Saleor 3.16.
   """
   customerIpAddress: String
@@ -36668,7 +36725,7 @@ type StoredPaymentMethodDeleteRequested implements Event @doc(category: "Payment
 }
 
 """
-Event sent to initialize a new session in payment gateway to store the payment method. 
+Event sent to initialize a new session in payment gateway to store the payment method.
 
 Added in Saleor 3.16.
 

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -167,10 +167,10 @@ class TransactionAction:
     ]
 
 
-class TransactionEventType:
+class TransactionEventOutputType:
     """Represents possible event types.
 
-    Added in Saleor 3.12.
+    Added in Saleor 3.xx.
 
     The following types are possible:
     AUTHORIZATION_SUCCESS - represents success authorization.
@@ -245,11 +245,99 @@ class TransactionEventType:
     ]
 
 
+class TransactionEventType:
+    """Represents possible event types.
+
+    Added in Saleor 3.12.
+
+    The following types are possible:
+    AUTHORIZATION_SUCCESS - represents success authorization.
+    AUTHORIZATION_FAILURE - represents failure authorization.
+    AUTHORIZATION_ADJUSTMENT - represents authorization adjustment.
+    AUTHORIZATION_REQUEST - represents authorization request.
+    AUTHORIZATION_ACTION_REQUIRED - represents authorization that needs
+    additional actions from the customer.
+    CHARGE_ACTION_REQUIRED - represents charge that needs
+    additional actions from the customer.
+    CHARGE_SUCCESS - represents success charge.
+    CHARGE_FAILURE - represents failure charge.
+    CHARGE_BACK - represents chargeback.
+    CHARGE_REQUEST - represents charge request.
+    REFUND_SUCCESS - represents success refund.
+    REFUND_FAILURE - represents failure refund.
+    REFUND_REVERSE - represents reverse refund.
+    REFUND_REQUEST - represents refund request.
+    CANCEL_SUCCESS - represents success cancel.
+    CANCEL_FAILURE - represents failure cancel.
+    CANCEL_REQUEST - represents cancel request.
+    INFO - represents info event.
+    """
+
+    AUTHORIZATION_SUCCESS = "authorization_success"
+    AUTHORIZATION_FAILURE = "authorization_failure"
+    AUTHORIZATION_ADJUSTMENT = "authorization_adjustment"
+    AUTHORIZATION_REQUEST = "authorization_request"
+    AUTHORIZATION_ACTION_REQUIRED = "authorization_action_required"
+    CHARGE_SUCCESS = "charge_success"
+    CHARGE_FAILURE = "charge_failure"
+    CHARGE_BACK = "charge_back"
+    CHARGE_ACTION_REQUIRED = "charge_action_required"
+    CHARGE_REQUEST = "charge_request"
+    REFUND_SUCCESS = "refund_success"
+    REFUND_FAILURE = "refund_failure"
+    REFUND_REVERSE = "refund_reverse"
+    REFUND_REQUEST = "refund_request"
+    CANCEL_SUCCESS = "cancel_success"
+    CANCEL_FAILURE = "cancel_failure"
+    CANCEL_REQUEST = "cancel_request"
+    INFO = "info"
+    REFUND_OR_CANCEL_REQUEST = "refund_or_cancel_request"
+    REFUND_OR_CANCEL_SUCCESS = "refund_or_cancel_success"
+    REFUND_OR_CANCEL_FAILURE = "refund_or_cancel_failure"
+
+    CHOICES = [
+        (AUTHORIZATION_SUCCESS, "Represents success authorization"),
+        (AUTHORIZATION_FAILURE, "Represents failure authorization"),
+        (AUTHORIZATION_ADJUSTMENT, "Represents authorization adjustment"),
+        (AUTHORIZATION_REQUEST, "Represents authorization request"),
+        (
+            AUTHORIZATION_ACTION_REQUIRED,
+            "Represents additional actions required for authorization.",
+        ),
+        (CHARGE_ACTION_REQUIRED, "Represents additional actions required for charge."),
+        (CHARGE_SUCCESS, "Represents success charge"),
+        (CHARGE_FAILURE, "Represents failure charge"),
+        (CHARGE_BACK, "Represents chargeback."),
+        (CHARGE_REQUEST, "Represents charge request"),
+        (REFUND_SUCCESS, "Represents success refund"),
+        (REFUND_FAILURE, "Represents failure refund"),
+        (REFUND_REVERSE, "Represents reverse refund"),
+        (REFUND_REQUEST, "Represents refund request"),
+        (CANCEL_SUCCESS, "Represents success cancel"),
+        (CANCEL_FAILURE, "Represents failure cancel"),
+        (CANCEL_REQUEST, "Represents cancel request"),
+        (INFO, "Represents an info event"),
+        (REFUND_OR_CANCEL_REQUEST, "Represents refund or cancel request"),
+        (REFUND_OR_CANCEL_SUCCESS, "Represents refund or cancel success"),
+        (REFUND_OR_CANCEL_FAILURE, "Represents refund or cancel failure"),
+    ]
+    REFUND_RELATED_EVENT_TYPES = [
+        REFUND_SUCCESS,
+        REFUND_FAILURE,
+        REFUND_REVERSE,
+        REFUND_REQUEST,
+        REFUND_OR_CANCEL_REQUEST,
+        REFUND_OR_CANCEL_SUCCESS,
+        REFUND_OR_CANCEL_FAILURE,
+    ]
+
+
 FAILED_TRANSACTION_EVENTS = [
     TransactionEventType.AUTHORIZATION_FAILURE,
     TransactionEventType.CHARGE_FAILURE,
     TransactionEventType.REFUND_FAILURE,
     TransactionEventType.CANCEL_FAILURE,
+    TransactionEventType.REFUND_OR_CANCEL_FAILURE,
 ]
 
 
@@ -261,6 +349,7 @@ OPTIONAL_PSP_REFERENCE_EVENTS = [
     TransactionEventType.REFUND_FAILURE,
     TransactionEventType.CHARGE_FAILURE,
     TransactionEventType.CANCEL_FAILURE,
+    TransactionEventType.REFUND_OR_CANCEL_FAILURE,
 ]
 
 OPTIONAL_AMOUNT_EVENTS = [


### PR DESCRIPTION
This PoC adds new `TransactionEventOutputTypeEnum` that will be used for resolving `TransactionItem`.

It has the same fields as existing `TransactionEventTypeEnum`.

Meanwhile existing `TarnsactionEventTypeEnum` has gained new REFUND_OR_CANCEL options. Old enum will be used only in the input type for `transactionEventReport` mutation
