### PR TITLE
Fix order-level discounts handling when using tax app for tax calculation.

### DIFF
--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -713,10 +713,10 @@ def test_split_manual_discount(
     draft_order_with_fixed_discount_order,
 ):
     # given
-    subtotal = Money(subtotal, currency="USD")
-    shipping = Money(shipping_price, currency="USD")
+    subtotal = Money(Decimal(subtotal), currency="USD")
+    shipping = Money(Decimal(shipping_price), currency="USD")
     discount = draft_order_with_fixed_discount_order.discounts.first()
-    discount.value = value
+    discount.value = Decimal(value)
     discount.value_type = value_type
 
     # when
@@ -725,8 +725,8 @@ def test_split_manual_discount(
     )
 
     # then
-    assert subtotal_discount == Money(subtotal_portion, "USD")
-    assert shipping_discount == Money(shipping_portion, "USD")
+    assert subtotal_discount == Money(Decimal(subtotal_portion), "USD")
+    assert shipping_discount == Money(Decimal(shipping_portion), "USD")
 
 
 def test_discount_info_for_logs(order_with_lines, voucher, order_promotion_with_rule):

--- a/saleor/discount/utils/manual_discount.py
+++ b/saleor/discount/utils/manual_discount.py
@@ -36,33 +36,17 @@ def split_manual_discount(
     """Discounts sent to tax app must be split into subtotal and shipping portion."""
     currency = subtotal.currency
     subtotal_discount, shipping_discount = zero_money(currency), zero_money(currency)
-    if discount.value_type == DiscountValueType.PERCENTAGE:
-        discounted_subtotal = apply_discount_to_value(
+    total = subtotal + shipping_price
+    if total.amount > 0:
+        discounted_total = apply_discount_to_value(
             value=discount.value,
             value_type=discount.value_type,
             currency=currency,
-            price_to_discount=subtotal,
+            price_to_discount=total,
         )
-        subtotal_discount = subtotal - discounted_subtotal
-        discounted_shipping_price = apply_discount_to_value(
-            value=discount.value,
-            value_type=discount.value_type,
-            currency=currency,
-            price_to_discount=shipping_price,
-        )
-        shipping_discount = shipping_price - discounted_shipping_price
-    elif discount.value_type == DiscountValueType.FIXED:
-        total = subtotal + shipping_price
-        if total.amount > 0:
-            discounted_total = apply_discount_to_value(
-                value=discount.value,
-                value_type=discount.value_type,
-                currency=currency,
-                price_to_discount=total,
-            )
-            total_discount = total - discounted_total
-            subtotal_discount = subtotal / total * total_discount
-            shipping_discount = total_discount - subtotal_discount
+        total_discount = total - discounted_total
+        subtotal_discount = subtotal / total * total_discount
+        shipping_discount = total_discount - subtotal_discount
 
     return quantize_price(subtotal_discount, currency), quantize_price(
         shipping_discount, currency

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -322,12 +322,15 @@ def create_or_update_discount_object_from_order_level_voucher(
     order, database_connection_name
 ):
     """Create or update discount object for ENTIRE_ORDER and SHIPPING voucher."""
-    if not order.voucher_id:
+    voucher = order.voucher
+    if not order.voucher_id or (
+        is_order_level_voucher(voucher)
+        and order.discounts.filter(type=DiscountType.MANUAL)
+    ):
         with allow_writer():
             order.discounts.filter(type=DiscountType.VOUCHER).delete()
             return
 
-    voucher = order.voucher
     if not is_order_level_voucher(voucher) and not is_shipping_voucher(voucher):
         return
 
@@ -339,13 +342,22 @@ def create_or_update_discount_object_from_order_level_voucher(
     if not voucher_channel_listing:
         return
 
-    price_to_discount = zero_money(order.currency)
+    discount_amount = zero_money(order.currency)
     if is_order_level_voucher(voucher):
-        price_to_discount = order.subtotal.net
+        discount_amount = voucher.get_discount_amount_for(
+            order.subtotal.net, order.channel
+        )
     if is_shipping_voucher(voucher):
-        price_to_discount = order.shipping_price_net
+        discount_amount = voucher.get_discount_amount_for(
+            order.undiscounted_base_shipping_price, order.channel
+        )
+        # Shipping voucher is tricky: it is associated with an order, but it
+        # decreases base price, similar to line level discounts
+        order.base_shipping_price = max(
+            order.undiscounted_base_shipping_price - discount_amount,
+            zero_money(order.currency),
+        )
 
-    discount_amount = voucher.get_discount_amount_for(price_to_discount, order.channel)
     discount_reason = f"Voucher code: {order.voucher_code}"
     discount_name = voucher.name or ""
 

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -372,20 +372,7 @@ class TaxableObject(BaseObjectType):
                 ]
             ).then(calculate_shipping_price)
 
-        # TODO (SHOPX-875): after adding `undiscounted_base_shipping_price` to
-        # Order model, the `root.base_shipping_price` should be used
-        def shipping_price_with_discount(tax_config):
-            return (
-                root.shipping_price_gross
-                if tax_config.prices_entered_with_tax
-                else root.shipping_price_net
-            )
-
-        return (
-            TaxConfigurationByChannelId(info.context)
-            .load(root.channel_id)
-            .then(shipping_price_with_discount)
-        )
+        return root.base_shipping_price
 
     @staticmethod
     def resolve_discounts(root: Union[Checkout, Order], info: ResolveInfo):

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -12,6 +12,7 @@ from ....discount import DiscountType
 from ....discount.utils.checkout import has_checkout_order_promotion
 from ....discount.utils.manual_discount import split_manual_discount
 from ....discount.utils.voucher import is_order_level_voucher
+from ....order.base_calculations import base_order_subtotal
 from ....order.models import Order, OrderLine
 from ....order.utils import get_order_country
 from ....tax.utils import get_charge_taxes
@@ -417,17 +418,21 @@ class TaxableObject(BaseObjectType):
                 .then(calculate_checkout_discounts)
             )
 
-        def map_discounts(discounts):
+        discounts = OrderDiscountsByOrderIDLoader(info.context).load(root.id)
+        order_lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
+
+        def calculate_order_discounts(results):
             # Only order level discounts, like entire order vouchers,
             # order promotions and manual discounts should be taken into account.
             # Manual discount needs to be split into subtotal and shipping portions.
+            (discounts, order_lines) = results
             taxable_discounts = []
             currency = root.currency
             for discount in discounts:
                 shipping_discount = Money(0, currency)
                 subtotal_discount = Money(0, currency)
                 if discount.type == DiscountType.MANUAL:
-                    subtotal = root.subtotal.net
+                    subtotal = base_order_subtotal(root, order_lines)
                     shipping = root.base_shipping_price
                     subtotal_discount, shipping_discount = split_manual_discount(
                         discount, subtotal, shipping
@@ -457,11 +462,7 @@ class TaxableObject(BaseObjectType):
 
             return taxable_discounts
 
-        return (
-            OrderDiscountsByOrderIDLoader(info.context)
-            .load(root.id)
-            .then(map_discounts)
-        )
+        return Promise.all([discounts, order_lines]).then(calculate_order_discounts)
 
     @staticmethod
     def resolve_lines(root: Union[Checkout, Order], info: ResolveInfo):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1739,9 +1739,13 @@ class Order(ModelObjectType[models.Order]):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_undiscounted_shipping_price(root: models.Order, info):
+        @allow_writer_in_context(info.context)
         def _resolve_undiscounted_shipping_price(data):
             lines, manager = data
-            return calculations.order_undiscounted_shipping(root, manager, lines)
+            database_connection_name = get_database_connection_name(info.context)
+            return calculations.order_undiscounted_shipping(
+                root, manager, lines, database_connection_name=database_connection_name
+            )
 
         lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
         manager = get_plugin_manager_promise(info.context)

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -7,10 +7,10 @@ from prices import Money, TaxedMoney
 from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
 from ..core.taxes import zero_money
-from ..discount import DiscountType, DiscountValueType, VoucherType
+from ..discount import DiscountType, DiscountValueType
 from ..discount.models import OrderDiscount
 from ..discount.utils.manual_discount import apply_discount_to_value
-from ..discount.utils.voucher import is_order_level_voucher
+from ..discount.utils.voucher import is_order_level_voucher, is_shipping_voucher
 from ..shipping.models import ShippingMethodChannelListing
 from .interface import OrderTaxedPricesData
 
@@ -93,16 +93,12 @@ def propagate_order_discount_on_order_prices(
     The function returns the subtotal and shipping price after applying the order
     discount.
     """
-    # TODO (SHOPX-875): add undiscounted_base_shipping_price field to Order model,
-    # and use it here
-    base_shipping_price = order.base_shipping_price
     base_subtotal = base_order_subtotal(order, lines)
     subtotal = base_subtotal
-    shipping_price = base_shipping_price
+    shipping_price = order.base_shipping_price
     currency = order.currency
     order_discounts_to_update = []
 
-    shipping_voucher_discount = None
     for order_discount in order.discounts.all():
         subtotal_before_discount = subtotal
         shipping_price_before_discount = shipping_price
@@ -115,8 +111,12 @@ def propagate_order_discount_on_order_prices(
                     currency=currency,
                     price_to_discount=subtotal,
                 )
-            elif voucher and voucher.type == VoucherType.SHIPPING:
-                shipping_voucher_discount = order_discount
+            # Shipping voucher is tricky: it is associated with an order, but it
+            # decreases base price, similar to line level discounts, so we should
+            # exclude it
+            if is_shipping_voucher(order_discount.voucher):
+                continue
+
         elif order_discount.type == DiscountType.ORDER_PROMOTION:
             subtotal = apply_discount_to_value(
                 value=order_discount.value,
@@ -161,19 +161,6 @@ def propagate_order_discount_on_order_prices(
         if order_discount.amount != total_discount_amount:
             order_discount.amount = total_discount_amount
             order_discounts_to_update.append(order_discount)
-
-    # Apply shipping voucher discount
-    if shipping_voucher_discount:
-        shipping_price = apply_discount_to_value(
-            value=shipping_voucher_discount.value,
-            value_type=shipping_voucher_discount.value_type,
-            currency=currency,
-            price_to_discount=shipping_price,
-        )
-        discount_amount = shipping_price_before_discount - shipping_price
-        if shipping_voucher_discount.amount != discount_amount:
-            shipping_voucher_discount.amount = discount_amount
-            order_discounts_to_update.append(shipping_voucher_discount)
 
     if order_discounts_to_update:
         OrderDiscount.objects.bulk_update(order_discounts_to_update, ["amount_value"])
@@ -328,9 +315,7 @@ def assign_order_prices(
     shipping_price: Money,
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ):
-    # TODO (SHOPX-875): set order.base_shipping_price as this price should include
-    # the shipping discount - must be done together with adding
-    # undiscounted_base_shipping_price to Order model
+    shipping_price = quantize_price(shipping_price, order.currency)
     order.shipping_price_net_amount = shipping_price.amount
     order.shipping_price_gross_amount = shipping_price.amount
     order.total_net_amount = subtotal.amount + shipping_price.amount

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -613,6 +613,7 @@ def order_undiscounted_shipping(
     manager: PluginsManager,
     lines: Optional[Iterable[OrderLine]] = None,
     force_update: bool = False,
+    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ) -> TaxedMoney:
     """Return the undiscounted shipping price of the order.
 
@@ -621,7 +622,9 @@ def order_undiscounted_shipping(
     and save them in the model directly.
     """
     currency = order.currency
-    order, _ = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order, _ = fetch_order_prices_if_expired(
+        order, manager, lines, force_update, database_connection_name
+    )
     return quantize_price(order.undiscounted_base_shipping_price, currency)
 
 

--- a/saleor/order/tests/benchmark/test_fetch_order_prices.py
+++ b/saleor/order/tests/benchmark/test_fetch_order_prices.py
@@ -41,7 +41,7 @@ def test_fetch_order_prices_catalogue_discount(
     tc.save()
 
     # when
-    with django_assert_num_queries(44):
+    with django_assert_num_queries(45):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then
@@ -136,7 +136,7 @@ def test_fetch_order_prices_multiple_catalogue_discounts(
     tc.save()
 
     # when
-    with django_assert_num_queries(44):
+    with django_assert_num_queries(45):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
 
     # then

--- a/saleor/order/tests/test_apply_order_discount.py
+++ b/saleor/order/tests/test_apply_order_discount.py
@@ -192,7 +192,7 @@ def test_apply_order_discounts_shipping_voucher(
         subtotal += line.base_unit_price * line.quantity
 
     discount_amount = shipping_price.amount
-    order_discount = order.discounts.create(
+    order.discounts.create(
         type=DiscountType.VOUCHER,
         value_type=DiscountValueType.FIXED,
         value=discount_amount,
@@ -207,18 +207,8 @@ def test_apply_order_discounts_shipping_voucher(
     discounted_subtotal, discounted_shipping_price = apply_order_discounts(order, lines)
 
     # then
-    assert discounted_shipping_price == zero_money(currency)
+    assert discounted_shipping_price == shipping_price
     assert discounted_subtotal == subtotal
-    assert order.subtotal_net_amount == discounted_subtotal.amount
-    assert order.subtotal_gross_amount == discounted_subtotal.amount
-    assert order.total_net == discounted_subtotal + discounted_shipping_price
-    assert order.total_gross == discounted_subtotal + discounted_shipping_price
-    assert order.shipping_price_net == discounted_shipping_price
-    assert order.shipping_price_gross == discounted_shipping_price
-    assert order.undiscounted_total_net == subtotal + shipping_price
-    assert order.undiscounted_total_gross == subtotal + shipping_price
-    order_discount.refresh_from_db()
-    assert order_discount.amount_value == shipping_price.amount
 
 
 def test_apply_order_discounts_zero_discount(order_with_lines):

--- a/saleor/order/tests/test_apply_order_discount.py
+++ b/saleor/order/tests/test_apply_order_discount.py
@@ -421,8 +421,12 @@ def test_apply_order_discounts_voucher_entire_order_and_manual_discount_fixed(
     assert quantize_price(order.total_gross, currency) == quantize_price(
         expected_shipping + expected_subtotal, currency
     )
-    assert order.shipping_price_net == discounted_shipping_price
-    assert order.shipping_price_gross == discounted_shipping_price
+    assert order.shipping_price_net == quantize_price(
+        discounted_shipping_price, currency
+    )
+    assert order.shipping_price_gross == quantize_price(
+        discounted_shipping_price, currency
+    )
     assert order.undiscounted_total_net == undiscounted_total
     assert order.undiscounted_total_gross == undiscounted_total
     voucher_order_discount.refresh_from_db()

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -1,23 +1,30 @@
 import json
 from decimal import Decimal
-from functools import partial
-from unittest.mock import ANY
+from unittest.mock import ANY, Mock
 
 import pytest
 from freezegun import freeze_time
-from prices import Money, TaxedMoney, fixed_discount
+from prices import Money, TaxedMoney
 
 from .....core.prices import quantize_price
-from .....discount import DiscountValueType, VoucherType
+from .....discount import (
+    DiscountType,
+    DiscountValueType,
+    RewardType,
+    RewardValueType,
+    VoucherType,
+)
 from .....discount.models import PromotionRule
 from .....graphql.core.utils import to_global_id_or_none
 from .....order import OrderStatus
 from .....order.calculations import fetch_order_prices_if_expired
 from .....order.models import Order
-from .....order.utils import update_discount_for_order_line
+from .....order.utils import (
+    create_order_discount_for_order,
+    update_discount_for_order_line,
+)
 from .....plugins.manager import get_plugins_manager
 from .....tax import TaxableObjectDiscountType
-from .....tests.fixtures import recalculate_order
 from .....webhook.event_types import WebhookEventSyncType
 from .....webhook.models import Webhook
 from .....webhook.transport.synchronous.transport import (
@@ -88,6 +95,13 @@ subscription {
 
 
 """
+
+
+@pytest.fixture
+def subscription_order_calculate_taxes(subscription_webhook):
+    return subscription_webhook(
+        TAXES_SUBSCRIPTION_QUERY, WebhookEventSyncType.ORDER_CALCULATE_TAXES
+    )
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -1008,35 +1022,31 @@ def test_draft_order_calculate_taxes_free_shipping_voucher(
 
 @freeze_time("2020-03-18 12:00:00")
 def test_order_calculate_taxes_with_manual_discount(
-    order_line,
+    order_with_lines,
     subscription_calculate_taxes_for_order,
+    tax_configuration_tax_app,
 ):
     # given
-    order = order_line.order
-    currency = order.currency
+    order = order_with_lines
+    shipping_price_amount = order.base_shipping_price_amount
 
-    order.total = order_line.total_price + order.shipping_price
-    order.undiscounted_total = order.total
-    order.save()
-
-    value = Decimal("20")
-    discount = partial(fixed_discount, discount=Money(value, order.currency))
-    order.total = discount(order.total)
-    order.save()
+    discount_value = Decimal("20")
     order.discounts.create(
         value_type=DiscountValueType.FIXED,
-        value=value,
+        value=discount_value,
         reason="Discount reason",
-        amount=(order.undiscounted_total - order.total).gross,
     )
 
-    shipping_price = Money(Decimal("10"), currency)
-    order.base_shipping_price = shipping_price
-    order.shipping_price_net = shipping_price
-    order.shipping_price_gross = shipping_price
+    line_1, line_2 = order.lines.all()
+    line_1_unit_price = line_1.base_unit_price_amount
+    line_2_unit_price = line_2.base_unit_price_amount
+    subtotal_amount = (
+        line_1_unit_price * line_1.quantity + line_2_unit_price * line_2.quantity
+    )
+    total_amount = subtotal_amount + shipping_price_amount
 
-    recalculate_order(order)
-    order.refresh_from_db()
+    manager = Mock(get_taxes_for_order=Mock(return_value={}))
+    fetch_order_prices_if_expired(order, manager, [line_1, line_2], True)
 
     webhook = subscription_calculate_taxes_for_order
     webhook.subscription_query = TAXES_SUBSCRIPTION_QUERY
@@ -1044,10 +1054,8 @@ def test_order_calculate_taxes_with_manual_discount(
 
     # Manual discount applies both to subtotal and shipping. For tax calculation it
     # requires to be split into subtotal and shipping portion.
-    subtotal = order.subtotal.net
-    total = subtotal + shipping_price
-    manual_discount_subtotal_portion = subtotal / total * value
-    manual_discount_shipping_portion = value - manual_discount_subtotal_portion
+    manual_discount_subtotal_portion = subtotal_amount / total_amount * discount_value
+    manual_discount_shipping_portion = discount_value - manual_discount_subtotal_portion
 
     # when
     deliveries = create_delivery_for_subscription_sync_event(
@@ -1074,20 +1082,37 @@ def test_order_calculate_taxes_with_manual_discount(
             "lines": [
                 {
                     "chargeTaxes": True,
-                    "productName": "Test product",
-                    "productSku": "SKU_A",
-                    "quantity": 3,
+                    "productName": line_1.product_name,
+                    "productSku": line_1.product_sku,
+                    "quantity": line_1.quantity,
                     "sourceLine": {
                         "__typename": "OrderLine",
-                        "id": to_global_id_or_none(order_line),
+                        "id": to_global_id_or_none(line_1),
                     },
-                    "totalPrice": {"amount": 36.9},
-                    "unitPrice": {"amount": 12.3},
-                    "variantName": "SKU_A",
-                }
+                    "totalPrice": {
+                        "amount": float(line_1_unit_price * line_1.quantity)
+                    },
+                    "unitPrice": {"amount": float(line_1_unit_price)},
+                    "variantName": line_1.variant_name,
+                },
+                {
+                    "chargeTaxes": True,
+                    "productName": line_2.product_name,
+                    "productSku": line_2.product_sku,
+                    "quantity": line_2.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_2),
+                    },
+                    "totalPrice": {
+                        "amount": float(line_2_unit_price * line_2.quantity)
+                    },
+                    "unitPrice": {"amount": float(line_2_unit_price)},
+                    "variantName": line_2.variant_name,
+                },
             ],
-            "pricesEnteredWithTax": True,
-            "shippingPrice": {"amount": float(shipping_price.amount)},
+            "pricesEnteredWithTax": False,
+            "shippingPrice": {"amount": float(shipping_price_amount)},
             "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
         },
     }
@@ -1131,29 +1156,38 @@ def test_order_calculate_taxes_empty_order(
     }
 
 
-@freeze_time("2020-03-18 12:00:00")
 def test_order_calculate_taxes_order_promotion(
-    order_with_lines_and_order_promotion, subscription_calculate_taxes_for_order
+    order_with_lines,
+    order_promotion_with_rule,
+    subscription_order_calculate_taxes,
+    tax_configuration_tax_app,
 ):
     # given
-    order = order_with_lines_and_order_promotion
-    order.status = OrderStatus.DRAFT
-    order.save(update_fields=["status"])
-    webhook = subscription_calculate_taxes_for_order
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    webhook = subscription_order_calculate_taxes
+    channel = order.channel
+    shipping_price_amount = order.base_shipping_price_amount
 
-    webhook.subscription_query = TAXES_SUBSCRIPTION_QUERY
-    webhook.save(update_fields=["subscription_query"])
+    line_1, line_2 = order.lines.all()
+    line_1_unit_price = line_1.base_unit_price_amount
+    line_2_unit_price = line_2.base_unit_price_amount
 
-    discount_amount = PromotionRule.objects.get().reward_value
+    promotion = order_promotion_with_rule
+    rule = promotion.rules.get()
+    rule.order_predicate = {
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 10}}}
+    }
+    rule.save(update_fields=["order_predicate"])
+    reward_value = Decimal(5)
+    assert rule.reward_value == reward_value
+    assert rule.reward_value_type == RewardValueType.FIXED
+    assert rule.reward_type == RewardType.SUBTOTAL_DISCOUNT
 
