### PR TITLE
Add tests for order promotions on draft orders

### DIFF
--- a/saleor/tests/e2e/orders/discounts/test_gift_promotion_applied_on_draft_order.py
+++ b/saleor/tests/e2e/orders/discounts/test_gift_promotion_applied_on_draft_order.py
@@ -1,0 +1,221 @@
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...promotions.utils import create_promotion, create_promotion_rule
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
+from ...utils import assign_permissions
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    order_lines_create,
+    order_update_shipping,
+)
+
+
+def prepare_order_promotion(
+    e2e_staff_api_client,
+    channel_id,
+    order_predicate_total_value,
+    gift_ids,
+):
+    promotion_name = "Promotion with gifts"
+    promotion_type = "ORDER"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+
+    order_predicate = {
+        "discountedObjectPredicate": {
+            "baseTotalPrice": {"range": {"gte": order_predicate_total_value}}
+        }
+    }
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": "gift rule",
+        "orderPredicate": order_predicate,
+        "rewardType": "GIFT",
+        "gifts": gift_ids,
+    }
+    create_promotion_rule(e2e_staff_api_client, input)
+
+    return promotion_id
+
+
+@pytest.mark.e2e
+def test_order_promotion_with_gift_reward_should_be_applied_to_draft_order_with_specific_subtotal_CORE_2140(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price = 30
+    product1_price = 60
+    product2_price = 15
+    country_tax_rate = 10
+    country = "US"
+    order_predicate_total_value = 150
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+    }
+
+    # Create channel, warehouse, shipping method and update tax configuration
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": True,
+                    "allowUnpaidOrders": False,
+                    "includeDraftOrderInVoucherUsage": False,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+    # Create products
+    (
+        _product_id,
+        product1_variant_id,
+        product1_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product1_price,
+        product_type_slug="shoes",
+    )
+    (
+        _product_id,
+        product2_variant_id,
+        _product2_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product2_price,
+        product_type_slug="sunglasses",
+    )
+
+    # Create order promotion
+    prepare_order_promotion(
+        e2e_staff_api_client,
+        channel_id,
+        order_predicate_total_value=order_predicate_total_value,
+        gift_ids=[product2_variant_id],
+    )
+
+    # Step 1 - Create a draft order for a product with fixed promotion
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product1_variant_id, "quantity": 2},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order = order["order"]
+
+    # Assert subtotal price
+    expected_subtotal_gross = round(product1_price * 2, 2)
+    expected_subtotal_tax = round(
+        expected_subtotal_gross * country_tax_rate / (100 + country_tax_rate), 2
+    )
+    assert order["subtotal"]["gross"]["amount"] == expected_subtotal_gross
+    assert order["subtotal"]["tax"]["amount"] == expected_subtotal_tax
+
+    # Step 3 - Update shipping method
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    order = order["order"]
+    assert order["deliveryMethod"]["id"] is not None
+
+    # Assert shipping price
+    assert order["shippingPrice"]["gross"]["amount"] == shipping_price
+    expected_shipping_tax = round(
+        (shipping_price * country_tax_rate) / (100 + country_tax_rate),
+        2,
+    )
+    assert order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+
+    # Assert total price
+    expected_total_price = round(expected_subtotal_gross + shipping_price, 2)
+    expected_total_tax = round(expected_subtotal_tax + expected_shipping_tax, 2)
+    assert order["total"]["gross"]["amount"] == expected_total_price
+    assert order["total"]["tax"]["amount"] == expected_total_tax
+
+    # Assert gift line
+    order_lines = order["lines"]
+    assert len(order_lines) == 2
+    gift_line = order_lines[1]
+    assert gift_line["totalPrice"]["gross"]["amount"] == 0
+    assert gift_line["isGift"] is True
+
+    # Assert undiscounted total price
+    assert order["undiscountedTotal"]["gross"]["amount"] == expected_total_price
+    assert order["undiscountedTotal"]["tax"]["amount"] == expected_total_tax
+
+    # Step 4 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    completed_order = order["order"]
+    assert completed_order["status"] == "UNFULFILLED"
+    assert completed_order["total"]["gross"]["amount"] == expected_total_price
+    assert completed_order["total"]["tax"]["amount"] == expected_total_tax
+    assert completed_order["subtotal"]["gross"]["amount"] == expected_subtotal_gross
+    assert completed_order["subtotal"]["tax"]["amount"] == expected_subtotal_tax
+    assert completed_order["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert completed_order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+    assert (
+        completed_order["undiscountedTotal"]["gross"]["amount"] == expected_total_price
+    )
+    assert completed_order["undiscountedTotal"]["tax"]["amount"] == expected_total_tax
+    assert completed_order["lines"][1]["isGift"] is True

