### PR TITLE
Allow providing `metadata` in `TransactionEventReport` mutation

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -9,6 +9,7 @@ from .....checkout.actions import transaction_amounts_for_checkout_updated
 from .....core.exceptions import PermissionDenied
 from .....core.prices import quantize_price
 from .....core.tracing import traced_atomic_transaction
+from .....core.utils.events import call_event
 from .....order import models as order_models
 from .....order.actions import order_transaction_updated
 from .....order.fetch import fetch_order_info
@@ -25,20 +26,32 @@ from .....payment.utils import (
 )
 from .....permission.auth_filters import AuthorizationFilters
 from .....permission.enums import PaymentPermissions
+from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_313, ADDED_IN_314, PREVIEW_FEATURE
+from ....core.descriptions import (
+    ADDED_IN_313,
+    ADDED_IN_314,
+    ADDED_IN_317,
+    PREVIEW_FEATURE,
+)
 from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.enums import TransactionEventReportErrorCode
 from ....core.mutations import ModelMutation
 from ....core.scalars import UUID, DateTime, PositiveDecimal
+from ....core.types import NonNullList
 from ....core.types import common as common_types
+from ....core.utils import WebhookEventInfo
 from ....core.validators import validate_one_of_args_is_in_mutation
+from ....meta.inputs import MetadataInput
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import TransactionActionEnum, TransactionEventTypeEnum
 from ...types import TransactionEvent, TransactionItem
 from ...utils import check_if_requestor_has_access
 from .utils import get_transaction_item
+
+if TYPE_CHECKING:
+    from .....plugins.manager import PluginsManager
 
 
 class TransactionEventReport(ModelMutation):
@@ -105,6 +118,13 @@ class TransactionEventReport(ModelMutation):
             graphene.NonNull(TransactionActionEnum),
             description="List of all possible actions for the transaction",
         )
+        metadata = NonNullList(
+            MetadataInput,
+            description=(
+                "Fields required to update the transaction metadata." + ADDED_IN_317
+            ),
+            required=False,
+        )
 
     class Meta:
         description = (
@@ -123,6 +143,29 @@ class TransactionEventReport(ModelMutation):
         model = payment_models.TransactionEvent
         object_type = TransactionEvent
         auto_permission_message = False
+        support_meta_field = True
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.TRANSACTION_ITEM_METADATA_UPDATED,
+                description=(
+                    "Optionally called when transaction's metadata was updated."
+                ),
+            ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.CHECKOUT_FULLY_PAID,
+                description=(
+                    "Optionally called when the checkout charge status "
+                    "changed to `FULL` or `OVERCHARGED`."
+                ),
+            ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.ORDER_UPDATED,
+                description=(
+                    "Optionally called when the transaction is related to the order "
+                    "and the order was updated."
+                ),
+            ),
+        ]
 
     @classmethod
     def _update_mutation_arguments_and_fields(cls, arguments, fields):
@@ -131,10 +174,12 @@ class TransactionEventReport(ModelMutation):
     @classmethod
     def update_transaction(
         cls,
+        manager: "PluginsManager",
         transaction: payment_models.TransactionItem,
         transaction_event: payment_models.TransactionEvent,
         available_actions: Optional[list[str]] = None,
         app: Optional["App"] = None,
+        metadata: Optional[list[dict]] = None,
     ):
         fields_to_update = [
             "authorized_value",
@@ -146,6 +191,7 @@ class TransactionEventReport(ModelMutation):
             "refund_pending_value",
             "cancel_pending_value",
             "modified_at",
+            "metadata",
         ]
 
         if (
@@ -173,6 +219,8 @@ class TransactionEventReport(ModelMutation):
             fields_to_update.append("app")
             fields_to_update.append("app_identifier")
         transaction.save(update_fields=fields_to_update)
+        if metadata:
+            call_event(manager.transaction_item_metadata_updated, transaction)
 
     @classmethod
     def clean_amount_value(
@@ -217,6 +265,7 @@ class TransactionEventReport(ModelMutation):
         external_url=None,
         message=None,
         available_actions=None,
+        metadata=None,
     ):
         validate_one_of_args_is_in_mutation("id", id, "token", token)
         transaction = get_transaction_item(id, token)
@@ -261,6 +310,7 @@ class TransactionEventReport(ModelMutation):
             transaction_event, transaction_event_data
         )
 
+        cls.validate_and_update_metadata(transaction, metadata, None)
         cls.clean_instance(info, transaction_event)
 
         if available_actions is not None:
