### PR TITLE
Do not stack manual line discounts with line-level vouchers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed a bug when saving webhook payload to Azure Storage - #16585 by @delemeator
 - Added validation for tax data received from tax app - #16720 by @zedzior
 - Fixed order-level discounts handling when using tax app for tax calculation - #16696 by @zedzior
+- Fixed bug when manual line discount doesn't override line-level vouchers - #16738 by @zedzior

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -192,7 +192,7 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
             # introducing unique_type on discount models, there was such a possibility.
             line_discounts_to_remove.extend(discounts_to_update[1:])
 
-        # manual line discount do not stack with other discounts
+        # manual line discount do not stack with other line discounts
         if [
             discount
             for discount in line_info.discounts

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -440,7 +440,10 @@ def prepare_line_discount_objects_for_voucher(
         if discounts_to_update := line_info.get_voucher_discounts():
             discount_to_update = discounts_to_update[0]
 
-        if not discount_amount or line.is_gift:
+        # manual line discount do not stack with other line discounts
+        manual_line_discount = line_info.get_manual_line_discount()
+
+        if not discount_amount or line.is_gift or manual_line_discount:
             if discount_to_update:
                 line_discounts_to_remove.append(discount_to_update)
             continue

--- a/saleor/graphql/order/mutations/order_line_discount_update.py
+++ b/saleor/graphql/order/mutations/order_line_discount_update.py
@@ -62,8 +62,6 @@ class OrderLineDiscountUpdate(OrderDiscountCommon):
         order_line_before_update = copy.deepcopy(order_line)
         app = get_app_promise(info.context).get()
         with traced_atomic_transaction():
-            # TODO: Apply fixed order line discount to its total instead of unit price.
-            #  https://github.com/saleor/saleor/issues/14879
             update_discount_for_order_line(
                 order_line,
                 order=order,

--- a/saleor/tests/e2e/orders/discounts/test_order_voucher_specific_product_and_manual_line_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_voucher_specific_product_and_manual_line_discount.py
@@ -1,0 +1,331 @@
+import pytest
+
+from .....product.tasks import recalculate_discounted_price_for_products_task
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
+from ...utils import assign_permissions
+from ...vouchers.utils import (
+    create_voucher,
+    create_voucher_channel_listing,
+)
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+    order_update_shipping,
+)
+from ..utils.order_line_discount_update import order_line_discount_update
+
+
+def prepare_voucher(
+    e2e_staff_api_client,
+    channel_id,
+    voucher_code,
+    voucher_discount_type,
+    voucher_discount_value,
+    voucher_type,
+    products,
+):
+    input = {
+        "code": voucher_code,
+        "discountValueType": voucher_discount_type,
+        "type": voucher_type,
+        "singleUse": True,
+        "applyOncePerOrder": False,
+        "products": products,
+    }
+
+    voucher_data = create_voucher(e2e_staff_api_client, input)
+
+    voucher_id = voucher_data["id"]
+    channel_listing = [
+        {
+            "channelId": channel_id,
+            "discountValue": voucher_discount_value,
+        },
+    ]
+    create_voucher_channel_listing(
+        e2e_staff_api_client,
+        voucher_id,
+        channel_listing,
+    )
+
+    return voucher_code, voucher_discount_value
+
+
+@pytest.mark.e2e
+def test_draft_order_with_voucher_specific_product_and_manual_line_discount(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    """Manual line discount should override line-level voucher."""
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price_net = 15
+    product1_price = 30
+    product2_price = 55
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": False,
+    }
+
+    # Create channel, warehouse, shipping method and update tax configuration
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price_net,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": True,
+                    "allowUnpaidOrders": False,
+                    "includeDraftOrderInVoucherUsage": False,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+
+    country_tax_rate = 10
+    tax_rate = 1 + country_tax_rate / 100
+    country = "US"
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+    (
+        product1_id,
+        product1_variant_id,
+        product1_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product1_price,
+        product_type_slug="shoes",
+    )
+    (
+        product2_id,
+        product2_variant_id,
+        product2_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product2_price,
+        product_type_slug="hoodies",
+    )
+
+    # Prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    # Create voucher for specific product
+    voucher_discount_amount = 10
+    voucher_code, voucher_discount_value = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        voucher_code="10usd_off",
+        voucher_discount_type="FIXED",
+        voucher_discount_value=voucher_discount_amount,
+        voucher_type="SPECIFIC_PRODUCT",
+        products=[product1_id, product2_id],
+    )
+
+    # Step 1 - Create a draft order
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product1_variant_id, "quantity": 1},
+        {"variantId": product2_variant_id, "quantity": 1},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order_line1 = order["order"]["lines"][0]
+    order_line2 = order["order"]["lines"][1]
+
+    assert order_line1["variant"]["id"] == product1_variant_id
+    assert order_line1["unitPrice"]["net"]["amount"] == product1_variant_price
+    assert order_line2["variant"]["id"] == product2_variant_id
+    assert order_line2["unitPrice"]["net"]["amount"] == product2_variant_price
+
+    undiscounted_subtotal_net = round(
+        product1_variant_price + product2_variant_price, 2
+    )
+    undiscounted_subtotal_gross = round(undiscounted_subtotal_net * tax_rate, 2)
+    assert order["order"]["subtotal"]["net"]["amount"] == undiscounted_subtotal_net
+    assert order["order"]["subtotal"]["gross"]["amount"] == undiscounted_subtotal_gross
+
+    # Step 3 - Add a shipping method to the order
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    assert order["order"]["deliveryMethod"]["id"] is not None
+
+    shipping_price_gross = round(shipping_price_net * tax_rate, 2)
+    shipping_tax = shipping_price_gross - shipping_price_net
+    assert order["order"]["shippingPrice"]["net"]["amount"] == shipping_price_net
+    assert order["order"]["shippingPrice"]["gross"]["amount"] == shipping_price_gross
+    undiscounted_total_net = round(undiscounted_subtotal_net + shipping_price_net, 2)
+
+    undiscounted_total_gross = round(
+        undiscounted_subtotal_gross + shipping_price_gross, 2
+    )
+    assert order["order"]["total"]["net"]["amount"] == undiscounted_total_net
+    assert order["order"]["total"]["gross"]["amount"] == undiscounted_total_gross
+
+    # Step 4 - Add voucher
+    order = draft_order_update(
+        e2e_staff_api_client, order_id, {"voucherCode": voucher_code}
+    )
+
+    assert order["order"]["voucherCode"] == voucher_code
+    line_1_price_with_voucher_discount = product1_variant_price - voucher_discount_value
+    order_line1 = order["order"]["lines"][0]
+    assert (
+        order_line1["unitPrice"]["net"]["amount"] == line_1_price_with_voucher_discount
+    )
+    assert order_line1["unitDiscountReason"] == f"Voucher code: {voucher_code}"
+
+    line_2_price_with_voucher_discount = product2_variant_price - voucher_discount_value
+    order_line2 = order["order"]["lines"][1]
+    assert (
+        order_line2["unitPrice"]["net"]["amount"] == line_2_price_with_voucher_discount
+    )
+    assert order_line2["unitDiscountReason"] == f"Voucher code: {voucher_code}"
+
+    subtotal_net_with_voucher = undiscounted_subtotal_net - 2 * voucher_discount_value
+    subtotal_gross_with_voucher = round(subtotal_net_with_voucher * tax_rate, 2)
+    assert order["order"]["subtotal"]["net"]["amount"] == subtotal_net_with_voucher
+    assert order["order"]["subtotal"]["gross"]["amount"] == subtotal_gross_with_voucher
+    assert (
+        order["order"]["subtotal"]["tax"]["amount"]
+        == subtotal_gross_with_voucher - subtotal_net_with_voucher
+    )
+
+    # Step 5 - Add manual line discount
+    manual_discount_value = 5
+    manual_discount_reason = "Manual discount reason"
+    assert manual_discount_value != voucher_discount_value
+    manual_line_discount_input = {
+        "valueType": "FIXED",
+        "value": manual_discount_value,
+        "reason": manual_discount_reason,
+    }
+    data = order_line_discount_update(
+        e2e_staff_api_client, order_line1["id"], manual_line_discount_input
+    )
+
+    line_1_price_with_manual_discount = product1_variant_price - manual_discount_value
+    order_line1 = data["order"]["lines"][0]
+    assert (
+        order_line1["unitPrice"]["net"]["amount"] == line_1_price_with_manual_discount
+    )
+    assert order_line1["unitPrice"]["gross"]["amount"] == round(
+        line_1_price_with_manual_discount * tax_rate, 2
+    )
+    assert order_line1["unitDiscountReason"] == manual_discount_reason
+    assert order_line1["unitDiscount"]["amount"] == manual_discount_value
+
+    order_line2 = data["order"]["lines"][1]
+    assert (
+        order_line2["unitPrice"]["net"]["amount"] == line_2_price_with_voucher_discount
+    )
+    assert order_line2["unitPrice"]["gross"]["amount"] == round(
+        line_2_price_with_voucher_discount * tax_rate, 2
+    )
+
+    subtotal_net = (
+        line_1_price_with_manual_discount + line_2_price_with_voucher_discount
+    )
+    subtotal_gross = round(subtotal_net * tax_rate, 2)
+    subtotal_tax = subtotal_gross - subtotal_net
+    assert data["order"]["subtotal"]["net"]["amount"] == subtotal_net
+    assert data["order"]["subtotal"]["gross"]["amount"] == subtotal_gross
+    assert data["order"]["subtotal"]["tax"]["amount"] == subtotal_tax
+
+    total_net = subtotal_net + shipping_price_net
+    total_gross = subtotal_gross + shipping_price_gross
+    total_tax = total_gross - total_net
+    assert data["order"]["total"]["net"]["amount"] == total_net
+    assert data["order"]["total"]["gross"]["amount"] == total_gross
+    assert data["order"]["total"]["tax"]["amount"] == total_tax
+
+    # Step 6 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    completed_order = order["order"]
+    assert completed_order["status"] == "UNFULFILLED"
+    assert completed_order["total"]["net"]["amount"] == total_net
+    assert completed_order["total"]["gross"]["amount"] == total_gross
+    assert completed_order["total"]["tax"]["amount"] == total_tax
+    assert completed_order["subtotal"]["net"]["amount"] == subtotal_net
+    assert completed_order["subtotal"]["gross"]["amount"] == subtotal_gross
+    assert completed_order["subtotal"]["tax"]["amount"] == subtotal_tax
+    assert completed_order["shippingPrice"]["net"]["amount"] == shipping_price_net
+    assert completed_order["shippingPrice"]["gross"]["amount"] == shipping_price_gross
+    assert completed_order["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert (
+        completed_order["lines"][0]["unitPrice"]["net"]["amount"]
+        == product1_variant_price - manual_discount_value
+    )
+    assert completed_order["lines"][0]["unitPrice"]["gross"]["amount"] == round(
+        line_1_price_with_manual_discount * tax_rate, 2
+    )
+    assert (
+        completed_order["lines"][0]["totalPrice"]["net"]["amount"]
+        == product1_variant_price - manual_discount_value
+    )
+    assert completed_order["lines"][0]["totalPrice"]["gross"]["amount"] == round(
+        line_1_price_with_manual_discount * tax_rate, 2
+    )
+    assert (
+        completed_order["lines"][1]["unitPrice"]["net"]["amount"]
+        == product2_variant_price - voucher_discount_value
+    )
+    assert completed_order["lines"][1]["unitPrice"]["gross"]["amount"] == round(
+        line_2_price_with_voucher_discount * tax_rate, 2
+    )
+    assert (
+        completed_order["lines"][1]["totalPrice"]["net"]["amount"]
+        == product2_variant_price - voucher_discount_value
+    )
+    assert completed_order["lines"][1]["totalPrice"]["gross"]["amount"] == round(
+        line_2_price_with_voucher_discount * tax_rate, 2
+    )