-    expected_shipping_price = Money("2.00", order.currency)
-    order.undiscounted_base_shipping_price = expected_shipping_price
-    order.base_shipping_price = expected_shipping_price
-    order.shipping_price = TaxedMoney(
-        net=expected_shipping_price, gross=expected_shipping_price
-    )
+    manager = Mock(get_taxes_for_order=Mock(return_value={}))
 
     # when
+    fetch_order_prices_if_expired(order, manager, None, True)
     deliveries = create_delivery_for_subscription_sync_event(
         WebhookEventSyncType.ORDER_CALCULATE_TAXES, order, webhook
     )
@@ -1166,34 +1200,443 @@ def test_order_calculate_taxes_order_promotion(
             "currency": "USD",
             "discounts": [
                 {
-                    "amount": {"amount": float(discount_amount)},
+                    "amount": {"amount": reward_value},
                     "type": TaxableObjectDiscountType.SUBTOTAL,
                 }
             ],
-            "channel": {"id": to_global_id_or_none(order.channel)},
+            "channel": {"id": to_global_id_or_none(channel)},
             "lines": [
                 {
                     "chargeTaxes": True,
-                    "productName": line.product_name,
-                    "productSku": line.product_sku,
-                    "quantity": line.quantity,
+                    "productName": line_1.product_name,
+                    "productSku": line_1.product_sku,
+                    "quantity": line_1.quantity,
                     "sourceLine": {
                         "__typename": "OrderLine",
-                        "id": to_global_id_or_none(line),
+                        "id": to_global_id_or_none(line_1),
                     },
-                    "totalPrice": {
-                        "amount": float(line.base_unit_price_amount * line.quantity)
+                    "totalPrice": {"amount": line_1_unit_price * line_1.quantity},
+                    "unitPrice": {"amount": line_1_unit_price},
+                    "variantName": line_1.variant_name,
+                },
+                {
+                    "chargeTaxes": True,
+                    "productName": line_2.product_name,
+                    "productSku": line_2.product_sku,
+                    "quantity": line_2.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_2),
                     },
-                    "unitPrice": {"amount": float(line.base_unit_price_amount)},
-                    "variantName": line.variant_name,
-                }
-                for line in order.lines.all()
+                    "totalPrice": {"amount": line_2_unit_price * line_2.quantity},
+                    "unitPrice": {"amount": line_2_unit_price},
+                    "variantName": line_2.variant_name,
+                },
             ],
