### PR TITLE
Add validation for tax data received from the Avatax plugin. 

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -271,6 +271,8 @@ def _fetch_checkout_prices_if_expired(
     Prices can be updated only if force_update == True, or if time elapsed from the
     last price update is greater than settings.CHECKOUT_PRICES_TTL.
     """
+    from .utils import checkout_info_for_logs
+
     if pregenerated_subscription_payloads is None:
         pregenerated_subscription_payloads = {}
 
@@ -315,6 +317,10 @@ def _fetch_checkout_prices_if_expired(
                 pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             )
         except TaxDataError as e:
+            if str(e) != TaxDataErrorMessage.EMPTY:
+                logger.warning(
+                    str(e), extra=checkout_info_for_logs(checkout_info, lines)
+                )
             _set_checkout_base_prices(checkout, checkout_info, lines)
             checkout.tax_error = str(e)
 
@@ -342,6 +348,10 @@ def _fetch_checkout_prices_if_expired(
                     pregenerated_subscription_payloads=pregenerated_subscription_payloads,
                 )
             except TaxDataError as e:
+                if str(e) != TaxDataErrorMessage.EMPTY:
+                    logger.warning(
+                        str(e), extra=checkout_info_for_logs(checkout_info, lines)
+                    )
                 _set_checkout_base_prices(checkout, checkout_info, lines)
                 checkout.tax_error = str(e)
         else:

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -474,7 +474,7 @@ def _call_plugin_or_tax_app(
             plugin_ids=plugin_ids,
         )
         if checkout.tax_error:
-            raise TaxDataError(TaxDataErrorMessage.EMPTY)
+            raise TaxDataError(checkout.tax_error)
     else:
         tax_data = manager.get_taxes_for_checkout(
             checkout_info,

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -17,6 +17,7 @@ from ...core.taxes import (
     TaxLineData,
     zero_taxed_money,
 )
+from ...graphql.core.utils import to_global_id_or_none
 from ...plugins import PLUGIN_IDENTIFIER_PREFIX
 from ...plugins.avatax.plugin import AvataxPlugin
 from ...plugins.avatax.tests.conftest import plugin_configuration  # noqa: F401
@@ -819,6 +820,7 @@ def test_fetch_checkout_data_tax_data_with_negative_values(
     # then
     assert checkout_info.checkout.tax_error == TaxDataErrorMessage.NEGATIVE_VALUE
     assert TaxDataErrorMessage.NEGATIVE_VALUE in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
 
 
 @pytest.mark.parametrize(
@@ -880,6 +882,7 @@ def test_fetch_checkout_data_tax_data_with_wrong_number_of_lines(
     # then
     assert checkout_info.checkout.tax_error == TaxDataErrorMessage.LINE_NUMBER
     assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
 
 
 @pytest.mark.parametrize(
@@ -936,6 +939,7 @@ def test_fetch_checkout_data_tax_data_with_price_overflow(
     # then
     assert checkout_info.checkout.tax_error == TaxDataErrorMessage.OVERFLOW
     assert TaxDataErrorMessage.OVERFLOW in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
 
 
 @patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
@@ -980,6 +984,7 @@ def test_fetch_order_data_plugin_tax_data_with_negative_values(
     # then
     assert checkout.tax_error == TaxDataErrorMessage.NEGATIVE_VALUE
     assert TaxDataErrorMessage.NEGATIVE_VALUE in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
 
 
 @patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
@@ -1029,6 +1034,7 @@ def test_fetch_order_data_plugin_tax_data_with_wrong_number_of_lines(
     # then
     assert checkout.tax_error == TaxDataErrorMessage.LINE_NUMBER
     assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
 
 
 @patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
@@ -1079,6 +1085,7 @@ def test_fetch_order_data_plugin_tax_data_with_wrong_number_of_lines_no_shipping
     # then
     assert checkout.tax_error == TaxDataErrorMessage.LINE_NUMBER
     assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
 
 
 @patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
@@ -1123,3 +1130,4 @@ def test_fetch_order_data_plugin_tax_data_price_overflow(
     # then
     assert checkout.tax_error == TaxDataErrorMessage.OVERFLOW
     assert TaxDataErrorMessage.OVERFLOW in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)

--- a/saleor/checkout/tests/test_utils.py
+++ b/saleor/checkout/tests/test_utils.py
@@ -1,9 +1,12 @@
 from decimal import Decimal
 
+import graphene
 import pytest
 from prices import Money, TaxedMoney
 
+from ...discount import DiscountType, DiscountValueType
 from ...tax.calculations import get_taxed_undiscounted_price
+from ..utils import checkout_info_for_logs
 
 BASE = Money("35.00", "USD")
 
@@ -50,3 +53,39 @@ def test_get_taxed_undiscounted_price(price, tax_rate, prices_entered_with_tax, 
     )
 
     assert result_price == result
+
+
+def test_checkout_info_for_logs(checkout_info, voucher, order_promotion_with_rule):
+    # given
+    checkout = checkout_info.checkout
+    voucher_code = voucher.codes.first().code
+    checkout.voucher_code = voucher_code
+
+    checkout_discount = checkout.discounts.create(
+        type=DiscountType.ORDER_PROMOTION,
+        value_type=DiscountValueType.FIXED,
+        value=Decimal(5),
+        amount_value=Decimal(5),
+        promotion_rule=order_promotion_with_rule.rules.first(),
+        currency=checkout.currency,
+    )
+    checkout_info.discounts = [checkout_discount]
+
+    lines_info = checkout_info.lines
+    line_discount = lines_info[0].line.discounts.create(
+        type=DiscountType.VOUCHER,
+        value_type=DiscountValueType.FIXED,
+        value=Decimal(5),
+        currency=checkout.currency,
+        amount_value=Decimal(5),
+        voucher=voucher,
+    )
+    lines_info[0].discounts = [line_discount]
+
+    # when
+    extra = checkout_info_for_logs(checkout_info, lines_info)
+
+    # then
+    assert extra["checkout_id"] == graphene.Node.to_global_id("Checkout", checkout.pk)
+    assert extra["discounts"]
+    assert extra["lines"][0]["discounts"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -503,9 +503,11 @@ def test_checkout_complete_calls_failing_plugin(
     settings,
 ):
     # given
+    tax_error_message = "Test error"
+
     def side_effect(checkout_info, *args, **kwargs):
         price = Money("10.0", checkout_info.checkout.currency)
-        checkout_info.checkout.tax_error = "Test error"
+        checkout_info.checkout.tax_error = tax_error_message
         return TaxedMoney(price, price)
 
     mock_calculate_checkout_line_total.side_effect = side_effect
@@ -542,7 +544,7 @@ def test_checkout_complete_calls_failing_plugin(
 
     checkout.refresh_from_db()
     assert checkout.price_expiration == timezone.now() + settings.CHECKOUT_PRICES_TTL
-    assert checkout.tax_error == "Empty tax data."
+    assert checkout.tax_error == tax_error_message
 
 
 @freeze_time()

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1217,9 +1217,11 @@ def test_draft_order_complete_calls_failing_plugin(
     channel_USD,
 ):
     # given
+    tax_error_message = "Test error"
+
     def side_effect(order, *args, **kwargs):
         price = Money("10.0", order.currency)
-        order.tax_error = "Test error"
+        order.tax_error = tax_error_message
         return OrderTaxedPricesData(
             price_with_discounts=TaxedMoney(price, price),
             undiscounted_price=TaxedMoney(price, price),
@@ -1253,7 +1255,7 @@ def test_draft_order_complete_calls_failing_plugin(
 
     order.refresh_from_db()
     assert not order.should_refresh_prices
-    assert order.tax_error == "Empty tax data."
+    assert order.tax_error == tax_error_message
 
 
 DRAFT_ORDER_COMPLETE_WITH_DISCOUNTS_MUTATION = """

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -36,7 +36,7 @@ from .base_calculations import apply_order_discounts, base_order_line_total
 from .fetch import EditableOrderLineInfo, fetch_draft_order_lines_info
 from .interface import OrderTaxedPricesData
 from .models import Order, OrderLine
-from .utils import log_address_if_validation_skipped_for_order
+from .utils import log_address_if_validation_skipped_for_order, order_info_for_logs
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +169,8 @@ def _recalculate_prices(
                 database_connection_name=database_connection_name,
             )
         except TaxDataError as e:
+            if str(e) != TaxDataErrorMessage.EMPTY:
+                logger.warning(str(e), extra=order_info_for_logs(order, lines))
             order.tax_error = str(e)
 
         if not should_charge_tax:
@@ -192,6 +194,8 @@ def _recalculate_prices(
                     database_connection_name=database_connection_name,
                 )
             except TaxDataError as e:
+                if str(e) != TaxDataErrorMessage.EMPTY:
+                    logger.warning(str(e), extra=order_info_for_logs(order, lines))
                 order.tax_error = str(e)
         else:
             _remove_tax(order, lines)

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -259,7 +259,7 @@ def _call_plugin_or_tax_app(
             plugin_ids=plugin_ids,
         )
         if order.tax_error:
-            raise TaxDataError(TaxDataErrorMessage.EMPTY)
+            raise TaxDataError(order.tax_error)
     else:
         tax_data = manager.get_taxes_for_order(order, tax_app_identifier)
         if tax_data is None:

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -15,6 +15,7 @@ from ...core.taxes import (
     zero_taxed_money,
 )
 from ...discount import DiscountValueType
+from ...graphql.core.utils import to_global_id_or_none
 from ...plugins import PLUGIN_IDENTIFIER_PREFIX
 from ...plugins.avatax.plugin import AvataxPlugin
 from ...plugins.avatax.tests.conftest import plugin_configuration  # noqa: F401
@@ -1350,6 +1351,7 @@ def test_fetch_order_data_tax_data_with_negative_values(
     # then
     assert order.tax_error == TaxDataErrorMessage.NEGATIVE_VALUE
     assert TaxDataErrorMessage.NEGATIVE_VALUE in caplog.text
+    assert caplog.records[0].order_id == to_global_id_or_none(order)
 
 
 @pytest.mark.parametrize(
@@ -1404,6 +1406,7 @@ def test_fetch_order_data_tax_data_with_wrong_number_of_lines(
     # then
     assert order.tax_error == TaxDataErrorMessage.LINE_NUMBER
     assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
+    assert caplog.records[0].order_id == to_global_id_or_none(order)
 
 
 @pytest.mark.parametrize(
@@ -1463,6 +1466,7 @@ def test_fetch_order_data_tax_data_with_price_overflow(
     # then
     assert order.tax_error == TaxDataErrorMessage.OVERFLOW
     assert TaxDataErrorMessage.OVERFLOW in caplog.text
+    assert caplog.records[0].order_id == to_global_id_or_none(order)
 
 
 @patch("saleor.plugins.avatax.plugin.get_order_tax_data")
@@ -1510,6 +1514,7 @@ def test_fetch_order_data_plugin_tax_data_with_negative_values(
     # then
     assert order.tax_error == TaxDataErrorMessage.NEGATIVE_VALUE
     assert TaxDataErrorMessage.NEGATIVE_VALUE in caplog.text
+    assert caplog.records[0].order_id == to_global_id_or_none(order)
 
 
 @patch("saleor.plugins.avatax.plugin.get_order_tax_data")
@@ -1552,6 +1557,7 @@ def test_fetch_order_data_plugin_tax_data_with_wrong_number_of_lines(
     # then
     assert order.tax_error == TaxDataErrorMessage.LINE_NUMBER
     assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
+    assert caplog.records[0].order_id == to_global_id_or_none(order)
 
 
 @patch("saleor.plugins.avatax.plugin.get_order_tax_data")
@@ -1603,6 +1609,7 @@ def test_fetch_order_data_plugin_tax_data_with_wrong_number_of_lines_no_shipping
     # then
     assert order.tax_error == TaxDataErrorMessage.LINE_NUMBER
     assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
+    assert caplog.records[0].order_id == to_global_id_or_none(order)
 
 
 @patch("saleor.plugins.avatax.plugin.get_order_tax_data")
@@ -1650,3 +1657,4 @@ def test_fetch_order_data_plugin_tax_data_price_overflow(
     # then
     assert order.tax_error == TaxDataErrorMessage.OVERFLOW
     assert TaxDataErrorMessage.OVERFLOW in caplog.text
+    assert caplog.records[0].order_id == to_global_id_or_none(order)

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -54,7 +54,7 @@ from . import (
     OrderStatus,
     events,
 )
-from .fetch import OrderLineInfo
+from .fetch import OrderLineInfo, fetch_draft_order_lines_info
 from .models import Order, OrderGrantedRefund, OrderLine
 
 if TYPE_CHECKING:
@@ -1210,3 +1210,71 @@ def get_address_for_order_taxes(order: "Order"):
     else:
         address = order.shipping_address or order.billing_address
     return address
+
+
+def order_info_for_logs(order: Order, lines: Iterable[OrderLine]):
+    from ..discount.utils.shared import discount_info_for_logs
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    tax_configuration = order.channel.tax_configuration
+    lines_info = fetch_draft_order_lines_info(order, lines)
+
+    return {
+        "order_id": order_id,
+        "orderId": order_id,
+        "order": {
+            "currency": order.currency,
+            "status": order.status,
+            "origin": order.origin,
+            "checkout_id": order.checkout_token,
+            "undiscounted_base_shipping_price_amount": order.undiscounted_base_shipping_price_amount,
+            "base_shipping_price_amount": order.base_shipping_price_amount,
+            "shipping_price_net_amount": order.shipping_price_net_amount,
+            "shipping_price_gross_amount": order.shipping_price_gross_amount,
+            "undiscounted_total_net_amount": order.undiscounted_total_net_amount,
+            "total_net_amount": order.total_net_amount,
+            "undiscounted_total_gross_amount": order.undiscounted_total_gross_amount,
+            "total_gross_amount": order.total_gross_amount,
+            "subtotal_net_amount": order.subtotal_net_amount,
+            "subtotal_gross_amount": order.subtotal_gross_amount,
+            "has_voucher_code": bool(order.voucher_code),
+            "tax_exemption": order.tax_exemption,
+            "tax_error": order.tax_error,
+        },
+        "tax_configuration": {
+            "charge_taxes": tax_configuration.charge_taxes,
+            "tax_calculation_strategy": tax_configuration.tax_calculation_strategy,
+            "prices_entered_with_tax": tax_configuration.prices_entered_with_tax,
+            "tax_app_id": tax_configuration.tax_app_id,
+        },
+        "discounts": discount_info_for_logs(order.discounts.all()),
+        "lines": [
+            {
+                "id": graphene.Node.to_global_id("OrderLine", line_info.line.pk),
+                "variant_id": graphene.Node.to_global_id(
+                    "ProductVariant", line_info.line.variant_id
+                ),
+                "quantity": line_info.line.quantity,
+                "is_gift_card": line_info.line.is_gift_card,
+                "is_price_overridden": line_info.line.is_price_overridden,
+                "undiscounted_base_unit_price_amount": line_info.line.undiscounted_base_unit_price_amount,
+                "base_unit_price_amount": line_info.line.base_unit_price_amount,
+                "undiscounted_unit_price_net_amount": line_info.line.undiscounted_unit_price_net_amount,
+                "undiscounted_unit_price_gross_amount": line_info.line.undiscounted_unit_price_gross_amount,
+                "unit_price_net_amount": line_info.line.unit_price_net_amount,
+                "unit_price_gross_amount": line_info.line.unit_price_gross_amount,
+                "undiscounted_total_price_net_amount": line_info.line.undiscounted_total_price_net_amount,
+                "undiscounted_total_price_gross_amount": line_info.line.undiscounted_total_price_gross_amount,
+                "total_price_net_amount": line_info.line.total_price_net_amount,
+                "total_price_gross_amount": line_info.line.total_price_gross_amount,
+                "has_voucher_code": bool(line_info.line.voucher_code),
+                "variant_listing_price": line_info.channel_listing.price_amount,
+                "variant_listing_discounted_price": line_info.channel_listing.discounted_price_amount,
+                "unit_discount_amount": line_info.line.unit_discount_amount,
+                "unit_discount_type": line_info.line.unit_discount_type,
+                "unit_discount_reason": line_info.line.unit_discount_reason,
+                "discounts": discount_info_for_logs(line_info.discounts),
+            }
+            for line_info in lines_info
+        ],
+    }

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -15,10 +15,21 @@ from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...checkout import base_calculations
 from ...checkout.fetch import fetch_checkout_lines
-from ...checkout.utils import log_address_if_validation_skipped_for_checkout
-from ...core.taxes import TaxError, TaxType, zero_taxed_money
+from ...checkout.utils import (
+    is_shipping_required as is_shipping_required_for_checkout,
+)
+from ...checkout.utils import (
+    log_address_if_validation_skipped_for_checkout,
+)
+from ...core.taxes import (
+    TaxDataErrorMessage,
+    TaxError,
+    TaxType,
+    zero_taxed_money,
+)
 from ...order import base_calculations as order_base_calculation
 from ...order.interface import OrderTaxedPricesData
+from ...order.utils import is_shipping_required as is_shipping_required_for_order
 from ...product.models import ProductType
 from ...tax import TaxCalculationStrategy
 from ...tax.utils import (
@@ -736,18 +747,31 @@ class AvataxPlugin(BasePlugin):
         base_value: Union[TaxedMoney, Decimal],
     ):
         if self._skip_plugin(base_value):
-            self._set_checkout_tax_error(checkout_info, lines_info)
+            self._set_checkout_tax_error(
+                checkout_info, lines_info, TaxDataErrorMessage.EMPTY
+            )
             return None
 
         valid = _validate_checkout(checkout_info, lines_info)
         if not valid:
-            self._set_checkout_tax_error(checkout_info, lines_info)
+            self._set_checkout_tax_error(
+                checkout_info, lines_info, TaxDataErrorMessage.EMPTY
+            )
             return None
 
         response = get_checkout_tax_data(checkout_info, lines_info, self.config)
 
         if not response or "error" in response:
-            self._set_checkout_tax_error(checkout_info, lines_info)
+            self._set_checkout_tax_error(
+                checkout_info, lines_info, TaxDataErrorMessage.EMPTY
+            )
+            return None
+
+        is_shipping_required = is_shipping_required_for_checkout(lines_info)
+        if tax_error := self.validate_tax_data(
+            response, lines_info, is_shipping_required
+        ):
+            self._set_checkout_tax_error(checkout_info, lines_info, tax_error)
             return None
 
         return response
@@ -756,34 +780,41 @@ class AvataxPlugin(BasePlugin):
         self,
         checkout_info: "CheckoutInfo",
         lines_info: Iterable["CheckoutLineInfo"],
+        tax_error_message: str,
     ) -> None:
         app_identifier = get_tax_app_identifier_for_checkout(checkout_info, lines_info)
         if app_identifier == self.PLUGIN_IDENTIFIER:
-            checkout_info.checkout.tax_error = "Empty tax data."
+            checkout_info.checkout.tax_error = tax_error_message
 
     def _get_order_tax_data(
         self, order: "Order", base_value: Union[Decimal, OrderTaxedPricesData]
     ):
         if self._skip_plugin(base_value):
-            self._set_order_tax_error(order)
+            self._set_order_tax_error(order, TaxDataErrorMessage.EMPTY)
             return None
 
         valid = _validate_order(order)
         if not valid:
-            self._set_order_tax_error(order)
+            self._set_order_tax_error(order, TaxDataErrorMessage.EMPTY)
             return None
 
         response = get_order_tax_data(order, self.config, False)
         if not response or "error" in response:
-            self._set_order_tax_error(order)
+            self._set_order_tax_error(order, TaxDataErrorMessage.EMPTY)
+            return None
+
+        lines = order.lines.all()
+        is_shipping_required = is_shipping_required_for_order(lines)
+        if tax_error := self.validate_tax_data(response, lines, is_shipping_required):
+            self._set_order_tax_error(order, tax_error)
             return None
 
         return response
 
-    def _set_order_tax_error(self, order: "Order") -> None:
+    def _set_order_tax_error(self, order: "Order", tax_error: str) -> None:
         app_identifier = get_tax_app_identifier_for_order(order)
         if app_identifier == self.PLUGIN_IDENTIFIER:
-            order.tax_error = "Empty tax data."
+            order.tax_error = tax_error
 
     @staticmethod
     def _get_unit_tax_rate(
@@ -910,3 +941,65 @@ class AvataxPlugin(BasePlugin):
                 )
 
             cls.validate_authentication(plugin_configuration)
+
+    @classmethod
+    def validate_tax_data(
+        cls, tax_data: dict[str, Any], lines: Iterable, is_shipping_required: bool
+    ) -> str:
+        if tax_data is None:
+            return TaxDataErrorMessage.EMPTY
+
+        if cls.check_negative_values_in_plugin_tax_data(tax_data):
+            logger.warning(TaxDataErrorMessage.NEGATIVE_VALUE)
+            return TaxDataErrorMessage.NEGATIVE_VALUE
+
+        if cls.check_line_number_in_plugin_tax_data(
+            tax_data, lines, is_shipping_required
+        ):
+            logger.warning(TaxDataErrorMessage.LINE_NUMBER)
+            return TaxDataErrorMessage.LINE_NUMBER
+
+        if cls.check_overflows_in_plugin_tax_data(tax_data):
+            logger.warning(TaxDataErrorMessage.OVERFLOW)
+            return TaxDataErrorMessage.OVERFLOW
+
+    @classmethod
+    def check_negative_values_in_plugin_tax_data(cls, tax_data: dict[str, Any]) -> bool:
+        """Check if tax data contains negative values."""
+        if not tax_data:
+            return False
+
+        for line in tax_data.get("lines", []):
+            if line.get("lineAmount", 0) < 0:
+                return True
+
+        return False
+
+    @classmethod
+    def check_line_number_in_plugin_tax_data(
+        cls, tax_data: dict[str, Any], lines: Iterable, is_shipping_required: bool
+    ) -> bool:
+        """Check if tax data contains same line number as input data."""
+        if not tax_data:
+            return False
+
+        tax_lines = tax_data.get("lines", [])
+        # shipping data is represented as additional order line
+        shipping_line = 1 if is_shipping_required else 0
+        if len(tax_lines) != sum(1 for _ in lines) + shipping_line:
+            return True
+
+        return False
+
+    @classmethod
+    def check_overflows_in_plugin_tax_data(cls, tax_data: dict[str, Any]) -> bool:
+        """Check if line prices are lower than a billion."""
+        if not tax_data:
+            return False
+
+        max_price = 999999999
+        for line in tax_data.get("lines", []):
+            if line.get("lineAmount", 0) > max_price:
+                return True
+
+        return False

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -21,6 +21,7 @@ from ...checkout.utils import (
 from ...checkout.utils import (
     log_address_if_validation_skipped_for_checkout,
 )
+from ...core.prices import MAXIMUM_PRICE
 from ...core.taxes import (
     TaxDataErrorMessage,
     TaxError,
@@ -946,7 +947,7 @@ class AvataxPlugin(BasePlugin):
     def validate_tax_data(
         cls, tax_data: dict[str, Any], lines: Iterable, is_shipping_required: bool
     ) -> str:
-        if tax_data is None:
+        if not tax_data:
             return TaxDataErrorMessage.EMPTY
 
         if cls.check_negative_values_in_plugin_tax_data(tax_data):
@@ -962,6 +963,8 @@ class AvataxPlugin(BasePlugin):
         if cls.check_overflows_in_plugin_tax_data(tax_data):
             logger.warning(TaxDataErrorMessage.OVERFLOW)
             return TaxDataErrorMessage.OVERFLOW
+
+        return ""
 
     @classmethod
     def check_negative_values_in_plugin_tax_data(cls, tax_data: dict[str, Any]) -> bool:
@@ -997,9 +1000,8 @@ class AvataxPlugin(BasePlugin):
         if not tax_data:
             return False
 
-        max_price = 999999999
         for line in tax_data.get("lines", []):
-            if line.get("lineAmount", 0) > max_price:
+            if line.get("lineAmount", 0) > MAXIMUM_PRICE:
                 return True
 
         return False

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -951,17 +951,14 @@ class AvataxPlugin(BasePlugin):
             return TaxDataErrorMessage.EMPTY
 
         if cls.check_negative_values_in_plugin_tax_data(tax_data):
-            logger.warning(TaxDataErrorMessage.NEGATIVE_VALUE)
             return TaxDataErrorMessage.NEGATIVE_VALUE
 
         if cls.check_line_number_in_plugin_tax_data(
             tax_data, lines, is_shipping_required
         ):
-            logger.warning(TaxDataErrorMessage.LINE_NUMBER)
             return TaxDataErrorMessage.LINE_NUMBER
 
         if cls.check_overflows_in_plugin_tax_data(tax_data):
-            logger.warning(TaxDataErrorMessage.OVERFLOW)
             return TaxDataErrorMessage.OVERFLOW
 
         return ""

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -988,8 +988,8 @@ class AvataxPlugin(BasePlugin):
 
         tax_lines = tax_data.get("lines", [])
         # shipping data is represented as additional order line
-        shipping_line = 1 if is_shipping_required else 0
-        if len(tax_lines) != sum(1 for _ in lines) + shipping_line:
+        expected_lines_length = len(list(lines)) + (1 if is_shipping_required else 0)
+        if len(tax_lines) != expected_lines_length:
             return True
 
         return False

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -6410,7 +6410,6 @@ def test_validate_plugin_tax_data_with_negative_values(lines_info, caplog):
 
     # then
     assert error_message == TaxDataErrorMessage.NEGATIVE_VALUE
-    assert TaxDataErrorMessage.NEGATIVE_VALUE in caplog.text
 
 
 def test_validate_plugin_tax_data_line_number(lines_info, caplog):
@@ -6435,7 +6434,6 @@ def test_validate_plugin_tax_data_line_number(lines_info, caplog):
 
     # then
     assert error_message == TaxDataErrorMessage.LINE_NUMBER
-    assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
 
 
 def test_validate_plugin_tax_data_price_overflow(lines_info, caplog):
@@ -6465,4 +6463,3 @@ def test_validate_plugin_tax_data_price_overflow(lines_info, caplog):
 
     # then
     assert error_message == TaxDataErrorMessage.OVERFLOW
-    assert TaxDataErrorMessage.OVERFLOW in caplog.text

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -11,9 +11,11 @@ from ..plugin import AvataxPlugin
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_total_use_cache(
     mock_cache_set,
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -42,6 +44,7 @@ def test_calculate_checkout_total_use_cache(
         )
     )
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", mocked_cache)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_total(
@@ -57,7 +60,9 @@ def test_calculate_checkout_total_use_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 def test_calculate_checkout_total_save_avatax_response_in_cache(
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -80,6 +85,7 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
     monkeypatch.setattr("saleor.plugins.avatax.api_post_request", mocked_avalara)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_total(
@@ -100,9 +106,11 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_subtotal_use_cache(
     mock_cache_set,
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -131,6 +139,7 @@ def test_calculate_checkout_subtotal_use_cache(
         )
     )
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", mocked_cache)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_subtotal(
@@ -146,7 +155,9 @@ def test_calculate_checkout_subtotal_use_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -169,6 +180,7 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
     monkeypatch.setattr("saleor.plugins.avatax.api_post_request", mocked_avalara)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_subtotal(
@@ -189,9 +201,11 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_shipping_use_cache(
     mock_cache_set,
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -220,6 +234,7 @@ def test_calculate_checkout_shipping_use_cache(
         )
     )
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", mocked_cache)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_shipping(
@@ -235,7 +250,9 @@ def test_calculate_checkout_shipping_use_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 def test_calculate_checkout_shipping_save_avatax_response_in_cache(
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -258,6 +275,7 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
     monkeypatch.setattr("saleor.plugins.avatax.api_post_request", mocked_avalara)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_shipping(
@@ -278,9 +296,11 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_line_total_use_cache(
     mock_cache_set,
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -310,6 +330,7 @@ def test_calculate_checkout_line_total_use_cache(
         )
     )
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", mocked_cache)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_line_total(
@@ -328,7 +349,9 @@ def test_calculate_checkout_line_total_use_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 def test_calculate_checkout_line_save_avatax_response_in_cache(
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -352,6 +375,7 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
     monkeypatch.setattr("saleor.plugins.avatax.api_post_request", mocked_avalara)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_line_total(
@@ -372,9 +396,11 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_line_unit_price_use_cache(
     mock_cache_set,
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -404,6 +430,7 @@ def test_calculate_checkout_line_unit_price_use_cache(
         )
     )
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", mocked_cache)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_line_unit_price(
@@ -422,7 +449,9 @@ def test_calculate_checkout_line_unit_price_use_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -446,6 +475,7 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
     monkeypatch.setattr("saleor.plugins.avatax.api_post_request", mocked_avalara)
+    mock_validate_tax_data.return_value = ""
 
     # then
     result = manager.calculate_checkout_line_unit_price(
@@ -472,9 +502,11 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_get_checkout_line_tax_rate_use_cache(
     mock_cache_set,
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -504,6 +536,7 @@ def test_get_checkout_line_tax_rate_use_cache(
         )
     )
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", mocked_cache)
+    mock_validate_tax_data.return_value = ""
     fake_unit_price = TaxedMoney(net=Money("2", "USD"), gross=Money("10", "USD"))
 
     # then
@@ -524,7 +557,9 @@ def test_get_checkout_line_tax_rate_use_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -548,6 +583,7 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
     monkeypatch.setattr("saleor.plugins.avatax.api_post_request", mocked_avalara)
+    mock_validate_tax_data.return_value = ""
     fake_unit_price = TaxedMoney(net=Money("2", "USD"), gross=Money("10", "USD"))
 
     # then
@@ -577,9 +613,11 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_get_checkout_shipping_tax_rate_use_cache(
     mock_cache_set,
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -608,6 +646,7 @@ def test_get_checkout_shipping_tax_rate_use_cache(
         )
     )
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", mocked_cache)
+    mock_validate_tax_data.return_value = ""
     fake_shipping_price = TaxedMoney(net=Money("2", "USD"), gross=Money("10", "USD"))
 
     # then
@@ -624,7 +663,9 @@ def test_get_checkout_shipping_tax_rate_use_cache(
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
 def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
+    mock_validate_tax_data,
     checkout_with_items_and_shipping,
     checkout_with_items_and_shipping_info,
     address,
@@ -647,6 +688,7 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
     monkeypatch.setattr("saleor.plugins.avatax.api_post_request", mocked_avalara)
+    mock_validate_tax_data.return_value = ""
     fake_shipping_price = TaxedMoney(net=Money("2", "USD"), gross=Money("10", "USD"))
 
     # then

--- a/saleor/tax/tests/test_utils.py
+++ b/saleor/tax/tests/test_utils.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 import pytest
 
-from ...core.taxes import TaxData, TaxDataError, TaxDataErrorMessage, TaxLineData
+from ...core.taxes import TaxData, TaxDataError, TaxLineData
 from ...core.utils.country import get_active_country
 from ..utils import (
     get_charge_taxes,
@@ -150,8 +150,6 @@ def test_validate_tax_data_with_negative_values(lines_info, caplog):
     with pytest.raises(TaxDataError):
         validate_tax_data(tax_data, lines_info)
 
-    assert TaxDataErrorMessage.NEGATIVE_VALUE in caplog.text
-
 
 def test_validate_tax_data_line_number(lines_info, caplog):
     # given
@@ -173,8 +171,6 @@ def test_validate_tax_data_line_number(lines_info, caplog):
     # when & then
     with pytest.raises(TaxDataError):
         validate_tax_data(tax_data, lines_info)
-
-    assert TaxDataErrorMessage.LINE_NUMBER in caplog.text
 
 
 def test_validate_tax_data_tax_rate_overflow(lines_info, caplog):
@@ -203,8 +199,6 @@ def test_validate_tax_data_tax_rate_overflow(lines_info, caplog):
     with pytest.raises(TaxDataError):
         validate_tax_data(tax_data, lines_info)
 
-    assert TaxDataErrorMessage.OVERFLOW in caplog.text
-
 
 def test_validate_tax_data_price_overflow(lines_info, caplog):
     # given
@@ -231,5 +225,3 @@ def test_validate_tax_data_price_overflow(lines_info, caplog):
     # when & then
     with pytest.raises(TaxDataError):
         validate_tax_data(tax_data, lines_info)
-
-    assert TaxDataErrorMessage.OVERFLOW in caplog.text

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -265,15 +265,12 @@ def validate_tax_data(
         raise TaxDataError(TaxDataErrorMessage.EMPTY)
 
     if check_negative_values_in_tax_data(tax_data):
-        logger.warning(TaxDataErrorMessage.NEGATIVE_VALUE)
         raise TaxDataError(TaxDataErrorMessage.NEGATIVE_VALUE)
 
     if check_line_number_in_tax_data(tax_data, lines):
-        logger.warning(TaxDataErrorMessage.LINE_NUMBER)
         raise TaxDataError(TaxDataErrorMessage.LINE_NUMBER)
 
     if check_overflows_in_tax_data(tax_data):
-        logger.warning(TaxDataErrorMessage.OVERFLOW)
         raise TaxDataError(TaxDataErrorMessage.OVERFLOW)
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -955,6 +955,15 @@ def checkout_with_items_and_shipping(checkout_with_items, address, shipping_meth
 
 
 @pytest.fixture
+def checkout_with_item_and_shipping(checkout_with_item, address, shipping_method):
+    checkout_with_item.shipping_address = address
+    checkout_with_item.shipping_method = shipping_method
+    checkout_with_item.billing_address = address
+    checkout_with_item.save()
+    return checkout_with_item
+
+
+@pytest.fixture
 def checkout_with_voucher(checkout, product, voucher):
     variant = product.variants.get()
     checkout_info = fetch_checkout_info(


### PR DESCRIPTION
I want to merge this change because it validates tax data received from the Avatax plugin. We consider tax data invalid when:
- contains negative values
- the number of lines from tax data doesn't match the line number from the order
- price value exceeds 999.999.999

Part of: https://linear.app/saleor/issue/SHOPX-919

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