--- a/saleor/tests/e2e/orders/discounts/test_manual_total_discount_applied_on_draft_order.py
+++ b/saleor/tests/e2e/orders/discounts/test_manual_total_discount_applied_on_draft_order.py
@@ -1,0 +1,406 @@
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
+from ...utils import assign_permissions
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    order_discount_add,
+    order_lines_create,
+    order_update_shipping,
+)
+
+
+@pytest.mark.e2e
+def test_manual_total_discount_fixed_should_be_applied_to_draft_order_CORE_0223(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price = 30
+    product1_price = 60
+    product2_price = 15
+    country_tax_rate = 10
+    country = "US"
+    discount_value = 10
+    discount_type = "FIXED"
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+    }
+
+    # Create channel, warehouse, shipping method and update tax configuration
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": True,
+                    "allowUnpaidOrders": False,
+                    "includeDraftOrderInVoucherUsage": False,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+
+    # Create products
+    (
+        _product_id,
+        product1_variant_id,
+        product1_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product1_price,
+        product_type_slug="shoes",
+    )
+    (
+        _product_id,
+        product2_variant_id,
+        _product2_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product2_price,
+        product_type_slug="sunglasses",
+    )
+
+    # Step 1 - Create a draft order for a product with fixed promotion
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product1_variant_id, "quantity": 2},
+        {"variantId": product2_variant_id, "quantity": 1},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order = order["order"]
+
+    # Assert subtotal price
+    expected_subtotal_gross = round((product1_price * 2) + product2_price, 2)
+    expected_subtotal_tax = round(
+        expected_subtotal_gross * country_tax_rate / (100 + country_tax_rate), 2
+    )
+    assert order["subtotal"]["gross"]["amount"] == expected_subtotal_gross
+    assert order["subtotal"]["tax"]["amount"] == expected_subtotal_tax
+
+    # Step 3 - Update shipping method
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    order = order["order"]
+    assert order["deliveryMethod"]["id"] is not None
+
+    # Assert shipping price
+    assert order["shippingPrice"]["gross"]["amount"] == shipping_price
+    expected_shipping_tax = round(
+        (shipping_price * country_tax_rate) / (100 + country_tax_rate),
+        2,
+    )
+    assert order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+
+    # Assert total price
+    expected_total_gross = round(expected_subtotal_gross + shipping_price, 2)
+    expected_total_tax = round(expected_subtotal_tax + expected_shipping_tax, 2)
+    assert order["total"]["gross"]["amount"] == expected_total_gross
+    assert order["total"]["tax"]["amount"] == expected_total_tax
+
+    # Step 4 - Update manual total discount
+    manual_discount_input = {
+        "valueType": discount_type,
+        "value": discount_value,
+    }
+    discount_data = order_discount_add(
+        e2e_staff_api_client,
+        order_id,
+        manual_discount_input,
+    )
+
+    # Assert discounts
+    discount = discount_data["order"]["discounts"][0]
+    assert discount is not None
+    assert discount["type"] == "MANUAL"
+    assert discount["valueType"] == discount_type
+    discount_amount = discount_value
+    assert discount["amount"]["amount"] == discount_amount
+
+    # Assert total price
+    expected_total_gross_after_discount = round(
+        expected_total_gross - discount_amount, 2
+    )
+    expected_total_tax_after_discount = round(
+        (expected_total_gross_after_discount * country_tax_rate)
+        / (100 + country_tax_rate),
+        2,
+    )
+    order = discount_data["order"]
+    assert order["total"]["gross"]["amount"] == expected_total_gross_after_discount
+    assert order["total"]["tax"]["amount"] == expected_total_tax_after_discount
+
+    # Assert undiscounted
+    assert order["undiscountedTotal"]["gross"]["amount"] == expected_total_gross
+    assert order["undiscountedTotal"]["tax"]["amount"] == expected_total_tax
+    assert order["undiscountedShippingPrice"]["amount"] == shipping_price
+
+    # Step 5 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    completed_order = order["order"]
+    assert completed_order["status"] == "UNFULFILLED"
+    assert completed_order["discounts"][0]["type"] == "MANUAL"
+    assert (
+        completed_order["total"]["gross"]["amount"]
+        == expected_total_gross_after_discount
+    )
+    assert (
+        completed_order["total"]["tax"]["amount"] == expected_total_tax_after_discount
+    )
+    assert (
+        completed_order["undiscountedTotal"]["gross"]["amount"] == expected_total_gross
+    )
+    assert completed_order["undiscountedTotal"]["tax"]["amount"] == expected_total_tax
+
+
+@pytest.mark.e2e
+def test_manual_total_discount_percentage_should_be_applied_to_draft_order_CORE_0224(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price = 30
+    product1_price = 60
+    product2_price = 15
+    country_tax_rate = 10
+    country = "US"
+    discount_value = 10
+    discount_type = "PERCENTAGE"
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+    }
+
+    # Create channel, warehouse, shipping method and update tax configuration
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": True,
+                    "allowUnpaidOrders": False,
+                    "includeDraftOrderInVoucherUsage": False,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+
+    # Create products
+    (
+        _product_id,
+        product1_variant_id,
+        product1_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product1_price,
+        product_type_slug="shoes",
+    )
+    (
+        _product_id,
+        product2_variant_id,
+        _product2_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product2_price,
+        product_type_slug="sunglasses",
+    )
+
+    # Step 1 - Create a draft order for a product with fixed promotion
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product1_variant_id, "quantity": 2},
+        {"variantId": product2_variant_id, "quantity": 1},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order = order["order"]
+
+    # Assert subtotal price
+    expected_subtotal_gross = round((product1_price * 2) + product2_price, 2)
+    expected_subtotal_tax = round(
+        expected_subtotal_gross * country_tax_rate / (100 + country_tax_rate), 2
+    )
+    assert order["subtotal"]["gross"]["amount"] == expected_subtotal_gross
+    assert order["subtotal"]["tax"]["amount"] == expected_subtotal_tax
+
+    # Step 3 - Update shipping method
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    order = order["order"]
+    assert order["deliveryMethod"]["id"] is not None
+
+    # Assert shipping price
+    assert order["shippingPrice"]["gross"]["amount"] == shipping_price
+    expected_shipping_tax = round(
+        (shipping_price * country_tax_rate) / (100 + country_tax_rate),
+        2,
+    )
+    assert order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+
+    # Assert total price
+    expected_total_gross = round(expected_subtotal_gross + shipping_price, 2)
+    expected_total_tax = round(expected_subtotal_tax + expected_shipping_tax, 2)
+    assert order["total"]["gross"]["amount"] == expected_total_gross
+    assert order["total"]["tax"]["amount"] == expected_total_tax
+
+    # Step 4 - Update manual total discount
+    manual_discount_input = {
+        "valueType": discount_type,
+        "value": discount_value,
+    }
+    discount_data = order_discount_add(
+        e2e_staff_api_client,
+        order_id,
+        manual_discount_input,
+    )
+
+    # Assert discounts
+    discount = discount_data["order"]["discounts"][0]
+    assert discount is not None
+    assert discount["type"] == "MANUAL"
+    assert discount["valueType"] == discount_type
+    discount_amount = round((expected_total_gross * discount_value) / 100, 2)
+    assert discount["amount"]["amount"] == discount_amount
+
+    # Assert total price
+    expected_total_gross_after_discount = round(
+        expected_total_gross - discount_amount, 2
+    )
+    expected_total_tax_after_discount = round(
+        (expected_total_gross_after_discount * country_tax_rate)
+        / (100 + country_tax_rate),
+        2,
+    )
+    order = discount_data["order"]
+    assert order["total"]["gross"]["amount"] == expected_total_gross_after_discount
+    assert order["total"]["tax"]["amount"] == expected_total_tax_after_discount
+
+    # Assert undiscounted
+    assert order["undiscountedTotal"]["gross"]["amount"] == expected_total_gross
+    assert order["undiscountedTotal"]["tax"]["amount"] == expected_total_tax
+    assert order["undiscountedShippingPrice"]["amount"] == shipping_price
+
+    # Step 5 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    completed_order = order["order"]
+    assert completed_order["status"] == "UNFULFILLED"
+    assert completed_order["discounts"][0]["type"] == "MANUAL"
+    assert (
+        completed_order["total"]["gross"]["amount"]
+        == expected_total_gross_after_discount
+    )
+    assert (
+        completed_order["total"]["tax"]["amount"] == expected_total_tax_after_discount
+    )
+    assert (
+        completed_order["undiscountedTotal"]["gross"]["amount"] == expected_total_gross
+    )
+    assert completed_order["undiscountedTotal"]["tax"]["amount"] == expected_total_tax