-            "pricesEnteredWithTax": True,
-            "shippingPrice": {"amount": float(float(expected_shipping_price.amount))},
-            "sourceObject": {
-                "__typename": "Order",
-                "id": to_global_id_or_none(order),
-            },
+            "pricesEnteredWithTax": False,
+            "shippingPrice": {"amount": shipping_price_amount},
+            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+        },
+    }
+
+
+def test_order_calculate_taxes_order_voucher_and_manual_discount(
+    order_with_lines,
+    voucher,
+    subscription_order_calculate_taxes,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    webhook = subscription_order_calculate_taxes
+    channel = order.channel
+    shipping_price_amount = order.base_shipping_price_amount
+
+    line_1, line_2 = order.lines.all()
+    line_1_unit_price = line_1.base_unit_price_amount
+    line_2_unit_price = line_2.base_unit_price_amount
+    subtotal_amount = (
+        line_1_unit_price * line_1.quantity + line_2_unit_price * line_2.quantity
+    )
+    total_amount = subtotal_amount + shipping_price_amount
+
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    order.voucher = voucher
+    order.save(update_fields=["voucher_id"])
+
+    manual_reward = Decimal(10)
+    create_order_discount_for_order(
+        order=order,
+        reason="Manual discount",
+        value_type=DiscountValueType.FIXED,
+        value=manual_reward,
+        type=DiscountType.MANUAL,
+    )
+
+    subtotal_manual_reward_portion = (subtotal_amount / total_amount) * manual_reward
+    shipping_manual_reward_portion = manual_reward - subtotal_manual_reward_portion
+
+    manager = Mock(get_taxes_for_order=Mock(return_value={}))
+
+    # when
+    fetch_order_prices_if_expired(order, manager, None, True)
+    deliveries = create_delivery_for_subscription_sync_event(
+        WebhookEventSyncType.ORDER_CALCULATE_TAXES, order, webhook
+    )
+
+    # then
+    manual_discount = order.discounts.get(type=DiscountType.MANUAL)
+    assert manual_discount.amount_value == manual_reward
+    assert not order.discounts.filter(type=DiscountType.VOUCHER).first()
+
+    assert json.loads(deliveries.payload.get_payload()) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {"id": to_global_id_or_none(order.shipping_address)},
+            "currency": "USD",
+            "discounts": [
+                {
+                    "amount": {"amount": subtotal_manual_reward_portion},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                },
+                {
+                    "amount": {"amount": shipping_manual_reward_portion},
+                    "type": TaxableObjectDiscountType.SHIPPING,
+                },
+            ],
+            "channel": {"id": to_global_id_or_none(channel)},
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": line_1.product_name,
+                    "productSku": line_1.product_sku,
+                    "quantity": line_1.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_1),
+                    },
+                    "totalPrice": {"amount": line_1_unit_price * line_1.quantity},
+                    "unitPrice": {"amount": line_1_unit_price},
+                    "variantName": line_1.variant_name,
+                },
+                {
+                    "chargeTaxes": True,
+                    "productName": line_2.product_name,
+                    "productSku": line_2.product_sku,
+                    "quantity": line_2.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_2),
+                    },
+                    "totalPrice": {"amount": line_2_unit_price * line_2.quantity},
+                    "unitPrice": {"amount": line_2_unit_price},
+                    "variantName": line_2.variant_name,
+                },
+            ],
+            "pricesEnteredWithTax": False,
+            "shippingPrice": {"amount": shipping_price_amount},
+            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+        },
+    }
+
+
+def test_order_calculate_taxes_order_promotion_and_manual_discount(
+    order_with_lines,
+    order_promotion_with_rule,
+    subscription_order_calculate_taxes,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    webhook = subscription_order_calculate_taxes
+    channel = order.channel
+    shipping_price_amount = order.base_shipping_price_amount
+
+    line_1, line_2 = order.lines.all()
+    line_1_unit_price = line_1.base_unit_price_amount
+    line_2_unit_price = line_2.base_unit_price_amount
+    subtotal_amount = (
+        line_1_unit_price * line_1.quantity + line_2_unit_price * line_2.quantity
+    )
+    total_amount = subtotal_amount + shipping_price_amount
+
+    promotion = order_promotion_with_rule
+    rule = promotion.rules.get()
+    rule.order_predicate = {
+        "discountedObjectPredicate": {"baseSubtotalPrice": {"range": {"gte": 10}}}
+    }
+    rule.save(update_fields=["order_predicate"])
+    assert rule.reward_type == RewardType.SUBTOTAL_DISCOUNT
+
+    manual_reward = Decimal(10)
+    create_order_discount_for_order(
+        order=order,
+        reason="Manual discount",
+        value_type=DiscountValueType.FIXED,
+        value=manual_reward,
+        type=DiscountType.MANUAL,
+    )
+
+    subtotal_manual_reward_portion = (subtotal_amount / total_amount) * manual_reward
+    shipping_manual_reward_portion = manual_reward - subtotal_manual_reward_portion
+
+    manager = Mock(get_taxes_for_order=Mock(return_value={}))
+
+    # when
+    fetch_order_prices_if_expired(order, manager, None, True)
+    deliveries = create_delivery_for_subscription_sync_event(
+        WebhookEventSyncType.ORDER_CALCULATE_TAXES, order, webhook
+    )
+
+    # then
+    manual_discount = order.discounts.get(type=DiscountType.MANUAL)
+    assert manual_discount.amount_value == manual_reward
+    assert not order.discounts.filter(type=DiscountType.ORDER_PROMOTION).first()
+
+    assert json.loads(deliveries.payload.get_payload()) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {"id": to_global_id_or_none(order.shipping_address)},
+            "currency": "USD",
+            "discounts": [
+                {
+                    "amount": {"amount": subtotal_manual_reward_portion},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                },
+                {
+                    "amount": {"amount": shipping_manual_reward_portion},
+                    "type": TaxableObjectDiscountType.SHIPPING,
+                },
+            ],
+            "channel": {"id": to_global_id_or_none(channel)},
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": line_1.product_name,
+                    "productSku": line_1.product_sku,
+                    "quantity": line_1.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_1),
+                    },
+                    "totalPrice": {"amount": line_1_unit_price * line_1.quantity},
+                    "unitPrice": {"amount": line_1_unit_price},
+                    "variantName": line_1.variant_name,
+                },
+                {
+                    "chargeTaxes": True,
+                    "productName": line_2.product_name,
+                    "productSku": line_2.product_sku,
+                    "quantity": line_2.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_2),
+                    },
+                    "totalPrice": {"amount": line_2_unit_price * line_2.quantity},
+                    "unitPrice": {"amount": line_2_unit_price},
+                    "variantName": line_2.variant_name,
+                },
+            ],
+            "pricesEnteredWithTax": False,
+            "shippingPrice": {"amount": shipping_price_amount},
+            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+        },
+    }
+
+
+def test_order_calculate_taxes_free_shipping_voucher_and_manual_discount_fixed(
+    order_with_lines,
+    voucher_free_shipping,
+    subscription_order_calculate_taxes,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    voucher = voucher_free_shipping
+    webhook = subscription_order_calculate_taxes
+    channel = order.channel
+    shipping_price_amount = order.base_shipping_price_amount
+
+    line_1, line_2 = order.lines.all()
+    line_1_unit_price = line_1.base_unit_price_amount
+    line_2_unit_price = line_2.base_unit_price_amount
+
+    assert voucher.type == VoucherType.SHIPPING
+    order.voucher = voucher
+    order.save(update_fields=["voucher_id"])
+
+    manual_reward = Decimal(10)
+    create_order_discount_for_order(
+        order=order,
+        reason="Manual discount",
+        value_type=DiscountValueType.FIXED,
+        value=manual_reward,
+        type=DiscountType.MANUAL,
+    )
+
+    # Since shipping is free, whole manual discount should be applied to subtotal
+    subtotal_manual_reward_portion = manual_reward
+
+    manager = Mock(get_taxes_for_order=Mock(return_value={}))
+
+    # when
+    fetch_order_prices_if_expired(order, manager, None, True)
+    deliveries = create_delivery_for_subscription_sync_event(
+        WebhookEventSyncType.ORDER_CALCULATE_TAXES, order, webhook
+    )
+
+    # then
+    manual_discount = order.discounts.get(type=DiscountType.MANUAL)
+    assert manual_discount.amount_value == subtotal_manual_reward_portion
+    voucher_discount = order.discounts.get(type=DiscountType.VOUCHER)
+    assert voucher_discount.amount_value == shipping_price_amount
+
+    assert json.loads(deliveries.payload.get_payload()) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {"id": to_global_id_or_none(order.shipping_address)},
+            "currency": "USD",
+            "discounts": [
+                {
+                    "amount": {"amount": subtotal_manual_reward_portion},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                },
+            ],
+            "channel": {"id": to_global_id_or_none(channel)},
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": line_1.product_name,
+                    "productSku": line_1.product_sku,
+                    "quantity": line_1.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_1),
+                    },
+                    "totalPrice": {"amount": line_1_unit_price * line_1.quantity},
+                    "unitPrice": {"amount": line_1_unit_price},
+                    "variantName": line_1.variant_name,
+                },
+                {
+                    "chargeTaxes": True,
+                    "productName": line_2.product_name,
+                    "productSku": line_2.product_sku,
+                    "quantity": line_2.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_2),
+                    },
+                    "totalPrice": {"amount": line_2_unit_price * line_2.quantity},
+                    "unitPrice": {"amount": line_2_unit_price},
+                    "variantName": line_2.variant_name,
+                },
+            ],
+            "pricesEnteredWithTax": False,
+            "shippingPrice": {"amount": 0},
+            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+        },
+    }
+
+
+def test_order_calculate_taxes_free_shipping_voucher_and_manual_discount_percentage(
+    order_with_lines,
+    voucher_free_shipping,
+    subscription_order_calculate_taxes,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.UNCONFIRMED
+    voucher = voucher_free_shipping
+    webhook = subscription_order_calculate_taxes
+    channel = order.channel
+    shipping_price_amount = order.base_shipping_price_amount
+
+    line_1, line_2 = order.lines.all()
+    line_1_unit_price = line_1.base_unit_price_amount
+    line_2_unit_price = line_2.base_unit_price_amount
+
+    subtotal_amount = (
+        line_1_unit_price * line_1.quantity + line_2_unit_price * line_2.quantity
+    )
+    total_amount = subtotal_amount + shipping_price_amount
+
+    assert voucher.type == VoucherType.SHIPPING
+    order.voucher = voucher
+    order.save(update_fields=["voucher_id"])
+    total_amount -= shipping_price_amount
+
+    manual_reward = Decimal(10)
+    create_order_discount_for_order(
+        order=order,
+        reason="Manual discount",
+        value_type=DiscountValueType.PERCENTAGE,
+        value=manual_reward,
+        type=DiscountType.MANUAL,
+    )
+
+    # Since shipping is free, whole manual discount should be applied to subtotal
+    subtotal_manual_reward_portion = manual_reward / 100 * total_amount
+
+    manager = Mock(get_taxes_for_order=Mock(return_value={}))
+
+    # when
+    fetch_order_prices_if_expired(order, manager, None, True)
+    deliveries = create_delivery_for_subscription_sync_event(
+        WebhookEventSyncType.ORDER_CALCULATE_TAXES, order, webhook
+    )
+
+    # then
+    manual_discount = order.discounts.get(type=DiscountType.MANUAL)
+    assert manual_discount.amount_value == subtotal_manual_reward_portion
+    voucher_discount = order.discounts.get(type=DiscountType.VOUCHER)
+    assert voucher_discount.amount_value == shipping_price_amount
+
+    assert json.loads(deliveries.payload.get_payload()) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {"id": to_global_id_or_none(order.shipping_address)},
+            "currency": "USD",
+            "discounts": [
+                {
+                    "amount": {"amount": subtotal_manual_reward_portion},
+                    "type": TaxableObjectDiscountType.SUBTOTAL,
+                },
+            ],
+            "channel": {"id": to_global_id_or_none(channel)},
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": line_1.product_name,
+                    "productSku": line_1.product_sku,
+                    "quantity": line_1.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_1),
+                    },
+                    "totalPrice": {"amount": line_1_unit_price * line_1.quantity},
+                    "unitPrice": {"amount": line_1_unit_price},
+                    "variantName": line_1.variant_name,
+                },
+                {
+                    "chargeTaxes": True,
+                    "productName": line_2.product_name,
+                    "productSku": line_2.product_sku,
+                    "quantity": line_2.quantity,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(line_2),
+                    },
+                    "totalPrice": {"amount": line_2_unit_price * line_2.quantity},
+                    "unitPrice": {"amount": line_2_unit_price},
+                    "variantName": line_2.variant_name,
+                },
+            ],
+            "pricesEnteredWithTax": False,
+            "shippingPrice": {"amount": 0},
+            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
         },
     }

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -102,7 +102,7 @@ def _set_order_totals(
 
     shipping_tax_rate = order.shipping_tax_rate or 0
     undiscounted_shipping_price = calculate_flat_rate_tax(
-        order.base_shipping_price,
+        order.undiscounted_base_shipping_price,
         Decimal(shipping_tax_rate * 100),
         prices_entered_with_tax,
     )

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -101,8 +101,11 @@ def _set_order_totals(
         undiscounted_subtotal += line.undiscounted_total_price
 
     shipping_tax_rate = order.shipping_tax_rate or 0
+    undiscounted_base_shipping_price = base_calculations.undiscounted_order_shipping(
+        order
+    )
     undiscounted_shipping_price = calculate_flat_rate_tax(
-        order.undiscounted_base_shipping_price,
+        undiscounted_base_shipping_price,
         Decimal(shipping_tax_rate * 100),
         prices_entered_with_tax,
     )

--- a/saleor/tests/e2e/orders/discounts/test_order_with_shipping_voucher_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_with_shipping_voucher_and_manual_order_discount.py
@@ -1,0 +1,177 @@
+from decimal import Decimal
+
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_default_shop
+from ...utils import assign_permissions
+from ...vouchers.utils import create_voucher, create_voucher_channel_listing
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_discount_add,
+    order_lines_create,
+)
+
+
+def prepare_shipping_voucher(
+    e2e_staff_api_client,
+    channel_id,
+    voucher_code,
+    voucher_discount_type,
+    voucher_discount_value,
+):
+    input = {
+        "code": voucher_code,
+        "discountValueType": voucher_discount_type,
+        "type": "SHIPPING",
+    }
+    voucher_data = create_voucher(e2e_staff_api_client, input)
+    voucher_id = voucher_data["id"]
+    channel_listing = [
+        {
+            "channelId": channel_id,
+            "discountValue": voucher_discount_value,
+        }
+    ]
+    create_voucher_channel_listing(
+        e2e_staff_api_client,
+        voucher_id,
+        channel_listing,
+    )
+
+    return voucher_discount_value, voucher_code
+
+
+@pytest.mark.e2e
+def test_order_with_shipping_voucher_and_manual_order_discount(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+    undiscounted_shipping_price = Decimal(10)
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=Decimal(15),
+    )
+
+    voucher_code = "free-shipping"
+    voucher_discount_value = Decimal(50)
+    prepare_shipping_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        voucher_code,
+        "PERCENTAGE",
+        voucher_discount_value,
+    )
+
+    # Step 1 - Create a draft order with shipping voucher
+    input = {
+        "channelId": channel_id,
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "shippingMethod": shipping_method_id,
+        "voucherCode": voucher_code,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert data["order"]["voucher"]["code"] == voucher_code
+
+    # Step 2 - Add order line
+    quantity = 3
+    lines = [{"variantId": product_variant_id, "quantity": quantity}]
+    data = order_lines_create(e2e_staff_api_client, order_id, lines)
+    undiscounted_subtotal = Decimal(quantity * product_variant_price)
+    undiscounted_total = undiscounted_subtotal + undiscounted_shipping_price
+
+    assert data["order"]["subtotal"]["gross"]["amount"] == undiscounted_subtotal
+    # TODO (SHOPX-1388): Shipping price is not updated when running `orderLinesCreate`
+    # assert undiscounted_shipping_price == data["order"]["undiscountedShippingPrice"]["amount"]
+
+    # Step 3 - Add shipping method to the order
+    input = {"shippingMethod": shipping_method_id}
+    data = draft_order_update(e2e_staff_api_client, order_id, input)
+    assert (
+        undiscounted_shipping_price
+        == data["order"]["undiscountedShippingPrice"]["amount"]
+    )
+    shipping_price = Decimal(data["order"]["shippingPrice"]["gross"]["amount"])
+    assert shipping_price == undiscounted_shipping_price * voucher_discount_value / 100
+    voucher_discount_amount = undiscounted_shipping_price - shipping_price
+    subtotal = Decimal(data["order"]["subtotal"]["gross"]["amount"])
+    assert undiscounted_subtotal == subtotal
+    total = Decimal(data["order"]["total"]["gross"]["amount"])
+    assert total == undiscounted_total - voucher_discount_amount
+
+    # Step 4 - Add manual discount to the order
+    manual_discount_value = Decimal(15)
+    manual_discount_input = {
+        "valueType": "FIXED",
+        "value": manual_discount_value,
+    }
+    data = order_discount_add(
+        e2e_staff_api_client,
+        order_id,
+        manual_discount_input,
+    )
+    manual_discount_subtotal_share = Decimal(subtotal / total * manual_discount_value)
+    manual_discount_shipping_share = (
+        manual_discount_value - manual_discount_subtotal_share
+    )
+    shipping_price = Decimal(data["order"]["shippingPrice"]["gross"]["amount"])
+
+    assert (
+        shipping_price
+        == undiscounted_shipping_price * voucher_discount_value / 100
+        - manual_discount_shipping_share
+    )
+    subtotal = Decimal(data["order"]["subtotal"]["gross"]["amount"])
+    assert subtotal == undiscounted_subtotal - manual_discount_subtotal_share
+    total = Decimal(data["order"]["total"]["gross"]["amount"])
+    assert total == undiscounted_total - voucher_discount_amount - manual_discount_value
+
+    # Step 5 - Complete the draft order
+    data = draft_order_complete(e2e_staff_api_client, order_id)
+    assert (
+        Decimal(data["order"]["undiscountedShippingPrice"]["amount"])
+        == undiscounted_shipping_price
+    )
+    assert Decimal(data["order"]["shippingPrice"]["gross"]["amount"]) == shipping_price
+    assert Decimal(data["order"]["subtotal"]["gross"]["amount"]) == subtotal
+    assert (
+        Decimal(data["order"]["undiscountedTotal"]["gross"]["amount"])
+        == undiscounted_total
+    )
+    assert Decimal(data["order"]["total"]["gross"]["amount"]) == total
+
+    order_line = data["order"]["lines"][0]
+    assert (
+        order_line["undiscountedUnitPrice"]["gross"]["amount"] == product_variant_price
+    )
+    assert order_line["unitPrice"]["gross"]["amount"] == Decimal(
+        product_variant_price
+    ) - Decimal(manual_discount_subtotal_share / quantity)

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -34,6 +34,9 @@ mutation DraftOrderComplete($id: ID!) {
           amount
         }
       }
