### PR TITLE
Fix pagination with inline fragments

### DIFF
--- a/saleor/graphql/core/tests/test_pagination.py
+++ b/saleor/graphql/core/tests/test_pagination.py
@@ -310,3 +310,46 @@ def test_query_with_pagination_and_fragments_no_first_or_last_raises_an_error(bo
         "the `books` connection."
     )
     assert str(result.errors[0]) == expected_err_msg
+
+
+QUERY_PAGINATION_WITH_INLINE_FRAGMENTS = """
+    query BooksPaginationTest($first: Int, $last: Int, $after: String, $before: String){
+        books(first: $first, last: $last, after: $after, before: $before) {
+            ...on BookTypeCountableConnection {
+                pageInfo {
+                    ...on PageInfo {
+                        endCursor
+                        hasNextPage
+                        hasPreviousPage
+                        startCursor
+                        __typename
+                    }
+                    __typename
+                }
+                edges {
+                    cursor
+                    node {
+                        ...on BookType {
+                            name
+                            __typename
+                        }
+                        __typename
+                    }
+                    __typename
+                }
+                __typename
+            }
+        }
+    }
+"""
+
+
+def test_query_with_pagination_and_inline_fragments(books):
+    page_size = 10
+    variables = {"first": page_size}
+
+    result = schema.execute(QUERY_PAGINATION_WITH_INLINE_FRAGMENTS, variables=variables)
+
+    assert not result.errors
+    content = result.data
+    assert len(content["books"]["edges"]) == page_size


### PR DESCRIPTION
Previous code incorrectly assumed that selections are either scalars or named fragment spreads and crashed when it encountered an inline fragment.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
