### PR TITLE
Automatic confirm paid checkouts

### DIFF
--- a/saleor/checkout/actions.py
+++ b/saleor/checkout/actions.py
@@ -247,7 +247,7 @@ def transaction_amounts_for_checkout_updated(
 
     channel = checkout_info.channel
     if (
-        channel.automatically_complete_paid_checkouts
+        channel.automatically_complete_fully_paid_checkouts
         and checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     ):
         complete_checkout(

--- a/saleor/checkout/payment_utils.py
+++ b/saleor/checkout/payment_utils.py
@@ -54,7 +54,7 @@ def _update_authorize_status(
         checkout_has_lines and checkout_total_gross <= zero_money_amount
     )
 
-    if total_covered <= zero_money_amount and checkout_with_only_zero_price_lines:
+    if checkout_with_only_zero_price_lines:
         checkout.authorize_status = CheckoutAuthorizeStatus.FULL
     elif total_covered == zero_money_amount:
         checkout.authorize_status = CheckoutAuthorizeStatus.NONE

--- a/saleor/checkout/tasks.py
+++ b/saleor/checkout/tasks.py
@@ -1,13 +1,20 @@
 import logging
 from decimal import Decimal
 
+import graphene
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db.models import Exists, OuterRef, Q, QuerySet, Subquery
 from django.utils import timezone
 
+from ..account.models import User
+from ..app.models import App
 from ..celeryconf import app
 from ..payment.models import TransactionItem
+from ..plugins.manager import get_plugins_manager
+from .complete_checkout import complete_checkout
+from .fetch import fetch_checkout_info, fetch_checkout_lines
 from .models import Checkout, CheckoutLine
 
 task_logger: logging.Logger = get_task_logger(__name__)
@@ -109,3 +116,57 @@ def delete_expired_checkouts(
         else:
             task_logger.warning("Invocation limit reached, aborting task")
     return total_deleted, has_more
+
+
+@app.task
+def automatic_checkout_completion_task(
+    checkout_pk,
+    user_id,
+    app_id,
+):
+    """Try to automatically complete the checkout.
+
+    If any error is raised during the process, it will be caught and logged.
+    """
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout_pk)
+    try:
+        checkout = Checkout.objects.get(pk=checkout_pk)
+    except Checkout.DoesNotExist:
+        return
+
+    user = User.objects.filter(pk=user_id).first()
+    app = App.objects.filter(pk=app_id).first()
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    task_logger.info(
+        "Automatic checkout completion triggered for checkout: %s.",
+        checkout_id,
+        extra={"checkout_id": checkout_id},
+    )
+    try:
+        complete_checkout(
+            manager=manager,
+            checkout_info=checkout_info,
+            lines=lines,
+            payment_data={},
+            store_source=False,
+            user=user,
+            app=app,
+        )
+    except ValidationError as error:
+        task_logger.warning(
+            "Automatic checkout completion failed for checkout: %s.",
+            checkout_id,
+            extra={
+                "checkout_id": checkout_id,
+                "error": str(error),
+            },
+        )
+    else:
+        task_logger.info(
+            "Automatic checkout completion succeeded for checkout: %s.",
+            checkout_id,
+            extra={"checkout_id": checkout_id},
+        )

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -41,7 +41,7 @@ def test_transaction_amounts_for_checkout_updated_fully_paid(
     transaction = transaction_item_generator(
         checkout_id=checkout.pk, charged_value=checkout_info.checkout.total.gross.amount
     )
-    assert checkout_info.channel.automatically_complete_paid_checkouts is False
+    assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
 
     # when
     transaction_amounts_for_checkout_updated(
@@ -76,8 +76,8 @@ def test_transaction_amounts_for_checkout_fully_paid_automatic_checkout_complete
         checkout_id=checkout.pk, charged_value=checkout_info.checkout.total.gross.amount
     )
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
     transaction_amounts_for_checkout_updated(
@@ -120,8 +120,8 @@ def test_transaction_amounts_for_checkout_updated_not_fully_paid_no_automatic_co
         charged_value=checkout_info.checkout.total.gross.amount / 2,
     )
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
     transaction_amounts_for_checkout_updated(
@@ -154,7 +154,7 @@ def test_transaction_amounts_for_checkout_updated_with_already_fully_paid(
     transaction_item_generator(
         checkout_id=checkout.pk, charged_value=checkout_info.checkout.total.gross.amount
     )
-    assert checkout_info.channel.automatically_complete_paid_checkouts is False
+    assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
 
     fetch_checkout_data(checkout_info, plugins_manager, lines, force_status_update=True)
 
@@ -192,8 +192,8 @@ def test_transaction_amounts_for_checkout_updated_0_checkout_automatic_complete(
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
     transaction = transaction_item_generator(checkout_id=checkout.pk, charged_value=0)
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
     transaction_amounts_for_checkout_updated(
@@ -235,7 +235,7 @@ def test_transaction_amounts_for_checkout_updated_fully_authorized(
         checkout_id=checkout.pk,
         authorized_value=checkout_info.checkout.total.gross.amount,
     )
-    assert checkout_info.channel.automatically_complete_paid_checkouts is False
+    assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
 
     # when
     transaction_amounts_for_checkout_updated(
@@ -271,8 +271,8 @@ def test_transaction_amounts_for_checkout_fully_authorized_automatic_checkout_co
         authorized_value=checkout_info.checkout.total.gross.amount,
     )
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
     transaction_amounts_for_checkout_updated(

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -24,11 +24,11 @@ from ..calculations import fetch_checkout_data
 from ..fetch import fetch_checkout_info, fetch_checkout_lines
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_amounts_for_checkout_updated_fully_paid(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
@@ -54,7 +54,7 @@ def test_transaction_amounts_for_checkout_updated_fully_paid(
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_with(checkout, webhooks=set())
-    assert not mocked_complete_checkout.called
+    assert not mocked_automatic_checkout_completion_task.called
 
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -57,11 +57,11 @@ def test_transaction_amounts_for_checkout_updated_fully_paid(
     assert not mocked_complete_checkout.called
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_amounts_for_checkout_fully_paid_automatic_checkout_complete(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
@@ -90,22 +90,16 @@ def test_transaction_amounts_for_checkout_fully_paid_automatic_checkout_complete
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_called_once_with(
-        manager=plugins_manager,
-        checkout_info=checkout_info,
-        lines=lines,
-        payment_data={},
-        store_source=False,
-        user=None,
-        app=app,
+    mocked_automatic_checkout_completion_task.assert_called_once_with(
+        checkout.pk, None, app.id
     )
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_amounts_for_checkout_updated_not_fully_paid_no_automatic_complete(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
@@ -134,14 +128,14 @@ def test_transaction_amounts_for_checkout_updated_not_fully_paid_no_automatic_co
     assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
     assert not mocked_fully_paid.called
-    assert not mocked_complete_checkout.called
+    assert not mocked_automatic_checkout_completion_task.called
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_amounts_for_checkout_updated_with_already_fully_paid(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
@@ -172,14 +166,14 @@ def test_transaction_amounts_for_checkout_updated_with_already_fully_paid(
     assert checkout.charge_status == CheckoutChargeStatus.OVERCHARGED
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     assert not mocked_fully_paid.called
-    assert not mocked_complete_checkout.called
+    assert not mocked_automatic_checkout_completion_task.called
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_amounts_for_checkout_updated_0_checkout_automatic_complete(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_item_total_0,
     transaction_item_generator,
     plugins_manager,
@@ -206,22 +200,16 @@ def test_transaction_amounts_for_checkout_updated_0_checkout_automatic_complete(
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_called_once_with(
-        manager=plugins_manager,
-        checkout_info=checkout_info,
-        lines=lines,
-        payment_data={},
-        store_source=False,
-        user=None,
-        app=app,
+    mocked_automatic_checkout_completion_task.assert_called_once_with(
+        checkout.pk, None, app.id
     )
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_amounts_for_checkout_updated_fully_authorized(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
@@ -248,14 +236,14 @@ def test_transaction_amounts_for_checkout_updated_fully_authorized(
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     assert not mocked_fully_paid.called
-    assert not mocked_complete_checkout.called
+    assert not mocked_automatic_checkout_completion_task.called
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_amounts_for_checkout_fully_authorized_automatic_checkout_complete(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
@@ -285,14 +273,8 @@ def test_transaction_amounts_for_checkout_fully_authorized_automatic_checkout_co
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     assert not mocked_fully_paid.called
-    mocked_complete_checkout.assert_called_once_with(
-        manager=plugins_manager,
-        checkout_info=checkout_info,
-        lines=lines,
-        payment_data={},
-        store_source=False,
-        user=staff_user,
-        app=None,
+    mocked_automatic_checkout_completion_task.assert_called_once_with(
+        checkout.pk, staff_user.id, None
     )
 
 

--- a/saleor/checkout/tests/test_tasks.py
+++ b/saleor/checkout/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from decimal import Decimal
 from unittest import mock
@@ -6,8 +7,13 @@ from uuid import UUID
 import pytest
 from django.utils import timezone
 
+from ...order.models import Order
 from ..models import Checkout
-from ..tasks import delete_expired_checkouts
+from ..tasks import (
+    automatic_checkout_completion_task,
+    delete_expired_checkouts,
+    task_logger,
+)
 
 
 def test_delete_expired_anonymous_checkouts(checkouts_list, variant, customer_user):
@@ -454,3 +460,83 @@ def test_aborts_deleting_checkouts_when_invocation_count_exhausted(
 
     # Should have stopped there
     mocked_task.assert_not_called()
+
+
+def test_automatic_checkout_completion_task(
+    checkout_with_prices, transaction_item_generator, app, caplog
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_pk = checkout.pk
+
+    caplog.set_level(logging.INFO, logger=task_logger.name)
+
+    transaction_item_generator(
+        checkout_id=checkout.pk, charged_value=checkout.total.gross.amount
+    )
+
+    # when
+    automatic_checkout_completion_task(checkout_pk, None, app.id)
+
+    # then
+    assert not Checkout.objects.filter(pk=checkout_pk).exists()
+    assert Order.objects.filter(checkout_token=checkout_pk).exists()
+
+    # checkout_id = graphene.Node.to_global_id("Checkout", checkout_pk)
+    # assert len(caplog.records) == 2
+    # assert caplog.records[0].message == (
+    #     f"Automatic checkout completion triggered for checkout: {checkout_id}"
+    # )
+    # assert caplog.records[0].checkout_id == checkout_id
+    # assert caplog.records[1].levelname == logging.INFO
+
+    # assert caplog.records[1].message == (
+    #     f"Automatic checkout completion succeeded for checkout: : {checkout_id}"
+    # )
+    # assert caplog.records[1].checkout_id == checkout_id
+    # assert caplog.records[1].levelname == logging.INFO
+
+
+def test_automatic_checkout_completion_task_missing_checkout(checkout, caplog):
+    # given
+    checkout_pk = checkout.pk
+    checkout.delete()
+
+    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.INFO)
+
+    # when
+    automatic_checkout_completion_task(checkout_pk, None, None)
+
+    # then
+    assert not caplog.records
+
+
+def test_automatic_checkout_completion_task_error_raised(checkout, app, caplog):
+    # given
+    checkout_pk = checkout.pk
+    checkout.billing_address = None
+    checkout.save(update_fields=["billing_address"])
+
+    caplog.set_level(logging.INFO, logger=task_logger.name)
+    caplog.set_level(logging.WARNING, logger=task_logger.name)
+
+    # when
+    automatic_checkout_completion_task(checkout_pk, None, app.id)
+
+    # then
+    assert Checkout.objects.filter(pk=checkout_pk).exists()
+    # checkout_id = graphene.Node.to_global_id("Checkout", checkout_pk)
+    # assert len(caplog.records) == 2
+    # assert caplog.records[0].message == (
+    #     f"Automatic checkout completion triggered for checkout: {checkout_id}"
+    # )
+    # assert caplog.records[0].checkout_id == checkout_id
+    # assert caplog.records[1].levelinfo == logging.INFO
+
+    # assert caplog.records[1].message == (
+    #     f"Automatic checkout completion failed for checkout: {checkout_id}"
+    # )
+    # assert caplog.records[1].checkout_id == checkout_id
+    # assert caplog.records[1].error
+    # assert caplog.records[1].levelinfo == logging.WARNING

--- a/saleor/checkout/tests/test_tasks.py
+++ b/saleor/checkout/tests/test_tasks.py
@@ -491,7 +491,7 @@ def test_automatic_checkout_completion_task(
         f"Automatic checkout completion triggered for checkout: {checkout_id}."
     )
     assert caplog.records[0].checkout_id == checkout_id
-    assert caplog.records[1].levelno == logging.INFO
+    assert caplog.records[0].levelno == logging.INFO
 
     assert caplog.records[1].message == (
         f"Automatic checkout completion succeeded for checkout: {checkout_id}."

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -394,7 +394,9 @@ class TransactionCreate(BaseMutation):
                 previous_refunded_value=Decimal(0),
             )
         if transaction_data.get("checkout_id") and money_data:
-            transaction_amounts_for_checkout_updated(new_transaction, manager)
+            transaction_amounts_for_checkout_updated(
+                new_transaction, manager, user, app
+            )
 
         if transaction_event:
             cls.create_transaction_event(transaction_event, new_transaction, user, app)

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -369,7 +369,9 @@ class TransactionEventReport(ModelMutation):
                     calculate_order_granted_refund_status(related_granted_refund)
             if transaction.checkout_id:
                 manager = get_plugin_manager_promise(info.context).get()
-                transaction_amounts_for_checkout_updated(transaction, manager)
+                transaction_amounts_for_checkout_updated(
+                    transaction, manager, user, app
+                )
         elif available_actions is not None and set(
             transaction.available_actions
         ) != set(available_actions):

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -253,6 +253,6 @@ class TransactionUpdate(TransactionCreate):
             )
         if instance.checkout_id and money_data:
             manager = get_plugin_manager_promise(info.context).get()
-            transaction_amounts_for_checkout_updated(instance, manager)
+            transaction_amounts_for_checkout_updated(instance, manager, user, app)
 
         return TransactionUpdate(transaction=instance)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -1176,11 +1176,11 @@ def test_transaction_create_for_checkout_by_staff(
     assert transaction.user == staff_api_client.user
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_create_for_checkout_fully_paid(
     mocked_checkout_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_prices,
     permission_manage_payments,
     staff_api_client,
@@ -1228,7 +1228,7 @@ def test_transaction_create_for_checkout_fully_paid(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
@@ -1290,11 +1290,11 @@ def test_transaction_create_for_checkout_fully_paid_automatic_completion(
     # TODO: check order events
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_create_for_checkout_fully_authorized(
     mocked_checkout_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_prices,
     permission_manage_payments,
     staff_api_client,
@@ -1342,7 +1342,7 @@ def test_transaction_create_for_checkout_fully_authorized(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_not_called()
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -8,7 +8,9 @@ from freezegun import freeze_time
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from .....checkout.models import Checkout
 from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
+from .....order.models import Order
 from .....order.utils import update_order_authorize_data, update_order_charge_data
 from .....payment import TransactionEventType
 from .....payment.error_codes import TransactionCreateErrorCode
@@ -1174,9 +1176,11 @@ def test_transaction_create_for_checkout_by_staff(
     assert transaction.user == staff_api_client.user
 
 
+@patch("saleor.checkout.complete_checkout.complete_checkout")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_create_for_checkout_fully_paid(
     mocked_checkout_fully_paid,
+    mocked_complete_checkout,
     checkout_with_prices,
     permission_manage_payments,
     staff_api_client,
@@ -1195,6 +1199,8 @@ def test_transaction_create_for_checkout_fully_paid(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    assert checkout.channel.automatically_complete_paid_checkouts is False
 
     variables = {
         "id": graphene.Node.to_global_id("Checkout", checkout.pk),
@@ -1222,6 +1228,181 @@ def test_transaction_create_for_checkout_fully_paid(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_complete_checkout.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_create_for_checkout_fully_paid_automatic_completion(
+    mocked_checkout_fully_paid,
+    checkout_with_prices,
+    permission_manage_payments,
+    staff_api_client,
+    plugins_manager,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+    ]
+    metadata = {"key": "test-1", "value": "123"}
+    private_metadata = {"key": "test-2", "value": "321"}
+
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    channel = checkout_info.channel
+    channel.automatically_complete_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+
+    checkout_token = checkout.pk
+
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountCharged": {
+                "amount": checkout_info.checkout.total.gross.amount,
+                "currency": "USD",
+            },
+            "metadata": [metadata],
+            "privateMetadata": [private_metadata],
+        },
+    }
+
+    # when
+    staff_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.FULL
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+    # TODO: check order events
+
+
+@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_create_for_checkout_fully_authorized(
+    mocked_checkout_fully_paid,
+    mocked_complete_checkout,
+    checkout_with_prices,
+    permission_manage_payments,
+    staff_api_client,
+    plugins_manager,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+    ]
+    metadata = {"key": "test-1", "value": "123"}
+    private_metadata = {"key": "test-2", "value": "321"}
+
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    assert checkout.channel.automatically_complete_paid_checkouts is False
+
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountAuthorized": {
+                "amount": checkout_info.checkout.total.gross.amount,
+                "currency": "USD",
+            },
+            "metadata": [metadata],
+            "privateMetadata": [private_metadata],
+        },
+    }
+
+    # when
+    staff_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    checkout.refresh_from_db()
+    assert checkout.charge_status == CheckoutChargeStatus.NONE
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+
+    mocked_checkout_fully_paid.assert_not_called()
+    mocked_complete_checkout.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_create_for_checkout_fully_authorized_automatic_completion(
+    mocked_checkout_fully_paid,
+    checkout_with_prices,
+    permission_manage_payments,
+    staff_api_client,
+    plugins_manager,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+    ]
+    metadata = {"key": "test-1", "value": "123"}
+    private_metadata = {"key": "test-2", "value": "321"}
+
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    channel = checkout_info.channel
+    channel.automatically_complete_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+
+    checkout_token = checkout.pk
+
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountAuthorized": {
+                "amount": checkout_info.checkout.total.gross.amount,
+                "currency": "USD",
+            },
+            "metadata": [metadata],
+            "privateMetadata": [private_metadata],
+        },
+    }
+
+    # when
+    staff_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    mocked_checkout_fully_paid.assert_not_called()
+
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+    # TODO: check order events
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -1200,7 +1200,7 @@ def test_transaction_create_for_checkout_fully_paid(
     checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
 
-    assert checkout.channel.automatically_complete_paid_checkouts is False
+    assert checkout.channel.automatically_complete_fully_paid_checkouts is False
 
     variables = {
         "id": graphene.Node.to_global_id("Checkout", checkout.pk),
@@ -1254,8 +1254,8 @@ def test_transaction_create_for_checkout_fully_paid_automatic_completion(
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
 
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     checkout_token = checkout.pk
 
@@ -1314,7 +1314,7 @@ def test_transaction_create_for_checkout_fully_authorized(
     checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
 
-    assert checkout.channel.automatically_complete_paid_checkouts is False
+    assert checkout.channel.automatically_complete_fully_paid_checkouts is False
 
     variables = {
         "id": graphene.Node.to_global_id("Checkout", checkout.pk),
@@ -1368,8 +1368,8 @@ def test_transaction_create_for_checkout_fully_authorized_automatic_completion(
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
 
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     checkout_token = checkout.pk
 

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -1367,7 +1367,7 @@ def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
     checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
 
-    assert checkout.channel.automatically_complete_paid_checkouts is False
+    assert checkout.channel.automatically_complete_fully_paid_checkouts is False
 
     psp_reference = "111-abc"
     transaction = transaction_item_generator(
@@ -1504,8 +1504,8 @@ def test_transaction_event_updates_checkout_full_paid_automatic_completion(
     checkout_token = checkout.token
 
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     psp_reference = "111-abc"
     transaction = transaction_item_generator(
@@ -1578,8 +1578,8 @@ def test_transaction_event_updates_checkout_full_paid_pending_charge_automatic_c
     checkout_token = checkout.token
 
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     psp_reference = "111-abc"
     transaction = transaction_item_generator(
@@ -1652,7 +1652,7 @@ def test_transaction_event_updates_checkout_fully_authorized(
     checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
 
-    assert checkout.channel.automatically_complete_paid_checkouts is False
+    assert checkout.channel.automatically_complete_fully_paid_checkouts is False
 
     psp_reference = "111-abc"
     transaction = transaction_item_generator(
@@ -1723,8 +1723,8 @@ def test_transaction_event_updates_checkout_fully_authorized_automatic_complete(
     checkout_token = checkout.token
 
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     psp_reference = "111-abc"
     transaction = transaction_item_generator(
@@ -1796,8 +1796,8 @@ def test_transaction_event_updates_checkout_fully_authorized_pending_automatic_c
     checkout_token = checkout.token
 
     channel = checkout_info.channel
-    channel.automatically_complete_paid_checkouts = True
-    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     psp_reference = "111-abc"
     transaction = transaction_item_generator(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -1349,11 +1349,11 @@ def test_transaction_event_updates_checkout_last_transaction_modified_at(
     assert checkout.last_transaction_modified_at == transaction.modified_at
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1416,14 +1416,14 @@ def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_full_paid_with_pending_charge_amount(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1483,7 +1483,7 @@ def test_transaction_event_updates_checkout_full_paid_with_pending_charge_amount
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
@@ -1634,11 +1634,11 @@ def test_transaction_event_updates_checkout_full_paid_pending_charge_automatic_c
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_fully_authorized(
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1701,7 +1701,7 @@ def test_transaction_event_updates_checkout_fully_authorized(
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_not_called()
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -12,7 +12,9 @@ from freezegun import freeze_time
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from .....checkout.models import Checkout
 from .....order import OrderGrantedRefundStatus, OrderStatus
+from .....order.models import Order
 from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment.models import TransactionEvent
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
@@ -1347,9 +1349,11 @@ def test_transaction_event_updates_checkout_last_transaction_modified_at(
     assert checkout.last_transaction_modified_at == transaction.modified_at
 
 
+@patch("saleor.checkout.complete_checkout.complete_checkout")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
     mocked_fully_paid,
+    mocked_complete_checkout,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1362,6 +1366,9 @@ def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
     checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    assert checkout.channel.automatically_complete_paid_checkouts is False
+
     psp_reference = "111-abc"
     transaction = transaction_item_generator(
         app=app_api_client.app, checkout_id=checkout.pk
@@ -1409,11 +1416,14 @@ def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_complete_checkout.assert_not_called()
 
 
+@patch("saleor.checkout.complete_checkout.complete_checkout")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_full_paid_with_pending_charge_amount(
     mocked_fully_paid,
+    mocked_complete_checkout,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1473,6 +1483,372 @@ def test_transaction_event_updates_checkout_full_paid_with_pending_charge_amount
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_complete_checkout.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_event_updates_checkout_full_paid_automatic_completion(
+    mocked_fully_paid,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    checkout_token = checkout.token
+
+    channel = checkout_info.channel
+    channel.automatically_complete_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+
+    psp_reference = "111-abc"
+    transaction = transaction_item_generator(
+        app=app_api_client.app, checkout_id=checkout.pk
+    )
+    transaction_item_generator(
+        app=app_api_client.app,
+        checkout_id=checkout.pk,
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": checkout_info.checkout.total.gross.amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.FULL
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+
+    mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_event_updates_checkout_full_paid_pending_charge_automatic_complete(
+    mocked_fully_paid,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    checkout_token = checkout.token
+
+    channel = checkout_info.channel
+    channel.automatically_complete_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+
+    psp_reference = "111-abc"
+    transaction = transaction_item_generator(
+        app=app_api_client.app, checkout_id=checkout.pk
+    )
+    transaction_item_generator(
+        app=app_api_client.app,
+        checkout_id=checkout.pk,
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_REQUEST.name,
+        "amount": checkout_info.checkout.total.gross.amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    # TODO:  to verify if it's correct
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.NONE
+
+    mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+
+
+@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_event_updates_checkout_fully_authorized(
+    mocked_fully_paid,
+    mocked_complete_checkout,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    assert checkout.channel.automatically_complete_paid_checkouts is False
+
+    psp_reference = "111-abc"
+    transaction = transaction_item_generator(
+        app=app_api_client.app, checkout_id=checkout.pk
+    )
+    transaction_item_generator(
+        app=app_api_client.app,
+        checkout_id=checkout.pk,
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.AUTHORIZATION_SUCCESS.name,
+        "amount": checkout_info.checkout.total.gross.amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    checkout.refresh_from_db()
+
+    assert checkout.charge_status == CheckoutChargeStatus.NONE
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_fully_paid.assert_not_called()
+    mocked_complete_checkout.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_event_updates_checkout_fully_authorized_automatic_complete(
+    mocked_fully_paid,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    checkout_token = checkout.token
+
+    channel = checkout_info.channel
+    channel.automatically_complete_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+
+    psp_reference = "111-abc"
+    transaction = transaction_item_generator(
+        app=app_api_client.app, checkout_id=checkout.pk
+    )
+    transaction_item_generator(
+        app=app_api_client.app,
+        checkout_id=checkout.pk,
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.AUTHORIZATION_SUCCESS.name,
+        "amount": checkout_info.checkout.total.gross.amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_fully_paid.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_transaction_event_updates_checkout_fully_authorized_pending_automatic_complete(
+    mocked_fully_paid,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    checkout_token = checkout.token
+
+    channel = checkout_info.channel
+    channel.automatically_complete_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_paid_checkouts"])
+
+    psp_reference = "111-abc"
+    transaction = transaction_item_generator(
+        app=app_api_client.app, checkout_id=checkout.pk
+    )
+    transaction_item_generator(
+        app=app_api_client.app,
+        checkout_id=checkout.pk,
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.AUTHORIZATION_REQUEST.name,
+        "amount": checkout_info.checkout.total.gross.amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    # TODO: to verify if it's correct
+    assert order.authorize_status == CheckoutAuthorizeStatus.NONE
+    mocked_fully_paid.assert_not_called()
 
 
 def test_transaction_event_report_with_info_event(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -1627,7 +1627,6 @@ def test_transaction_event_updates_checkout_full_paid_pending_charge_automatic_c
         checkout.refresh_from_db()
 
     order = Order.objects.get(checkout_token=checkout_token)
-    # TODO:  to verify if it's correct
     assert order.charge_status == CheckoutChargeStatus.NONE
     assert order.authorize_status == CheckoutAuthorizeStatus.NONE
 
@@ -1846,7 +1845,6 @@ def test_transaction_event_updates_checkout_fully_authorized_pending_automatic_c
 
     order = Order.objects.get(checkout_token=checkout_token)
     assert order.charge_status == CheckoutChargeStatus.NONE
-    # TODO: to verify if it's correct
     assert order.authorize_status == CheckoutAuthorizeStatus.NONE
     mocked_fully_paid.assert_not_called()
 

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -1816,13 +1816,13 @@ def test_order_doesnt_exists(
 @pytest.mark.parametrize(
     "result", [TransactionEventType.CHARGE_REQUEST, TransactionEventType.CHARGE_SUCCESS]
 )
-@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
+@mock.patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
 def test_checkout_fully_paid(
     mocked_initialize,
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     result,
     user_api_client,
     checkout_with_prices,
@@ -1865,7 +1865,7 @@ def test_checkout_fully_paid(
     assert not content["data"]["transactionInitialize"]["errors"]
     checkout.refresh_from_db()
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
@@ -1989,13 +1989,13 @@ def test_checkout_fully_paid_pending_charge_automatic_completion(
         TransactionEventType.AUTHORIZATION_SUCCESS,
     ],
 )
-@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
+@mock.patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
 def test_checkout_fully_authorized(
     mocked_initialize,
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     result,
     user_api_client,
     checkout_with_prices,
@@ -2039,7 +2039,7 @@ def test_checkout_fully_authorized(
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
     mocked_fully_paid.assert_not_called()
 
 

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -12,8 +12,10 @@ from .....channel import TransactionFlowStrategy
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from .....checkout.models import Checkout
 from .....core.prices import quantize_price
 from .....order import OrderChargeStatus, OrderStatus
+from .....order.models import Order
 from .....payment import TransactionEventType, TransactionItemIdempotencyUniqueError
 from .....payment.interface import (
     PaymentGatewayData,
@@ -1814,11 +1816,13 @@ def test_order_doesnt_exists(
 @pytest.mark.parametrize(
     "result", [TransactionEventType.CHARGE_REQUEST, TransactionEventType.CHARGE_SUCCESS]
 )
+@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
 @mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
 def test_checkout_fully_paid(
     mocked_initialize,
     mocked_fully_paid,
+    mocked_complete_checkout,
     result,
     user_api_client,
     checkout_with_prices,
@@ -1834,6 +1838,8 @@ def test_checkout_fully_paid(
     expected_app_identifier = "webhook.app.identifier"
     webhook_app.identifier = expected_app_identifier
     webhook_app.save()
+
+    assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
 
     expected_psp_reference = "ppp-123"
     expected_response = transaction_session_response.copy()
@@ -1859,8 +1865,294 @@ def test_checkout_fully_paid(
     assert not content["data"]["transactionInitialize"]["errors"]
     checkout.refresh_from_db()
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_complete_checkout.assert_not_called()
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_checkout_fully_paid_automatic_completion(
+    mocked_initialize,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "action": None,
+        "amount": None,
+        "id": to_global_id_or_none(checkout),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionInitialize"]["errors"]
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.FULL
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_checkout_fully_paid_pending_charge_automatic_completion(
+    mocked_initialize,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "action": None,
+        "amount": None,
+        "id": to_global_id_or_none(checkout),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionInitialize"]["errors"]
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.NONE
+    mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+    ],
+)
+@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_checkout_fully_authorized(
+    mocked_initialize,
+    mocked_fully_paid,
+    mocked_complete_checkout,
+    result,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = result.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "action": None,
+        "amount": None,
+        "id": to_global_id_or_none(checkout),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionInitialize"]["errors"]
+    checkout.refresh_from_db()
+    assert checkout.charge_status == CheckoutChargeStatus.NONE
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_complete_checkout.assert_not_called()
+    mocked_fully_paid.assert_not_called()
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_checkout_fully_authorized_automatic_completion(
+    mocked_initialize,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.AUTHORIZATION_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "action": None,
+        "amount": None,
+        "id": to_global_id_or_none(checkout),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionInitialize"]["errors"]
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_fully_paid.assert_not_called()
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_checkout_fully_authorizaed_pending_authorization_automatic_completion(
+    mocked_initialize,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.AUTHORIZATION_REQUEST.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "action": None,
+        "amount": None,
+        "id": to_global_id_or_none(checkout),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionInitialize"]["errors"]
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.NONE
+    mocked_fully_paid.assert_not_called()
 
 
 def test_user_missing_permission_for_customer_ip_address(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -12,8 +12,10 @@ from .....channel import TransactionFlowStrategy
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from .....checkout.models import Checkout
 from .....core.prices import quantize_price
 from .....order import OrderChargeStatus, OrderStatus
+from .....order.models import Order
 from .....payment import FAILED_TRANSACTION_EVENTS, TransactionEventType
 from .....payment.interface import (
     PaymentGatewayData,
@@ -1111,11 +1113,13 @@ def test_app_attached_to_transaction_doesnt_exist(
 @pytest.mark.parametrize(
     "result", [TransactionEventType.CHARGE_REQUEST, TransactionEventType.CHARGE_SUCCESS]
 )
+@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
 @mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
 def test_checkout_fully_paid(
     mocked_process,
     mocked_fully_paid,
+    mocked_complete_checkout,
     result,
     user_api_client,
     checkout_with_prices,
@@ -1132,6 +1136,8 @@ def test_checkout_fully_paid(
     expected_app_identifier = "webhook.app.identifier"
     webhook_app.identifier = expected_app_identifier
     webhook_app.save()
+
+    assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
 
     transaction_item = transaction_item_generator(
         checkout_id=checkout.pk,
@@ -1168,8 +1174,354 @@ def test_checkout_fully_paid(
 
     checkout.refresh_from_db()
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_complete_checkout.assert_not_called()
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_checkout_fully_paid_automatic_completion(
+    mocked_process,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout.pk,
+        app=webhook_app,
+    )
+    TransactionEvent.objects.create(
+        include_in_calculations=False,
+        transaction=transaction_item,
+        amount_value=checkout_info.checkout.total_gross_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionProcess"]["errors"]
+
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.FULL
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_checkout_fully_paid_pending_automatic_completion(
+    mocked_process,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout.pk,
+        app=webhook_app,
+    )
+    TransactionEvent.objects.create(
+        include_in_calculations=False,
+        transaction=transaction_item,
+        amount_value=checkout_info.checkout.total_gross_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionProcess"]["errors"]
+
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.NONE
+    mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+    ],
+)
+@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_checkout_fully_authorized(
+    mocked_process,
+    mocked_fully_paid,
+    mocked_complete_checkout,
+    result,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout.pk,
+        app=webhook_app,
+    )
+    TransactionEvent.objects.create(
+        include_in_calculations=False,
+        transaction=transaction_item,
+        amount_value=checkout_info.checkout.total_gross_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.AUTHORIZATION_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = result.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionProcess"]["errors"]
+
+    checkout.refresh_from_db()
+    mocked_fully_paid.assert_not_called()
+    mocked_complete_checkout.assert_not_called()
+    assert checkout.charge_status == CheckoutChargeStatus.NONE
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_checkout_fully_authorized_automatic_completion(
+    mocked_process,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout.pk,
+        app=webhook_app,
+    )
+    TransactionEvent.objects.create(
+        include_in_calculations=False,
+        transaction=transaction_item,
+        amount_value=checkout_info.checkout.total_gross_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.AUTHORIZATION_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.AUTHORIZATION_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionProcess"]["errors"]
+
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_fully_paid.assert_not_called()
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_checkout_fully_authorized_pending_automatic_completion(
+    mocked_process,
+    mocked_fully_paid,
+    user_api_client,
+    checkout_with_prices,
+    webhook_app,
+    transaction_session_response,
+    plugins_manager,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_token = checkout.token
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    transaction_item = transaction_item_generator(
+        checkout_id=checkout.pk,
+        app=webhook_app,
+    )
+    TransactionEvent.objects.create(
+        include_in_calculations=False,
+        transaction=transaction_item,
+        amount_value=checkout_info.checkout.total_gross_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.AUTHORIZATION_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
+    expected_response["result"] = TransactionEventType.AUTHORIZATION_REQUEST.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionProcess"]["errors"]
+
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    order = Order.objects.get(checkout_token=checkout_token)
+    assert order.charge_status == CheckoutChargeStatus.NONE
+    assert order.authorize_status == CheckoutAuthorizeStatus.NONE
+    mocked_fully_paid.assert_not_called()
 
 
 def test_transaction_process_doesnt_accept_old_id(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -1113,13 +1113,13 @@ def test_app_attached_to_transaction_doesnt_exist(
 @pytest.mark.parametrize(
     "result", [TransactionEventType.CHARGE_REQUEST, TransactionEventType.CHARGE_SUCCESS]
 )
-@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
+@mock.patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
 def test_checkout_fully_paid(
     mocked_process,
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     result,
     user_api_client,
     checkout_with_prices,
@@ -1174,7 +1174,7 @@ def test_checkout_fully_paid(
 
     checkout.refresh_from_db()
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
@@ -1322,13 +1322,13 @@ def test_checkout_fully_paid_pending_automatic_completion(
         TransactionEventType.AUTHORIZATION_SUCCESS,
     ],
 )
-@mock.patch("saleor.checkout.complete_checkout.complete_checkout")
+@mock.patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @mock.patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 @mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
 def test_checkout_fully_authorized(
     mocked_process,
     mocked_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     result,
     user_api_client,
     checkout_with_prices,
@@ -1383,7 +1383,7 @@ def test_checkout_fully_authorized(
 
     checkout.refresh_from_db()
     mocked_fully_paid.assert_not_called()
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -2586,11 +2586,11 @@ def test_transaction_update_for_checkout_updates_payment_statuses(
     assert checkout_with_items.authorize_status == CheckoutAuthorizeStatus.PARTIAL
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_update_for_checkout_fully_paid(
     mocked_checkout_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_prices,
     permission_manage_payments,
     app_api_client,
@@ -2636,7 +2636,7 @@ def test_transaction_update_for_checkout_fully_paid(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
@@ -2695,11 +2695,11 @@ def test_transaction_update_for_checkout_fully_paid_automatic_completion(
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
 
 
-@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_update_for_checkout_fully_authorized(
     mocked_checkout_fully_paid,
-    mocked_complete_checkout,
+    mocked_automatic_checkout_completion_task,
     checkout_with_prices,
     permission_manage_payments,
     app_api_client,
@@ -2745,7 +2745,7 @@ def test_transaction_update_for_checkout_fully_authorized(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_not_called()
-    mocked_complete_checkout.assert_not_called()
+    mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")

--- a/saleor/payment/tests/test_tasks.py
+++ b/saleor/payment/tests/test_tasks.py
@@ -31,7 +31,9 @@ def test_transaction_release_funds_for_checkout_task_checkout_with_new_last_chan
             checkout_id=checkout.pk,
             charged_value=Decimal(100),
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
 
     with freeze_time(time_before_ttl):
         checkout.automatically_refundable = True
@@ -64,7 +66,9 @@ def test_transaction_release_funds_for_checkout_task_checkout_not_refundable(
             checkout_id=checkout.pk,
             charged_value=Decimal(100),
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
         checkout.automatically_refundable = False
         checkout.save(update_fields=["automatically_refundable", "last_change"])
 
@@ -96,7 +100,9 @@ def test_transaction_release_funds_for_checkout_task_checkout_with_new_tr_modifi
             checkout_id=checkout.pk,
             charged_value=Decimal(100),
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
 
     with freeze_time(time_after_ttl):
         checkout.automatically_refundable = True
@@ -129,7 +135,9 @@ def test_transaction_release_funds_for_checkout_task_checkout_with_none_status(
             checkout_id=checkout.pk,
             charged_value=0,
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
         checkout.automatically_refundable = True
         checkout.save(update_fields=["automatically_refundable", "last_change"])
 
@@ -251,7 +259,9 @@ def test_transaction_release_funds_for_checkout_task_refund_already_requested(
             checkout_id=checkout.pk,
             charged_value=Decimal(100),
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
         checkout.automatically_refundable = True
         checkout.save(update_fields=["automatically_refundable", "last_change"])
     transaction_item.events.create(type=TransactionEventType.REFUND_REQUEST)
@@ -283,7 +293,9 @@ def test_transaction_release_funds_for_checkout_task_cancel_already_requested(
             checkout_id=checkout.pk,
             authorized_value=Decimal(100),
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
         checkout.automatically_refundable = True
         checkout.save(update_fields=["automatically_refundable", "last_change"])
     transaction_item.events.create(type=TransactionEventType.CANCEL_REQUEST)
@@ -315,7 +327,9 @@ def test_transaction_release_funds_for_checkout_task_transaction_with_authorizat
             checkout_id=checkout.pk,
             authorized_value=Decimal(100),
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
         checkout.automatically_refundable = True
         checkout.save(update_fields=["automatically_refundable", "last_change"])
 
@@ -359,7 +373,9 @@ def test_transaction_release_funds_for_checkout_task_transaction_with_charge(
             checkout_id=checkout.pk,
             charged_value=Decimal(100),
         )
-        transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, plugins_manager, user=None, app=None
+        )
         checkout.automatically_refundable = True
         checkout.save(update_fields=["automatically_refundable", "last_change"])
 

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -1,12 +1,13 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 import pytz
 from django.utils import timezone
 from freezegun import freeze_time
 
+from ...checkout import CheckoutAuthorizeStatus
 from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...order import OrderAuthorizeStatus, OrderChargeStatus, OrderGrantedRefundStatus
 from ...plugins.manager import get_plugins_manager
@@ -985,6 +986,215 @@ def test_create_transaction_event_from_request_and_webhook_response_full_event(
     assert event.external_url == event_url
     assert event.message == event_cause
     assert event.type == event_type
+
+
+@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_create_transaction_event_from_request_when_paid(
+    mocked_checkout_fully_paid,
+    mocked_complete_checkout,
+    transaction_item_generator,
+    app,
+    checkout_with_prices,
+):
+    # given
+    checkout = checkout_with_prices
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=checkout.total.gross.amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    event_amount = checkout.total.gross.amount
+    event_type = TransactionEventType.CHARGE_SUCCESS
+
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    flush_post_commit_hooks()
+    checkout.refresh_from_db()
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_complete_checkout.assert_not_called()
+
+
+@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_create_transaction_event_from_request_when_authorized(
+    mocked_checkout_fully_paid,
+    mocked_complete_checkout,
+    transaction_item_generator,
+    app,
+    checkout_with_prices,
+):
+    # given
+    checkout = checkout_with_prices
+
+    channel = checkout.channel
+    assert channel.automatically_complete_fully_paid_checkouts is False
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.AUTHORIZATION_REQUEST,
+        amount_value=checkout.total.gross.amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    event_amount = checkout.total.gross.amount
+    event_type = TransactionEventType.AUTHORIZATION_SUCCESS
+
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    flush_post_commit_hooks()
+    checkout.refresh_from_db()
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_checkout_fully_paid.assert_not_called()
+    mocked_complete_checkout.assert_not_called()
+
+
+@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_create_transaction_event_from_request_when_paid_triggers_checkout_completion(
+    mocked_checkout_fully_paid,
+    mocked_complete_checkout,
+    transaction_item_generator,
+    app,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=checkout.total.gross.amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    event_amount = checkout.total.gross.amount
+    event_type = TransactionEventType.CHARGE_SUCCESS
+
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    flush_post_commit_hooks()
+    checkout.refresh_from_db()
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_complete_checkout.assert_called_once_with(
+        manager=ANY,
+        checkout_info=checkout_info,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        user=None,
+        app=app,
+    )
+
+
+@patch("saleor.checkout.complete_checkout.complete_checkout")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+def test_create_transaction_event_from_request_when_authorized_triggers_checkout_completion(
+    mocked_checkout_fully_paid,
+    mocked_complete_checkout,
+    transaction_item_generator,
+    app,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+
+    channel = checkout_info.channel
+    channel.automatically_complete_fully_paid_checkouts = True
+    channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.AUTHORIZATION_REQUEST,
+        amount_value=checkout.total.gross.amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    event_amount = checkout.total.gross.amount
+    event_type = TransactionEventType.AUTHORIZATION_SUCCESS
+
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    flush_post_commit_hooks()
+    checkout.refresh_from_db()
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_checkout_fully_paid.assert_not_called()
+    mocked_complete_checkout.assert_called_once_with(
+        manager=ANY,
+        checkout_info=checkout_info,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        user=None,
+        app=app,
+    )
 
 
 def test_create_transaction_event_from_request_and_webhook_response_incorrect_data(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1281,7 +1281,9 @@ def create_transaction_event_for_transaction_session(
                 previous_refunded_value=previous_refunded_value,
             )
         elif transaction_item.checkout_id:
-            transaction_amounts_for_checkout_updated(transaction_item, manager)
+            transaction_amounts_for_checkout_updated(
+                transaction_item, manager, app=app, user=None
+            )
     elif event.psp_reference and transaction_item.psp_reference != event.psp_reference:
         transaction_item.psp_reference = event.psp_reference
         transaction_item.save(update_fields=["psp_reference", "modified_at"])
@@ -1388,7 +1390,9 @@ def create_transaction_event_from_request_and_webhook_response(
     elif transaction_item.checkout_id:
         manager = get_plugins_manager(allow_replica=True)
         recalculate_refundable_for_checkout(transaction_item, request_event, event)
-        transaction_amounts_for_checkout_updated(transaction_item, manager)
+        transaction_amounts_for_checkout_updated(
+            transaction_item, manager, app=app, user=None
+        )
     return event
 
 


### PR DESCRIPTION
Introduce automatic checkout completion.

- The automatic completion might happen:
    - as a result of the `TransactionCreate` mutation, when the created transaction covers the checkout total
    - as a result of the `TransactionEventReport` mutation, when the reported event causes the checkout total to be covered
    - as a result of the `TransactionUpdate` mutation, when the updates causes the checkout total to be covered
    - as a result of `TransactionInitialize`
    - as a result of `TransactionProcess`
    - as a result of `TransactionRequestAction`, after processing the response for sync webhooks: `TRANSACTION_CHARGE_REQUESTED`
- The checkout is considered ready to complete when:
    - `checkout.authorization_status` is `FULL` .
- Log the whole process of the automatic completion

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
