### PR TITLE
Fix `EventPayload` and `EventDelivery` creation (#16721)

### DIFF
--- a/saleor/webhook/tests/test_webhook_protocols.py
+++ b/saleor/webhook/tests/test_webhook_protocols.py
@@ -459,7 +459,7 @@ def test_trigger_webhooks_async_pick_up_queue_based_on_protocol(
     expected_data = serialize("json", [order_with_lines])
 
     # when
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(7):
         trigger_webhooks_async(
             expected_data,
             WebhookEventAsyncType.ORDER_CREATED,

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from celery import group
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.db import transaction
 
 from ....celeryconf import app
 from ....core import EventDeliveryStatus
@@ -136,10 +137,12 @@ def create_deliveries_for_subscriptions(
         )
 
     with allow_writer():
-        EventPayload.objects.bulk_create_with_payload_files(
-            event_payloads, event_payloads_data
-        )
-        return EventDelivery.objects.bulk_create(event_deliveries)
+        # Use transaction to ensure EventPayload and EventDelivery are created together, preventing inconsistent DB state.
+        with transaction.atomic():
+            EventPayload.objects.bulk_create_with_payload_files(
+                event_payloads, event_payloads_data
+            )
+            return EventDelivery.objects.bulk_create(event_deliveries)
 
 
 def group_webhooks_by_subscription(webhooks):
@@ -213,14 +216,16 @@ def trigger_webhooks_async(
             raise NotImplementedError("No payload was provided for regular webhooks.")
 
         with allow_writer():
-            payload = EventPayload.objects.create_with_payload_file(data)
-            deliveries.extend(
-                create_event_delivery_list_for_webhooks(
-                    webhooks=regular_webhooks,
-                    event_payload=payload,
-                    event_type=event_type,
+            # Use transaction to ensure EventPayload and EventDelivery are created together, preventing inconsistent DB state.
+            with transaction.atomic():
+                payload = EventPayload.objects.create_with_payload_file(data)
+                deliveries.extend(
+                    create_event_delivery_list_for_webhooks(
+                        webhooks=regular_webhooks,
+                        event_payload=payload,
+                        event_type=event_type,
+                    )
                 )
-            )
     if subscription_webhooks:
         deliveries.extend(
             create_deliveries_for_subscriptions(

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import transaction
 
 from ....celeryconf import app
 from ....core import EventDeliveryStatus
@@ -262,15 +263,17 @@ def create_delivery_for_subscription_sync_event(
         # log the issue and continue without creating a delivery.
         return None
     with allow_writer():
-        event_payload = EventPayload.objects.create_with_payload_file(
-            json.dumps({**data})
-        )
-        event_delivery = EventDelivery.objects.create(
-            status=EventDeliveryStatus.PENDING,
-            event_type=event_type,
-            payload=event_payload,
-            webhook=webhook,
-        )
+        # Use transaction to ensure EventPayload and EventDelivery are created together, preventing inconsistent DB state.
+        with transaction.atomic():
+            event_payload = EventPayload.objects.create_with_payload_file(
+                json.dumps({**data})
+            )
+            event_delivery = EventDelivery.objects.create(
+                status=EventDeliveryStatus.PENDING,
+                event_type=event_type,
+                payload=event_payload,
+                webhook=webhook,
+            )
     return event_delivery
 
 
@@ -300,13 +303,15 @@ def trigger_webhook_sync(
             return None
     else:
         with allow_writer():
-            event_payload = EventPayload.objects.create_with_payload_file(payload)
-            delivery = EventDelivery.objects.create(
-                status=EventDeliveryStatus.PENDING,
-                event_type=event_type,
-                payload=event_payload,
-                webhook=webhook,
-            )
+            # Use transaction to ensure EventPayload and EventDelivery are created together, preventing inconsistent DB state.
+            with transaction.atomic():
+                event_payload = EventPayload.objects.create_with_payload_file(payload)
+                delivery = EventDelivery.objects.create(
+                    status=EventDeliveryStatus.PENDING,
+                    event_type=event_type,
+                    payload=event_payload,
+                    webhook=webhook,
+                )
 
     kwargs = {}
     if timeout:
@@ -364,17 +369,22 @@ def trigger_all_webhooks_sync(
                 return None
         else:
             with allow_writer():
-                if event_payload is None:
-                    event_payload = EventPayload.objects.create_with_payload_file(
-                        generate_payload()
-                    )
-                delivery = EventDelivery.objects.create(
+                delivery = EventDelivery(
                     status=EventDeliveryStatus.PENDING,
                     event_type=event_type,
                     payload=event_payload,
                     webhook=webhook,
                 )
-
+                if event_payload is None:
+                    # Use transaction to ensure EventPayload and EventDelivery are created together, preventing inconsistent DB state.
+                    with transaction.atomic():
+                        event_payload = EventPayload.objects.create_with_payload_file(
+                            generate_payload()
+                        )
+                        delivery.payload = event_payload
+                        delivery.save()
+                else:
+                    delivery.save()
         response_data = send_webhook_request_sync(delivery)
         if parsed_response := parse_response(response_data):
             return parsed_response


### PR DESCRIPTION
I want to merge this change as it ensure atomic creation of EventPayload and related EventDelivery. This will prevent inconsistent DB state where payloads exist without deliveries what can lead to errors

Port #16721 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