--- a/saleor/tests/e2e/orders/discounts/test_promotion_applied_on_draft_order_with_specific_subtotal.py
+++ b/saleor/tests/e2e/orders/discounts/test_promotion_applied_on_draft_order_with_specific_subtotal.py
@@ -1,0 +1,258 @@
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...promotions.utils import create_promotion, create_promotion_rule
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
+from ...utils import assign_permissions
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    order_lines_create,
+    order_update_shipping,
+)
+
+
+def prepare_order_promotion(
+    e2e_staff_api_client,
+    channel_id,
+    discount_value,
+    discount_type,
+    order_predicate_total_value,
+):
+    promotion_name = "Black Friday Subtotal Promotion"
+    promotion_type = "ORDER"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+    order_predicate = {
+        "discountedObjectPredicate": {
+            "baseSubtotalPrice": {"eq": order_predicate_total_value}
+        }
+    }
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": "test rule",
+        "orderPredicate": order_predicate,
+        "rewardType": "SUBTOTAL_DISCOUNT",
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
+    create_promotion_rule(e2e_staff_api_client, input)
+
+    return promotion_id
+
+
+@pytest.mark.e2e
+def test_order_promotion_should_be_applied_to_draft_order_with_specific_subtotal_CORE_2127(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price = 10
+    product1_price = 15
+    product2_price = 30
+    country_tax_rate = 10
+    country = "US"
+    order_promotion_value = 15
+    order_promotion_discount_type = "FIXED"
+    order_predicate_total_value = 45
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+    }
+
+    # Create channel, warehouse, shipping method and update tax configuration
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": True,
+                    "allowUnpaidOrders": False,
+                    "includeDraftOrderInVoucherUsage": False,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+    # Create products
+    (
+        _product_id,
+        product1_variant_id,
+        product1_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product1_price,
+        product_type_slug="shoes",
+    )
+    (
+        _product_id,
+        product2_variant_id,
+        product2_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product2_price,
+        product_type_slug="hoodies",
+    )
+
+    # Create order promotion
+    order_promotion_id = prepare_order_promotion(
+        e2e_staff_api_client,
+        channel_id,
+        discount_value=order_promotion_value,
+        discount_type=order_promotion_discount_type,
+        order_predicate_total_value=order_predicate_total_value,
+    )
+
+    # Step 1 - Create a draft order for a product with fixed promotion
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product1_variant_id, "quantity": 1},
+        {"variantId": product2_variant_id, "quantity": 1},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order = order["order"]
+
+    # Assert discount
+    assert order["discounts"][0]["type"] == "ORDER_PROMOTION"
+    assert order["discounts"][0]["value"] == order_promotion_value
+    assert order["discounts"][0]["reason"] == f"Promotion: {order_promotion_id}"
+    expected_discount_amount = order_promotion_value
+    assert order["discounts"][0]["amount"]["amount"] == expected_discount_amount
+
+    # Assert subtotal price
+    expected_subtotal_gross_before_promo = round(product1_price + product2_price, 2)
+    expected_subtotal_gross_after_promo = round(
+        expected_subtotal_gross_before_promo - order_promotion_value, 2
+    )
+    expected_subtotal_tax_after_promo = round(
+        expected_subtotal_gross_after_promo
+        * country_tax_rate
+        / (100 + country_tax_rate),
+        2,
+    )
+    assert order["subtotal"]["gross"]["amount"] == expected_subtotal_gross_after_promo
+    assert order["subtotal"]["tax"]["amount"] == expected_subtotal_tax_after_promo
+
+    # Step 3 - Update shipping method
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    order = order["order"]
+    assert order["deliveryMethod"]["id"] is not None
+
+    # Assert shipping price
+    assert order["shippingPrice"]["gross"]["amount"] == shipping_price
+    expected_shipping_tax = round(
+        (shipping_price * country_tax_rate) / (100 + country_tax_rate),
+        2,
+    )
+    assert order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+
+    # Assert total price
+    expected_total_price = round(
+        expected_subtotal_gross_after_promo + shipping_price, 2
+    )
+    expected_total_tax = round(
+        expected_subtotal_tax_after_promo + expected_shipping_tax, 2
+    )
+    assert order["total"]["gross"]["amount"] == expected_total_price
+    assert order["total"]["tax"]["amount"] == expected_total_tax
+
+    # Assert undiscounted total price
+    expected_undiscounted_total_gross = round(
+        expected_subtotal_gross_before_promo + shipping_price, 2
+    )
+    expected_undiscounted_total_tax = round(
+        expected_undiscounted_total_gross * country_tax_rate / (100 + country_tax_rate),
+        2,
+    )
+    assert (
+        order["undiscountedTotal"]["gross"]["amount"]
+        == expected_undiscounted_total_gross
+    )
+    assert (
+        order["undiscountedTotal"]["tax"]["amount"] == expected_undiscounted_total_tax
+    )
+
+    # Step 4 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    completed_order = order["order"]
+    assert completed_order["status"] == "UNFULFILLED"
+    assert completed_order["total"]["gross"]["amount"] == expected_total_price
+    assert completed_order["total"]["tax"]["amount"] == expected_total_tax
+    assert (
+        completed_order["subtotal"]["gross"]["amount"]
+        == expected_subtotal_gross_after_promo
+    )
+    assert (
+        completed_order["subtotal"]["tax"]["amount"]
+        == expected_subtotal_tax_after_promo
+    )
+    assert completed_order["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert completed_order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+    assert (
+        completed_order["undiscountedTotal"]["gross"]["amount"]
+        == expected_undiscounted_total_gross
+    )
+    assert (
+        completed_order["undiscountedTotal"]["tax"]["amount"]
+        == expected_undiscounted_total_tax
+    )
+    assert completed_order["discounts"][0]["type"] == "ORDER_PROMOTION"

