### PR TITLE
Release 3.20.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.36",
+  "version": "3.20.37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.36",
+      "version": "3.20.37",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.36",
+  "version": "3.20.37",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.36"
+version = "3.20.37"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.36"
+__version__ = "3.20.37"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.20.37 (6034b7dbfb)
* Bump uvicorn to the version which supports new multiprocess manager (#16739) (#16833) (3dd8be92fe)
* Prevent double shipping voucher discount in checkout tax paylod when subscription query is not provided. (#16829) (2ab1f71098)
