### PR TITLE
Automatic checkout completion adjustment

### DIFF
--- a/saleor/checkout/tasks.py
+++ b/saleor/checkout/tasks.py
@@ -118,7 +118,7 @@ def delete_expired_checkouts(
     return total_deleted, has_more
 
 
-@app.task
+@app.task(queue=settings.AUTOMATIC_CHECKOUT_COMPLETION_QUEUE_NAME)
 def automatic_checkout_completion_task(
     checkout_pk,
     user_id,

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -11,7 +11,6 @@ from freezegun import freeze_time
 from ...core.models import EventDelivery
 from ...core.utils.events import call_event_including_protected_events
 from ...plugins.manager import get_plugins_manager
-from ...tests.utils import flush_post_commit_hooks
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .. import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from ..actions import (
@@ -32,6 +31,7 @@ def test_transaction_amounts_for_checkout_updated_fully_paid(
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_items
@@ -44,12 +44,12 @@ def test_transaction_amounts_for_checkout_updated_fully_paid(
     assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
 
     # when
-    transaction_amounts_for_checkout_updated(
-        transaction, manager=plugins_manager, user=None, app=None
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            transaction, manager=plugins_manager, user=None, app=None
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
@@ -66,6 +66,7 @@ def test_transaction_amounts_for_checkout_fully_paid_automatic_checkout_complete
     transaction_item_generator,
     plugins_manager,
     app,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_items
@@ -80,12 +81,12 @@ def test_transaction_amounts_for_checkout_fully_paid_automatic_checkout_complete
     channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
-    transaction_amounts_for_checkout_updated(
-        transaction, manager=plugins_manager, user=None, app=app
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            transaction, manager=plugins_manager, user=None, app=app
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
@@ -103,6 +104,7 @@ def test_transaction_amounts_for_checkout_updated_not_fully_paid_no_automatic_co
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_items
@@ -118,12 +120,12 @@ def test_transaction_amounts_for_checkout_updated_not_fully_paid_no_automatic_co
     channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
-    transaction_amounts_for_checkout_updated(
-        transaction, manager=plugins_manager, user=None, app=None
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            transaction, manager=plugins_manager, user=None, app=None
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
@@ -139,6 +141,7 @@ def test_transaction_amounts_for_checkout_updated_with_already_fully_paid(
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_items
@@ -156,12 +159,12 @@ def test_transaction_amounts_for_checkout_updated_with_already_fully_paid(
         checkout_id=checkout.pk, charged_value=checkout_info.checkout.total.gross.amount
     )
     # when
-    transaction_amounts_for_checkout_updated(
-        second_transaction, manager=plugins_manager, user=None, app=None
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            second_transaction, manager=plugins_manager, user=None, app=None
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.OVERCHARGED
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
@@ -178,6 +181,7 @@ def test_transaction_amounts_for_checkout_updated_0_checkout_automatic_complete(
     transaction_item_generator,
     plugins_manager,
     app,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_item_total_0
@@ -190,12 +194,12 @@ def test_transaction_amounts_for_checkout_updated_0_checkout_automatic_complete(
     channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
-    transaction_amounts_for_checkout_updated(
-        transaction, manager=plugins_manager, user=None, app=app
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            transaction, manager=plugins_manager, user=None, app=app
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
@@ -213,6 +217,7 @@ def test_transaction_amounts_for_checkout_updated_fully_authorized(
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_items
@@ -226,12 +231,12 @@ def test_transaction_amounts_for_checkout_updated_fully_authorized(
     assert checkout_info.channel.automatically_complete_fully_paid_checkouts is False
 
     # when
-    transaction_amounts_for_checkout_updated(
-        transaction, manager=plugins_manager, user=None, app=None
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            transaction, manager=plugins_manager, user=None, app=None
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
@@ -248,6 +253,7 @@ def test_transaction_amounts_for_checkout_fully_authorized_automatic_checkout_co
     transaction_item_generator,
     plugins_manager,
     staff_user,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_items
@@ -263,12 +269,12 @@ def test_transaction_amounts_for_checkout_fully_authorized_automatic_checkout_co
     channel.save(update_fields=["automatically_complete_fully_paid_checkouts"])
 
     # when
-    transaction_amounts_for_checkout_updated(
-        transaction, manager=plugins_manager, user=staff_user, app=None
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            transaction, manager=plugins_manager, user=staff_user, app=None
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
@@ -290,6 +296,7 @@ def test_transaction_amounts_for_checkout_updated_updates_last_transaction_modif
     checkout_with_items,
     transaction_item_generator,
     plugins_manager,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_items
@@ -308,12 +315,12 @@ def test_transaction_amounts_for_checkout_updated_updates_last_transaction_modif
     )
 
     # when
-    transaction_amounts_for_checkout_updated(
-        transaction, manager=plugins_manager, user=None, app=None
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        transaction_amounts_for_checkout_updated(
+            transaction, manager=plugins_manager, user=None, app=None
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.last_transaction_modified_at == transaction.modified_at
     mocked_fully_paid.assert_called_with(checkout, webhooks=set())

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -932,6 +932,11 @@ COLLECTION_PRODUCT_UPDATED_QUEUE_NAME = os.environ.get(
     "COLLECTION_PRODUCT_UPDATED_QUEUE_NAME", None
 )
 
+# Queue name for execution of automatic checkout completion
+AUTOMATIC_CHECKOUT_COMPLETION_QUEUE_NAME = os.environ.get(
+    "AUTOMATIC_CHECKOUT_COMPLETION_QUEUE_NAME", None
+)
+
 # Lock time for request password reset mutation per user (seconds)
 RESET_PASSWORD_LOCK_TIME = parse(
     os.environ.get("RESET_PASSWORD_LOCK_TIME", "15 minutes")


### PR DESCRIPTION
Address comments from https://github.com/saleor/saleor/pull/16785

- Add a new queue for automatic checkout completion
- Ensure that automatic checkout completion is called once
- Do not use `flush_post_commit_hooks` in tests

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
