### PR TITLE
Drop ADDED_IN and FEATURE_PREVIEW for versions below 3.18 (Order, Checkout, Discount)

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -11,7 +11,7 @@ from ....checkout.fetch import (
 from ....checkout.utils import add_promo_code_to_checkout, invalidate_checkout
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -29,7 +29,7 @@ class CheckoutAddPromoCode(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         checkout_id = graphene.ID(

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -8,7 +8,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import AddressInput
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, ADDED_IN_35, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
@@ -25,7 +25,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(
@@ -45,7 +45,6 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             required=False,
             description=(
                 "The rules for changing validation for received billing address data."
-                + ADDED_IN_35
             ),
         )
 

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -23,7 +23,7 @@ from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...account.i18n import I18nMixin
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, ADDED_IN_38, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.fields import JSONString
 from ...core.mutations import BaseMutation
@@ -59,7 +59,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(
@@ -94,9 +94,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         )
         metadata = NonNullList(
             MetadataInput,
-            description=(
-                "Fields required to update the checkout metadata." + ADDED_IN_38
-            ),
+            description=("Fields required to update the checkout metadata."),
             required=False,
         )
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -17,13 +17,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_35,
-    ADDED_IN_36,
-    ADDED_IN_38,
-    DEPRECATED_IN_3X_FIELD,
-)
+from ...core.descriptions import DEPRECATED_IN_3X_FIELD
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelMutation
@@ -110,7 +104,6 @@ class CheckoutLineInput(BaseInputObjectType):
             "Custom price of the item. Can be set only by apps "
             "with `HANDLE_CHECKOUTS` permission. When the line with the same variant "
             "will be provided multiple times, the last price will be used."
-            + ADDED_IN_31
         ),
     )
     force_new_line = graphene.Boolean(
@@ -118,12 +111,12 @@ class CheckoutLineInput(BaseInputObjectType):
         default_value=False,
         description=(
             "Flag that allow force splitting the same variant into multiple lines "
-            "by skipping the matching logic. " + ADDED_IN_36
+            "by skipping the matching logic. "
         ),
     )
     metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the object's metadata." + ADDED_IN_38),
+        description=("Fields required to update the object's metadata."),
         required=False,
     )
 
@@ -163,9 +156,7 @@ class CheckoutCreateInput(BaseInputObjectType):
     )
     validation_rules = CheckoutValidationRules(
         required=False,
-        description=(
-            "The checkout validation rules that can be changed." + ADDED_IN_35
-        ),
+        description=("The checkout validation rules that can be changed."),
     )
 
     class Meta:

--- a/saleor/graphql/checkout/mutations/checkout_create_from_order.py
+++ b/saleor/graphql/checkout/mutations/checkout_create_from_order.py
@@ -13,7 +13,6 @@ from ....product.models import ProductVariant
 from ....warehouse.availability import check_stock_and_preorder_quantity_bulk
 from ....warehouse.reservations import get_reservation_length, is_reservation_enabled
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_314, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.types import BaseObjectType, Error, common
@@ -73,9 +72,7 @@ class CheckoutCreateFromOrder(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Create new checkout from existing order." + ADDED_IN_314 + PREVIEW_FEATURE
-        )
+        description = "Create new checkout from existing order."
         doc_category = DOC_CATEGORY_CHECKOUT
         error_type_class = CheckoutCreateFromOrderError
 

