### PR TITLE
Log the warning when checkout and order are missing for provided payment in Stripe webhooks

### DIFF
--- a/saleor/payment/gateways/stripe/tests/test_webhooks.py
+++ b/saleor/payment/gateways/stripe/tests/test_webhooks.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from decimal import Decimal
 from unittest.mock import Mock, patch
 
@@ -29,6 +30,7 @@ from ..consts import (
     WEBHOOK_SUCCESS_EVENT,
 )
 from ..webhooks import (
+    _channel_slug_is_different_from_payment_channel_slug,
     _finalize_checkout,
     _process_payment_with_checkout,
     _update_payment_with_new_transaction,
@@ -1720,3 +1722,94 @@ def test_handle_successful_payment_intent_for_checkout_when_already_processing_c
     assert payment.order
     transaction = payment.transactions.get(kind=TransactionKind.CAPTURE)
     assert transaction.token == payment_intent.id
+
+
+def test_channel_slug_is_different_from_payment_channel_slug_for_checkout_false(
+    payment, checkout
+):
+    # given
+    payment.checkout = checkout
+    payment.order = None
+    payment.save(update_fields=["checkout", "order"])
+
+    channel_slug = checkout.channel.slug
+
+    # when
+    result = _channel_slug_is_different_from_payment_channel_slug(channel_slug, payment)
+
+    # then
+    assert result is False
+
+
+def test_channel_slug_is_different_from_payment_channel_slug_for_checkout_true(
+    payment, checkout
+):
+    # given
+    payment.checkout = checkout
+    payment.order = None
+    payment.save(update_fields=["checkout", "order"])
+
+    channel_slug = "test"
+
+    # when
+    result = _channel_slug_is_different_from_payment_channel_slug(channel_slug, payment)
+
+    # then
+    assert result is True
+
+
+def test_channel_slug_is_different_from_payment_channel_slug_for_order_false(
+    payment, order
+):
+    # given
+    payment.checkout = None
+    payment.order = order
+    payment.save(update_fields=["checkout", "order"])
+
+    channel_slug = order.channel.slug
+
+    # when
+    result = _channel_slug_is_different_from_payment_channel_slug(channel_slug, payment)
+
+    # then
+    assert result is False
+
+
+def test_channel_slug_is_different_from_payment_channel_slug_for_order_true(
+    payment, order
+):
+    # given
+    payment.checkout = None
+    payment.order = order
+    payment.save(update_fields=["checkout", "order"])
+
+    channel_slug = "test"
+
+    # when
+    result = _channel_slug_is_different_from_payment_channel_slug(channel_slug, payment)
+
+    # then
+    assert result is True
+
+
+def test_channel_slug_is_different_from_payment_channel_slug_no_order_or_checkout(
+    payment, caplog
+):
+    # given
+    payment.checkout = None
+    payment.order = None
+    payment.save(update_fields=["checkout", "order"])
+    caplog.set_level(logging.WARNING)
+
+    channel_slug = "test"
+
+    # when
+    result = _channel_slug_is_different_from_payment_channel_slug(channel_slug, payment)
+
+    # then
+    assert result is True
+    assert (
+        caplog.records[0].message
+        == "Both payment.checkout and payment.order cannot be None"
+    )
+    assert caplog.records[0].payment_id == payment.id

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -115,9 +115,11 @@ def _channel_slug_is_different_from_payment_channel_slug(
     elif order is not None:
         return channel_slug != order.channel.slug
     else:
-        raise ValueError(
-            "Both payment.checkout and payment.order cannot be None"
-        )  # pragma: no cover
+        logger.warning(
+            "Both payment.checkout and payment.order cannot be None",
+            extra={"payment_id": payment.id},
+        )
+        return True
 
 
 def _get_payment(payment_intent_id: str, with_lock=True) -> Optional[Payment]:


### PR DESCRIPTION
Log the warning instead of raising `ValueError` when both order and checkout are missing for the provided payment in Stipe webhooks.

Port of https://github.com/saleor/saleor/pull/16737

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
