### PR TITLE
Fix missing voucher_code assignment in order

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1231,7 +1231,9 @@ def _create_order_from_checkout(
 
     # voucher
     voucher = checkout_info.voucher
-    voucher_code = checkout_info.checkout.voucher_code
+    voucher_code = (
+        checkout_info.voucher_code.code if checkout_info.voucher_code else None
+    )
 
     # shipping
     undiscounted_base_shipping_price = base_checkout_undiscounted_delivery_price(

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1231,6 +1231,7 @@ def _create_order_from_checkout(
 
     # voucher
     voucher = checkout_info.voucher
+    voucher_code = checkout_info.checkout.voucher_code
 
     # shipping
     undiscounted_base_shipping_price = base_checkout_undiscounted_delivery_price(
@@ -1280,6 +1281,7 @@ def _create_order_from_checkout(
         total=taxed_total,  # money field not supported by mypy_django_plugin
         shipping_tax_rate=shipping_tax_rate,
         voucher=voucher,
+        voucher_code=voucher_code,
         checkout_token=str(checkout_info.checkout.token),
         origin=OrderOrigin.CHECKOUT,
         channel=checkout_info.channel,

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -775,6 +775,7 @@ def test_order_from_checkout_with_voucher(
     assert order_discount.type == DiscountType.VOUCHER
     assert order_discount.voucher == voucher_percentage
     assert order_discount.voucher_code == code.code
+    assert order.voucher_code == code.code
 
     code.refresh_from_db()
     assert code.used == voucher_used_count + 1


### PR DESCRIPTION
- Corrected missing assignment to voucher_code in checkout process.
- Ensures voucher is properly tracked during order creation.

I want to merge this change because, without the assignment of the voucher_code, the system loses track of the voucher code during order creation, making it hard to track which voucher code is being used in an order.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

No docs updates required.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
