### PR TITLE
[TEST] Add test for update metadata on draft order

### DIFF
--- a/saleor/tests/e2e/metadata/utils/__init__.py
+++ b/saleor/tests/e2e/metadata/utils/__init__.py
@@ -1,7 +1,11 @@
+from .delete_metadata import delete_metadata
+from .delete_private_metadata import delete_private_metadata
 from .update_metadata import update_metadata
 from .update_private_metadata import update_private_metadata
 
 __all__ = [
+    "delete_metadata",
+    "delete_private_metadata",
     "update_metadata",
     "update_private_metadata",
 ]

--- a/saleor/tests/e2e/metadata/utils/delete_metadata.py
+++ b/saleor/tests/e2e/metadata/utils/delete_metadata.py
@@ -1,11 +1,11 @@
 from ...utils import get_graphql_content
 
-METADATA_UPDATE_MUTATION = """
-mutation UpdateMetadata(
+METADATA_DELETE_MUTATION = """
+mutation DeleteMetadata(
     $id: ID!,
-    $input:[MetadataInput!]!,
+    $keys:[String!]!,
    ) {
-  updateMetadata(id: $id, input: $input) {
+  deleteMetadata(id: $id, keys: $keys) {
     errors {
         message
         field
@@ -21,21 +21,21 @@ mutation UpdateMetadata(
 """
 
 
-def update_metadata(
+def delete_metadata(
     staff_api_client,
     id,
-    input,
+    keys,
 ):
-    variables = {"id": id, "input": input}
+    variables = {"id": id, "keys": keys}
     response = staff_api_client.post_graphql(
-        METADATA_UPDATE_MUTATION,
+        METADATA_DELETE_MUTATION,
         variables,
     )
 
     content = get_graphql_content(response)
 
-    assert content["data"]["updateMetadata"]["errors"] == []
+    assert content["data"]["deleteMetadata"]["errors"] == []
 
-    metadata = content["data"]["updateMetadata"]["item"]["metadata"]
+    metadata = content["data"]["deleteMetadata"]["item"]["metadata"]
     assert metadata is not None
     return metadata

--- a/saleor/tests/e2e/metadata/utils/delete_private_metadata.py
+++ b/saleor/tests/e2e/metadata/utils/delete_private_metadata.py
@@ -1,0 +1,41 @@
+from ...utils import get_graphql_content
+
+PRIVATE_METADATA_DELETE_MUTATION = """
+mutation DeletePrivateMetadata(
+    $id: ID!,
+    $keys:[String!]!,
+   ) {
+  deletePrivateMetadata(id: $id, keys: $keys) {
+    errors {
+        message
+        field
+    }
+    item {
+      privateMetadata {
+        key
+        value
+      }
+    }
+  }
+}
+"""
+
+
+def delete_private_metadata(
+    staff_api_client,
+    id,
+    keys,
+):
+    variables = {"id": id, "keys": keys}
+    response = staff_api_client.post_graphql(
+        PRIVATE_METADATA_DELETE_MUTATION,
+        variables,
+    )
+
+    content = get_graphql_content(response)
+
+    assert content["data"]["deletePrivateMetadata"]["errors"] == []
+
+    data = content["data"]["deletePrivateMetadata"]["item"]["privateMetadata"]
+    assert data is not None
+    return data

--- a/saleor/tests/e2e/orders/test_update_draft_order_metadata.py
+++ b/saleor/tests/e2e/orders/test_update_draft_order_metadata.py
@@ -1,0 +1,146 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..metadata.utils import (
+    delete_metadata,
+    delete_private_metadata,
+    update_metadata,
+    update_private_metadata,
+)
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    order_lines_create,
+    order_query,
+    order_update_shipping,
+)
+
+
+@pytest.mark.e2e
+def test_update_metadata_draft_order_CORE_0245(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    product_price = 33.33
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=product_price
+    )
+
+    # Step 1 - Create a draft order
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 2 - Add metadata to draft order
+    metadata_input = [
+        {"key": "metadataToBeUpdated", "value": "test value"},
+        {"key": "metadataToBeRemoved", "value": "A"},
+        {"key": "testEntityCode", "value": "A"},
+    ]
+    metadata = update_metadata(e2e_staff_api_client, order_id, metadata_input)
+    assert len(metadata) == 3
+    assert metadata[0]["key"] == "metadataToBeRemoved"
+    assert metadata[0]["value"] == "A"
+    assert metadata[1]["key"] == "metadataToBeUpdated"
+    assert metadata[1]["value"] == "test value"
+    assert metadata[2]["key"] == "testEntityCode"
+    assert metadata[2]["value"] == "A"
+
+    # Step 3 - Add order lines to the order
+    lines = [
+        {"variantId": product_variant_id, "quantity": 1},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    assert len(order["order"]["lines"]) == 1
+
+    # Step 4 - Update draft order metadata value
+    metadata_input = [{"key": "metadataToBeUpdated", "value": "updated value"}]
+    metadata = update_metadata(e2e_staff_api_client, order_id, metadata_input)
+    assert len(metadata) == 3
+    assert metadata[0]["key"] == "metadataToBeRemoved"
+    assert metadata[0]["value"] == "A"
+    assert metadata[1]["key"] == "metadataToBeUpdated"
+    assert metadata[1]["value"] == "updated value"
+    assert metadata[2]["key"] == "testEntityCode"
+    assert metadata[2]["value"] == "A"
+
+    # Step 5 - Add a shipping method to the order
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    assert order["order"]["deliveryMethod"]["id"] is not None
+
+    # Step 6 - Remove metadata from draft order
+    metadata_to_remove = ["metadataToBeRemoved"]
+    metadata = delete_metadata(e2e_staff_api_client, order_id, metadata_to_remove)
+    assert len(metadata) == 2
+    assert metadata[0]["key"] == "metadataToBeUpdated"
+    assert metadata[0]["value"] == "updated value"
+    assert metadata[1]["key"] == "testEntityCode"
+    assert metadata[1]["value"] == "A"
+
+    # Step 7 - Update private metadata
+    private_metadata = [
+        {"key": "privateMetadata", "value": "private value"},
+        {"key": "privateMetadataToBeRemoved", "value": "private value"},
+    ]
+    private_metadata = update_private_metadata(
+        e2e_staff_api_client, order_id, private_metadata
+    )
+    assert len(private_metadata) == 2
+    assert private_metadata[0]["key"] == "privateMetadata"
+    assert private_metadata[0]["value"] == "private value"
+    assert private_metadata[1]["key"] == "privateMetadataToBeRemoved"
+    assert private_metadata[1]["value"] == "private value"
+
+    # Step 8 - Delete private metadata
+    private_metadata_to_remove = ["privateMetadataToBeRemoved"]
+    private_metadata = delete_private_metadata(
+        e2e_staff_api_client, order_id, private_metadata_to_remove
+    )
+    assert len(private_metadata) == 1
+    assert private_metadata[0]["key"] == "privateMetadata"
+    assert private_metadata[0]["value"] == "private value"
+
+    # Step 8 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+
+    # Step 9 - Check if metadata is present in the order
+    order = order_query(e2e_staff_api_client, order_id)
+    metadata = order["metadata"]
+    private_metadata = order["privateMetadata"]
+    assert metadata[0]["key"] == "metadataToBeUpdated"
+    assert metadata[0]["value"] == "updated value"
+    assert metadata[1]["key"] == "testEntityCode"
+    assert metadata[1]["value"] == "A"
+    assert private_metadata[0]["key"] == "privateMetadata"
+    assert private_metadata[0]["value"] == "private value"

--- a/saleor/tests/e2e/orders/utils/order_query.py
+++ b/saleor/tests/e2e/orders/utils/order_query.py
@@ -3,7 +3,7 @@ from saleor.graphql.tests.utils import get_graphql_content
 ORDER_QUERY = """
 query OrderDetails($id: ID!) {
   order(id: $id) {
-    shippingMethods {
+    availableShippingMethods {
       id
       active
     }

--- a/saleor/tests/e2e/orders/utils/order_query.py
+++ b/saleor/tests/e2e/orders/utils/order_query.py
@@ -3,7 +3,7 @@ from saleor.graphql.tests.utils import get_graphql_content
 ORDER_QUERY = """
 query OrderDetails($id: ID!) {
   order(id: $id) {
-    availableShippingMethods {
+    shippingMethods {
       id
       active
     }
@@ -17,8 +17,8 @@ query OrderDetails($id: ID!) {
       token
     }
     events {
-        type
-      }
+      type
+    }
     channel {
       id
       name
@@ -56,9 +56,16 @@ query OrderDetails($id: ID!) {
     transactions {
       id
     }
+    metadata {
+      key
+      value
+    }
+    privateMetadata {
+      key
+      value
+    }
   }
 }
-
 """
 
 


### PR DESCRIPTION
I want to merge this change because it covers test [CORE_0245 Should be able to update draft order metadata](https://saleor.testmo.net/repositories/5?group_id=112&pagination_current=2&case_id=24366)

Internal task:
https://linear.app/saleor/issue/QAG-220/implement-core-e2e-for-applying-metadata-to-draft-orders

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