@@ -308,10 +358,12 @@ class TransactionEventReport(ModelMutation):
             previous_charged_value = transaction.charged_value
             previous_refunded_value = transaction.refunded_value
             cls.update_transaction(
+                manager,
                 transaction,
                 transaction_event,
                 available_actions=available_actions,
                 app=app,
+                metadata=metadata,
             )
             if transaction.order_id:
                 order = cast(order_models.Order, transaction.order)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -42,6 +42,10 @@ fragment TransactionEventData on TransactionEventReport {
                 id
             }
         }
+        metadata {
+            key
+            value
+        }
     }
     transactionEvent {
         id
@@ -2465,3 +2469,147 @@ def test_transaction_event_report_missing_amount_error_raised(
     assert len(errors) == 1
     assert errors[0]["field"] == "amount"
     assert errors[0]["code"] == TransactionEventReportErrorCode.REQUIRED.name
+
+
+@patch("saleor.plugins.manager.PluginsManager.transaction_item_metadata_updated")
+def test_transaction_event_report_update_transaction_metadata(
+    transaction_item_metadata_updated_mock,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    amount = Decimal("11.00")
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    metadata = {"key": "test key", "value": "test value"}
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+        "metadata": [metadata],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $metadata: [MetadataInput!]
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            metadata: $metadata
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    transaction_data = transaction_report_data["transaction"]
+    assert len(transaction_data["metadata"]) == 1
+    assert transaction_data["metadata"][0] == metadata
+
+    event = TransactionEvent.objects.filter(
+        type=TransactionEventType.CHARGE_SUCCESS
+    ).first()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == TransactionEventTypeEnum.CHARGE_SUCCESS.value
+    assert event.amount_value == amount
+    assert event.currency == transaction.currency
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+    transaction_item_metadata_updated_mock.assert_called_once_with(transaction)
+
+
+@patch("saleor.plugins.manager.PluginsManager.transaction_item_metadata_updated")
+def test_transaction_event_report_metadata_not_provided(
+    transaction_item_metadata_updated_mock,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    amount = Decimal("11.00")
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+        "metadata": [],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $metadata: [MetadataInput!]
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            metadata: $metadata
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    transaction_data = transaction_report_data["transaction"]
+    assert len(transaction_data["metadata"]) == 0
+
+    event = TransactionEvent.objects.filter(
+        type=TransactionEventType.CHARGE_SUCCESS
+    ).first()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == TransactionEventTypeEnum.CHARGE_SUCCESS.value
+    assert event.amount_value == amount
+    assert event.currency == transaction.currency
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+    transaction_item_metadata_updated_mock.assert_not_called()

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -46,6 +46,10 @@ fragment TransactionEventData on TransactionEventReport {
             key
             value
         }
+        privateMetadata {
+            key
+            value
+        }
     }
     transactionEvent {
         id
@@ -2491,7 +2495,7 @@ def test_transaction_event_report_update_transaction_metadata(
         "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
         "amount": amount,
         "pspReference": psp_reference,
-        "metadata": [metadata],
+        "transactionMetadata": [metadata],
     }
     query = (
         MUTATION_DATA_FRAGMENT
@@ -2501,14 +2505,14 @@ def test_transaction_event_report_update_transaction_metadata(
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
-        $metadata: [MetadataInput!]
+        $transactionMetadata: [MetadataInput!]
     ) {
         transactionEventReport(
             id: $id
             type: $type
             amount: $amount
             pspReference: $pspReference
-            metadata: $metadata
+            transactionMetadata: $transactionMetadata
         ) {
             ...TransactionEventData
         }
@@ -2563,7 +2567,8 @@ def test_transaction_event_report_metadata_not_provided(
         "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
         "amount": amount,
         "pspReference": psp_reference,
-        "metadata": [],
+        "transactionMetadata": [],
+        "transactionPrivateMetadata": [],
     }
     query = (
         MUTATION_DATA_FRAGMENT
@@ -2573,14 +2578,16 @@ def test_transaction_event_report_metadata_not_provided(
         $type: TransactionEventTypeEnum!
         $amount: PositiveDecimal!
         $pspReference: String!
-        $metadata: [MetadataInput!]
+        $transactionMetadata: [MetadataInput!]
+        $transactionPrivateMetadata: [MetadataInput!]
     ) {
         transactionEventReport(
             id: $id
             type: $type
             amount: $amount
             pspReference: $pspReference
-            metadata: $metadata
+            transactionMetadata: $transactionMetadata
+            transactionPrivateMetadata: $transactionPrivateMetadata
         ) {
             ...TransactionEventData
         }
@@ -2599,6 +2606,79 @@ def test_transaction_event_report_metadata_not_provided(
 
     transaction_data = transaction_report_data["transaction"]
     assert len(transaction_data["metadata"]) == 0
+
+    event = TransactionEvent.objects.filter(
+        type=TransactionEventType.CHARGE_SUCCESS
+    ).first()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == TransactionEventTypeEnum.CHARGE_SUCCESS.value
+    assert event.amount_value == amount
+    assert event.currency == transaction.currency
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+    transaction_item_metadata_updated_mock.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.transaction_item_metadata_updated")
+def test_transaction_event_report_update_transaction_private_metadata(
+    transaction_item_metadata_updated_mock,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    psp_reference = "111-abc"
+    amount = Decimal("11.00")
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    private_metadata = {"key": "test key", "value": "test value"}
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+        "transactionPrivateMetadata": [private_metadata],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $transactionPrivateMetadata: [MetadataInput!]
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            transactionPrivateMetadata: $transactionPrivateMetadata
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    transaction_data = transaction_report_data["transaction"]
+    assert len(transaction_data["privateMetadata"]) == 1
+    assert transaction_data["privateMetadata"][0] == private_metadata
 
     event = TransactionEvent.objects.filter(
         type=TransactionEventType.CHARGE_SUCCESS

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16907,6 +16907,11 @@ type Mutation {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
+  
+  Triggers the following webhook events:
+  - TRANSACTION_ITEM_METADATA_UPDATED (async): Optionally called when transaction's metadata was updated.
+  - CHECKOUT_FULLY_PAID (async): Optionally called when the checkout charge status changed to `FULL` or `OVERCHARGED`.
+  - ORDER_UPDATED (async): Optionally called when the transaction is related to the order and the order was updated.
   """
   transactionEventReport(
     """
@@ -16930,6 +16935,13 @@ type Mutation {
     """The message related to the event."""
     message: String
 
+    """
+    Fields required to update the transaction metadata.
+    
+    Added in Saleor 3.17.
+    """
+    metadata: [MetadataInput!]
+
     """PSP Reference of the event to report."""
     pspReference: String!
 
@@ -16947,7 +16959,7 @@ type Mutation {
 
     """Current status of the event to report."""
     type: TransactionEventTypeEnum!
-  ): TransactionEventReport @doc(category: "Payments")
+  ): TransactionEventReport @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [TRANSACTION_ITEM_METADATA_UPDATED, CHECKOUT_FULLY_PAID, ORDER_UPDATED], syncEvents: [])
 
   """
   Initializes a payment gateway session. It triggers the webhook `PAYMENT_GATEWAY_INITIALIZE_SESSION`, to the requested `paymentGateways`. If `paymentGateways` is not provided, the webhook will be send to all subscribed payment gateways. There is a limit of 100 transaction items per checkout / order.
@@ -24790,8 +24802,13 @@ Added in Saleor 3.13.
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
+
+Triggers the following webhook events:
+- TRANSACTION_ITEM_METADATA_UPDATED (async): Optionally called when transaction's metadata was updated.
+- CHECKOUT_FULLY_PAID (async): Optionally called when the checkout charge status changed to `FULL` or `OVERCHARGED`.
+- ORDER_UPDATED (async): Optionally called when the transaction is related to the order and the order was updated.
 """
-type TransactionEventReport @doc(category: "Payments") {
+type TransactionEventReport @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [TRANSACTION_ITEM_METADATA_UPDATED, CHECKOUT_FULLY_PAID, ORDER_UPDATED], syncEvents: []) {
   """Defines if the reported event hasn't been processed earlier."""
   alreadyProcessed: Boolean
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16935,13 +16935,6 @@ type Mutation {
     """The message related to the event."""
     message: String
 
-    """
-    Fields required to update the transaction metadata.
-    
-    Added in Saleor 3.17.
-    """
-    metadata: [MetadataInput!]
-
     """PSP Reference of the event to report."""
     pspReference: String!
 
@@ -16956,6 +16949,20 @@ type Mutation {
     Added in Saleor 3.14.
     """
     token: UUID
+
+    """
+    Fields required to update the transaction metadata.
+    
+    Added in Saleor 3.17.
+    """
+    transactionMetadata: [MetadataInput!]
+
+    """
+    Fields required to update the transaction private metadata.
+    
+    Added in Saleor 3.17.
+    """
+    transactionPrivateMetadata: [MetadataInput!]
 
     """Current status of the event to report."""
     type: TransactionEventTypeEnum!


### PR DESCRIPTION
Extend `TransactionEventReport` mutation with `metadata` input field that allows providing transaction metadata.

Port of https://github.com/saleor/saleor/pull/16736

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
