### PR TITLE
Fix clearorders command not to raise IntegrityError

### DIFF
--- a/saleor/core/management/commands/clearorders.py
+++ b/saleor/core/management/commands/clearorders.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 
 from ....account.models import Address, CustomerEvent, CustomerNote, User
 from ....checkout.models import Checkout, CheckoutLine, CheckoutMetadata
-from ....discount.models import OrderDiscount
+from ....discount.models import OrderDiscount, OrderLineDiscount
 from ....giftcard.models import GiftCard, GiftCardEvent, GiftCardTag
 from ....invoice.models import Invoice, InvoiceEvent
 from ....order.models import Fulfillment, FulfillmentLine, Order, OrderEvent, OrderLine
@@ -109,6 +109,9 @@ class Command(BaseCommand):
         self.stdout.write("Removed gift cards")
 
     def delete_orders(self):
+        line_discounts = OrderLineDiscount.objects.all()
+        line_discounts._raw_delete(line_discounts.db)  # type: ignore[attr-defined] # raw access # noqa: E501
+
         discounts = OrderDiscount.objects.all()
         discounts._raw_delete(discounts.db)  # type: ignore[attr-defined] # raw access # noqa: E501
 


### PR DESCRIPTION
I want to merge this change because it prevents `clearorders` command from raising `IntegrityError`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