+      undiscountedShippingPrice {
+        amount
+      }
       shippingPrice {
         gross {
           amount

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -97,6 +97,9 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
           amount
         }
       }
+      undiscountedShippingPrice {
+        amount
+      }
       shippingMethod {
         id
       }

--- a/saleor/tests/e2e/orders/utils/order_discount_add.py
+++ b/saleor/tests/e2e/orders/utils/order_discount_add.py
@@ -16,6 +16,15 @@ mutation OrderDiscountAdd($input: OrderDiscountCommonInput!, $id: ID!) {
         valueType
         type
       }
+      shippingPrice {
+        ...BaseTaxedMoney
+      }
+      total {
+        ...BaseTaxedMoney
+      }
+      subtotal {
+        ...BaseTaxedMoney
+      }
     }
   }
 }

--- a/saleor/tests/e2e/orders/utils/order_discount_add.py
+++ b/saleor/tests/e2e/orders/utils/order_discount_add.py
@@ -28,6 +28,19 @@ mutation OrderDiscountAdd($input: OrderDiscountCommonInput!, $id: ID!) {
     }
   }
 }
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
+}
 """
 
 

--- a/saleor/tests/e2e/orders/utils/order_lines_create.py
+++ b/saleor/tests/e2e/orders/utils/order_lines_create.py
@@ -18,15 +18,10 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
         ...BaseTaxedMoney
       }
       total {
-        gross {
-          amount
-        }
-        net {
-          amount
-        }
-        tax {
-          amount
-        }
+        ...BaseTaxedMoney
+      }
+      subtotal {
+        ...BaseTaxedMoney
       }
       isShippingRequired
       lines {
@@ -36,20 +31,10 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
           id
         }
         totalPrice {
-          gross {
-            amount
-          }
-          net {
-            amount
-          }
-          tax {
-            amount
-          }
+          ...BaseTaxedMoney
         }
         unitPrice {
-          gross {
-            amount
-          }
+          ...BaseTaxedMoney
         }
         unitDiscountReason
         undiscountedUnitPrice {
@@ -65,6 +50,19 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
       message
     }
   }
+}
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
 }
 """
 