--- a/saleor/tests/e2e/orders/discounts/test_promotion_applied_on_draft_order_with_specific_total.py
+++ b/saleor/tests/e2e/orders/discounts/test_promotion_applied_on_draft_order_with_specific_total.py
@@ -1,0 +1,245 @@
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...promotions.utils import create_promotion, create_promotion_rule
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
+from ...utils import assign_permissions
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    order_lines_create,
+    order_update_shipping,
+)
+
+
+def prepare_order_promotion(
+    e2e_staff_api_client,
+    channel_id,
+    discount_value,
+    discount_type,
+    order_predicate_total_value,
+):
+    promotion_name = "Black Friday Subtotal Promotion"
+    promotion_type = "ORDER"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+    order_predicate = {
+        "discountedObjectPredicate": {
+            "baseTotalPrice": {"eq": order_predicate_total_value}
+        }
+    }
+
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": "test rule",
+        "orderPredicate": order_predicate,
+        "rewardType": "SUBTOTAL_DISCOUNT",
+        "rewardValue": discount_value,
+        "rewardValueType": discount_type,
+    }
+    create_promotion_rule(e2e_staff_api_client, input)
+
+    return promotion_id
+
+
+@pytest.mark.e2e
+def test_order_promotion_should_be_applied_to_draft_order_with_specific_total_CORE_2126(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price = 10
+    product_price = 15
+    country_tax_rate = 10
+    country = "US"
+    order_promotion_value = 15
+    order_promotion_discount_type = "PERCENTAGE"
+    order_predicate_total_value = 25
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+    }
+
+    # Create channel, warehouse, shipping method and update tax configuration
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": True,
+                    "allowUnpaidOrders": False,
+                    "includeDraftOrderInVoucherUsage": False,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+    # Create product
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=product_price
+    )
+
+    # Create order promotion
+    order_promotion_id = prepare_order_promotion(
+        e2e_staff_api_client,
+        channel_id,
+        discount_value=order_promotion_value,
+        discount_type=order_promotion_discount_type,
+        order_predicate_total_value=order_predicate_total_value,
+    )
+
+    # Step 1 - Create a draft order for a product with fixed promotion
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product_variant_id, "quantity": 1},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order = order["order"]
+
+    # Assert subtotal price
+    assert order["subtotal"]["gross"]["amount"] == product_price
+    expected_subtotal_tax = round(
+        product_price * country_tax_rate / (100 + country_tax_rate), 2
+    )
+    assert order["subtotal"]["tax"]["amount"] == expected_subtotal_tax
+
+    # Step 3 - Update shipping method
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    order = order["order"]
+    assert order["deliveryMethod"]["id"] is not None
+
+    # Assert shipping price
+    assert order["shippingPrice"]["gross"]["amount"] == shipping_price
+    expected_shipping_tax = round(
+        (shipping_price * country_tax_rate) / (100 + country_tax_rate),
+        2,
+    )
+    assert order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+
+    # Assert discount
+    assert order["discounts"][0]["type"] == "ORDER_PROMOTION"
+    assert order["discounts"][0]["value"] == order_promotion_value
+    assert order["discounts"][0]["reason"] == f"Promotion: {order_promotion_id}"
+    expected_discount_amount = round(product_price * order_promotion_value / 100, 2)
+    assert order["discounts"][0]["amount"]["amount"] == expected_discount_amount
+
+    # Assert subtotal price
+    expected_subtotal_gross_after_promo = round(
+        product_price - expected_discount_amount, 2
+    )
+    expected_subtotal_tax_after_promo = round(
+        expected_subtotal_gross_after_promo
+        * country_tax_rate
+        / (100 + country_tax_rate),
+        2,
+    )
+    assert order["subtotal"]["gross"]["amount"] == expected_subtotal_gross_after_promo
+    assert order["subtotal"]["tax"]["amount"] == expected_subtotal_tax_after_promo
+
+    # Assert total price
+    expected_total_price = round(
+        expected_subtotal_gross_after_promo + shipping_price, 2
+    )
+    expected_total_tax = round(
+        expected_subtotal_tax_after_promo + expected_shipping_tax, 2
+    )
+    assert order["total"]["gross"]["amount"] == expected_total_price
+    assert order["total"]["tax"]["amount"] == expected_total_tax
+
+    # Assert undiscounted total price
+    expected_undiscounted_total_gross = round(product_price + shipping_price, 2)
+    expected_undiscounted_total_tax = round(
+        expected_undiscounted_total_gross * country_tax_rate / (100 + country_tax_rate),
+        2,
+    )
+    assert (
+        order["undiscountedTotal"]["gross"]["amount"]
+        == expected_undiscounted_total_gross
+    )
+    assert (
+        order["undiscountedTotal"]["tax"]["amount"] == expected_undiscounted_total_tax
+    )
+
+    # Step 4 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    completed_order = order["order"]
+    assert completed_order["status"] == "UNFULFILLED"
+    assert completed_order["total"]["gross"]["amount"] == expected_total_price
+    assert completed_order["total"]["tax"]["amount"] == expected_total_tax
+    assert (
+        completed_order["subtotal"]["gross"]["amount"]
+        == expected_subtotal_gross_after_promo
+    )
+    assert (
+        completed_order["subtotal"]["tax"]["amount"]
+        == expected_subtotal_tax_after_promo
+    )
+    assert completed_order["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert completed_order["shippingPrice"]["tax"]["amount"] == expected_shipping_tax
+    assert (
+        completed_order["undiscountedTotal"]["gross"]["amount"]
+        == expected_undiscounted_total_gross
+    )
+    assert (
+        completed_order["undiscountedTotal"]["tax"]["amount"]
+        == expected_undiscounted_total_tax
+    )
+    assert completed_order["discounts"][0]["type"] == "ORDER_PROMOTION"

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -63,6 +63,7 @@ mutation DraftOrderComplete($id: ID!) {
         unitDiscountReason
         unitDiscountType
         unitDiscountValue
+        isGift
       }
     }
   }

