### PR TITLE
[TEST] Add e2e to changing lines on draft order

### DIFF
--- a/saleor/tests/e2e/orders/discounts/test_order_with_shipping_voucher_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_with_shipping_voucher_and_manual_order_discount.py
@@ -46,7 +46,7 @@ def prepare_shipping_voucher(
 
 
 @pytest.mark.e2e
-def test_order_with_shipping_voucher_and_manual_order_discount(
+def test_order_with_shipping_voucher_and_manual_order_discount_CORE_0249(
     e2e_staff_api_client,
     shop_permissions,
     permission_manage_product_types_and_attributes,

--- a/saleor/tests/e2e/orders/test_manage_products_on_draft_order.py
+++ b/saleor/tests/e2e/orders/test_manage_products_on_draft_order.py
@@ -1,0 +1,121 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    order_line_delete,
+    order_line_update,
+    order_lines_create,
+    order_update_shipping,
+)
+
+
+@pytest.mark.e2e
+def test_should_change_lines_on_draft_orders_CORE_0246(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+    shipping_price = 10
+    product1_price = 9
+    product2_price = 21
+
+    (
+        _product1_id,
+        product1_variant_id,
+        product1_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product1_price,
+        product_type_slug="test-product-type1",
+    )
+
+    (
+        _product2_id,
+        product2_variant_id,
+        product2_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=product2_price,
+        product_type_slug="test-product-type2",
+    )
+
+    # Step 1 - Create a draft order
+    input = {
+        "channelId": channel_id,
+        "userEmail": "customer@example.com",
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 2 - Add order lines to the order
+    lines = [
+        {"variantId": product1_variant_id, "quantity": 2},
+        {"variantId": product2_variant_id, "quantity": 5},
+    ]
+    order = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order_lines = order["order"]["lines"]
+    assert len(order_lines) == 2
+    line1_total = product1_variant_price * 2
+    line2_total = product2_variant_price * 5
+    assert order_lines[0]["totalPrice"]["gross"]["amount"] == line1_total
+    assert order_lines[1]["totalPrice"]["gross"]["amount"] == line2_total
+    first_order_line_id = order_lines[0]["id"]
+    second_order_line_id = order_lines[1]["id"]
+    assert order["order"]["subtotal"]["gross"]["amount"] == line1_total + line2_total
+
+    # Step 3 - Update second order line quantity
+    input = {"quantity": 2}
+
+    order = order_line_update(e2e_staff_api_client, second_order_line_id, input)
+    order_lines = order["order"]["lines"]
+    assert len(order_lines) == 2
+    line2_total = product2_variant_price * 2
+    assert order["order"]["lines"][1]["quantity"] == 2
+    assert order["order"]["lines"][1]["totalPrice"]["gross"]["amount"] == line2_total
+    assert order["order"]["subtotal"]["gross"]["amount"] == line1_total + line2_total
+
+    # Step 4 - Remove first order line
+    order = order_line_delete(e2e_staff_api_client, first_order_line_id)
+    assert len(order["order"]["lines"]) == 1
+    assert order["order"]["lines"][0]["id"] == second_order_line_id
+    assert order["order"]["subtotal"]["gross"]["amount"] == line2_total
+
+    # Step 5 - Add a shipping method to the order
+    input = {"shippingMethod": shipping_method_id}
+    order = order_update_shipping(e2e_staff_api_client, order_id, input)
+    assert order["order"]["deliveryMethod"]["id"] is not None
+    assert order["order"]["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert order["order"]["total"]["gross"]["amount"] == line2_total + shipping_price
+
+    # Step 6 - Complete the draft order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    assert len(order["order"]["lines"]) == 1
+    assert order["order"]["lines"][0]["id"] == second_order_line_id
+    assert order["order"]["total"]["gross"]["amount"] == line2_total + shipping_price
+    assert order["order"]["shippingPrice"]["gross"]["amount"] == shipping_price

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -10,6 +10,7 @@ from .order_fulfill import order_fulfill
 from .order_fulfill_add_tracking import order_add_tracking
 from .order_fulfillment_cancel import order_fulfillment_cancel
 from .order_invoice_create import order_invoice_create
+from .order_line_delete import order_line_delete
 from .order_line_update import order_line_update
 from .order_lines_create import order_lines_create
 from .order_mark_as_paid import mark_order_paid
@@ -38,4 +39,5 @@ __all__ = [
     "order_update_shipping",
     "draft_order_bulk_delete",
     "order_line_update",
+    "order_line_delete",
 ]

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -52,6 +52,7 @@ mutation DraftOrderComplete($id: ID!) {
         }
       }
       lines {
+        id
         productVariantId
         quantity
         unitDiscount {

--- a/saleor/tests/e2e/orders/utils/order_line_delete.py
+++ b/saleor/tests/e2e/orders/utils/order_line_delete.py
@@ -1,0 +1,81 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+ORDER_LINE_DELETE_MUTATION = """
+mutation orderLineDelete($lineId: ID!) {
+  orderLineDelete(id: $lineId) {
+    order {
+      id
+      shippingMethods {
+        id
+        price {
+          amount
+        }
+      }
+      total {
+        ...BaseTaxedMoney
+      }
+      subtotal {
+        ...BaseTaxedMoney
+      }
+      undiscountedTotal {
+        ...BaseTaxedMoney
+      }
+      isShippingRequired
+      lines {
+        id
+        quantity
+        variant {
+          id
+        }
+        totalPrice {
+          ...BaseTaxedMoney
+        }
+        unitPrice {
+          ...BaseTaxedMoney
+        }
+        unitDiscountReason
+        unitDiscountType
+        unitDiscountValue
+        unitDiscount {
+          amount
+        }
+        undiscountedUnitPrice {
+          gross {
+            amount
+          }
+        }
+      }
+    }
+    errors {
+      code
+      field
+      message
+    }
+  }
+}
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
+}
+"""
+
+
+def order_line_delete(
+    api_client,
+    order_line_id,
+):
+    variables = {"lineId": order_line_id}
+
+    response = api_client.post_graphql(ORDER_LINE_DELETE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    return content["data"]["orderLineDelete"]


### PR DESCRIPTION
I want to merge this change because it adds a test to manage products on draft order
[Should be able to change lines on draft orders CORE_0246](https://saleor.testmo.net/repositories/5?group_id=112&pagination_current=2&case_id=24368)

Internal task https://linear.app/saleor/issue/QAG-222/implement-core-e2e-for-managing-products-on-draft-orders


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