--- a/saleor/tests/e2e/orders/utils/order_lines_create.py
+++ b/saleor/tests/e2e/orders/utils/order_lines_create.py
@@ -11,6 +11,12 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
           amount
         }
       }
+      undiscountedShippingPrice {
+        amount
+      }
+      shippingPrice {
+        ...BaseTaxedMoney
+      }
       total {
         gross {
           amount

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -81,6 +81,7 @@ from ..discount.models import (
     VoucherTranslation,
 )
 from ..discount.utils.voucher import (
+    create_or_update_discount_object_from_order_level_voucher,
     get_products_voucher_discount,
     validate_voucher_in_order,
 )
@@ -90,7 +91,7 @@ from ..graphql.core.utils import to_global_id_or_none
 from ..menu.models import Menu, MenuItem, MenuItemTranslation
 from ..order import OrderOrigin, OrderStatus
 from ..order.actions import cancel_fulfillment, fulfill_order_lines
-from ..order.base_calculations import apply_order_discounts
+from ..order.base_calculations import base_order_subtotal
 from ..order.events import (
     OrderEvents,
     fulfillment_refunded_event,
@@ -148,6 +149,7 @@ from ..shipping.models import (
 )
 from ..shipping.utils import convert_to_shipping_method_data
 from ..site.models import SiteSettings
+from ..tax import TaxCalculationStrategy
 from ..tax.utils import calculate_tax_rate, get_tax_class_kwargs_for_order_line
 from ..thumbnail.models import Thumbnail
 from ..warehouse import WarehouseClickAndCollectOption
@@ -5805,7 +5807,12 @@ def draft_order_with_free_shipping_voucher(
 
     order.voucher = voucher_free_shipping
     order.voucher_code = voucher_code.code
-    subtotal, shipping_price = apply_order_discounts(order, order.lines.all())
+    create_or_update_discount_object_from_order_level_voucher(
+        order, settings.DATABASE_CONNECTION_DEFAULT_NAME
+    )
+
+    subtotal = base_order_subtotal(order, order.lines.all())
+    shipping_price = order.base_shipping_price
     order.subtotal = TaxedMoney(gross=subtotal, net=subtotal)
     order.shipping_price = TaxedMoney(net=shipping_price, gross=shipping_price)
     total = subtotal + shipping_price
@@ -9858,3 +9865,25 @@ def setup_order_webhooks(
         )
 
     return _setup
+
+
+@pytest.fixture
+def tax_configuration_flat_rates(channel_USD):
+    tc = channel_USD.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.prices_entered_with_tax = False
+    tc.tax_calculation_strategy = TaxCalculationStrategy.FLAT_RATES
+    tc.tax_app_id = "avatax.app"
+    tc.save()
+    return tc
+
+
+@pytest.fixture
+def tax_configuration_tax_app(channel_USD):
+    tc = channel_USD.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.prices_entered_with_tax = False
+    tc.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tc.tax_app_id = "avatax.app"
+    tc.save()
+    return tc


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/16696

I want to merge this change because order calculation returns wrong results when the tax app is used for tax calculation and an order has order-level discounts.

In general, this PR does four things:

1. Make sure Saleor does not propagate the order level discounts to order lines when using tax app. Flat rates and plugin requires the propagation, but tax app does it itself.
2. Shipping vouchers, despite being associated with an order, decrease the base price, similar to line-level discounts. Therefore they shouldn't be propagated together with other order-level discounts.
3. Make sure all the tests inside test_fetch_order_prices.py are based on the same configuration (have flat rates tax strategy)
4. Make sure order-level discounts are not combined

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