--- a/saleor/tests/e2e/orders/discounts/test_order_voucher_specific_product_and_manual_line_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_voucher_specific_product_and_manual_line_discount.py
@@ -57,7 +57,7 @@ def prepare_voucher(
 
 
 @pytest.mark.e2e
-def test_draft_order_with_voucher_specific_product_and_manual_line_discount(
+def test_draft_order_with_voucher_specific_product_and_manual_line_discount_CORE_0250(
     e2e_staff_api_client,
     shop_permissions,
     permission_manage_product_types_and_attributes,

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -63,6 +63,12 @@ mutation DraftOrderComplete($id: ID!) {
         unitPrice {
           ...BaseTaxedMoney
         }
+        undiscountedTotalPrice {
+          ...BaseTaxedMoney
+        }
+        totalPrice {
+          ...BaseTaxedMoney
+        }
         unitDiscountReason
         unitDiscountType
         unitDiscountValue

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -11,6 +11,7 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
     order {
       id
       lines {
+        id
         totalPrice {
           ...BaseTaxedMoney
         }

--- a/saleor/tests/e2e/orders/utils/order_line_discount_update.py
+++ b/saleor/tests/e2e/orders/utils/order_line_discount_update.py
@@ -1,0 +1,84 @@
+from .....graphql.tests.utils import get_graphql_content
+
+ORDER_LINE_DISCOUNT_UPDATE = """
+mutation OrderLineDiscountUpdate($input: OrderDiscountCommonInput!, $orderLineId: ID!){
+  orderLineDiscountUpdate(orderLineId: $orderLineId, input: $input){
+    order {
+      id
+      voucherCode
+      voucher {
+        id
+      }
+      total {
+        ...BaseTaxedMoney
+      }
+      undiscountedTotal {
+        ...BaseTaxedMoney
+      }
+      subtotal {
+        ...BaseTaxedMoney
+      }
+      shippingPrice {
+        ...BaseTaxedMoney
+      }
+      undiscountedShippingPrice {
+        amount
+      }
+      lines {
+            id
+            undiscountedUnitPrice {
+            ...BaseTaxedMoney
+            }
+            unitPrice {
+            ...BaseTaxedMoney
+            }
+            totalPrice {
+             ...BaseTaxedMoney
+            }
+            undiscountedTotalPrice {
+            ...BaseTaxedMoney
+            }
+            quantity
+            unitDiscount {
+            amount
+            }
+            unitDiscountValue
+            unitDiscountReason
+            voucherCode
+        }
+    }
+    errors{
+      field
+      message
+      code
+    }
+  }
+}
+
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+}
+"""
+
+
+def order_line_discount_update(api_client, id, input):
+    variables = {"orderLineId": id, "input": input}
+
+    response = api_client.post_graphql(
+        ORDER_LINE_DISCOUNT_UPDATE,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderLineDiscountUpdate"]
+    assert not data["errors"]
+
+    return data


### PR DESCRIPTION
I want to merge this change because manual line discounts should override voucher line discounts, same as it behaves with catalog promotions.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
