### PR TITLE
[TEST] Add test to complete draft order for existing customer

### DIFF
--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
@@ -15,14 +15,17 @@ from .utils import (
 def create_active_customer(
     e2e_staff_api_client,
 ):
-    email = "user@saleor.io"
+    customer_input = {
+        "email": "user@saleor.io",
+        "isActive": True,
+    }
 
     user_data = create_customer(
         e2e_staff_api_client,
-        email,
-        is_active=True,
+        customer_input,
     )
     user_id = user_data["id"]
+    email = user_data["email"]
 
     return user_id, email
 

--- a/saleor/tests/e2e/orders/test_complete_draft_order_for_existing_customer.py
+++ b/saleor/tests/e2e/orders/test_complete_draft_order_for_existing_customer.py
@@ -1,0 +1,133 @@
+import pytest
+
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..users.utils import create_customer
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+)
+
+
+@pytest.mark.e2e
+def test_complete_draft_order_for_existing_customer_CORE_0237(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_users,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_users,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    product_price = 10
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    _product_id, product_variant_id, _product_variant_price = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        product_price,
+    )
+
+    customer_address = {
+        "city": "Fort Wayne",
+        "cityArea": "",
+        "companyName": "",
+        "country": "US",
+        "countryArea": "Indiana",
+        "firstName": "Charles",
+        "lastName": "Hembree",
+        "phone": "12136399632",
+        "postalCode": "46802",
+        "streetAddress1": "1183 Cessna Drive",
+        "streetAddress2": "",
+    }
+    customer_input = {
+        "email": "new3@com.com",
+        "firstName": "Charles",
+        "lastName": "Hembree",
+        "note": "Important customer",
+        "defaultBillingAddress": customer_address,
+        "defaultShippingAddress": customer_address,
+    }
+
+    user_data = create_customer(
+        e2e_staff_api_client,
+        customer_input,
+    )
+    user_id = user_data["id"]
+    user_email = user_data["email"]
+
+    # Step 1 - Create draft order
+    draft_order_input = {
+        "channelId": channel_id,
+        "user": user_id,
+        "shippingAddress": customer_address,
+        "billingAddress": customer_address,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+    assert order_id is not None
+    assert data["order"]["status"] == "DRAFT"
+    assert data["order"]["user"]["id"] == user_id
+    assert data["order"]["user"]["email"] == user_email
+    assert (
+        data["order"]["shippingAddress"]["streetAddress1"]
+        == customer_address["streetAddress1"]
+    )
+    assert (
+        data["order"]["billingAddress"]["streetAddress1"]
+        == customer_address["streetAddress1"]
+    )
+
+    # Step 2 - Add lines to the order
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        }
+    ]
+    order_lines = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id == product_variant_id
+
+    # Step 3 - Update order's shipping method
+    input = {"shippingMethod": shipping_method_id}
+    draft_order = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id is not None
+
+    # Step 4 - Complete the order and check it's status
+    order = draft_order_complete(
+        e2e_staff_api_client,
+        order_id,
+    )
+    order = order["order"]
+    assert order["user"]["id"] == user_id
+    assert order["user"]["email"] == user_email
+    assert order["status"] == "UNFULFILLED"

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -10,6 +10,10 @@ mutation DraftOrderComplete($id: ID!) {
     }
     order {
       id
+      user {
+        id
+        email
+      }
       undiscountedTotal {
         ...BaseTaxedMoney
       }

--- a/saleor/tests/e2e/orders/utils/draft_order_create.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_create.py
@@ -11,6 +11,11 @@ mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
     order {
       id
       created
+      status
+      user {
+        id
+        email
+      }
       discounts {
         amount {
           amount

--- a/saleor/tests/e2e/users/test_create_and_update_customer_with_metadata.py
+++ b/saleor/tests/e2e/users/test_create_and_update_customer_with_metadata.py
@@ -16,14 +16,17 @@ def test_create_and_update_customer_with_metadata_core_1514(
     assign_permissions(e2e_staff_api_client, permissions)
 
     # Step 1 - Create a customer with metadata
-    email = "new3@com.com"
     metadata = [{"key": "customer_code", "value": "abc"}]
     private_metadata = [{"key": "priv_customer_code", "value": "priv_abc"}]
+    customer_input = {
+        "email": "new3@com.com",
+        "metadata": metadata,
+        "privateMetadata": private_metadata,
+    }
+
     user_data = create_customer(
         e2e_staff_api_client,
-        email,
-        metadata,
-        private_metadata,
+        customer_input,
     )
 
     assert user_data is not None

--- a/saleor/tests/e2e/users/test_should_bulk_update_customers_metadata.py
+++ b/saleor/tests/e2e/users/test_should_bulk_update_customers_metadata.py
@@ -18,8 +18,8 @@ def test_should_bulk_update_customers_metadata_core_1513(
     # Step 1 - Create customers
     customer_ids = []
     for i in range(5):
-        email = f"test_{i + 1}@saleor.io"
-        user_data = create_customer(e2e_staff_api_client, email)
+        customer_input = {"email": f"test_{i + 1}@saleor.io"}
+        user_data = create_customer(e2e_staff_api_client, customer_input)
         user_id = user_data["id"]
         customer_ids.append(user_id)
         assert customer_ids is not None

--- a/saleor/tests/e2e/users/utils/create_customer.py
+++ b/saleor/tests/e2e/users/utils/create_customer.py
@@ -12,6 +12,7 @@ mutation CreateCustomer ($input: UserCreateInput!) {
     }
     user {
       id
+      email
       metadata {
         key
         value
@@ -28,19 +29,9 @@ mutation CreateCustomer ($input: UserCreateInput!) {
 
 def create_customer(
     staff_api_client,
-    email,
-    metadata=None,
-    private_metadata=None,
-    is_active=False,
+    input_data,
 ):
-    variables = {
-        "input": {
-            "email": email,
-            "metadata": metadata,
-            "privateMetadata": private_metadata,
-            "isActive": is_active,
-        }
-    }
+    variables = {"input": input_data}
 
     response = staff_api_client.post_graphql(
         CUSTOMER_CREATE_MUTATION,


### PR DESCRIPTION
I want to merge this change because it covers the scenario:
[Should be able to complete draft order for existing customer CORE_0237](https://saleor.testmo.net/repositories/5?group_id=112&pagination_current=2&case_id=24345)

Internal task https://linear.app/saleor/issue/QAG-224/implement-core-e2e-for-set-customer-on-draft-orders

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
