### PR TITLE
Add product SKU to order bulk create

### DIFF
--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -425,6 +425,10 @@ class OrderBulkCreateOrderLineInput(BaseInputObjectType):
     )
     variant_name = graphene.String(description="The name of the product variant.")
     product_name = graphene.String(description="The name of the product.")
+    product_sku = graphene.String(
+        required=False,
+        description="The SKU of the product.",
+    )
     translated_variant_name = graphene.String(
         description="Translation of the product variant name."
     )
@@ -1607,6 +1611,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             translated_variant_name=order_line_input.get("translated_variant_name")
             or "",
             product_variant_id=(variant.get_global_id() if variant else None),
+            product_sku=order_line_input.get("product_sku"),
             created_at=order_line_input["created_at"],
             is_shipping_required=order_line_input["is_shipping_required"],
             is_gift_card=order_line_input["is_gift_card"],

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -427,7 +427,7 @@ class OrderBulkCreateOrderLineInput(BaseInputObjectType):
     product_name = graphene.String(description="The name of the product.")
     product_sku = graphene.String(
         required=False,
-        description="The SKU of the product.",
+        description="The SKU of the product." + ADDED_IN_318,
     )
     translated_variant_name = graphene.String(
         description="Translation of the product variant name."

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -70,6 +70,7 @@ ORDER_BULK_CREATE = """
                             id
                         }
                         productName
+                        productSku
                         variantName
                         translatedVariantName
                         translatedProductName
@@ -600,6 +601,7 @@ def test_order_bulk_create(
         "ProductVariant", variant.id
     )
     assert order_line["productName"] == "Product Name"
+    assert order_line["productSku"] is None
     assert order_line["variantName"] == "Variant Name"
     assert order_line["translatedProductName"] == "Nazwa Produktu"
     assert order_line["translatedVariantName"] == "Nazwa Wariantu"
@@ -629,6 +631,7 @@ def test_order_bulk_create(
     db_order_line = OrderLine.objects.get()
     assert db_order_line.variant == variant
     assert db_order_line.product_name == "Product Name"
+    assert db_order_line.product_sku is None
     assert db_order_line.variant_name == "Variant Name"
     assert db_order_line.translated_product_name == "Nazwa Produktu"
     assert db_order_line.translated_variant_name == "Nazwa Wariantu"
@@ -858,6 +861,7 @@ def test_order_bulk_create_multiple_lines(
     line_2["variantId"] = graphene.Node.to_global_id("ProductVariant", variant_2.id)
     line_2["totalPrice"]["gross"] = 60
     line_2["totalPrice"]["net"] = 50
+    line_2["productSku"] = "TEST-SKU"
     order["lines"].append(line_2)
 
     staff_api_client.user.user_permissions.add(
@@ -881,17 +885,21 @@ def test_order_bulk_create_multiple_lines(
     line_1 = order["lines"][0]
     assert line_1["unitPrice"]["gross"]["amount"] == Decimal(120 / 5)
     assert line_1["unitPrice"]["net"]["amount"] == Decimal(100 / 5)
+    assert line_1["productSku"] is None
     line_2 = order["lines"][1]
     assert line_2["unitPrice"]["gross"]["amount"] == Decimal(60 / 5)
     assert line_2["unitPrice"]["net"]["amount"] == Decimal(50 / 5)
+    assert line_2["productSku"] == "TEST-SKU"
 
     db_lines = OrderLine.objects.all()
     db_line_1 = db_lines[0]
     assert db_line_1.unit_price.gross.amount == Decimal(120 / 5)
     assert db_line_1.unit_price.net.amount == Decimal(100 / 5)
+    assert db_line_1.product_sku is None
     db_line_2 = db_lines[1]
     assert db_line_2.unit_price.gross.amount == Decimal(60 / 5)
     assert db_line_2.unit_price.net.amount == Decimal(50 / 5)
+    assert db_line_2.product_sku == "TEST-SKU"
 
     assert order["total"]["gross"]["amount"] == 180
     assert order["total"]["net"]["amount"] == 150

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26479,6 +26479,9 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   """The name of the product."""
   productName: String
 
+  """The SKU of the product."""
+  productSku: String
+
   """Translation of the product variant name."""
   translatedVariantName: String
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26479,7 +26479,11 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   """The name of the product."""
   productName: String
 
-  """The SKU of the product."""
+  """
+  The SKU of the product.
+  
+  Added in Saleor 3.18.
+  """
   productSku: String
 
   """Translation of the product variant name."""


### PR DESCRIPTION
Add missing input `productSku` to `orderBulkCreate` mutation

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
