### PR TITLE
Fix `test_split_manual_discount` to silent warnings

### DIFF
--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -713,10 +713,10 @@ def test_split_manual_discount(
     draft_order_with_fixed_discount_order,
 ):
     # given
-    subtotal = Money(subtotal, currency="USD")
-    shipping = Money(shipping_price, currency="USD")
+    subtotal = Money(Decimal(subtotal), currency="USD")
+    shipping = Money(Decimal(shipping_price), currency="USD")
     discount = draft_order_with_fixed_discount_order.discounts.first()
-    discount.value = value
+    discount.value = Decimal(value)
     discount.value_type = value_type
 
     # when
@@ -725,8 +725,8 @@ def test_split_manual_discount(
     )
 
     # then
-    assert subtotal_discount == Money(subtotal_portion, "USD")
-    assert shipping_discount == Money(shipping_portion, "USD")
+    assert subtotal_discount == Money(Decimal(subtotal_portion), "USD")
+    assert shipping_discount == Money(Decimal(shipping_portion), "USD")
 
 
 def test_discount_info_for_logs(order_with_lines, voucher, order_promotion_with_rule):


### PR DESCRIPTION
I want to merge this change because `test_split_manual_discount` produced warnings due to passing `float` to `Money` type.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