--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -9,7 +9,7 @@ from ....permission.enums import AccountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import User
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -26,7 +26,7 @@ class CheckoutCustomerAttach(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_customer_detach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_detach.py
@@ -6,7 +6,7 @@ from ....permission.auth_filters import AuthorizationFilters
 from ....permission.enums import AccountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -23,7 +23,7 @@ class CheckoutCustomerDetach(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -26,7 +26,7 @@ from ....warehouse import models as warehouse_models
 from ....webhook.const import APP_ID_PREFIX
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_31, ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -44,7 +44,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(
@@ -62,7 +62,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             "Updates the delivery method (shipping method or pick up point) "
             "of the checkout. "
             "Updates the checkout shipping_address for click and collect delivery "
-            "for a warehouse address. " + ADDED_IN_31
+            "for a warehouse address. "
         )
         doc_category = DOC_CATEGORY_CHECKOUT
         error_type_class = CheckoutError

--- a/saleor/graphql/checkout/mutations/checkout_email_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_email_update.py
@@ -5,7 +5,7 @@ from ....checkout.actions import call_checkout_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -21,7 +21,7 @@ class CheckoutEmailUpdate(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_language_code_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_language_code_update.py
@@ -4,7 +4,7 @@ from saleor.checkout.actions import call_checkout_event
 from saleor.webhook.event_types import WebhookEventAsyncType
 
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import BaseMutation
@@ -21,7 +21,7 @@ class CheckoutLanguageCodeUpdate(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_line_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_line_delete.py
@@ -6,7 +6,7 @@ from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import invalidate_checkout
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -22,7 +22,7 @@ class CheckoutLineDelete(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -12,7 +12,7 @@ from ....warehouse.reservations import get_reservation_length, is_reservation_en
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -42,7 +42,7 @@ class CheckoutLinesAdd(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -7,7 +7,7 @@ from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import invalidate_checkout
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -24,7 +24,7 @@ class CheckoutLinesDelete(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -9,9 +9,6 @@ from ...app.dataloaders import get_app_promise
 from ...checkout.types import CheckoutLine
 from ...core import ResolveInfo
 from ...core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_34,
-    ADDED_IN_36,
     DEPRECATED_IN_3X_INPUT,
 )
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
@@ -51,11 +48,10 @@ class CheckoutLineUpdateInput(BaseInputObjectType):
             "Custom price of the item. Can be set only by apps "
             "with `HANDLE_CHECKOUTS` permission. When the line with the same variant "
             "will be provided multiple times, the last price will be used."
-            + ADDED_IN_31
         ),
     )
     line_id = graphene.ID(
-        description="ID of the line." + ADDED_IN_36,
+        description="ID of the line.",
         required=False,
     )
 
@@ -68,7 +64,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -15,7 +15,7 @@ from ....checkout.utils import (
 )
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -36,7 +36,7 @@ class CheckoutRemovePromoCode(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -23,7 +23,7 @@ from ....warehouse.reservations import is_reservation_enabled
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
-from ...core.descriptions import ADDED_IN_34, ADDED_IN_35, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -50,7 +50,7 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(
@@ -71,7 +71,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             required=False,
             description=(
                 "The rules for changing validation for received shipping address data."
-                + ADDED_IN_35
             ),
         )
 

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -19,7 +19,7 @@ from ....shipping.utils import convert_to_shipping_method_data
 from ....webhook.const import APP_ID_PREFIX
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -36,7 +36,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
+            description="The checkout's ID.",
             required=False,
         )
         token = UUID(

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -10,7 +10,6 @@ from ....permission.enums import CheckoutPermissions
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_32, ADDED_IN_38
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import Error, NonNullList
@@ -59,16 +58,12 @@ class OrderCreateFromCheckout(BaseMutation):
         )
         private_metadata = NonNullList(
             MetadataInput,
-            description=(
-                "Fields required to update the checkout private metadata." + ADDED_IN_38
-            ),
+            description=("Fields required to update the checkout private metadata."),
             required=False,
         )
         metadata = NonNullList(
             MetadataInput,
-            description=(
-                "Fields required to update the checkout metadata." + ADDED_IN_38
-            ),
+            description=("Fields required to update the checkout metadata."),
             required=False,
         )
 
@@ -77,7 +72,6 @@ class OrderCreateFromCheckout(BaseMutation):
         description = (
             "Create new order from existing checkout. Requires the "
             "following permissions: AUTHENTICATED_APP and HANDLE_CHECKOUTS."
-            + ADDED_IN_32
         )
         doc_category = DOC_CATEGORY_ORDERS
         object_type = Order

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -8,8 +8,6 @@ from ...permission.enums import (
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_34,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
 )
@@ -58,9 +56,7 @@ class CheckoutQueries(graphene.ObjectType):
             f"{AccountPermissions.IMPERSONATE_USER.name}, "
             f"{PaymentPermissions.HANDLE_PAYMENTS.name}. "
         ),
-        id=graphene.Argument(
-            graphene.ID, description="The checkout's ID." + ADDED_IN_34
-        ),
+        id=graphene.Argument(graphene.ID, description="The checkout's ID."),
         token=graphene.Argument(
             UUID,
             description=(
@@ -72,10 +68,8 @@ class CheckoutQueries(graphene.ObjectType):
     # FIXME we could optimize the below field
     checkouts = FilterConnectionField(
         CheckoutCountableConnection,
-        sort_by=CheckoutSortingInput(description="Sort checkouts." + ADDED_IN_31),
-        filter=CheckoutFilterInput(
-            description="Filtering options for checkouts." + ADDED_IN_31
-        ),
+        sort_by=CheckoutSortingInput(description="Sort checkouts."),
+        filter=CheckoutFilterInput(description="Filtering options for checkouts."),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -41,13 +41,6 @@ from ..checkout.dataloaders import (
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
 from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_34,
-    ADDED_IN_35,
-    ADDED_IN_38,
-    ADDED_IN_39,
-    ADDED_IN_313,
-    ADDED_IN_315,
     ADDED_IN_318,
     ADDED_IN_319,
     ADDED_IN_321,
@@ -141,12 +134,8 @@ class CheckoutLineProblemInsufficientStock(
 
     class Meta:
         description = (
-            (
-                "Indicates insufficient stock for a given checkout line."
-                "Placing the order will not be possible until solving this problem."
-            )
-            + ADDED_IN_315
-            + PREVIEW_FEATURE
+            "Indicates insufficient stock for a given checkout line."
+            "Placing the order will not be possible until solving this problem."
         )
         doc_category = DOC_CATEGORY_CHECKOUT
 
@@ -160,12 +149,8 @@ class CheckoutLineProblemVariantNotAvailable(BaseObjectType):
 
     class Meta:
         description = (
-            (
-                "The variant assigned to the checkout line is not available."
-                "Placing the order will not be possible until solving this problem."
-            )
-            + ADDED_IN_315
-            + PREVIEW_FEATURE
+            "The variant assigned to the checkout line is not available."
+            "Placing the order will not be possible until solving this problem."
         )
         doc_category = DOC_CATEGORY_CHECKOUT
 
@@ -176,11 +161,7 @@ class CheckoutLineProblem(graphene.Union):
             CheckoutLineProblemInsufficientStock,
             CheckoutLineProblemVariantNotAvailable,
         )
-        description = (
-            "Represents an problem in the checkout line."
-            + ADDED_IN_315
-            + PREVIEW_FEATURE
-        )
+        description = "Represents an problem in the checkout line."
         doc_category = DOC_CATEGORY_CHECKOUT
 
     @classmethod
@@ -195,9 +176,7 @@ class CheckoutLineProblem(graphene.Union):
 class CheckoutProblem(graphene.Union):
     class Meta:
         types = [] + list(CheckoutLineProblem._meta.types)
-        description = (
-            "Represents an problem in the checkout." + ADDED_IN_315 + PREVIEW_FEATURE
-        )
+        description = "Represents an problem in the checkout."
         doc_category = DOC_CATEGORY_CHECKOUT
 
     @classmethod
@@ -259,10 +238,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
         required=True,
     )
     problems = NonNullList(
-        CheckoutLineProblem,
-        description="List of problems with the checkout line."
-        + ADDED_IN_315
-        + PREVIEW_FEATURE,
+        CheckoutLineProblem, description="List of problems with the checkout line."
     )
     is_gift = graphene.Boolean(
         description="Determine if the line is a gift." + ADDED_IN_319 + PREVIEW_FEATURE,
@@ -272,7 +248,6 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
         description = "Represents an item in the checkout."
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
         model = models.CheckoutLine
-        metadata_since = ADDED_IN_35
 
     @staticmethod
     def resolve_variant(root: models.CheckoutLine, info: ResolveInfo):
@@ -482,7 +457,7 @@ class DeliveryMethod(graphene.Union):
         description = (
             "Represents a delivery method chosen for the checkout. "
             '`Warehouse` type is used when checkout is marked as "click and collect" '
-            "and `ShippingMethod` otherwise." + ADDED_IN_31
+            "and `ShippingMethod` otherwise."
         )
         types = (Warehouse, ShippingMethod)
 
@@ -503,7 +478,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     )
     updated_at = DateTime(
         required=True,
-        description=("Time of last modification of the given checkout." + ADDED_IN_313),
+        description=("Time of last modification of the given checkout."),
     )
     last_change = DateTime(
         required=True,
@@ -612,9 +587,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     available_collection_points = NonNullList(
         Warehouse,
         required=True,
-        description=(
-            "Collection points that can be used for this order." + ADDED_IN_31
-        ),
+        description=("Collection points that can be used for this order."),
     )
     available_payment_gateways = BaseField(
         NonNullList(PaymentGateway),
@@ -640,7 +613,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     stock_reservation_expires = DateTime(
         description=(
             "Date when oldest stock reservation for this checkout "
-            "expires or null if no stock is reserved." + ADDED_IN_31
+            "expires or null if no stock is reserved."
         ),
     )
     lines = NonNullList(
@@ -688,7 +661,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     )
     delivery_method = BaseField(
         DeliveryMethod,
-        description=("The delivery method selected for this checkout." + ADDED_IN_31),
+        description=("The delivery method selected for this checkout."),
         webhook_events_info=[
             WebhookEventInfo(
                 type=WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
@@ -718,9 +691,7 @@ class Checkout(ModelObjectType[models.Checkout]):
         ],
     )
     tax_exemption = graphene.Boolean(
-        description=(
-            "Returns True if checkout has to be exempt from taxes." + ADDED_IN_38
-        ),
+        description=("Returns True if checkout has to be exempt from taxes."),
         required=True,
     )
     token = graphene.Field(UUID, description="The checkout's token.", required=True)
@@ -741,11 +712,7 @@ class Checkout(ModelObjectType[models.Checkout]):
 
     total_balance = BaseField(
         Money,
-        description=(
-            "The difference between the paid and the checkout total amount."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
-        ),
+        description=("The difference between the paid and the checkout total amount."),
         required=True,
         webhook_events_info=[
             WebhookEventInfo(
@@ -763,21 +730,15 @@ class Checkout(ModelObjectType[models.Checkout]):
         description=(
             "List of transactions for the checkout. Requires one of the "
             "following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS."
-            + ADDED_IN_34
-            + PREVIEW_FEATURE
         ),
     )
     display_gross_prices = graphene.Boolean(
-        description=(
-            "Determines whether displayed prices should include taxes." + ADDED_IN_39
-        ),
+        description=("Determines whether displayed prices should include taxes."),
         required=True,
     )
     authorize_status = BaseField(
         CheckoutAuthorizeStatusEnum,
-        description=(
-            "The authorize status of the checkout." + ADDED_IN_313 + PREVIEW_FEATURE
-        ),
+        description=("The authorize status of the checkout."),
         required=True,
         webhook_events_info=[
             WebhookEventInfo(
@@ -788,9 +749,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     )
     charge_status = BaseField(
         CheckoutChargeStatusEnum,
-        description=(
-            "The charge status of the checkout." + ADDED_IN_313 + PREVIEW_FEATURE
-        ),
+        description=("The charge status of the checkout."),
         required=True,
         webhook_events_info=[
             WebhookEventInfo(
@@ -805,7 +764,7 @@ class Checkout(ModelObjectType[models.Checkout]):
             "List of user's stored payment methods that can be used in this checkout "
             "session. It uses the channel that the checkout was created in. "
             "When `amount` is not provided, `checkout.total` will be used as a default "
-            "value." + ADDED_IN_315 + PREVIEW_FEATURE
+            "value."
         ),
         amount=PositiveDecimal(
             description="Amount that will be used to fetch stored payment methods."
@@ -814,9 +773,7 @@ class Checkout(ModelObjectType[models.Checkout]):
 
     problems = NonNullList(
         CheckoutProblem,
-        description=(
-            "List of problems with the checkout." + ADDED_IN_315 + PREVIEW_FEATURE
-        ),
+        description=("List of problems with the checkout."),
     )
 
     class Meta:

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -10,7 +10,6 @@ from .....product.utils.product import (
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.utils import get_webhooks_for_event
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelBulkDeleteMutation
 from ....core.types import DiscountError, NonNullList
@@ -26,7 +25,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes promotions." + ADDED_IN_317 + PREVIEW_FEATURE
+        description = "Deletes promotions."
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -17,7 +17,7 @@ from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....channel.types import Channel
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_317, ADDED_IN_319, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.scalars import JSON, DateTime
@@ -99,7 +99,7 @@ class PromotionCreate(ModelMutation):
         )
 
     class Meta:
-        description = "Creates a new promotion." + ADDED_IN_317 + PREVIEW_FEATURE
+        description = "Creates a new promotion."
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_delete.py
@@ -10,7 +10,6 @@ from .....product.utils.product import (
 )
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.types import Error
 from ....core.utils import WebhookEventInfo
@@ -30,7 +29,7 @@ class PromotionDelete(ModelDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes a promotion." + ADDED_IN_317 + PREVIEW_FEATURE
+        description = "Deletes a promotion."
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
@@ -9,7 +9,6 @@ from .....product.utils.product import mark_products_in_channels_as_dirty
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.types import Error
@@ -56,7 +55,7 @@ class PromotionRuleCreate(ModelMutation):
         )
 
     class Meta:
-        description = "Creates a new promotion rule." + ADDED_IN_317 + PREVIEW_FEATURE
+        description = "Creates a new promotion rule."
         model = models.PromotionRule
         object_type = PromotionRule
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
@@ -10,7 +10,6 @@ from .....product.utils.product import (
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.types import Error
 from ....core.utils import WebhookEventInfo
@@ -31,7 +30,7 @@ class PromotionRuleDelete(ModelDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes a promotion rule." + ADDED_IN_317 + PREVIEW_FEATURE
+        description = "Deletes a promotion rule."
         model = models.PromotionRule
         object_type = PromotionRule
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -11,7 +11,7 @@ from .....product.utils.product import mark_products_in_channels_as_dirty
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_317, ADDED_IN_319, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.types import Error, NonNullList
@@ -78,9 +78,7 @@ class PromotionRuleUpdate(ModelMutation):
         )
 
     class Meta:
-        description = (
-            "Updates an existing promotion rule." + ADDED_IN_317 + PREVIEW_FEATURE
-        )
+        description = "Updates an existing promotion rule."
         model = models.PromotionRule
         object_type = PromotionRule
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_update.py
@@ -13,7 +13,6 @@ from .....plugins.manager import PluginsManager
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.types import Error
@@ -47,7 +46,7 @@ class PromotionUpdate(ModelMutation):
         )
 
     class Meta:
-        description = "Updates an existing promotion." + ADDED_IN_317 + PREVIEW_FEATURE
+        description = "Updates an existing promotion."
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/sale/sale_create.py
+++ b/saleor/graphql/discount/mutations/sale/sale_create.py
@@ -13,7 +13,7 @@ from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel import ChannelContext
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_MUTATION
+from ....core.descriptions import DEPRECATED_IN_3X_MUTATION
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.scalars import DateTime, PositiveDecimal
@@ -38,7 +38,7 @@ class SaleInput(BaseInputObjectType):
     )
     variants = NonNullList(
         graphene.ID,
-        descriptions="Product variant related to the discount." + ADDED_IN_31,
+        descriptions="Product variant related to the discount.",
         name="variants",
     )
     categories = NonNullList(

--- a/saleor/graphql/discount/mutations/voucher/voucher_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_add_catalogues.py
@@ -7,7 +7,6 @@ from .....product.utils import get_products_ids_without_variants
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel import ChannelContext
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_31
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import BaseMutation
 from ....core.types import BaseInputObjectType, DiscountError, NonNullList
@@ -33,7 +32,7 @@ class CatalogueInput(BaseInputObjectType):
     )
     variants = NonNullList(
         graphene.ID,
-        description="Product variant related to the discount." + ADDED_IN_31,
+        description="Product variant related to the discount.",
         name="variants",
     )
 

--- a/saleor/graphql/discount/mutations/voucher/voucher_create.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_create.py
@@ -10,7 +10,6 @@ from .....webhook.event_types import WebhookEventAsyncType
 from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.descriptions import (
-    ADDED_IN_31,
     ADDED_IN_318,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
@@ -55,7 +54,7 @@ class VoucherInput(BaseInputObjectType):
     )
     variants = NonNullList(
         graphene.ID,
-        description="Variants discounted by the voucher." + ADDED_IN_31,
+        description="Variants discounted by the voucher.",
         name="variants",
     )
     collections = NonNullList(

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -4,10 +4,8 @@ from ...permission.enums import DiscountPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.descriptions import (
-    ADDED_IN_317,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
 )
 from ..core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ..core.fields import FilterConnectionField, PermissionsField
@@ -150,7 +148,7 @@ class DiscountQueries(graphene.ObjectType):
         id=graphene.Argument(
             graphene.ID, description="ID of the promotion.", required=True
         ),
-        description="Look up a promotion by ID." + ADDED_IN_317 + PREVIEW_FEATURE,
+        description="Look up a promotion by ID.",
         permissions=[
             DiscountPermissions.MANAGE_DISCOUNTS,
         ],
@@ -160,7 +158,7 @@ class DiscountQueries(graphene.ObjectType):
         PromotionCountableConnection,
         where=PromotionWhereInput(description="Where filtering options."),
         sort_by=PromotionSortingInput(description="Sort promotions."),
-        description="List of the promotions." + ADDED_IN_317 + PREVIEW_FEATURE,
+        description="List of the promotions.",
         permissions=[DiscountPermissions.MANAGE_DISCOUNTS],
         doc_category=DOC_CATEGORY_DISCOUNTS,
     )

--- a/saleor/graphql/discount/types/promotion_events.py
+++ b/saleor/graphql/discount/types/promotion_events.py
@@ -8,7 +8,6 @@ from ....permission.enums import AccountPermissions, AppPermission
 from ...account.dataloaders import UserByUserIdLoader
 from ...account.utils import is_owner_or_has_one_of_perms
 from ...app.dataloaders import AppByIdLoader
-from ...core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
 from ...core.scalars import DateTime
@@ -81,11 +80,7 @@ class PromotionEventInterface(graphene.Interface):
 
 class PromotionCreatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
-        description = (
-            "History log of the promotion created event."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion created event."
         interfaces = [relay.Node, PromotionEventInterface]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS
@@ -93,11 +88,7 @@ class PromotionCreatedEvent(ModelObjectType[models.PromotionEvent]):
 
 class PromotionUpdatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
-        description = (
-            "History log of the promotion updated event."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion updated event."
         interfaces = [relay.Node, PromotionEventInterface]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS
@@ -105,11 +96,7 @@ class PromotionUpdatedEvent(ModelObjectType[models.PromotionEvent]):
 
 class PromotionStartedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
-        description = (
-            "History log of the promotion started event."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion started event."
         interfaces = [relay.Node, PromotionEventInterface]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS
@@ -117,9 +104,7 @@ class PromotionStartedEvent(ModelObjectType[models.PromotionEvent]):
 
 class PromotionEndedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
-        description = (
-            "History log of the promotion ended event." + ADDED_IN_317 + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion ended event."
         interfaces = [relay.Node, PromotionEventInterface]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS
@@ -127,11 +112,7 @@ class PromotionEndedEvent(ModelObjectType[models.PromotionEvent]):
 
 class PromotionRuleEventInterface(graphene.Interface):
     class Meta:
-        description = (
-            "History log of the promotion event related to rule."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion event related to rule."
         interfaces = [relay.Node]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS
@@ -147,11 +128,7 @@ class PromotionRuleEventInterface(graphene.Interface):
 
 class PromotionRuleCreatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
-        description = (
-            "History log of the promotion rule created event."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion rule created event."
         interfaces = [relay.Node, PromotionEventInterface, PromotionRuleEventInterface]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS
@@ -159,11 +136,7 @@ class PromotionRuleCreatedEvent(ModelObjectType[models.PromotionEvent]):
 
 class PromotionRuleUpdatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
-        description = (
-            "History log of the promotion rule created event."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion rule created event."
         interfaces = [relay.Node, PromotionEventInterface, PromotionRuleEventInterface]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS
@@ -171,11 +144,7 @@ class PromotionRuleUpdatedEvent(ModelObjectType[models.PromotionEvent]):
 
 class PromotionRuleDeletedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
-        description = (
-            "History log of the promotion rule created event."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
-        )
+        description = "History log of the promotion rule created event."
         interfaces = [relay.Node, PromotionEventInterface, PromotionRuleEventInterface]
         model = models.PromotionEvent
         doc_category = DOC_CATEGORY_DISCOUNTS

--- a/saleor/graphql/discount/types/promotions.py
+++ b/saleor/graphql/discount/types/promotions.py
@@ -6,7 +6,7 @@ from ....permission.auth_filters import AuthorizationFilters
 from ...channel.types import Channel
 from ...core import ResolveInfo
 from ...core.connection import CountableConnection
-from ...core.descriptions import ADDED_IN_317, ADDED_IN_319, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
 from ...core.scalars import JSON, DateTime, PositiveDecimal
@@ -54,8 +54,6 @@ class Promotion(ModelObjectType[models.Promotion]):
         description = (
             "Represents the promotion that allow creating discounts based on given "
             "conditions, and is visible to all the customers."
-            + ADDED_IN_317
-            + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, ObjectWithMetadata]
         model = models.Promotion
@@ -135,7 +133,7 @@ class PromotionRule(ModelObjectType[models.PromotionRule]):
     class Meta:
         description = (
             "Represents the promotion rule that specifies the conditions that must "
-            "be met to apply the promotion discount." + ADDED_IN_317 + PREVIEW_FEATURE
+            "be met to apply the promotion discount."
         )
         interfaces = [relay.Node]
         model = models.PromotionRule

--- a/saleor/graphql/discount/types/sales.py
+++ b/saleor/graphql/discount/types/sales.py
@@ -15,7 +15,7 @@ from ...channel.types import (
 from ...core import ResolveInfo
 from ...core.connection import CountableConnection, create_connection_slice
 from ...core.context import get_database_connection_name
-from ...core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_TYPE
+from ...core.descriptions import DEPRECATED_IN_3X_TYPE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import ConnectionField, PermissionsField
 from ...core.scalars import DateTime
@@ -98,7 +98,7 @@ class Sale(ChannelContextTypeWithMetadata, ModelObjectType[models.Promotion]):
     )
     variants = ConnectionField(
         ProductVariantCountableConnection,
-        description="List of product variants this sale applies to." + ADDED_IN_31,
+        description="List of product variants this sale applies to.",
         permissions=[
             DiscountPermissions.MANAGE_DISCOUNTS,
         ],

--- a/saleor/graphql/discount/types/vouchers.py
+++ b/saleor/graphql/discount/types/vouchers.py
@@ -15,7 +15,6 @@ from ...core import ResolveInfo, types
 from ...core.connection import CountableConnection, create_connection_slice
 from ...core.context import get_database_connection_name
 from ...core.descriptions import (
-    ADDED_IN_31,
     ADDED_IN_318,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
@@ -152,7 +151,7 @@ class Voucher(ChannelContextTypeWithMetadata[models.Voucher]):
     )
     variants = ConnectionField(
         ProductVariantCountableConnection,
-        description="List of product variants this voucher applies to." + ADDED_IN_31,
+        description="List of product variants this voucher applies to.",
         permissions=[
             DiscountPermissions.MANAGE_DISCOUNTS,
         ],

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -11,7 +11,7 @@ from ...permission.utils import has_one_of_permissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.context import get_database_connection_name
-from ..core.descriptions import ADDED_IN_310, DEPRECATED_IN_3X_FIELD
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.doc_category import DOC_CATEGORY_ORDERS
 from ..core.enums import ReportingPeriod
 from ..core.fields import (
@@ -111,7 +111,7 @@ class OrderQueries(graphene.ObjectType):
         external_reference=graphene.Argument(
             graphene.String,
             description=(
-                f"External ID of an order. {ADDED_IN_310}."
+                "External ID of an order. "
                 "\n\nRequires one of the following permissions: MANAGE_ORDERS."
             ),
         ),

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -67,16 +67,6 @@ from ..channel.types import Channel
 from ..checkout.utils import prevent_sync_event_circular_query
 from ..core.connection import CountableConnection
 from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_34,
-    ADDED_IN_35,
-    ADDED_IN_38,
-    ADDED_IN_39,
-    ADDED_IN_310,
-    ADDED_IN_311,
-    ADDED_IN_313,
-    ADDED_IN_314,
-    ADDED_IN_315,
     ADDED_IN_318,
     ADDED_IN_319,
     ADDED_IN_320,
@@ -235,7 +225,7 @@ class OrderGrantedRefundLine(ModelObjectType[models.OrderGrantedRefundLine]):
     reason = graphene.String(description="Reason for refunding the line.")
 
     class Meta:
-        description = "Represents granted refund line." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Represents granted refund line."
         model = models.OrderGrantedRefundLine
 
     @staticmethod
@@ -264,15 +254,10 @@ class OrderGrantedRefund(ModelObjectType[models.OrderGrantedRefund]):
         description=(
             "If true, the refunded amount includes the shipping price."
             "If false, the refunded amount does not include the shipping price."
-            + ADDED_IN_315
-            + PREVIEW_FEATURE
         ),
     )
     lines = NonNullList(
-        OrderGrantedRefundLine,
-        description="Lines assigned to the granted refund."
-        + ADDED_IN_315
-        + PREVIEW_FEATURE,
+        OrderGrantedRefundLine, description="Lines assigned to the granted refund."
     )
     status = graphene.Field(
         OrderGrantedRefundStatusEnum,
@@ -295,7 +280,7 @@ class OrderGrantedRefund(ModelObjectType[models.OrderGrantedRefund]):
     )
 
     class Meta:
-        description = "The details of granted refund." + ADDED_IN_313 + PREVIEW_FEATURE
+        description = "The details of granted refund."
         model = models.OrderGrantedRefund
 
     @staticmethod
@@ -447,9 +432,7 @@ class OrderEvent(ModelObjectType[models.OrderEvent]):
     )
     related = graphene.Field(
         lambda: OrderEvent,
-        description="The order event which is related to this event."
-        + ADDED_IN_315
-        + PREVIEW_FEATURE,
+        description="The order event which is related to this event.",
     )
     discount = graphene.Field(
         OrderEventDiscountObject, description="The discount applied to the order."
@@ -706,13 +689,12 @@ class Fulfillment(ModelObjectType[models.Fulfillment]):
     )
     shipping_refunded_amount = graphene.Field(
         Money,
-        description="Amount of refunded shipping price." + ADDED_IN_314,
+        description="Amount of refunded shipping price.",
         required=False,
     )
     total_refunded_amount = graphene.Field(
         Money,
-        description="Total refunded amount assigned to this fulfillment."
-        + ADDED_IN_314,
+        description="Total refunded amount assigned to this fulfillment.",
         required=False,
     )
 
@@ -846,7 +828,6 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     )
     is_price_overridden = graphene.Boolean(
         description="Returns True, if the line unit price was overridden."
-        + ADDED_IN_314,
     )
     variant = graphene.Field(
         ProductVariant,
@@ -876,12 +857,11 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         required=False,
         description=(
             "Denormalized sale ID, set when order line is created for a product "
-            "variant that is on sale." + ADDED_IN_314
+            "variant that is on sale."
         ),
     )
     quantity_to_fulfill = graphene.Int(
-        required=True,
-        description="A quantity of items remaining to be fulfilled." + ADDED_IN_31,
+        required=True, description="A quantity of items remaining to be fulfilled."
     )
     unit_discount_type = graphene.Field(
         DiscountValueTypeEnum,
@@ -889,9 +869,7 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     )
     tax_class = PermissionsField(
         TaxClass,
-        description=(
-            "Denormalized tax class of the product in this order line." + ADDED_IN_39
-        ),
+        description=("Denormalized tax class of the product in this order line."),
         required=False,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
@@ -900,25 +878,24 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     )
     tax_class_name = graphene.Field(
         graphene.String,
-        description="Denormalized name of the tax class." + ADDED_IN_39,
+        description="Denormalized name of the tax class.",
         required=False,
     )
     tax_class_metadata = NonNullList(
         MetadataItem,
         required=True,
-        description="Denormalized public metadata of the tax class." + ADDED_IN_39,
+        description="Denormalized public metadata of the tax class.",
     )
     tax_class_private_metadata = NonNullList(
         MetadataItem,
         required=True,
         description=(
             "Denormalized private metadata of the tax class. Requires staff "
-            "permissions to access." + ADDED_IN_39
+            "permissions to access."
         ),
     )
     voucher_code = graphene.String(
-        required=False,
-        description="Voucher code that was used for this order line." + ADDED_IN_314,
+        required=False, description="Voucher code that was used for this order line."
     )
     is_gift = graphene.Boolean(
         description="Determine if the line is a gift." + ADDED_IN_319 + PREVIEW_FEATURE,
@@ -928,7 +905,6 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         description = "Represents order line of particular order."
         model = models.OrderLine
         interfaces = [relay.Node, ObjectWithMetadata]
-        metadata_since = ADDED_IN_35
 
     @staticmethod
     @traced_resolver
@@ -1278,9 +1254,7 @@ class Order(ModelObjectType[models.Order]):
     )
     available_collection_points = NonNullList(
         Warehouse,
-        description=(
-            "Collection points that can be used for this order." + ADDED_IN_31
-        ),
+        description=("Collection points that can be used for this order."),
         required=True,
     )
     invoices = NonNullList(
@@ -1309,24 +1283,22 @@ class Order(ModelObjectType[models.Order]):
         description="User-friendly payment status.", required=True
     )
     authorize_status = OrderAuthorizeStatusEnum(
-        description=("The authorize status of the order." + ADDED_IN_34),
+        description=("The authorize status of the order."),
         required=True,
     )
     charge_status = OrderChargeStatusEnum(
-        description=("The charge status of the order." + ADDED_IN_34),
+        description=("The charge status of the order."),
         required=True,
     )
     tax_exemption = graphene.Boolean(
-        description=(
-            "Returns True if order has to be exempt from taxes." + ADDED_IN_38
-        ),
+        description=("Returns True if order has to be exempt from taxes."),
         required=True,
     )
     transactions = NonNullList(
         TransactionItem,
         description=(
             "List of transactions for the order. Requires one of the "
-            "following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS." + ADDED_IN_34
+            "following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS."
         ),
         required=True,
     )
@@ -1357,8 +1329,7 @@ class Order(ModelObjectType[models.Order]):
     )
     shipping_tax_class = PermissionsField(
         TaxClass,
-        description="Denormalized tax class assigned to the shipping method."
-        + ADDED_IN_39,
+        description="Denormalized tax class assigned to the shipping method.",
         required=False,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
@@ -1369,7 +1340,6 @@ class Order(ModelObjectType[models.Order]):
         graphene.String,
         description=(
             "Denormalized name of the tax class assigned to the shipping method."
-            + ADDED_IN_39
         ),
         required=False,
     )
@@ -1378,7 +1348,6 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Denormalized public metadata of the shipping method's tax class."
-            + ADDED_IN_39
         ),
     )
     shipping_tax_class_private_metadata = NonNullList(
@@ -1386,7 +1355,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Denormalized private metadata of the shipping method's tax class. "
-            "Requires staff permissions to access." + ADDED_IN_39
+            "Requires staff permissions to access."
         ),
     )
     token = graphene.String(
@@ -1434,12 +1403,12 @@ class Order(ModelObjectType[models.Order]):
         required=True,
     )
     total_charged = graphene.Field(
-        Money, description="Amount charged for the order." + ADDED_IN_313, required=True
+        Money, description="Amount charged for the order.", required=True
     )
 
     total_canceled = graphene.Field(
         Money,
-        description="Amount canceled for the order." + ADDED_IN_313,
+        description="Amount canceled for the order.",
         required=True,
     )
 
@@ -1468,7 +1437,7 @@ class Order(ModelObjectType[models.Order]):
     )
     delivery_method = graphene.Field(
         DeliveryMethod,
-        description=("The delivery method selected for this order." + ADDED_IN_31),
+        description=("The delivery method selected for this order."),
     )
     language_code = graphene.String(
         deprecation_reason=(
@@ -1511,47 +1480,37 @@ class Order(ModelObjectType[models.Order]):
         required=True,
     )
     display_gross_prices = graphene.Boolean(
-        description=(
-            "Determines whether displayed prices should include taxes." + ADDED_IN_39
-        ),
+        description=("Determines whether displayed prices should include taxes."),
         required=True,
     )
     external_reference = graphene.String(
-        description=f"External ID of this order. {ADDED_IN_310}", required=False
+        description="External ID of this order.", required=False
     )
     checkout_id = graphene.ID(
-        description=(
-            f"ID of the checkout that the order was created from. {ADDED_IN_311}"
-        ),
+        description=("ID of the checkout that the order was created from."),
         required=False,
     )
 
     granted_refunds = PermissionsField(
         NonNullList(OrderGrantedRefund),
         required=True,
-        description="List of granted refunds." + ADDED_IN_313 + PREVIEW_FEATURE,
+        description="List of granted refunds.",
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
     total_granted_refund = PermissionsField(
         Money,
         required=True,
-        description="Total amount of granted refund." + ADDED_IN_313 + PREVIEW_FEATURE,
+        description="Total amount of granted refund.",
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
     total_refunded = graphene.Field(
-        Money,
-        required=True,
-        description="Total refund amount for the order."
-        + ADDED_IN_313
-        + PREVIEW_FEATURE,
+        Money, required=True, description="Total refund amount for the order."
     )
     total_refund_pending = PermissionsField(
         Money,
         required=True,
         description=(
             "Total amount of ongoing refund requests for the order's transactions."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
@@ -1560,8 +1519,6 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Total amount of ongoing authorize requests for the order's transactions."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
@@ -1570,8 +1527,6 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Total amount of ongoing charge requests for the order's transactions."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
@@ -1580,8 +1535,6 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Total amount of ongoing cancel requests for the order's transactions."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
@@ -1591,7 +1544,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "The difference amount between granted refund and the "
-            "amounts that are pending and refunded." + ADDED_IN_313 + PREVIEW_FEATURE
+            "amounts that are pending and refunded."
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -818,8 +818,6 @@ type Query {
     """
     External ID of an order. 
     
-    Added in Saleor 3.10..
-    
     Requires one of the following permissions: MANAGE_ORDERS.
     """
     externalReference: String
@@ -1228,10 +1226,6 @@ type Query {
   """
   Look up a promotion by ID.
   
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   promotion(
@@ -1241,10 +1235,6 @@ type Query {
 
   """
   List of the promotions.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
@@ -1320,11 +1310,7 @@ type Query {
   Requires one of the following permissions to query a checkout, if a checkout is in inactive channel: MANAGE_CHECKOUTS, IMPERSONATE_USER, HANDLE_PAYMENTS.
   """
   checkout(
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -1341,18 +1327,10 @@ type Query {
   Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   """
   checkouts(
-    """
-    Sort checkouts.
-    
-    Added in Saleor 3.1.
-    """
+    """Sort checkouts."""
     sortBy: CheckoutSortingInput
 
-    """
-    Filtering options for checkouts.
-    
-    Added in Saleor 3.1.
-    """
+    """Filtering options for checkouts."""
     filter: CheckoutFilterInput
 
     """Slug of a channel for which the data should be returned."""
@@ -9448,8 +9426,6 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
   """
   List of product variants this voucher applies to.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   variants(
@@ -10103,8 +10079,6 @@ type Sale implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   List of product variants this sale applies to.
-  
-  Added in Saleor 3.1.
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
@@ -10914,11 +10888,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   """The date and time when the checkout was created."""
   created: DateTime!
 
-  """
-  Time of last modification of the given checkout.
-  
-  Added in Saleor 3.13.
-  """
+  """Time of last modification of the given checkout."""
   updatedAt: DateTime!
   lastChange: DateTime! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `updatedAt` instead.")
 
@@ -10989,11 +10959,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   """
   shippingMethods: [ShippingMethod!]! @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS])
 
-  """
-  Collection points that can be used for this order.
-  
-  Added in Saleor 3.1.
-  """
+  """Collection points that can be used for this order."""
   availableCollectionPoints: [Warehouse!]!
 
   """
@@ -11018,8 +10984,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   Date when oldest stock reservation for this checkout expires or null if no stock is reserved.
-  
-  Added in Saleor 3.1.
   """
   stockReservationExpires: DateTime
 
@@ -11048,8 +11012,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   """
   The delivery method selected for this checkout.
   
-  Added in Saleor 3.1.
-  
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
   - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
@@ -11064,11 +11026,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   """
   subtotalPrice: TaxedMoney! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
 
-  """
-  Returns True if checkout has to be exempt from taxes.
-  
-  Added in Saleor 3.8.
-  """
+  """Returns True if checkout has to be exempt from taxes."""
   taxExemption: Boolean!
 
   """The checkout's token."""
@@ -11085,10 +11043,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   """
   The difference between the paid and the checkout total amount.
   
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11099,26 +11053,14 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactions: [TransactionItem!]
 
-  """
-  Determines whether displayed prices should include taxes.
-  
-  Added in Saleor 3.9.
-  """
+  """Determines whether displayed prices should include taxes."""
   displayGrossPrices: Boolean!
 
   """
   The authorize status of the checkout.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
@@ -11128,10 +11070,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   """
   The charge status of the checkout.
   
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Triggers the following webhook events:
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
@@ -11139,23 +11077,13 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   List of user's stored payment methods that can be used in this checkout session. It uses the channel that the checkout was created in. When `amount` is not provided, `checkout.total` will be used as a default value.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   storedPaymentMethods(
     """Amount that will be used to fetch stored payment methods."""
     amount: PositiveDecimal
   ): [StoredPaymentMethod!]
 
-  """
-  List of problems with the checkout.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """List of problems with the checkout."""
   problems: [CheckoutProblem!]
 }
 
@@ -11418,11 +11346,7 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
   """The ID of the checkout line."""
   id: ID!
 
-  """
-  List of private metadata items. Requires staff permissions to access.
-  
-  Added in Saleor 3.5.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
 
   """
@@ -11430,22 +11354,18 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
 
-  """
-  List of public metadata items. Can be accessed without permissions.
-  
-  Added in Saleor 3.5.
-  """
+  """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
 
   """
@@ -11453,14 +11373,14 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
 
@@ -11495,13 +11415,7 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
   """Indicates whether the item need to be delivered."""
   requiresShipping: Boolean!
 
-  """
-  List of problems with the checkout line.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """List of problems with the checkout line."""
   problems: [CheckoutLineProblem!]
 
   """
@@ -11514,21 +11428,11 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
   isGift: Boolean
 }
 
-"""
-Represents an problem in the checkout line.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents an problem in the checkout line."""
 union CheckoutLineProblem = CheckoutLineProblemInsufficientStock | CheckoutLineProblemVariantNotAvailable
 
 """
 Indicates insufficient stock for a given checkout line.Placing the order will not be possible until solving this problem.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CheckoutLineProblemInsufficientStock @doc(category: "Checkout") {
   """Available quantity of a variant."""
@@ -11543,10 +11447,6 @@ type CheckoutLineProblemInsufficientStock @doc(category: "Checkout") {
 
 """
 The variant assigned to the checkout line is not available.Placing the order will not be possible until solving this problem.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CheckoutLineProblemVariantNotAvailable @doc(category: "Checkout") {
   """The line that has variant that is not available."""
@@ -11555,8 +11455,6 @@ type CheckoutLineProblemVariantNotAvailable @doc(category: "Checkout") {
 
 """
 Represents a delivery method chosen for the checkout. `Warehouse` type is used when checkout is marked as "click and collect" and `ShippingMethod` otherwise.
-
-Added in Saleor 3.1.
 """
 union DeliveryMethod = Warehouse | ShippingMethod
 
@@ -11838,11 +11736,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Shipping methods related to this order."""
   shippingMethods: [ShippingMethod!]!
 
-  """
-  Collection points that can be used for this order.
-  
-  Added in Saleor 3.1.
-  """
+  """Collection points that can be used for this order."""
   availableCollectionPoints: [Warehouse!]!
 
   """
@@ -11868,31 +11762,17 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """User-friendly payment status."""
   paymentStatusDisplay: String!
 
-  """
-  The authorize status of the order.
-  
-  Added in Saleor 3.4.
-  """
+  """The authorize status of the order."""
   authorizeStatus: OrderAuthorizeStatusEnum!
 
-  """
-  The charge status of the order.
-  
-  Added in Saleor 3.4.
-  """
+  """The charge status of the order."""
   chargeStatus: OrderChargeStatusEnum!
 
-  """
-  Returns True if order has to be exempt from taxes.
-  
-  Added in Saleor 3.8.
-  """
+  """Returns True if order has to be exempt from taxes."""
   taxExemption: Boolean!
 
   """
   List of transactions for the order. Requires one of the following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS.
-  
-  Added in Saleor 3.4.
   """
   transactions: [TransactionItem!]!
 
@@ -11924,30 +11804,18 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """
   Denormalized tax class assigned to the shipping method.
   
-  Added in Saleor 3.9.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   shippingTaxClass: TaxClass
 
-  """
-  Denormalized name of the tax class assigned to the shipping method.
-  
-  Added in Saleor 3.9.
-  """
+  """Denormalized name of the tax class assigned to the shipping method."""
   shippingTaxClassName: String
 
-  """
-  Denormalized public metadata of the shipping method's tax class.
-  
-  Added in Saleor 3.9.
-  """
+  """Denormalized public metadata of the shipping method's tax class."""
   shippingTaxClassMetadata: [MetadataItem!]!
 
   """
   Denormalized private metadata of the shipping method's tax class. Requires staff permissions to access.
-  
-  Added in Saleor 3.9.
   """
   shippingTaxClassPrivateMetadata: [MetadataItem!]!
   token: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `id` instead.")
@@ -11991,18 +11859,10 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Amount captured for the order."""
   totalCaptured: Money! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `totalCharged` instead.")
 
-  """
-  Amount charged for the order.
-  
-  Added in Saleor 3.13.
-  """
+  """Amount charged for the order."""
   totalCharged: Money!
 
-  """
-  Amount canceled for the order.
-  
-  Added in Saleor 3.13.
-  """
+  """Amount canceled for the order."""
   totalCanceled: Money!
 
   """
@@ -12023,11 +11883,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Returns True, if order requires shipping."""
   isShippingRequired: Boolean!
 
-  """
-  The delivery method selected for this order.
-  
-  Added in Saleor 3.1.
-  """
+  """The delivery method selected for this order."""
   deliveryMethod: DeliveryMethod
   languageCode: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
 
@@ -12049,33 +11905,17 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """List of errors that occurred during order validation."""
   errors: [OrderError!]!
 
-  """
-  Determines whether displayed prices should include taxes.
-  
-  Added in Saleor 3.9.
-  """
+  """Determines whether displayed prices should include taxes."""
   displayGrossPrices: Boolean!
 
-  """
-  External ID of this order. 
-  
-  Added in Saleor 3.10.
-  """
+  """External ID of this order."""
   externalReference: String
 
-  """
-  ID of the checkout that the order was created from. 
-  
-  Added in Saleor 3.11.
-  """
+  """ID of the checkout that the order was created from."""
   checkoutId: ID
 
   """
   List of granted refunds.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_ORDERS.
   """
@@ -12084,29 +11924,15 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """
   Total amount of granted refund.
   
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalGrantedRefund: Money!
 
-  """
-  Total refund amount for the order.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Total refund amount for the order."""
   totalRefunded: Money!
 
   """
   Total amount of ongoing refund requests for the order's transactions.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_ORDERS.
   """
@@ -12115,20 +11941,12 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """
   Total amount of ongoing authorize requests for the order's transactions.
   
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalAuthorizePending: Money!
 
   """
   Total amount of ongoing charge requests for the order's transactions.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_ORDERS.
   """
@@ -12137,20 +11955,12 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """
   Total amount of ongoing cancel requests for the order's transactions.
   
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   totalCancelPending: Money!
 
   """
   The difference amount between granted refund and the amounts that are pending and refunded.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_ORDERS.
   """
@@ -12233,18 +12043,10 @@ type Fulfillment implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Warehouse from fulfillment was fulfilled."""
   warehouse: Warehouse
 
-  """
-  Amount of refunded shipping price.
-  
-  Added in Saleor 3.14.
-  """
+  """Amount of refunded shipping price."""
   shippingRefundedAmount: Money
 
-  """
-  Total refunded amount assigned to this fulfillment.
-  
-  Added in Saleor 3.14.
-  """
+  """Total refunded amount assigned to this fulfillment."""
   totalRefundedAmount: Money
 }
 
@@ -12275,11 +12077,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """ID of the order line."""
   id: ID!
 
-  """
-  List of private metadata items. Requires staff permissions to access.
-  
-  Added in Saleor 3.5.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
 
   """
@@ -12287,22 +12085,18 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
 
-  """
-  List of public metadata items. Can be accessed without permissions.
-  
-  Added in Saleor 3.5.
-  """
+  """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
 
   """
@@ -12310,14 +12104,14 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
 
@@ -12382,11 +12176,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Price of the order line without discounts."""
   undiscountedTotalPrice: TaxedMoney!
 
-  """
-  Returns True, if the line unit price was overridden.
-  
-  Added in Saleor 3.14.
-  """
+  """Returns True, if the line unit price was overridden."""
   isPriceOverridden: Boolean
 
   """
@@ -12409,16 +12199,10 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """
   Denormalized sale ID, set when order line is created for a product variant that is on sale.
-  
-  Added in Saleor 3.14.
   """
   saleId: ID
 
-  """
-  A quantity of items remaining to be fulfilled.
-  
-  Added in Saleor 3.1.
-  """
+  """A quantity of items remaining to be fulfilled."""
   quantityToFulfill: Int!
 
   """Type of the discount: fixed or percent"""
@@ -12427,38 +12211,22 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """
   Denormalized tax class of the product in this order line.
   
-  Added in Saleor 3.9.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
 
-  """
-  Denormalized name of the tax class.
-  
-  Added in Saleor 3.9.
-  """
+  """Denormalized name of the tax class."""
   taxClassName: String
 
-  """
-  Denormalized public metadata of the tax class.
-  
-  Added in Saleor 3.9.
-  """
+  """Denormalized public metadata of the tax class."""
   taxClassMetadata: [MetadataItem!]!
 
   """
   Denormalized private metadata of the tax class. Requires staff permissions to access.
-  
-  Added in Saleor 3.9.
   """
   taxClassPrivateMetadata: [MetadataItem!]!
 
-  """
-  Voucher code that was used for this order line.
-  
-  Added in Saleor 3.14.
-  """
+  """Voucher code that was used for this order line."""
   voucherCode: String
 
   """
@@ -12931,13 +12699,7 @@ type OrderEvent implements Node @doc(category: "Orders") {
   """The order which is related to this order."""
   relatedOrder: Order
 
-  """
-  The order event which is related to this event.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order event which is related to this event."""
   related: OrderEvent
 
   """The discount applied to the order."""
@@ -13158,13 +12920,7 @@ enum AddressTypeEnum {
   SHIPPING
 }
 
-"""
-The details of granted refund.
-
-Added in Saleor 3.13.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""The details of granted refund."""
 type OrderGrantedRefund @doc(category: "Orders") {
   id: ID!
 
@@ -13190,20 +12946,10 @@ type OrderGrantedRefund @doc(category: "Orders") {
 
   """
   If true, the refunded amount includes the shipping price.If false, the refunded amount does not include the shipping price.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingCostsIncluded: Boolean!
 
-  """
-  Lines assigned to the granted refund.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Lines assigned to the granted refund."""
   lines: [OrderGrantedRefundLine!]
 
   """
@@ -13228,13 +12974,7 @@ type OrderGrantedRefund @doc(category: "Orders") {
   transaction: TransactionItem
 }
 
-"""
-Represents granted refund line.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents granted refund line."""
 type OrderGrantedRefundLine {
   id: ID!
 
@@ -13462,13 +13202,7 @@ enum TokenizedPaymentFlowEnum @doc(category: "Payments") {
 
 scalar JSON
 
-"""
-Represents an problem in the checkout.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents an problem in the checkout."""
 union CheckoutProblem = CheckoutLineProblemInsufficientStock | CheckoutLineProblemVariantNotAvailable
 
 type CheckoutCountableConnection @doc(category: "Checkout") {
@@ -14568,10 +14302,6 @@ enum VoucherSortField {
 
 """
 Represents the promotion that allow creating discounts based on given conditions, and is visible to all the customers.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type Promotion implements Node & ObjectWithMetadata @doc(category: "Discounts") {
   id: ID!
@@ -14661,10 +14391,6 @@ enum PromotionTypeEnum @doc(category: "Discounts") {
 
 """
 Represents the promotion rule that specifies the conditions that must be met to apply the promotion discount.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PromotionRule implements Node @doc(category: "Discounts") {
   id: ID!
@@ -14764,13 +14490,7 @@ enum RewardTypeEnum @doc(category: "Discounts") {
 
 union PromotionEvent = PromotionCreatedEvent | PromotionUpdatedEvent | PromotionStartedEvent | PromotionEndedEvent | PromotionRuleCreatedEvent | PromotionRuleUpdatedEvent | PromotionRuleDeletedEvent
 
-"""
-History log of the promotion created event.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion created event."""
 type PromotionCreatedEvent implements Node & PromotionEventInterface @doc(category: "Discounts") {
   id: ID!
 
@@ -14815,13 +14535,7 @@ enum PromotionEventsEnum @doc(category: "Discounts") {
   RULE_DELETED
 }
 
-"""
-History log of the promotion updated event.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion updated event."""
 type PromotionUpdatedEvent implements Node & PromotionEventInterface @doc(category: "Discounts") {
   id: ID!
 
@@ -14839,13 +14553,7 @@ type PromotionUpdatedEvent implements Node & PromotionEventInterface @doc(catego
   createdBy: UserOrApp
 }
 
-"""
-History log of the promotion started event.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion started event."""
 type PromotionStartedEvent implements Node & PromotionEventInterface @doc(category: "Discounts") {
   id: ID!
 
@@ -14863,13 +14571,7 @@ type PromotionStartedEvent implements Node & PromotionEventInterface @doc(catego
   createdBy: UserOrApp
 }
 
-"""
-History log of the promotion ended event.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion ended event."""
 type PromotionEndedEvent implements Node & PromotionEventInterface @doc(category: "Discounts") {
   id: ID!
 
@@ -14887,13 +14589,7 @@ type PromotionEndedEvent implements Node & PromotionEventInterface @doc(category
   createdBy: UserOrApp
 }
 
-"""
-History log of the promotion rule created event.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion rule created event."""
 type PromotionRuleCreatedEvent implements Node & PromotionEventInterface & PromotionRuleEventInterface @doc(category: "Discounts") {
   id: ID!
 
@@ -14914,25 +14610,13 @@ type PromotionRuleCreatedEvent implements Node & PromotionEventInterface & Promo
   ruleId: String
 }
 
-"""
-History log of the promotion event related to rule.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion event related to rule."""
 interface PromotionRuleEventInterface {
   """The rule ID associated with the promotion event."""
   ruleId: String
 }
 
-"""
-History log of the promotion rule created event.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion rule created event."""
 type PromotionRuleUpdatedEvent implements Node & PromotionEventInterface & PromotionRuleEventInterface @doc(category: "Discounts") {
   id: ID!
 
@@ -14953,13 +14637,7 @@ type PromotionRuleUpdatedEvent implements Node & PromotionEventInterface & Promo
   ruleId: String
 }
 
-"""
-History log of the promotion rule created event.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""History log of the promotion rule created event."""
 type PromotionRuleDeletedEvent implements Node & PromotionEventInterface & PromotionRuleEventInterface @doc(category: "Discounts") {
   id: ID!
 
@@ -18420,11 +18098,7 @@ type Mutation {
   ): ExternalNotificationTrigger @deprecated(reason: "\\n\\nDEPRECATED: this mutation will be removed in Saleor 4.0.")
 
   """
-  Creates a new promotion.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Creates a new promotion. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18438,11 +18112,7 @@ type Mutation {
   ): PromotionCreate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_CREATED, PROMOTION_STARTED], syncEvents: [])
 
   """
-  Updates an existing promotion.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Updates an existing promotion. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18460,11 +18130,7 @@ type Mutation {
   ): PromotionUpdate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_UPDATED, PROMOTION_STARTED, PROMOTION_ENDED], syncEvents: [])
 
   """
-  Deletes a promotion.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Deletes a promotion. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18477,11 +18143,7 @@ type Mutation {
   ): PromotionDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_DELETED], syncEvents: [])
 
   """
-  Creates a new promotion rule.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Creates a new promotion rule. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18494,11 +18156,7 @@ type Mutation {
   ): PromotionRuleCreate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_RULE_CREATED], syncEvents: [])
 
   """
-  Updates an existing promotion rule.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Updates an existing promotion rule. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18514,11 +18172,7 @@ type Mutation {
   ): PromotionRuleUpdate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_RULE_UPDATED], syncEvents: [])
 
   """
-  Deletes a promotion rule.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Deletes a promotion rule. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18567,11 +18221,7 @@ type Mutation {
   ): PromotionRuleTranslate @doc(category: "Discounts")
 
   """
-  Deletes promotions.
-  
-  Added in Saleor 3.17.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Deletes promotions. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18921,11 +18571,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """Gift card code or voucher code."""
@@ -18956,11 +18602,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -18970,11 +18612,7 @@ type Mutation {
     """
     token: UUID
 
-    """
-    The rules for changing validation for received billing address data.
-    
-    Added in Saleor 3.5.
-    """
+    """The rules for changing validation for received billing address data."""
     validationRules: CheckoutAddressValidationRules
   ): CheckoutBillingAddressUpdate @doc(category: "Checkout") @webhookEventsInfo(asyncEvents: [CHECKOUT_UPDATED], syncEvents: [])
 
@@ -19001,18 +18639,10 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
-    """
-    Fields required to update the checkout metadata.
-    
-    Added in Saleor 3.8.
-    """
+    """Fields required to update the checkout metadata."""
     metadata: [MetadataInput!]
 
     """Client-side generated data required to finalize the payment."""
@@ -19051,13 +18681,7 @@ type Mutation {
     input: CheckoutCreateInput!
   ): CheckoutCreate @doc(category: "Checkout") @webhookEventsInfo(asyncEvents: [CHECKOUT_CREATED], syncEvents: [])
 
-  """
-  Create new checkout from existing order.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Create new checkout from existing order."""
   checkoutCreateFromOrder(
     """ID of a order that will be used to create the checkout."""
     id: ID!
@@ -19084,11 +18708,7 @@ type Mutation {
     """
     customerId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -19115,11 +18735,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -19163,11 +18779,7 @@ type Mutation {
     """email."""
     email: String!
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -19192,11 +18804,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """ID of the checkout line to delete."""
@@ -19217,11 +18825,7 @@ type Mutation {
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutLinesDelete(
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """A list of checkout lines."""
@@ -19249,11 +18853,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -19283,11 +18883,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -19317,11 +18913,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """Gift card code or voucher code."""
@@ -19379,11 +18971,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """The mailing address to where the checkout will be shipped."""
@@ -19396,11 +18984,7 @@ type Mutation {
     """
     token: UUID
 
-    """
-    The rules for changing validation for received shipping address data.
-    
-    Added in Saleor 3.5.
-    """
+    """The rules for changing validation for received shipping address data."""
     validationRules: CheckoutAddressValidationRules
   ): CheckoutShippingAddressUpdate @doc(category: "Checkout") @webhookEventsInfo(asyncEvents: [CHECKOUT_UPDATED], syncEvents: [])
 
@@ -19419,11 +19003,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """Shipping method."""
@@ -19440,8 +19020,6 @@ type Mutation {
   """
   Updates the delivery method (shipping method or pick up point) of the checkout. Updates the checkout shipping_address for click and collect delivery for a warehouse address. 
   
-  Added in Saleor 3.1.
-  
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Triggered when updating the checkout delivery method with the external one.
   - CHECKOUT_UPDATED (async): A checkout was updated.
@@ -19450,11 +19028,7 @@ type Mutation {
     """Delivery Method ID (`Warehouse` ID or `ShippingMethod` ID)."""
     deliveryMethodId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """
@@ -19479,11 +19053,7 @@ type Mutation {
     """
     checkoutId: ID
 
-    """
-    The checkout's ID.
-    
-    Added in Saleor 3.4.
-    """
+    """The checkout's ID."""
     id: ID
 
     """New language code."""
@@ -19499,8 +19069,6 @@ type Mutation {
 
   """
   Create new order from existing checkout. Requires the following permissions: AUTHENTICATED_APP and HANDLE_CHECKOUTS.
-  
-  Added in Saleor 3.2.
   
   Triggers the following webhook events:
   - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
@@ -19518,18 +19086,10 @@ type Mutation {
     """ID of a checkout that will be converted to an order."""
     id: ID!
 
-    """
-    Fields required to update the checkout metadata.
-    
-    Added in Saleor 3.8.
-    """
+    """Fields required to update the checkout metadata."""
     metadata: [MetadataInput!]
 
-    """
-    Fields required to update the checkout private metadata.
-    
-    Added in Saleor 3.8.
-    """
+    """Fields required to update the checkout private metadata."""
     privateMetadata: [MetadataInput!]
 
     """
@@ -27933,11 +27493,7 @@ input ExternalNotificationTriggerInput {
 }
 
 """
-Creates a new promotion.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Creates a new promotion. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28114,11 +27670,7 @@ input DiscountedObjectWhereInput @doc(category: "Discounts") {
 }
 
 """
-Updates an existing promotion.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Updates an existing promotion. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28167,11 +27719,7 @@ input PromotionUpdateInput {
 }
 
 """
-Deletes a promotion.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Deletes a promotion. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28202,11 +27750,7 @@ enum PromotionDeleteErrorCode {
 }
 
 """
-Creates a new promotion rule.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Creates a new promotion rule. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28313,11 +27857,7 @@ input PromotionRuleCreateInput {
 }
 
 """
-Updates an existing promotion rule.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Updates an existing promotion rule. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28430,11 +27970,7 @@ input PromotionRuleUpdateInput {
 }
 
 """
-Deletes a promotion rule.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Deletes a promotion rule. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28511,11 +28047,7 @@ input PromotionRuleTranslationInput {
 }
 
 """
-Deletes promotions.
-
-Added in Saleor 3.17.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Deletes promotions. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -28684,11 +28216,7 @@ input CatalogueInput @doc(category: "Discounts") {
   """Collections related to the discount."""
   collections: [ID!]
 
-  """
-  Product variant related to the discount.
-  
-  Added in Saleor 3.1.
-  """
+  """Product variant related to the discount."""
   variants: [ID!]
 }
 
@@ -28800,11 +28328,7 @@ input VoucherInput @doc(category: "Discounts") {
   """Products discounted by the voucher."""
   products: [ID!]
 
-  """
-  Variants discounted by the voucher.
-  
-  Added in Saleor 3.1.
-  """
+  """Variants discounted by the voucher."""
   variants: [ID!]
 
   """Collections discounted by the voucher."""
@@ -29366,11 +28890,7 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   """Checkout language code."""
   languageCode: LanguageCodeEnum
 
-  """
-  The checkout validation rules that can be changed.
-  
-  Added in Saleor 3.5.
-  """
+  """The checkout validation rules that can be changed."""
   validationRules: CheckoutValidationRules
 }
 
@@ -29383,23 +28903,15 @@ input CheckoutLineInput @doc(category: "Checkout") {
 
   """
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
-  
-  Added in Saleor 3.1.
   """
   price: PositiveDecimal
 
   """
-  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. 
-  
-  Added in Saleor 3.6.
+  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic.
   """
   forceNewLine: Boolean = false
 
-  """
-  Fields required to update the object's metadata.
-  
-  Added in Saleor 3.8.
-  """
+  """Fields required to update the object's metadata."""
   metadata: [MetadataInput!]
 }
 
@@ -29415,13 +28927,7 @@ input CheckoutValidationRules @doc(category: "Checkout") {
   billingAddress: CheckoutAddressValidationRules
 }
 
-"""
-Create new checkout from existing order.
-
-Added in Saleor 3.14.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Create new checkout from existing order."""
 type CheckoutCreateFromOrder @doc(category: "Checkout") {
   """Variants that were not attached to the checkout."""
   unavailableVariants: [CheckoutCreateFromOrderUnavailableVariant!]
@@ -29599,16 +29105,10 @@ input CheckoutLineUpdateInput @doc(category: "Checkout") {
 
   """
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
-  
-  Added in Saleor 3.1.
   """
   price: PositiveDecimal
 
-  """
-  ID of the line.
-  
-  Added in Saleor 3.6.
-  """
+  """ID of the line."""
   lineId: ID
 }
 
@@ -29716,8 +29216,6 @@ type CheckoutShippingMethodUpdate @doc(category: "Checkout") @webhookEventsInfo(
 """
 Updates the delivery method (shipping method or pick up point) of the checkout. Updates the checkout shipping_address for click and collect delivery for a warehouse address. 
 
-Added in Saleor 3.1.
-
 Triggers the following webhook events:
 - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Triggered when updating the checkout delivery method with the external one.
 - CHECKOUT_UPDATED (async): A checkout was updated.
@@ -29743,8 +29241,6 @@ type CheckoutLanguageCodeUpdate @doc(category: "Checkout") @webhookEventsInfo(as
 
 """
 Create new order from existing checkout. Requires the following permissions: AUTHENTICATED_APP and HANDLE_CHECKOUTS.
-
-Added in Saleor 3.2.
 
 Triggers the following webhook events:
 - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.


### PR DESCRIPTION
I want to merge this change because it drops ADDED_IN and FEATURE_PREVIEW for versions < 3.18 in modules:
- Order
- Checkout
- Discount

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