--- a/saleor/tests/e2e/orders/utils/order_discount_add.py
+++ b/saleor/tests/e2e/orders/utils/order_discount_add.py
@@ -2,22 +2,50 @@ from saleor.graphql.tests.utils import get_graphql_content
 
 ORDER_DISCOUNT_ADD_MUTATION = """
 mutation OrderDiscountAdd($input: OrderDiscountCommonInput!, $id: ID!) {
-  orderDiscountAdd(input:$input, orderId: $id) {
-    errors{
+  orderDiscountAdd(input: $input, orderId: $id) {
+    errors {
+      message
+      field
+    }
+    order {
+      errors {
         message
         field
-        }
-    order {
-      errors{message field}
+      }
       id
+      total {
+        ...BaseTaxedMoney
+      }
+      undiscountedTotal {
+        ...BaseTaxedMoney
+      }
+      undiscountedShippingPrice {
+        amount
+      }
       discounts {
         id
         value
         valueType
         type
+        amount {
+          amount
+        }
       }
     }
   }
+}
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
 }
 """
 

--- a/saleor/tests/e2e/orders/utils/order_update_shipping.py
+++ b/saleor/tests/e2e/orders/utils/order_update_shipping.py
@@ -28,10 +28,22 @@ mutation OrderUpdateShipping($input: OrderUpdateShippingInput!, $id: ID!) {
       shippingPrice {
         ...BaseTaxedMoney
       }
+      undiscountedShippingPrice {
+        amount
+      }
       voucher {
         id
         code
         discountValue
+      }
+      discounts {
+        type
+        value
+        reason
+        valueType
+        amount {
+          amount
+        }
       }
       lines {
         totalPrice {
@@ -41,6 +53,7 @@ mutation OrderUpdateShipping($input: OrderUpdateShippingInput!, $id: ID!) {
           ...BaseTaxedMoney
         }
         unitDiscountReason
+        isGift
       }
     }
   }


### PR DESCRIPTION
I want to merge this change because it adds tests for order promotion and manual discounts on draft orders


[CORE_0223	Should be able to apply manual fixed discount for total order on draft order](https://saleor.testmo.net/repositories/5?group_id=112&case_id=24328)
[CORE_0224	Should be able to apply manual percentage discount for total order on draft order](https://saleor.testmo.net/repositories/5?group_id=112&case_id=24327)
[CORE_2126	Order promotion should be applied to draft order with specific total](https://saleor.testmo.net/repositories/5?group_id=11&case_id=7967)
[CORE_2127	Order promotion should be applied to draft order with specific subtotal](https://saleor.testmo.net/repositories/5?group_id=133&case_id=7968)
[CORE_2140	Order promotion with gift reward should be applied to draft order with specific total](https://saleor.testmo.net/repositories/5?group_id=11&case_id=24332)

It's part of the task: https://linear.app/saleor/issue/QAG-218/implement-core-e2e-for-discounts-in-draft-orders


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
