### PR TITLE
Do not stack manual line discounts with line-level vouchers.

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -564,7 +564,7 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
             # introducing unique_type on discount models, there was such a possibility.
             line_discounts_to_remove.extend(discounts_to_update[1:])
 
-        # manual line discount do not stack with other discounts
+        # manual line discount do not stack with other line discounts
         if [
             discount
             for discount in line_info.discounts
@@ -1879,7 +1879,10 @@ def prepare_line_discount_objects_for_voucher(
         if discounts_to_update := line_info.get_voucher_discounts():
             discount_to_update = discounts_to_update[0]
 
-        if not discount_amount or line.is_gift:
+        # manual line discount do not stack with other line discounts
+        manual_line_discount = line_info.get_manual_line_discount()
+
+        if not discount_amount or line.is_gift or manual_line_discount:
             if discount_to_update:
                 line_discounts_to_remove.append(discount_to_update)
             continue

--- a/saleor/graphql/order/mutations/order_line_discount_update.py
+++ b/saleor/graphql/order/mutations/order_line_discount_update.py
@@ -62,8 +62,6 @@ class OrderLineDiscountUpdate(OrderDiscountCommon):
         order_line_before_update = copy.deepcopy(order_line)
         app = get_app_promise(info.context).get()
         with traced_atomic_transaction():
-            # TODO: Apply fixed order line discount to its total instead of unit price.
-            #  https://github.com/saleor/saleor/issues/14879
             update_discount_for_order_line(
                 order_line,
                 order=order,

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -2067,6 +2067,7 @@ def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
     plugins_manager,
     tax_configuration_flat_rates,
 ):
+    """Manual line discount should not stack with other line discounts."""
     # given
     order = order_with_lines
     order.status = OrderStatus.UNCONFIRMED
@@ -2074,8 +2075,8 @@ def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
     tax_rate = Decimal("1.23")
 
     voucher_listing = voucher.channel_listings.get(channel=order.channel)
-    unit_discount_amount = Decimal("2")
-    voucher_listing.discount_value = unit_discount_amount
+    voucher_discount_value = Decimal("2")
+    voucher_listing.discount_value = voucher_discount_value
     voucher_listing.save(update_fields=["discount_value"])
 
     voucher.discount_value_type = DiscountValueType.FIXED
@@ -2088,12 +2089,13 @@ def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
     order.voucher_code = voucher.codes.first().code
 
     # create manual order line discount
-    manual_line_discount_amount = Decimal("3")
+    manual_line_discount_value = Decimal("3")
     manual_line_discount = discounted_line.discounts.create(
         value_type=DiscountValueType.FIXED,
-        value=manual_line_discount_amount,
+        value=manual_line_discount_value,
         name="Manual line discount",
         type=DiscountType.MANUAL,
+        reason="Manual line discount",
     )
 
     shipping_price = order.shipping_price.net
@@ -2110,35 +2112,44 @@ def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
     # then
     discounted_line.refresh_from_db()
     line_1.refresh_from_db()
-    voucher_discount_amount = unit_discount_amount * discounted_line.quantity
-    manual_discount_amount = manual_line_discount_amount * discounted_line.quantity
+
+    manual_discount_amount = manual_line_discount_value * discounted_line.quantity
+    assert (
+        order.total_net_amount
+        == subtotal.amount + shipping_price.amount - manual_discount_amount
+    )
     assert (
         order.total_gross_amount
-        == (
-            subtotal.amount
-            + shipping_price.amount
-            - voucher_discount_amount
-            - manual_discount_amount
-        )
-        * tax_rate
+        == (subtotal.amount + shipping_price.amount - manual_discount_amount) * tax_rate
     )
-    assert order.subtotal_gross_amount == quantize_price(
-        (subtotal.amount - manual_discount_amount - voucher_discount_amount) * tax_rate,
-        currency,
+    assert order.subtotal_net_amount == subtotal.amount - manual_discount_amount
+    assert (
+        order.subtotal_gross_amount
+        == (subtotal.amount - manual_discount_amount) * tax_rate
     )
+    assert order.undiscounted_total_net == subtotal + shipping_price
     assert order.undiscounted_total_gross == (subtotal + shipping_price) * tax_rate
+    assert order.shipping_price_net == shipping_price
     assert order.shipping_price_gross == shipping_price * tax_rate
     assert order.base_shipping_price == shipping_price
 
     assert (
         discounted_line.base_unit_price_amount
         == discounted_line.undiscounted_base_unit_price_amount
-        - unit_discount_amount
-        - manual_line_discount_amount
+        - manual_line_discount_value
+    )
+    assert (
+        discounted_line.total_price_net_amount
+        == discounted_line.unit_price_net_amount * discounted_line.quantity
     )
     assert (
         discounted_line.total_price_gross_amount
-        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+        == discounted_line.unit_price_net_amount * discounted_line.quantity * tax_rate
+    )
+    assert (
+        discounted_line.undiscounted_total_price_net_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
     )
     assert (
         discounted_line.undiscounted_total_price_gross_amount
@@ -2146,17 +2157,23 @@ def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
         * discounted_line.quantity
         * tax_rate
     )
-    assert (
-        discounted_line.unit_discount_amount
-        == unit_discount_amount + manual_line_discount_amount
-    )
+    assert discounted_line.unit_discount_amount == manual_line_discount_value
     assert discounted_line.unit_discount_type == DiscountValueType.FIXED
-    assert discounted_line.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+    assert discounted_line.unit_discount_reason == manual_line_discount.reason
 
     assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
     assert (
+        line_1.total_price_net_amount
+        == order.subtotal_net_amount - discounted_line.total_price_net_amount
+    )
+    assert (
         line_1.total_price_gross_amount
-        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+        == (order.subtotal_net_amount - discounted_line.total_price_net_amount)
+        * tax_rate
+    )
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
     )
     assert (
         line_1.undiscounted_total_price_gross_amount
@@ -2166,13 +2183,7 @@ def test_fetch_order_prices_manual_line_discount_voucher_specific_product(
     assert line_1.unit_discount_type is None
     assert line_1.unit_discount_reason is None
 
-    assert discounted_line.discounts.count() == 2
-    voucher_line_discount = discounted_line.discounts.get(type=DiscountType.VOUCHER)
-    assert voucher_line_discount.amount_value == voucher_discount_amount
-    assert voucher_line_discount.value_type == DiscountValueType.FIXED
-    assert voucher_line_discount.type == DiscountType.VOUCHER
-    assert voucher_line_discount.reason == f"Voucher code: {order.voucher_code}"
-    assert voucher_line_discount.value == voucher_discount_amount
+    assert discounted_line.discounts.count() == 1
 
     manual_line_discount.refresh_from_db()
     assert manual_line_discount.amount_value == manual_discount_amount
@@ -2185,14 +2196,15 @@ def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_orde
     plugins_manager,
     tax_configuration_flat_rates,
 ):
+    """Manual line discount should not stack with other line discounts."""
     # given
     order = order_with_lines
     order.status = OrderStatus.UNCONFIRMED
     tax_rate = Decimal("1.23")
 
     voucher_listing = voucher.channel_listings.get(channel=order.channel)
-    discount_amount = Decimal("3")
-    voucher_listing.discount_value = discount_amount
+    voucher_discount_value = Decimal("3")
+    voucher_listing.discount_value = voucher_discount_value
     voucher_listing.save(update_fields=["discount_value"])
 
     voucher.apply_once_per_order = True
@@ -2205,20 +2217,14 @@ def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_orde
     order.voucher_code = voucher.codes.first().code
 
     # create manual order line discount
-    manual_line_discount_amount = Decimal("3")
+    manual_line_discount_value = Decimal("3")
     manual_line_discount = discounted_line.discounts.create(
         value_type=DiscountValueType.FIXED,
-        value=manual_line_discount_amount,
+        value=manual_line_discount_value,
         name="Manual line discount",
         type=DiscountType.MANUAL,
         reason="Manual line discount",
     )
-
-    shipping_price = order.shipping_price.net
-    currency = order.currency
-    subtotal = zero_money(currency)
-    for line in lines:
-        subtotal += line.base_unit_price * line.quantity
 
     shipping_price = order.shipping_price.net
     currency = order.currency
@@ -2234,39 +2240,44 @@ def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_orde
     # then
     discounted_line.refresh_from_db()
     line_1.refresh_from_db()
-    voucher_discount_amount = discount_amount
-    manual_discount_amount = manual_line_discount_amount * discounted_line.quantity
+
+    manual_discount_amount = manual_line_discount_value * discounted_line.quantity
+    assert (
+        order.total_net_amount
+        == subtotal.amount + shipping_price.amount - manual_discount_amount
+    )
     assert (
         order.total_gross_amount
-        == (
-            subtotal.amount
-            + shipping_price.amount
-            - voucher_discount_amount
-            - manual_discount_amount
-        )
-        * tax_rate
+        == (subtotal.amount + shipping_price.amount - manual_discount_amount) * tax_rate
     )
-    shipping_discount = shipping_price - order.shipping_price_net
-    subtotal_order_discount = manual_discount_amount - shipping_discount.amount
-    assert order.subtotal_gross_amount == quantize_price(
-        (subtotal.amount - subtotal_order_discount - voucher_discount_amount)
-        * tax_rate,
-        currency,
+    assert order.subtotal_net_amount == subtotal.amount - manual_discount_amount
+    assert (
+        order.subtotal_gross_amount
+        == (subtotal.amount - manual_discount_amount) * tax_rate
     )
+    assert order.undiscounted_total_net == subtotal + shipping_price
     assert order.undiscounted_total_gross == (subtotal + shipping_price) * tax_rate
-    assert order.shipping_price_gross == (shipping_price - shipping_discount) * tax_rate
+    assert order.shipping_price_net == shipping_price
+    assert order.shipping_price_gross == shipping_price * tax_rate
     assert order.base_shipping_price == shipping_price
 
-    unit_discount_amount = discount_amount / discounted_line.quantity
     assert (
         discounted_line.base_unit_price_amount
         == discounted_line.undiscounted_base_unit_price_amount
-        - unit_discount_amount
-        - manual_line_discount_amount
+        - manual_line_discount_value
+    )
+    assert (
+        discounted_line.total_price_net_amount
+        == discounted_line.unit_price_net_amount * discounted_line.quantity
     )
     assert (
         discounted_line.total_price_gross_amount
-        == discounted_line.unit_price_gross_amount * discounted_line.quantity
+        == discounted_line.unit_price_net_amount * discounted_line.quantity * tax_rate
+    )
+    assert (
+        discounted_line.undiscounted_total_price_net_amount
+        == discounted_line.undiscounted_base_unit_price_amount
+        * discounted_line.quantity
     )
     assert (
         discounted_line.undiscounted_total_price_gross_amount
@@ -2274,20 +2285,23 @@ def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_orde
         * discounted_line.quantity
         * tax_rate
     )
-    assert (
-        discounted_line.unit_discount_amount
-        == manual_line_discount_amount + unit_discount_amount
-    )
+    assert discounted_line.unit_discount_amount == manual_line_discount_value
     assert discounted_line.unit_discount_type == DiscountValueType.FIXED
-    assert (
-        discounted_line.unit_discount_reason
-        == f"{manual_line_discount.reason}; Voucher code: {order.voucher_code}"
-    )
+    assert discounted_line.unit_discount_reason == manual_line_discount.reason
 
     assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
     assert (
+        line_1.total_price_net_amount
+        == order.subtotal_net_amount - discounted_line.total_price_net_amount
+    )
+    assert (
         line_1.total_price_gross_amount
-        == order.subtotal_gross_amount - discounted_line.total_price_gross_amount
+        == (order.subtotal_net_amount - discounted_line.total_price_net_amount)
+        * tax_rate
+    )
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == line_1.undiscounted_base_unit_price_amount * line_1.quantity
     )
     assert (
         line_1.undiscounted_total_price_gross_amount
@@ -2297,13 +2311,7 @@ def test_fetch_order_prices_manual_line_discount_and_voucher_apply_once_per_orde
     assert line_1.unit_discount_type is None
     assert line_1.unit_discount_reason is None
 
-    assert discounted_line.discounts.count() == 2
-    voucher_line_discount = discounted_line.discounts.get(type=DiscountType.VOUCHER)
-    assert voucher_line_discount.amount_value == voucher_discount_amount
-    assert voucher_line_discount.value_type == DiscountValueType.FIXED
-    assert voucher_line_discount.type == DiscountType.VOUCHER
-    assert voucher_line_discount.reason == f"Voucher code: {order.voucher_code}"
-    assert voucher_line_discount.value == voucher_discount_amount
+    assert discounted_line.discounts.count() == 1
 
     manual_line_discount.refresh_from_db()
     assert manual_line_discount.amount_value == manual_discount_amount

--- a/saleor/tests/e2e/orders/discounts/test_order_voucher_specific_product_and_manual_line_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_voucher_specific_product_and_manual_line_discount.py
@@ -1,0 +1,331 @@
+import pytest
+
+from .....product.tasks import recalculate_discounted_price_for_products_task
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
+from ...utils import assign_permissions
+from ...vouchers.utils import (
+    create_voucher,
+    create_voucher_channel_listing,
+)
+from ..utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+    order_update_shipping,
+)
+from ..utils.order_line_discount_update import order_line_discount_update
+
+
+def prepare_voucher(
+    e2e_staff_api_client,
+    channel_id,
+    voucher_code,
+    voucher_discount_type,
+    voucher_discount_value,
+    voucher_type,
+    products,
+):
+    input = {
+        "code": voucher_code,
+        "discountValueType": voucher_discount_type,
+        "type": voucher_type,
+        "singleUse": True,
+        "applyOncePerOrder": False,
+        "products": products,
+    }
+
+    voucher_data = create_voucher(e2e_staff_api_client, input)
+
+    voucher_id = voucher_data["id"]
+    channel_listing = [
+        {
+            "channelId": channel_id,
+            "discountValue": voucher_discount_value,
+        },
+    ]
+    create_voucher_channel_listing(
+        e2e_staff_api_client,
+        voucher_id,
+        channel_listing,
+    )
+
+    return voucher_code, voucher_discount_value
+
+
+@pytest.mark.e2e
+def test_draft_order_with_voucher_specific_product_and_manual_line_discount_CORE_0250(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    """Manual line discount should override line-level voucher."""
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price_net = 15
+    product1_price = 30
+    product2_price = 55
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": False,
+    }
+
+    # Create channel, warehouse, shipping method and update tax configuration
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price_net,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": True,
+                    "allowUnpaidOrders": False,
+                    "includeDraftOrderInVoucherUsage": False,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+
+    country_tax_rate = 10
+    tax_rate = 1 + country_tax_rate / 100
+    country = "US"
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+    (
+        product1_id,
+        product1_variant_id,
+        product1_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product1_price,
+        product_type_slug="shoes",
+    )
+    (
+        product2_id,
+        product2_variant_id,
+        product2_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product2_price,
+        product_type_slug="hoodies",
+    )
+
+    # Prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    # Create voucher for specific product
+    voucher_discount_amount = 10
+    voucher_code, voucher_discount_value = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        voucher_code="10usd_off",
+        voucher_discount_type="FIXED",
+        voucher_discount_value=voucher_discount_amount,
+        voucher_type="SPECIFIC_PRODUCT",
+        products=[product1_id, product2_id],
+    )
+
+    # Step 1 - Create a draft order
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product1_variant_id, "quantity": 1},
+        {"variantId": product2_variant_id, "quantity": 1},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order_line1 = order["order"]["lines"][0]
+    order_line2 = order["order"]["lines"][1]
+
+    assert order_line1["variant"]["id"] == product1_variant_id
+    assert order_line1["unitPrice"]["net"]["amount"] == product1_variant_price
+    assert order_line2["variant"]["id"] == product2_variant_id
+    assert order_line2["unitPrice"]["net"]["amount"] == product2_variant_price
+
+    undiscounted_subtotal_net = round(
+        product1_variant_price + product2_variant_price, 2
+    )
+    undiscounted_subtotal_gross = round(undiscounted_subtotal_net * tax_rate, 2)
+    assert order["order"]["subtotal"]["net"]["amount"] == undiscounted_subtotal_net
+    assert order["order"]["subtotal"]["gross"]["amount"] == undiscounted_subtotal_gross
+
+    # Step 3 - Add a shipping method to the order
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    assert order["order"]["deliveryMethod"]["id"] is not None
+
+    shipping_price_gross = round(shipping_price_net * tax_rate, 2)
+    shipping_tax = shipping_price_gross - shipping_price_net
+    assert order["order"]["shippingPrice"]["net"]["amount"] == shipping_price_net
+    assert order["order"]["shippingPrice"]["gross"]["amount"] == shipping_price_gross
+    undiscounted_total_net = round(undiscounted_subtotal_net + shipping_price_net, 2)
+
+    undiscounted_total_gross = round(
+        undiscounted_subtotal_gross + shipping_price_gross, 2
+    )
+    assert order["order"]["total"]["net"]["amount"] == undiscounted_total_net
+    assert order["order"]["total"]["gross"]["amount"] == undiscounted_total_gross
+
+    # Step 4 - Add voucher
+    order = draft_order_update(
+        e2e_staff_api_client, order_id, {"voucherCode": voucher_code}
+    )
+
+    assert order["order"]["voucherCode"] == voucher_code
+    line_1_price_with_voucher_discount = product1_variant_price - voucher_discount_value
+    order_line1 = order["order"]["lines"][0]
+    assert (
+        order_line1["unitPrice"]["net"]["amount"] == line_1_price_with_voucher_discount
+    )
+    assert order_line1["unitDiscountReason"] == f"Voucher code: {voucher_code}"
+
+    line_2_price_with_voucher_discount = product2_variant_price - voucher_discount_value
+    order_line2 = order["order"]["lines"][1]
+    assert (
+        order_line2["unitPrice"]["net"]["amount"] == line_2_price_with_voucher_discount
+    )
+    assert order_line2["unitDiscountReason"] == f"Voucher code: {voucher_code}"
+
+    subtotal_net_with_voucher = undiscounted_subtotal_net - 2 * voucher_discount_value
+    subtotal_gross_with_voucher = round(subtotal_net_with_voucher * tax_rate, 2)
+    assert order["order"]["subtotal"]["net"]["amount"] == subtotal_net_with_voucher
+    assert order["order"]["subtotal"]["gross"]["amount"] == subtotal_gross_with_voucher
+    assert (
+        order["order"]["subtotal"]["tax"]["amount"]
+        == subtotal_gross_with_voucher - subtotal_net_with_voucher
+    )
+
+    # Step 5 - Add manual line discount
+    manual_discount_value = 5
+    manual_discount_reason = "Manual discount reason"
+    assert manual_discount_value != voucher_discount_value
+    manual_line_discount_input = {
+        "valueType": "FIXED",
+        "value": manual_discount_value,
+        "reason": manual_discount_reason,
+    }
+    data = order_line_discount_update(
+        e2e_staff_api_client, order_line1["id"], manual_line_discount_input
+    )
+
+    line_1_price_with_manual_discount = product1_variant_price - manual_discount_value
+    order_line1 = data["order"]["lines"][0]
+    assert (
+        order_line1["unitPrice"]["net"]["amount"] == line_1_price_with_manual_discount
+    )
+    assert order_line1["unitPrice"]["gross"]["amount"] == round(
+        line_1_price_with_manual_discount * tax_rate, 2
+    )
+    assert order_line1["unitDiscountReason"] == manual_discount_reason
+    assert order_line1["unitDiscount"]["amount"] == manual_discount_value
+
+    order_line2 = data["order"]["lines"][1]
+    assert (
+        order_line2["unitPrice"]["net"]["amount"] == line_2_price_with_voucher_discount
+    )
+    assert order_line2["unitPrice"]["gross"]["amount"] == round(
+        line_2_price_with_voucher_discount * tax_rate, 2
+    )
+
+    subtotal_net = (
+        line_1_price_with_manual_discount + line_2_price_with_voucher_discount
+    )
+    subtotal_gross = round(subtotal_net * tax_rate, 2)
+    subtotal_tax = subtotal_gross - subtotal_net
+    assert data["order"]["subtotal"]["net"]["amount"] == subtotal_net
+    assert data["order"]["subtotal"]["gross"]["amount"] == subtotal_gross
+    assert data["order"]["subtotal"]["tax"]["amount"] == subtotal_tax
+
+    total_net = subtotal_net + shipping_price_net
+    total_gross = subtotal_gross + shipping_price_gross
+    total_tax = total_gross - total_net
+    assert data["order"]["total"]["net"]["amount"] == total_net
+    assert data["order"]["total"]["gross"]["amount"] == total_gross
+    assert data["order"]["total"]["tax"]["amount"] == total_tax
+
+    # Step 6 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    completed_order = order["order"]
+    assert completed_order["status"] == "UNFULFILLED"
+    assert completed_order["total"]["net"]["amount"] == total_net
+    assert completed_order["total"]["gross"]["amount"] == total_gross
+    assert completed_order["total"]["tax"]["amount"] == total_tax
+    assert completed_order["subtotal"]["net"]["amount"] == subtotal_net
+    assert completed_order["subtotal"]["gross"]["amount"] == subtotal_gross
+    assert completed_order["subtotal"]["tax"]["amount"] == subtotal_tax
+    assert completed_order["shippingPrice"]["net"]["amount"] == shipping_price_net
+    assert completed_order["shippingPrice"]["gross"]["amount"] == shipping_price_gross
+    assert completed_order["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert (
+        completed_order["lines"][0]["unitPrice"]["net"]["amount"]
+        == product1_variant_price - manual_discount_value
+    )
+    assert completed_order["lines"][0]["unitPrice"]["gross"]["amount"] == round(
+        line_1_price_with_manual_discount * tax_rate, 2
+    )
+    assert (
+        completed_order["lines"][0]["totalPrice"]["net"]["amount"]
+        == product1_variant_price - manual_discount_value
+    )
+    assert completed_order["lines"][0]["totalPrice"]["gross"]["amount"] == round(
+        line_1_price_with_manual_discount * tax_rate, 2
+    )
+    assert (
+        completed_order["lines"][1]["unitPrice"]["net"]["amount"]
+        == product2_variant_price - voucher_discount_value
+    )
+    assert completed_order["lines"][1]["unitPrice"]["gross"]["amount"] == round(
+        line_2_price_with_voucher_discount * tax_rate, 2
+    )
+    assert (
+        completed_order["lines"][1]["totalPrice"]["net"]["amount"]
+        == product2_variant_price - voucher_discount_value
+    )
+    assert completed_order["lines"][1]["totalPrice"]["gross"]["amount"] == round(
+        line_2_price_with_voucher_discount * tax_rate, 2
+    )

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -12,6 +12,7 @@ from .order_invoice_create import order_invoice_create
 from .order_lines_create import order_lines_create
 from .order_mark_as_paid import mark_order_paid
 from .order_query import order_query
+from .order_update_shipping import order_update_shipping
 from .order_void import order_void, raw_order_void
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "order_add_tracking",
     "order_fulfillment_cancel",
     "order_invoice_create",
+    "order_update_shipping",
 ]

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -11,48 +11,38 @@ mutation DraftOrderComplete($id: ID!) {
     order {
       id
       undiscountedTotal {
-        gross {
-          amount
-        }
+        ...BaseTaxedMoney
       }
       totalBalance {
         amount
       }
       total {
-        gross {
-          amount
-        }
-        net {
-          amount
-        }
-        tax {
-          amount
-        }
+        ...BaseTaxedMoney
       }
       subtotal {
-        gross {
-          amount
-        }
+        ...BaseTaxedMoney
       }
       undiscountedShippingPrice {
         amount
       }
       shippingPrice {
-        gross {
-          amount
-        }
-        net {
-          amount
-        }
-        tax {
-          amount
-        }
+        ...BaseTaxedMoney
       }
-      displayGrossPrices
       status
       voucher {
         id
         code
+      }
+      discounts {
+        id
+        type
+        name
+        valueType
+        value
+        reason
+        amount {
+          amount
+        }
       }
       paymentStatus
       isPaid
@@ -68,14 +58,10 @@ mutation DraftOrderComplete($id: ID!) {
           amount
         }
         undiscountedUnitPrice {
-          gross {
-            amount
-          }
+          ...BaseTaxedMoney
         }
         unitPrice {
-          gross {
-            amount
-          }
+          ...BaseTaxedMoney
         }
         undiscountedTotalPrice {
           ...BaseTaxedMoney
@@ -86,9 +72,23 @@ mutation DraftOrderComplete($id: ID!) {
         unitDiscountReason
         unitDiscountType
         unitDiscountValue
+        isGift
       }
     }
   }
+}
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
 }
 """
 

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -77,6 +77,12 @@ mutation DraftOrderComplete($id: ID!) {
             amount
           }
         }
+        undiscountedTotalPrice {
+          ...BaseTaxedMoney
+        }
+        totalPrice {
+          ...BaseTaxedMoney
+        }
         unitDiscountReason
         unitDiscountType
         unitDiscountValue

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -13,50 +13,38 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
       lines {
         id
         totalPrice {
-          gross {
-            amount
-          }
-          tax {
-            amount
-          }
+          ...BaseTaxedMoney
         }
         unitPrice {
-          gross {
-            amount
-          }
+          ...BaseTaxedMoney
         }
         unitDiscountReason
       }
       subtotal {
-        gross {
-          amount
-        }
-        net {
-          amount
-        }
-        tax {
-          amount
-        }
+        ...BaseTaxedMoney
       }
       totalBalance {
         amount
       }
       total {
-        gross {
-          amount
-        }
-        net {
-          amount
-        }
-        tax {
-          amount
-        }
+        ...BaseTaxedMoney
       }
       voucherCode
       voucher {
         id
         code
         discountValue
+      }
+      discounts {
+        id
+        type
+        name
+        valueType
+        value
+        reason
+        amount {
+          amount
+        }
       }
       billingAddress {
         firstName
@@ -88,21 +76,10 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
       }
       isShippingRequired
       shippingPrice {
-        gross {
-          amount
-        }
-        net {
-          amount
-        }
-        tax {
-          amount
-        }
+        ...BaseTaxedMoney
       }
       undiscountedShippingPrice {
         amount
-      }
-      shippingMethod {
-        id
       }
       shippingMethods {
         id
@@ -121,6 +98,19 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
       }
     }
   }
+}
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
 }
 """
 

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -11,6 +11,7 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
     order {
       id
       lines {
+        id
         totalPrice {
           gross {
             amount

--- a/saleor/tests/e2e/orders/utils/order_line_discount_update.py
+++ b/saleor/tests/e2e/orders/utils/order_line_discount_update.py
@@ -1,0 +1,84 @@
+from .....graphql.tests.utils import get_graphql_content
+
+ORDER_LINE_DISCOUNT_UPDATE = """
+mutation OrderLineDiscountUpdate($input: OrderDiscountCommonInput!, $orderLineId: ID!){
+  orderLineDiscountUpdate(orderLineId: $orderLineId, input: $input){
+    order {
+      id
+      voucherCode
+      voucher {
+        id
+      }
+      total {
+        ...BaseTaxedMoney
+      }
+      undiscountedTotal {
+        ...BaseTaxedMoney
+      }
+      subtotal {
+        ...BaseTaxedMoney
+      }
+      shippingPrice {
+        ...BaseTaxedMoney
+      }
+      undiscountedShippingPrice {
+        amount
+      }
+      lines {
+            id
+            undiscountedUnitPrice {
+            ...BaseTaxedMoney
+            }
+            unitPrice {
+            ...BaseTaxedMoney
+            }
+            totalPrice {
+             ...BaseTaxedMoney
+            }
+            undiscountedTotalPrice {
+            ...BaseTaxedMoney
+            }
+            quantity
+            unitDiscount {
+            amount
+            }
+            unitDiscountValue
+            unitDiscountReason
+            voucherCode
+        }
+    }
+    errors{
+      field
+      message
+      code
+    }
+  }
+}
+
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+}
+"""
+
+
+def order_line_discount_update(api_client, id, input):
+    variables = {"orderLineId": id, "input": input}
+
+    response = api_client.post_graphql(
+        ORDER_LINE_DISCOUNT_UPDATE,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderLineDiscountUpdate"]
+    assert not data["errors"]
+
+    return data

--- a/saleor/tests/e2e/orders/utils/order_update_shipping.py
+++ b/saleor/tests/e2e/orders/utils/order_update_shipping.py
@@ -1,0 +1,96 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+ORDER_UPDATE_SHIPPING_MUTATION = """
+mutation OrderUpdateShipping($input: OrderUpdateShippingInput!, $id: ID!) {
+  orderUpdateShipping(input: $input, order: $id) {
+    errors {
+      message
+      field
+      code
+    }
+    order {
+      id
+      subtotal {
+        ...BaseTaxedMoney
+      }
+      total {
+        ...BaseTaxedMoney
+      }
+      undiscountedTotal {
+        ...BaseTaxedMoney
+      }
+      deliveryMethod {
+        __typename
+        ... on ShippingMethod {
+          id
+        }
+      }
+      shippingPrice {
+        ...BaseTaxedMoney
+      }
+      undiscountedShippingPrice {
+        amount
+      }
+      voucher {
+        id
+        code
+        discountValue
+      }
+      discounts {
+        type
+        value
+        reason
+        valueType
+        amount {
+          amount
+        }
+      }
+      lines {
+        totalPrice {
+          ...BaseTaxedMoney
+        }
+        unitPrice {
+          ...BaseTaxedMoney
+        }
+        unitDiscountReason
+        isGift
+      }
+    }
+  }
+}
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
+}
+"""
+
+
+def order_update_shipping(
+    api_client,
+    id,
+    input,
+):
+    variables = {"id": id, "input": input}
+
+    response = api_client.post_graphql(
+        ORDER_UPDATE_SHIPPING_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderUpdateShipping"]
+    order_id = data["order"]["id"]
+    errors = data["errors"]
+
+    assert errors == []
+    assert order_id == id
+
+    return data

--- a/saleor/tests/e2e/product/utils/preparing_product.py
+++ b/saleor/tests/e2e/product/utils/preparing_product.py
@@ -14,9 +14,11 @@ def prepare_product(
     warehouse_id,
     channel_id,
     variant_price,
+    product_type_slug="default",
 ):
     product_type_data = create_product_type(
         e2e_staff_api_client,
+        slug=product_type_slug,
     )
     product_type_id = product_type_data["id"]
 


### PR DESCRIPTION
I want to merge this change because manual line discounts should override voucher line discounts, same as it behaves with catalog promotions.

Port: https://github.com/saleor/saleor/pull/16738

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
