### PR TITLE
Add `orders` doc category to filterable subscription webhooks

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -32369,7 +32369,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): DraftOrderCreated
+  ): DraftOrderCreated @doc(category: "Orders")
 
   """
   Event sent when draft order is updated.
@@ -32383,7 +32383,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): DraftOrderUpdated
+  ): DraftOrderUpdated @doc(category: "Orders")
 
   """
   Event sent when draft order is deleted.
@@ -32397,7 +32397,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): DraftOrderDeleted
+  ): DraftOrderDeleted @doc(category: "Orders")
 
   """
   Event sent when new order is created.
@@ -32411,7 +32411,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderCreated
+  ): OrderCreated @doc(category: "Orders")
 
   """
   Event sent when order is updated.
@@ -32425,7 +32425,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderUpdated
+  ): OrderUpdated @doc(category: "Orders")
 
   """
   Event sent when order is confirmed.
@@ -32439,7 +32439,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderConfirmed
+  ): OrderConfirmed @doc(category: "Orders")
 
   """
   Payment has been made. The order may be partially or fully paid.
@@ -32453,7 +32453,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderPaid
+  ): OrderPaid @doc(category: "Orders")
 
   """
   Event sent when order is fully paid.
@@ -32467,7 +32467,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderFullyPaid
+  ): OrderFullyPaid @doc(category: "Orders")
 
   """
   The order received a refund. The order may be partially or fully refunded.
@@ -32481,7 +32481,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderRefunded
+  ): OrderRefunded @doc(category: "Orders")
 
   """
   The order is fully refunded.
@@ -32495,7 +32495,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderFullyRefunded
+  ): OrderFullyRefunded @doc(category: "Orders")
 
   """
   Event sent when order is fulfilled.
@@ -32509,7 +32509,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderFulfilled
+  ): OrderFulfilled @doc(category: "Orders")
 
   """
   Event sent when order is cancelled.
@@ -32523,7 +32523,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderCancelled
+  ): OrderCancelled @doc(category: "Orders")
 
   """
   Event sent when order becomes expired.
@@ -32537,7 +32537,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderExpired
+  ): OrderExpired @doc(category: "Orders")
 
   """
   Event sent when order metadata is updated.
@@ -32551,7 +32551,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderMetadataUpdated
+  ): OrderMetadataUpdated @doc(category: "Orders")
 
   """
   Event sent when orders are imported.
@@ -32565,7 +32565,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the order belongs to one of the provided channels. If the channel slug list is empty, orders that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
-  ): OrderBulkCreated
+  ): OrderBulkCreated @doc(category: "Orders")
 }
 
 interface Event {

--- a/saleor/graphql/schema_printer.py
+++ b/saleor/graphql/schema_printer.py
@@ -232,7 +232,11 @@ def print_implemented_interfaces(type_: GraphQLObjectType) -> str:
 
 
 def print_object(type_: GrapheneObjectType) -> str:
-    include_doc_category_directives = type_.name in ["Mutation", "Query"]
+    include_doc_category_directives = type_.name in [
+        "Mutation",
+        "Query",
+        "Subscription",
+    ]
     return (
         print_description(type_)
         + f"type {type_.name}"

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -76,6 +76,7 @@ from ..core.doc_category import (
     DOC_CATEGORY_TAXES,
     DOC_CATEGORY_USERS,
 )
+from ..core.fields import BaseField
 from ..core.scalars import JSON, DateTime, PositiveDecimal
 from ..core.types import NonNullList, SubscriptionObjectType
 from ..core.types.order_or_checkout import OrderOrCheckout
@@ -2725,7 +2726,7 @@ class Subscription(SubscriptionObjectType):
         Event,
         description="Look up subscription event." + ADDED_IN_32,
     )
-    draft_order_created = graphene.Field(
+    draft_order_created = BaseField(
         DraftOrderCreated,
         description=(
             "Event sent when new draft order is created."
@@ -2734,48 +2735,54 @@ class Subscription(SubscriptionObjectType):
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    draft_order_updated = graphene.Field(
+    draft_order_updated = BaseField(
         DraftOrderUpdated,
         description=(
             "Event sent when draft order is updated." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    draft_order_deleted = graphene.Field(
+    draft_order_deleted = BaseField(
         DraftOrderDeleted,
         description=(
             "Event sent when draft order is deleted." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_created = graphene.Field(
+    order_created = BaseField(
         OrderCreated,
         description=(
             "Event sent when new order is created." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_updated = graphene.Field(
+    order_updated = BaseField(
         OrderUpdated,
         description=(
             "Event sent when order is updated." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_confirmed = graphene.Field(
+    order_confirmed = BaseField(
         OrderConfirmed,
         description=(
             "Event sent when order is confirmed." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_paid = graphene.Field(
+    order_paid = BaseField(
         OrderPaid,
         description=(
             "Payment has been made. The order may be partially or fully paid."
@@ -2784,16 +2791,18 @@ class Subscription(SubscriptionObjectType):
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_fully_paid = graphene.Field(
+    order_fully_paid = BaseField(
         OrderFullyPaid,
         description=(
             "Event sent when order is fully paid." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_refunded = graphene.Field(
+    order_refunded = BaseField(
         OrderRefunded,
         description=(
             "The order received a refund. The order may be partially or fully "
@@ -2801,38 +2810,43 @@ class Subscription(SubscriptionObjectType):
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_fully_refunded = graphene.Field(
+    order_fully_refunded = BaseField(
         OrderFullyRefunded,
         description=("The order is fully refunded." + ADDED_IN_320 + PREVIEW_FEATURE),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_fulfilled = graphene.Field(
+    order_fulfilled = BaseField(
         OrderFulfilled,
         description=(
             "Event sent when order is fulfilled." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_cancelled = graphene.Field(
+    order_cancelled = BaseField(
         OrderCancelled,
         description=(
             "Event sent when order is cancelled." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_expired = graphene.Field(
+    order_expired = BaseField(
         OrderExpired,
         description=(
             "Event sent when order becomes expired." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_metadata_updated = graphene.Field(
+    order_metadata_updated = BaseField(
         OrderMetadataUpdated,
         description=(
             "Event sent when order metadata is updated."
@@ -2841,13 +2855,15 @@ class Subscription(SubscriptionObjectType):
         ),
         resolver=default_order_resolver,
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
-    order_bulk_created = graphene.Field(
+    order_bulk_created = BaseField(
         OrderBulkCreated,
         description=(
             "Event sent when orders are imported." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
         channels=channels_argument,
+        doc_category=DOC_CATEGORY_ORDERS,
     )
 
     class Meta:


### PR DESCRIPTION
I want to merge this change because it adds orders as doc_category to the filterable subscription webhooks.
Port of changes from: #16816

> [!NOTE]  
> Porting these changes as saleor-docs's api-references are generated based on the Saleor's newest release. So to keep the docs up-to-date with new doc_category, we need to add it to the latest release.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
