### PR TITLE
Release 3.20.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.34",
+  "version": "3.20.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.34",
+      "version": "3.20.35",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.34",
+  "version": "3.20.35",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.34"
+version = "3.20.35"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.34"
+__version__ = "3.20.35"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Allow automatic checkout completion (#16782) (2ce37dbae9)
* Add missing doc category to filterable subscription webhooks (#16817) (dac436ecc4)
* New release flow (#16743) (2b3ec5e80c)
* Update description for `CheckoutFullyPaid` subscription webhook (#16794) (c42057e881)
* Fix `clearorders` command not to raise `IntegrityError` (#16788) (0d4299f552)
