### PR TITLE
Log the warning when checkout and order are missing for provided payment in Stripe webhooks

### DIFF
--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -114,9 +114,11 @@ def _channel_slug_is_different_from_payment_channel_slug(
     elif order is not None:
         return channel_slug != order.channel.slug
     else:
-        raise ValueError(
-            "Both payment.checkout and payment.order cannot be None"
-        )  # pragma: no cover
+        logger.warning(
+            "Both payment.checkout and payment.order cannot be None",
+            extra={"payment_id": payment.id},
+        )
+        return True
 
 
 def _get_payment(payment_intent_id: str, with_lock=True) -> Optional[Payment]:


### PR DESCRIPTION
Log the warning instead of raising `ValueError` when both order and checkout are missing for the provided payment in Stipe webhooks.

Port of https://github.com/saleor/saleor/pull/16737

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
