### PR TITLE
Refactor webhooks tests

### DIFF
--- a/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
+++ b/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
@@ -71,8 +71,9 @@ def test_list_stored_payment_methods_with_static_payload(
     response = plugin.list_stored_payment_methods(data, [])
 
     # then
-    delivery = EventDelivery.objects.get()
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     mocked_cache_get.assert_called_once_with(expected_cache_key)
     mocked_cache_set.assert_called_once_with(
@@ -119,9 +120,11 @@ def test_list_stored_payment_methods_subscription_issuing_principal(
     response = plugin.list_stored_payment_methods(data, [])
 
     # then
-    delivery = EventDelivery.objects.get()
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
+    delivery = mock_request.mock_calls[0].args[0]
     delivery_subscription_payload = json.loads(delivery.payload.get_payload())
     assert delivery_subscription_payload == {
         "issuingPrincipal": {"id": graphene.Node.to_global_id("User", customer_user.pk)}
@@ -165,9 +168,11 @@ def test_list_stored_payment_methods_subscription_issuing_principal_as_app(
     response = plugin.list_stored_payment_methods(data, [])
 
     # then
-    delivery = EventDelivery.objects.get()
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
+    delivery = mock_request.mock_calls[0].args[0]
     delivery_subscription_payload = json.loads(delivery.payload.get_payload())
     assert delivery_subscription_payload == {
         "issuingPrincipal": {
@@ -225,8 +230,9 @@ def test_list_stored_payment_methods_with_subscription_payload(
     response = plugin.list_stored_payment_methods(data, [])
 
     # then
-    delivery = EventDelivery.objects.get()
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     mocked_cache_get.assert_called_once_with(expected_cache_key)
     mocked_cache_set.assert_called_once_with(
@@ -339,8 +345,9 @@ def test_list_stored_payment_methods_app_returns_incorrect_response(
     response = plugin.list_stored_payment_methods(data, [])
 
     # then
-    delivery = EventDelivery.objects.get()
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     mocked_cache_get.assert_called_once_with(expected_cache_key)
     assert not mocked_cache_set.called

--- a/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
+++ b/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import graphene
 
-from ....core.models import EventDelivery
 from ....payment.interface import ListStoredPaymentMethodsRequestData
 from ....settings import WEBHOOK_SYNC_TIMEOUT
 from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TIMEOUT

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
@@ -73,16 +73,16 @@ def _assert_with_static_payload(
 
 def _assert_fields(payload, webhook, expected_data, response, mock_request):
     webhook_app = webhook.app
-    event_payload = EventPayload.objects.get()
+    mock_request.assert_called_once()
+    delivery = mock_request.mock_calls[0].args[0]
+    event_payload = delivery.payload
     assert json.loads(event_payload.get_payload()) == payload
-    delivery = EventDelivery.objects.get()
     assert delivery.status == EventDeliveryStatus.PENDING
     assert (
         delivery.event_type == WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
     )
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     assert response == [
         PaymentGatewayData(app_identifier=webhook_app.identifier, data=expected_data)
     ]

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
@@ -4,7 +4,6 @@ from unittest import mock
 import graphene
 import pytest
 
-from ....core.models import EventDelivery
 from ....payment.interface import (
     PaymentGatewayInitializeTokenizationRequestData,
     PaymentGatewayInitializeTokenizationResponseData,

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
@@ -73,13 +73,16 @@ def test_payment_gateway_initialize_tokenization_with_static_payload(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.SUCCESSFULLY_INITIALIZED,
@@ -127,13 +130,16 @@ def test_payment_gateway_initialize_tokenization_with_subscription_payload(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "data": expected_data,
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.SUCCESSFULLY_INITIALIZED,
@@ -180,9 +186,9 @@ def test_payment_gateway_initialize_tokenization_missing_correct_response_from_w
     )
 
     # then
-    delivery = EventDelivery.objects.get()
-
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     assert response == PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
@@ -229,13 +235,16 @@ def test_payment_gateway_initialize_tokenization_failure_from_app(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_INITIALIZE,

--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -83,14 +83,17 @@ def test_payment_method_initialize_tokenization_with_static_payload(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
         "payment_flow_to_support": "interactive",
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
@@ -143,14 +146,17 @@ def test_payment_method_initialize_tokenization_with_subscription_payload(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "data": expected_data,
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
         "paymentFlowToSupport": "INTERACTIVE",
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
@@ -202,9 +208,9 @@ def test_payment_method_initialize_tokenization_missing_correct_response_from_we
     )
 
     # then
-    delivery = EventDelivery.objects.get()
-
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
@@ -253,14 +259,17 @@ def test_payment_method_initialize_tokenization_failure_from_app(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
         "payment_flow_to_support": "interactive",
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
@@ -310,14 +319,17 @@ def test_payment_method_initialize_tokenization_additional_action_required(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
         "payment_flow_to_support": "interactive",
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED,
@@ -375,14 +387,17 @@ def test_payment_method_initialize_tokenization_missing_required_id(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
         "payment_flow_to_support": "interactive",
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
@@ -489,9 +504,12 @@ def test_expected_result_invalidates_cache_for_app(
     )
 
     # then
-    delivery = EventDelivery.objects.filter(
-        event_type=WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
-    ).first()
+    mocked_request.assert_called()
+    assert mocked_request.mock_calls[-1].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mocked_request.mock_calls[-1].args[0]
+    assert delivery.event_type==WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
     assert json.loads(delivery.payload.get_payload()) == {
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "data": expected_data,
@@ -501,8 +519,6 @@ def test_expected_result_invalidates_cache_for_app(
 
     # delete the same cache key as created when fetching stored payment methods
     mocked_cache_delete.assert_called_once_with(expected_cache_key)
-
-    mocked_request.assert_called_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=result,

--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -4,7 +4,6 @@ from unittest import mock
 import graphene
 import pytest
 
-from ....core.models import EventDelivery
 from ....payment import TokenizedPaymentFlow
 from ....payment.interface import (
     ListStoredPaymentMethodsRequestData,
@@ -509,7 +508,10 @@ def test_expected_result_invalidates_cache_for_app(
     # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     delivery = mocked_request.mock_calls[-1].args[0]
-    assert delivery.event_type==WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    assert (
+        delivery.event_type
+        == WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    )
     assert json.loads(delivery.payload.get_payload()) == {
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "data": expected_data,

--- a/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
@@ -4,7 +4,6 @@ from unittest import mock
 import graphene
 import pytest
 
-from ....core.models import EventDelivery
 from ....payment.interface import (
     ListStoredPaymentMethodsRequestData,
     PaymentMethodProcessTokenizationRequestData,

--- a/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
@@ -85,14 +85,17 @@ def test_payment_method_process_tokenization_with_static_payload(
     response = plugin.payment_method_process_tokenization(request_data, previous_value)
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "id": expected_payment_method_id,
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
@@ -148,14 +151,17 @@ def test_payment_method_process_tokenization_with_subscription_payload(
     response = plugin.payment_method_process_tokenization(request_data, previous_value)
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "data": expected_data,
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
         "id": expected_payment_method_id,
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
@@ -208,9 +214,9 @@ def test_payment_method_process_tokenization_missing_correct_response_from_webho
     response = plugin.payment_method_process_tokenization(request_data, previous_value)
 
     # then
-    delivery = EventDelivery.objects.get()
-
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
@@ -262,14 +268,17 @@ def test_payment_method_process_tokenization_failure_from_app(
     response = plugin.payment_method_process_tokenization(request_data, previous_value)
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "id": expected_payment_method_id,
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
@@ -321,14 +330,17 @@ def test_payment_method_process_tokenization_additional_action_required(
     response = plugin.payment_method_process_tokenization(request_data, previous_value)
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "id": expected_payment_method_id,
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED,
@@ -388,14 +400,17 @@ def test_payment_method_process_tokenization_missing_required_id(
     response = plugin.payment_method_process_tokenization(request_data, previous_value)
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
         "data": expected_data,
         "id": expected_payment_method_id,
     }
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
@@ -504,9 +519,11 @@ def test_expected_result_invalidates_cache_for_app(
     response = plugin.payment_method_process_tokenization(request_data, previous_value)
 
     # then
-    delivery = EventDelivery.objects.filter(
-        event_type=WebhookEventSyncType.PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION
-    ).first()
+    mocked_request.assert_called()
+    assert mocked_request.mock_calls[-1].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mocked_request.mock_calls[-1].args[0]
     assert json.loads(delivery.payload.get_payload()) == {
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "data": expected_data,
@@ -516,8 +533,6 @@ def test_expected_result_invalidates_cache_for_app(
 
     # delete the same cache key as created when fetching stored payment methods
     mocked_cache_delete.assert_called_once_with(expected_cache_key)
-
-    mocked_request.assert_called_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == PaymentMethodTokenizationResponseData(
         result=result,

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -72,8 +72,8 @@ def test_trigger_webhook_sync(mock_request, payment_app):
     trigger_webhook_sync(
         WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app.webhooks.first(), False
     )
-    event_delivery = EventDelivery.objects.first()
-    mock_request.assert_called_once_with(event_delivery)
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
 
 @mock.patch(
@@ -155,10 +155,12 @@ def test_send_webhook_request_sync_successful_attempt(
     # when
     response_data = send_webhook_request_sync(event_delivery)
 
-    attempt = EventDeliveryAttempt.objects.first()
-
     # then
     mock_clear_delivery.assert_called_once_with(event_delivery)
+    mock_observability.assert_called_once()
+    # TODO (PE-371): Assert EventDeliveryAttempt DB object wasn't created
+
+    attempt = mock_observability.mock_calls[0].args[0]
     assert event_delivery.status == EventDeliveryStatus.SUCCESS
     assert attempt.status == EventDeliveryStatus.SUCCESS
     assert attempt.duration == expected_data["duration"].total_seconds()

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -5,7 +5,6 @@ from unittest.mock import call
 import graphene
 import pytest
 
-from ....core.models import EventDelivery
 from ....graphql.tests.utils import get_graphql_content
 from ....order import OrderStatus
 from ....webhook.const import CACHE_EXCLUDED_SHIPPING_TIME

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -681,8 +681,8 @@ def test_trigger_webhook_sync(mock_request, shipping_app):
     trigger_webhook_sync(
         WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, webhook, False
     )
-    event_delivery = EventDelivery.objects.first()
-    mock_request.assert_called_once_with(event_delivery)
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
 
 @mock.patch("saleor.webhook.transport.synchronous.transport.cache.set")

--- a/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
@@ -79,7 +79,11 @@ def test_stored_payment_method_request_delete_with_static_payload(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(
         {
             "payment_method_id": payment_method_id,
@@ -87,7 +91,6 @@ def test_stored_payment_method_request_delete_with_static_payload(
             "channel_slug": channel_USD.slug,
         }
     )
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED, error=None
@@ -133,7 +136,11 @@ def test_stored_payment_method_request_delete_with_subscription_payload(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(
         {
             "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
@@ -141,7 +148,6 @@ def test_stored_payment_method_request_delete_with_subscription_payload(
             "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
         }
     )
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED, error=None
@@ -187,7 +193,11 @@ def test_stored_payment_method_request_delete_failure_from_app(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
     assert delivery.payload.get_payload() == json.dumps(
         {
             "payment_method_id": payment_method_id,
@@ -195,7 +205,6 @@ def test_stored_payment_method_request_delete_failure_from_app(
             "channel_slug": channel_USD.slug,
         }
     )
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE,
@@ -242,9 +251,9 @@ def test_stored_payment_method_request_delete_missing_response_from_webhook(
     )
 
     # then
-    delivery = EventDelivery.objects.get()
-
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELIVER,
@@ -291,9 +300,9 @@ def test_stored_payment_method_request_delete_incorrect_result_response_from_web
     )
 
     # then
-    delivery = EventDelivery.objects.get()
-
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE,
@@ -340,9 +349,9 @@ def test_stored_payment_method_request_delete_missing_result_in_response_from_we
     )
 
     # then
-    delivery = EventDelivery.objects.get()
-
-    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+    mock_request.assert_called_once()
+    assert mock_request.mock_calls[0].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE,
@@ -436,9 +445,12 @@ def test_stored_payment_method_request_delete_invalidates_cache_for_app(
     )
 
     # then
-    delivery = EventDelivery.objects.filter(
-        event_type=WebhookEventSyncType.STORED_PAYMENT_METHOD_DELETE_REQUESTED
-    ).first()
+    mocked_request.assert_called()
+    assert mocked_request.mock_calls[-1].kwargs["timeout"] == WEBHOOK_SYNC_TIMEOUT
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mocked_request.mock_calls[-1].args[0]
+    assert delivery.event_type==WebhookEventSyncType.STORED_PAYMENT_METHOD_DELETE_REQUESTED
     assert delivery.payload.get_payload() == json.dumps(
         {
             "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
@@ -448,8 +460,6 @@ def test_stored_payment_method_request_delete_invalidates_cache_for_app(
     )
     # delete the same cache key as created when fetching stored payment methods
     mocked_cache_delete.assert_called_once_with(expected_cache_key)
-
-    mocked_request.assert_called_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED, error=None

--- a/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
@@ -4,7 +4,6 @@ from unittest import mock
 import graphene
 import pytest
 
-from ....core.models import EventDelivery
 from ....payment.interface import (
     ListStoredPaymentMethodsRequestData,
     StoredPaymentMethodRequestDeleteData,
@@ -450,7 +449,10 @@ def test_stored_payment_method_request_delete_invalidates_cache_for_app(
     # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     delivery = mocked_request.mock_calls[-1].args[0]
-    assert delivery.event_type==WebhookEventSyncType.STORED_PAYMENT_METHOD_DELETE_REQUESTED
+    assert (
+        delivery.event_type
+        == WebhookEventSyncType.STORED_PAYMENT_METHOD_DELETE_REQUESTED
+    )
     assert delivery.payload.get_payload() == json.dumps(
         {
             "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -66,14 +66,14 @@ def test_get_taxes_for_order(
     tax_data = plugin.get_taxes_for_order(order, app_identifier, None)
 
     # then
-    payload = EventPayload.objects.get()
-    assert payload.get_payload() == generate_order_payload_for_tax_calculation(order)
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    
+    delivery = mock_request.mock_calls[0].args[0]
+    assert delivery.payload.get_payload() == generate_order_payload_for_tax_calculation(order)
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
-    assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -182,14 +182,14 @@ def test_get_taxes_for_order_with_sync_subscription(
     tax_data = plugin.get_taxes_for_order(order, app_identifier, None)
 
     # then
-    payload = EventPayload.objects.get()
-    assert payload.get_payload() == json.dumps({"taxBase": {"currency": "USD"}})
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
+    assert delivery.payload.get_payload() == json.dumps({"taxBase": {"currency": "USD"}})
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
-    assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -234,14 +234,14 @@ def test_get_taxes_for_checkout_with_sync_subscription(
         request=ANY,  # SaleorContext,
         app=tax_app,
     )
-    payload = EventPayload.objects.get()
-    assert payload.get_payload() == json.dumps(expected_payload)
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
+    assert delivery.payload.get_payload() == json.dumps(expected_payload)
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
-    assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -289,13 +289,13 @@ def test_get_taxes_for_checkout_with_sync_subscription_with_pregenerated_payload
 
     # then
     mock_generate_payload.assert_not_called()
-    payload = EventPayload.objects.get()
-    assert payload.get_payload() == json.dumps(expected_payload)
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
+    assert delivery.payload.get_payload() == json.dumps(expected_payload)
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
-    assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....core import EventDeliveryStatus
-from ....core.models import EventDelivery, EventPayload
 from ....core.taxes import TaxType
 from ....graphql.webhook.utils import get_subscription_query_hash
 from ....webhook.event_types import WebhookEventSyncType
@@ -68,9 +67,11 @@ def test_get_taxes_for_order(
     # then
     mock_request.assert_called_once()
     # TODO (PE-371): Assert EventDelivery DB object wasn't created
-    
+
     delivery = mock_request.mock_calls[0].args[0]
-    assert delivery.payload.get_payload() == generate_order_payload_for_tax_calculation(order)
+    assert delivery.payload.get_payload() == generate_order_payload_for_tax_calculation(
+        order
+    )
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.webhook == webhook
@@ -186,7 +187,9 @@ def test_get_taxes_for_order_with_sync_subscription(
     # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
     delivery = mock_request.mock_calls[0].args[0]
-    assert delivery.payload.get_payload() == json.dumps({"taxBase": {"currency": "USD"}})
+    assert delivery.payload.get_payload() == json.dumps(
+        {"taxBase": {"currency": "USD"}}
+    )
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.webhook == webhook

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -122,7 +122,7 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     webhook_app = webhook.app
     mock_request.assert_called_once()
     # TODO (PE-371): Assert EventDelivery DB object wasn't created
-    
+
     delivery = mock_request.mock_calls[0].args[0]
 
     assert json.loads(delivery.payload.get_payload()) == payload

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -120,14 +120,15 @@ def _assert_with_static_payload(
 
 def _assert_fields(payload, webhook, expected_response, response, mock_request):
     webhook_app = webhook.app
-    event_payload = EventPayload.objects.get()
-    assert json.loads(event_payload.get_payload()) == payload
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+    
+    delivery = mock_request.mock_calls[0].args[0]
+
+    assert json.loads(delivery.payload.get_payload()) == payload
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION
-    assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     assert response == TransactionSessionResult(
         app_identifier=webhook_app.identifier, response=expected_response, error=None
     )

--- a/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
@@ -104,14 +104,15 @@ def _assert_with_static_payload(
 
 def _assert_fields(payload, webhook, expected_response, response, mock_request):
     webhook_app = webhook.app
-    event_payload = EventPayload.objects.get()
-    assert json.loads(event_payload.get_payload()) == payload
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
+
+    assert json.loads(delivery.payload.get_payload()) == payload
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_PROCESS_SESSION
-    assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     assert response == TransactionSessionResult(
         app_identifier=webhook_app.identifier, response=expected_response, error=None
     )

--- a/saleor/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_webhook.py
@@ -75,8 +75,11 @@ def test_trigger_webhook_sync_with_subscription(
         False,
         payment,
     )
-    event_delivery = EventDelivery.objects.first()
 
     # then
-    assert json.loads(event_delivery.payload.get_payload()) == expected_payment_payload
-    mock_request.assert_called_once_with(event_delivery)
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
+    assert json.loads(delivery.payload.get_payload()) == expected_payment_payload
+

--- a/saleor/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_webhook.py
@@ -82,4 +82,3 @@ def test_trigger_webhook_sync_with_subscription(
 
     delivery = mock_request.mock_calls[0].args[0]
     assert json.loads(delivery.payload.get_payload()) == expected_payment_payload
-

--- a/saleor/webhook/tests/test_tax_webhook_tasks.py
+++ b/saleor/webhook/tests/test_tax_webhook_tasks.py
@@ -55,14 +55,15 @@ def test_trigger_tax_webhook_sync(
     tax_data = trigger_all_webhooks_sync(event_type, lambda: data, parse_tax_data)
 
     # then
-    payload = EventPayload.objects.get()
-    assert payload.get_payload() == data
-    delivery = EventDelivery.objects.get()
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
+
+    delivery = mock_request.mock_calls[0].args[0]
+
+    assert delivery.payload.get_payload() == data
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == event_type
-    assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(delivery)
     assert tax_data == parse_tax_data(tax_data_response)
 
 
@@ -82,15 +83,14 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_first(
 
     # then
     successful_webhook = tax_checkout_webhooks[0]
+    mock_request.assert_called_once()
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
-    payload = EventPayload.objects.get()
-    assert payload.get_payload() == data
-    delivery = EventDelivery.objects.order_by("pk").first()
+    delivery = mock_request.mock_calls[0].args[0]
+    assert delivery.payload.get_payload() == data
     assert delivery.status == EventDeliveryStatus.PENDING
     assert delivery.event_type == event_type
-    assert delivery.payload == payload
     assert delivery.webhook == successful_webhook
-    mock_request.assert_called_once_with(delivery)
     assert tax_data == parse_tax_data(tax_data_response)
 
 
@@ -109,20 +109,18 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_last(
     tax_data = trigger_all_webhooks_sync(event_type, lambda: data, parse_tax_data)
 
     # then
+    assert mock_request.call_count == 3
+    # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
-    payload = EventPayload.objects.get()
-    assert payload.get_payload() == data
-    deliveries = list(EventDelivery.objects.order_by("pk"))
-    for call, delivery, webhook in zip(
-        mock_request.call_args_list, deliveries, tax_checkout_webhooks
+    for call, webhook in zip(
+        mock_request.mock_calls, tax_checkout_webhooks
     ):
+        delivery = call.args[0]
         assert delivery.status == EventDeliveryStatus.PENDING
         assert delivery.event_type == event_type
-        assert delivery.payload == payload
+        assert delivery.payload.get_payload() == data
         assert delivery.webhook == webhook
-        assert call[0] == (delivery,)
 
-    assert mock_request.call_count == 3
     assert tax_data == parse_tax_data(tax_data_response)
 
 

--- a/saleor/webhook/tests/test_tax_webhook_tasks.py
+++ b/saleor/webhook/tests/test_tax_webhook_tasks.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 
 from ...core import EventDeliveryStatus
-from ...core.models import EventDelivery, EventPayload
 from ..event_types import WebhookEventSyncType
 from ..models import Webhook, WebhookEvent
 from ..transport.synchronous import trigger_all_webhooks_sync
@@ -112,9 +111,7 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_last(
     assert mock_request.call_count == 3
     # TODO (PE-371): Assert EventDelivery DB object wasn't created
 
-    for call, webhook in zip(
-        mock_request.mock_calls, tax_checkout_webhooks
-    ):
+    for call, webhook in zip(mock_request.mock_calls, tax_checkout_webhooks):
         delivery = call.args[0]
         assert delivery.status == EventDeliveryStatus.PENDING
         assert delivery.event_type == event_type


### PR DESCRIPTION
I want to merge this change because of https://github.com/saleor/saleor/pull/16632

We aim to skip saving EventDelivery and EventPayload objects in case of successful sync webhook delivery to avoid obsolete DB and S3 operations (writing objects to delete them right away)

This solution breaks most sync webhook tests because assertions are based on DB objects and we need to refactor them before delivering final implenetation.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
