### PR TITLE
Drop ADDED_IN and FEATURE_PREVIEW for versions below 3.18 (most of Saleor)

### DIFF
--- a/saleor/graphql/channel/schema.py
+++ b/saleor/graphql/channel/schema.py
@@ -2,7 +2,6 @@ import graphene
 
 from ...permission.auth_filters import AuthorizationFilters
 from ..core import ResolveInfo
-from ..core.descriptions import ADDED_IN_36
 from ..core.doc_category import DOC_CATEGORY_CHANNELS
 from ..core.fields import BaseField, PermissionsField
 from ..core.types import NonNullList
@@ -26,7 +25,7 @@ class ChannelQueries(graphene.ObjectType):
         ),
         slug=graphene.Argument(
             graphene.String,
-            description="Slug of the channel." + ADDED_IN_36,
+            description="Slug of the channel.",
             required=False,
         ),
         description="Look up a channel by ID or slug.",

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -21,15 +21,6 @@ from ...permission.enums import (
 from ..account.enums import CountryCodeEnum
 from ..core import ResolveInfo
 from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_35,
-    ADDED_IN_36,
-    ADDED_IN_37,
-    ADDED_IN_312,
-    ADDED_IN_313,
-    ADDED_IN_314,
-    ADDED_IN_315,
-    ADDED_IN_316,
     ADDED_IN_318,
     ADDED_IN_320,
     DEPRECATED_IN_3X_FIELD,
@@ -181,7 +172,7 @@ class StockSettings(BaseObjectType):
     )
 
     class Meta:
-        description = "Represents the channel stock settings." + ADDED_IN_37
+        description = "Represents the channel stock settings."
         doc_category = DOC_CATEGORY_PRODUCTS
 
 
@@ -197,7 +188,6 @@ class CheckoutSettings(ObjectType):
             "Some of the `problems` can block the finalizing checkout process. "
             "The legacy flow will be removed in Saleor 4.0. "
             "The flow with `checkout.problems` will be the default one."
-            + ADDED_IN_315
             + DEPRECATED_IN_3X_FIELD
         ),
     )
@@ -216,11 +206,7 @@ class CheckoutSettings(ObjectType):
     )
 
     class Meta:
-        description = (
-            "Represents the channel-specific checkout settings."
-            + ADDED_IN_315
-            + PREVIEW_FEATURE
-        )
+        description = "Represents the channel-specific checkout settings."
         doc_category = DOC_CATEGORY_CHECKOUT
 
 
@@ -244,8 +230,6 @@ class OrderSettings(ObjectType):
         required=False,
         description=(
             "Expiration time in minutes. Default null - means do not expire any orders."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
         ),
     )
 
@@ -257,23 +241,17 @@ class OrderSettings(ObjectType):
             "and attached to the order when it's manually marked as paid."
             "\n`PAYMENT_FLOW` - [default option] creates the `Payment` object."
             "\n`TRANSACTION_FLOW` - creates the `TransactionItem` object."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
         ),
     )
     delete_expired_orders_after = Day(
         required=True,
-        description=(
-            "The time in days after expired orders will be deleted."
-            + ADDED_IN_314
-            + PREVIEW_FEATURE
-        ),
+        description=("The time in days after expired orders will be deleted."),
     )
     allow_unpaid_orders = graphene.Boolean(
         required=True,
         description=(
             "Determine if it is possible to place unpaid order by calling "
-            "`checkoutComplete` mutation." + ADDED_IN_315 + PREVIEW_FEATURE
+            "`checkoutComplete` mutation."
         ),
     )
     include_draft_order_in_voucher_usage = graphene.Boolean(
@@ -295,7 +273,7 @@ class PaymentSettings(ObjectType):
         description=(
             "Determine the transaction flow strategy to be used. "
             "Include the selected option in the payload sent to the payment app, as a "
-            "requested action for the transaction." + ADDED_IN_316 + PREVIEW_FEATURE
+            "requested action for the transaction."
         ),
     )
 
@@ -351,7 +329,7 @@ class Channel(ModelObjectType):
         description=(
             "Default country for the channel. Default country can be "
             "used in checkout to determine the stock quantities or calculate taxes "
-            "when the country was not explicitly provided." + ADDED_IN_31
+            "when the country was not explicitly provided."
         ),
         required=True,
         permissions=[
@@ -361,7 +339,7 @@ class Channel(ModelObjectType):
     )
     warehouses = PermissionsField(
         NonNullList(Warehouse),
-        description="List of warehouses assigned to this channel." + ADDED_IN_35,
+        description="List of warehouses assigned to this channel.",
         required=True,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_APP,
@@ -370,18 +348,17 @@ class Channel(ModelObjectType):
     )
     countries = NonNullList(
         CountryDisplay,
-        description="List of shippable countries for the channel." + ADDED_IN_36,
+        description="List of shippable countries for the channel.",
     )
 
     available_shipping_methods_per_country = graphene.Field(
         NonNullList("saleor.graphql.shipping.types.ShippingMethodsPerCountry"),
         countries=graphene.Argument(NonNullList(CountryCodeEnum)),
-        description="Shipping methods that are available for the channel."
-        + ADDED_IN_36,
+        description="Shipping methods that are available for the channel.",
     )
     stock_settings = PermissionsField(
         StockSettings,
-        description=("Define the stock setting for this channel." + ADDED_IN_37),
+        description=("Define the stock setting for this channel."),
         required=True,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_APP,
@@ -390,7 +367,7 @@ class Channel(ModelObjectType):
     )
     order_settings = PermissionsField(
         OrderSettings,
-        description="Channel-specific order settings." + ADDED_IN_312,
+        description="Channel-specific order settings.",
         required=True,
         permissions=[
             ChannelPermissions.MANAGE_CHANNELS,
@@ -400,9 +377,7 @@ class Channel(ModelObjectType):
 
     checkout_settings = PermissionsField(
         CheckoutSettings,
-        description="Channel-specific checkout settings."
-        + ADDED_IN_315
-        + PREVIEW_FEATURE,
+        description="Channel-specific checkout settings.",
         required=True,
         permissions=[
             ChannelPermissions.MANAGE_CHANNELS,
@@ -411,9 +386,7 @@ class Channel(ModelObjectType):
     )
     payment_settings = PermissionsField(
         PaymentSettings,
-        description="Channel-specific payment settings."
-        + ADDED_IN_316
-        + PREVIEW_FEATURE,
+        description="Channel-specific payment settings.",
         required=True,
         permissions=[
             ChannelPermissions.MANAGE_CHANNELS,
@@ -436,7 +409,6 @@ class Channel(ModelObjectType):
         description = "Represents channel."
         model = models.Channel
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
-        metadata_since = ADDED_IN_315
 
     @staticmethod
     def resolve_tax_configuration(root: models.Channel, info: ResolveInfo):

--- a/saleor/graphql/giftcard/schema.py
+++ b/saleor/graphql/giftcard/schema.py
@@ -7,7 +7,6 @@ from ...permission.enums import GiftcardPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.context import get_database_connection_name
-from ..core.descriptions import ADDED_IN_31, ADDED_IN_315, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import NonNullList
@@ -47,15 +46,11 @@ class GiftCardQueries(graphene.ObjectType):
     )
     gift_cards = FilterConnectionField(
         GiftCardCountableConnection,
-        sort_by=GiftCardSortingInput(description="Sort gift cards." + ADDED_IN_31),
-        filter=GiftCardFilterInput(
-            description=("Filtering options for gift cards." + ADDED_IN_31)
-        ),
+        sort_by=GiftCardSortingInput(description="Sort gift cards."),
+        filter=GiftCardFilterInput(description=("Filtering options for gift cards.")),
         search=graphene.String(
             description="Search gift cards by email and name of user, "
             "who created or used the gift card, and by code."
-            + ADDED_IN_315
-            + PREVIEW_FEATURE
         ),
         description="List of gift cards.",
         permissions=[
@@ -65,7 +60,7 @@ class GiftCardQueries(graphene.ObjectType):
     )
     gift_card_currencies = PermissionsField(
         NonNullList(graphene.String),
-        description="List of gift card currencies." + ADDED_IN_31,
+        description="List of gift card currencies.",
         required=True,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
@@ -77,7 +72,7 @@ class GiftCardQueries(graphene.ObjectType):
         filter=GiftCardTagFilterInput(
             description="Filtering options for gift card tags."
         ),
-        description="List of gift card tags." + ADDED_IN_31,
+        description="List of gift card tags.",
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
         ],

--- a/saleor/graphql/giftcard/sorters.py
+++ b/saleor/graphql/giftcard/sorters.py
@@ -1,4 +1,3 @@
-from ..core.descriptions import ADDED_IN_38
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.types import BaseEnum, SortInputObjectType
 
@@ -16,10 +15,7 @@ class GiftCardSortField(BaseEnum):
     def description(self):
         if self.name in GiftCardSortField.__enum__._member_names_:
             sort_name = self.name.lower().replace("_", " ")
-            description = f"Sort gift cards by {sort_name}."
-            if self.name == "CREATED_AT":
-                description += ADDED_IN_38
-            return description
+            return f"Sort gift cards by {sort_name}."
         raise ValueError(f"Unsupported enum value: {self.value}")
 
 

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -20,7 +20,7 @@ from ..channel import ChannelContext
 from ..channel.dataloaders import ChannelByIdLoader
 from ..core.connection import CountableConnection
 from ..core.context import get_database_connection_name
-from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.fields import PermissionsField
 from ..core.scalars import Date, DateTime
@@ -110,7 +110,7 @@ class GiftCardEvent(ModelObjectType[models.GiftCardEvent]):
     old_expiry_date = Date(description="Previous gift card expiry date.")
 
     class Meta:
-        description = "History log of the gift card." + ADDED_IN_31
+        description = "History log of the gift card."
         model = models.GiftCardEvent
         interfaces = [graphene.relay.Node]
 
@@ -224,7 +224,7 @@ class GiftCardTag(ModelObjectType[models.GiftCardTag]):
     )
 
     class Meta:
-        description = "The gift card tag." + ADDED_IN_31
+        description = "The gift card tag."
         model = models.GiftCardTag
         interfaces = [graphene.relay.Node]
 
@@ -255,18 +255,17 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     )
     created_by = graphene.Field(
         "saleor.graphql.account.types.User",
-        description=("The user who bought or issued a gift card." + ADDED_IN_31),
+        description=("The user who bought or issued a gift card."),
     )
     used_by = graphene.Field(
         "saleor.graphql.account.types.User",
-        description=("The customer who used a gift card." + ADDED_IN_31),
+        description=("The customer who used a gift card."),
         deprecation_reason=DEPRECATED_IN_3X_FIELD,
     )
     created_by_email = graphene.String(
         required=False,
         description=(
             "Email address of the user who bought or issued gift card."
-            + ADDED_IN_31
             + "\n\nRequires one of the following permissions: "
             f"{AccountPermissions.MANAGE_USERS.name}, "
             f"{AuthorizationFilters.OWNER.name}."
@@ -274,9 +273,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     )
     used_by_email = graphene.String(
         required=False,
-        description=(
-            "Email address of the customer who used a gift card." + ADDED_IN_31
-        ),
+        description=("Email address of the customer who used a gift card."),
         deprecation_reason=DEPRECATED_IN_3X_FIELD,
     )
     last_used_on = DateTime(description="Date and time when gift card was last used.")
@@ -285,21 +282,20 @@ class GiftCard(ModelObjectType[models.GiftCard]):
         App,
         description=(
             "App which created the gift card."
-            + ADDED_IN_31
             + "\n\nRequires one of the following permissions: "
             f"{AppPermission.MANAGE_APPS.name}, {AuthorizationFilters.OWNER.name}."
         ),
     )
     product = graphene.Field(
         "saleor.graphql.product.types.products.Product",
-        description="Related gift card product." + ADDED_IN_31,
+        description="Related gift card product.",
     )
     events = PermissionsField(
         NonNullList(GiftCardEvent),
         filter=GiftCardEventFilterInput(
             description="Filtering options for gift card events."
         ),
-        description=("List of events associated with the gift card." + ADDED_IN_31),
+        description=("List of events associated with the gift card."),
         required=True,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
@@ -307,16 +303,14 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     )
     tags = PermissionsField(
         NonNullList(GiftCardTag),
-        description="The gift card tag." + ADDED_IN_31,
+        description="The gift card tag.",
         required=True,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
         ],
     )
     bought_in_channel = graphene.String(
-        description=(
-            "Slug of the channel where the gift card was bought." + ADDED_IN_31
-        ),
+        description=("Slug of the channel where the gift card was bought."),
         required=False,
     )
     is_active = graphene.Boolean(required=True)

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -255,11 +255,11 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     )
     created_by = graphene.Field(
         "saleor.graphql.account.types.User",
-        description=("The user who bought or issued a gift card."),
+        description="The user who bought or issued a gift card.",
     )
     used_by = graphene.Field(
         "saleor.graphql.account.types.User",
-        description=("The customer who used a gift card."),
+        description="The customer who used a gift card.",
         deprecation_reason=DEPRECATED_IN_3X_FIELD,
     )
     created_by_email = graphene.String(
@@ -273,7 +273,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     )
     used_by_email = graphene.String(
         required=False,
-        description=("Email address of the customer who used a gift card."),
+        description="Email address of the customer who used a gift card.",
         deprecation_reason=DEPRECATED_IN_3X_FIELD,
     )
     last_used_on = DateTime(description="Date and time when gift card was last used.")
@@ -295,7 +295,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
         filter=GiftCardEventFilterInput(
             description="Filtering options for gift card events."
         ),
-        description=("List of events associated with the gift card."),
+        description="List of events associated with the gift card.",
         required=True,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
@@ -310,7 +310,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
         ],
     )
     bought_in_channel = graphene.String(
-        description=("Slug of the channel where the gift card was bought."),
+        description="Slug of the channel where the gift card was bought.",
         required=False,
     )
     is_active = graphene.Boolean(required=True)

--- a/saleor/graphql/invoice/types.py
+++ b/saleor/graphql/invoice/types.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ...invoice import models
-from ..core.descriptions import ADDED_IN_310, DEPRECATED_IN_3X_FIELD
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.scalars import DateTime
 from ..core.types import Job, ModelObjectType
 from ..meta.types import ObjectWithMetadata
@@ -28,7 +28,7 @@ class Invoice(ModelObjectType[models.Invoice]):
     url = graphene.String(description=("URL to view/download an invoice."))
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
-        description="Order related to the invoice." + ADDED_IN_310,
+        description="Order related to the invoice.",
     )
 
     class Meta:

--- a/saleor/graphql/page/sorters.py
+++ b/saleor/graphql/page/sorters.py
@@ -1,4 +1,4 @@
-from ..core.descriptions import ADDED_IN_38, DEPRECATED_IN_3X_INPUT
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.types import BaseEnum, SortInputObjectType
 
@@ -24,8 +24,6 @@ class PageSortField(BaseEnum):
                 description += DEPRECATED_IN_3X_INPUT
             if self.name == "CREATION_DATE":
                 description += DEPRECATED_IN_3X_INPUT
-            if self.name == "CREATED_AT":
-                description += ADDED_IN_38
             return description
         raise ValueError(f"Unsupported enum value: {self.value}")
 

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -12,7 +12,7 @@ from ..core.connection import (
     filter_connection_queryset,
 )
 from ..core.context import get_database_connection_name
-from ..core.descriptions import ADDED_IN_33, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import FilterConnectionField, JSONString, PermissionsField
@@ -131,7 +131,7 @@ class Page(ModelObjectType[models.Page]):
             "Use the `publishedAt` field to fetch the publication date."
         ),
     )
-    published_at = DateTime(description="The page publication date." + ADDED_IN_33)
+    published_at = DateTime(description="The page publication date.")
     is_published = graphene.Boolean(
         required=True, description="Determines if the page is published."
     )

--- a/saleor/graphql/payment/filters.py
+++ b/saleor/graphql/payment/filters.py
@@ -1,6 +1,5 @@
 import django_filters
 
-from ..core.descriptions import ADDED_IN_38
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.filters import GlobalIDMultipleChoiceFilter
 from ..core.types import FilterInputObjectType
@@ -8,9 +7,7 @@ from .types import Payment
 
 
 class PaymentFilter(django_filters.FilterSet):
-    ids = GlobalIDMultipleChoiceFilter(
-        field_name="id", help_text=f"Filter by ids. {ADDED_IN_38}"
-    )
+    ids = GlobalIDMultipleChoiceFilter(field_name="id", help_text="Filter by ids.")
     checkouts = GlobalIDMultipleChoiceFilter(field_name="checkout")
 
     class Meta:

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -3,7 +3,6 @@ import graphene
 from ...permission.enums import OrderPermissions, PaymentPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.scalars import UUID
@@ -55,7 +54,7 @@ class PaymentQueries(graphene.ObjectType):
     )
     transaction = PermissionsField(
         TransactionItem,
-        description="Look up a transaction by ID." + ADDED_IN_36 + PREVIEW_FEATURE,
+        description="Look up a transaction by ID.",
         id=graphene.Argument(
             graphene.ID,
             description=(

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -14,15 +14,6 @@ from ..app.dataloaders import ActiveAppsByAppIdentifierLoader, AppByIdLoader
 from ..checkout.dataloaders import CheckoutByTokenLoader
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
-from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_34,
-    ADDED_IN_36,
-    ADDED_IN_313,
-    ADDED_IN_314,
-    ADDED_IN_315,
-    PREVIEW_FEATURE,
-)
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import JSONString, PermissionsField
 from ..core.scalars import JSON, DateTime
@@ -126,7 +117,6 @@ class PaymentSource(BaseObjectType):
         required=True,
         description=(
             "List of public metadata items."
-            + ADDED_IN_31
             + "\n\nCan be accessed without permissions."
         ),
     )
@@ -204,10 +194,10 @@ class Payment(ModelObjectType[models.Payment]):
     )
     partial = graphene.Boolean(
         required=True,
-        description="Informs whether this is a partial payment." + ADDED_IN_314,
+        description="Informs whether this is a partial payment.",
     )
     psp_reference = graphene.String(
-        required=False, description="PSP reference of the payment." + ADDED_IN_314
+        required=False, description="PSP reference of the payment."
     )
 
     class Meta:
@@ -316,36 +306,36 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
         description="Date and time at which a transaction event was created.",
     )
     psp_reference = graphene.String(
-        description="PSP reference of transaction." + ADDED_IN_313, required=True
+        description="PSP reference of transaction.", required=True
     )
     message = graphene.String(
-        description="Message related to the transaction's event." + ADDED_IN_313,
+        description="Message related to the transaction's event.",
         required=True,
     )
     external_url = graphene.String(
         description=(
             "The url that will allow to redirect user to "
-            "payment provider page with transaction details." + ADDED_IN_313
+            "payment provider page with transaction details."
         ),
         required=True,
     )
     amount = graphene.Field(
         Money,
         required=True,
-        description="The amount related to this event." + ADDED_IN_313,
+        description="The amount related to this event.",
     )
     type = graphene.Field(
         TransactionEventTypeEnum,
-        description="The type of action related to this event." + ADDED_IN_313,
+        description="The type of action related to this event.",
     )
 
     created_by = graphene.Field(
         "saleor.graphql.core.types.user_or_app.UserOrApp",
-        description=("User or App that created the transaction event." + ADDED_IN_313),
+        description=("User or App that created the transaction event."),
     )
 
     idempotency_key = graphene.String(
-        description="Idempotency key assigned to the event." + ADDED_IN_314,
+        description="Idempotency key assigned to the event.",
         required=False,
     )
 
@@ -410,7 +400,7 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
 
 class TransactionItem(ModelObjectType[models.TransactionItem]):
     token = graphene.Field(
-        UUIDScalar, description="The transaction token." + ADDED_IN_314, required=True
+        UUIDScalar, description="The transaction token.", required=True
     )
     created_at = DateTime(
         required=True,
@@ -435,7 +425,6 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         required=True,
         description=(
             "Total amount of ongoing authorization requests for the transaction."
-            + ADDED_IN_313
         ),
     )
     refunded_amount = graphene.Field(
@@ -444,24 +433,18 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     refund_pending_amount = graphene.Field(
         Money,
         required=True,
-        description=(
-            "Total amount of ongoing refund requests for the transaction."
-            + ADDED_IN_313
-        ),
+        description=("Total amount of ongoing refund requests for the transaction."),
     )
 
     canceled_amount = graphene.Field(
         Money,
         required=True,
-        description="Total amount canceled for this payment." + ADDED_IN_313,
+        description="Total amount canceled for this payment.",
     )
     cancel_pending_amount = graphene.Field(
         Money,
         required=True,
-        description=(
-            "Total amount of ongoing cancel requests for the transaction."
-            + ADDED_IN_313
-        ),
+        description=("Total amount of ongoing cancel requests for the transaction."),
     )
     charged_amount = graphene.Field(
         Money, description="Total amount charged for this payment.", required=True
@@ -469,48 +452,41 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     charge_pending_amount = graphene.Field(
         Money,
         required=True,
-        description=(
-            "Total amount of ongoing charge requests for the transaction."
-            + ADDED_IN_313
-        ),
+        description=("Total amount of ongoing charge requests for the transaction."),
     )
-    name = graphene.String(
-        description="Name of the transaction." + ADDED_IN_313, required=True
-    )
+    name = graphene.String(description="Name of the transaction.", required=True)
     message = graphene.String(
-        description="Message related to the transaction." + ADDED_IN_313, required=True
+        description="Message related to the transaction.", required=True
     )
 
     psp_reference = graphene.String(
-        description="PSP reference of transaction." + ADDED_IN_313, required=True
+        description="PSP reference of transaction.", required=True
     )
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
-        description="The related order." + ADDED_IN_36,
+        description="The related order.",
     )
     checkout = graphene.Field(
         "saleor.graphql.checkout.types.Checkout",
-        description="The related checkout." + ADDED_IN_314,
+        description="The related checkout.",
     )
     events = NonNullList(
         TransactionEvent, required=True, description="List of all transaction's events."
     )
     created_by = graphene.Field(
         "saleor.graphql.core.types.user_or_app.UserOrApp",
-        description=("User or App that created the transaction." + ADDED_IN_313),
+        description=("User or App that created the transaction."),
     )
     external_url = graphene.String(
         description=(
             "The url that will allow to redirect user to "
-            "payment provider page with transaction details." + ADDED_IN_313
+            "payment provider page with transaction details."
         ),
         required=True,
     )
 
     class Meta:
-        description = (
-            "Represents a payment transaction." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Represents a payment transaction."
         interfaces = [relay.Node, ObjectWithMetadata]
         model = models.TransactionItem
 
@@ -721,7 +697,7 @@ class StoredPaymentMethod(BaseObjectType):
     class Meta:
         description = (
             "Represents a payment method stored for user (tokenized) in payment "
-            "gateway." + ADDED_IN_315 + PREVIEW_FEATURE
+            "gateway."
         )
         doc_category = DOC_CATEGORY_PAYMENTS
 

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -433,7 +433,7 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     refund_pending_amount = graphene.Field(
         Money,
         required=True,
-        description=("Total amount of ongoing refund requests for the transaction."),
+        description="Total amount of ongoing refund requests for the transaction.",
     )
 
     canceled_amount = graphene.Field(
@@ -444,7 +444,7 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     cancel_pending_amount = graphene.Field(
         Money,
         required=True,
-        description=("Total amount of ongoing cancel requests for the transaction."),
+        description="Total amount of ongoing cancel requests for the transaction.",
     )
     charged_amount = graphene.Field(
         Money, description="Total amount charged for this payment.", required=True
@@ -452,7 +452,7 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     charge_pending_amount = graphene.Field(
         Money,
         required=True,
-        description=("Total amount of ongoing charge requests for the transaction."),
+        description="Total amount of ongoing charge requests for the transaction.",
     )
     name = graphene.String(description="Name of the transaction.", required=True)
     message = graphene.String(

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -35,7 +35,6 @@ from ...product.models import (
 from ...product.search import search_products
 from ...warehouse.models import Allocation, Reservation, Stock, Warehouse
 from ..channel.filters import get_channel_slug_from_filter_data
-from ..core.descriptions import ADDED_IN_38, ADDED_IN_317
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
 from ..core.filters import (
     BooleanWhereFilter,
@@ -752,20 +751,20 @@ class ProductFilter(MetadataFilterBase):
     published_from = ObjectTypeFilter(
         input_class=DateTime,
         method="filter_published_from",
-        help_text=f"Filter by the publication date. {ADDED_IN_38}",
+        help_text="Filter by the publication date.",
     )
     is_available = django_filters.BooleanFilter(
         method="filter_is_available",
-        help_text=f"Filter by availability for purchase. {ADDED_IN_38}",
+        help_text="Filter by availability for purchase.",
     )
     available_from = ObjectTypeFilter(
         input_class=DateTime,
         method="filter_available_from",
-        help_text=f"Filter by the date of availability for purchase. {ADDED_IN_38}",
+        help_text="Filter by the date of availability for purchase.",
     )
     is_visible_in_listing = django_filters.BooleanFilter(
         method="filter_listed",
-        help_text=f"Filter by visibility in product listings. {ADDED_IN_38}",
+        help_text="Filter by visibility in product listings.",
     )
     collections = GlobalIDMultipleChoiceFilter(method=filter_collections)
     categories = GlobalIDMultipleChoiceFilter(method=filter_categories)
@@ -1360,7 +1359,7 @@ class CategoryFilter(MetadataFilterBase):
     updated_at = ObjectTypeFilter(
         input_class=DateTimeRangeInput,
         method=filter_updated_at_range,
-        help_text=f"Filter by when was the most recent update. {ADDED_IN_317}",
+        help_text="Filter by when was the most recent update.",
     )
 
     class Meta:

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -10,11 +10,8 @@ from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.descriptions import (
-    ADDED_IN_310,
-    ADDED_IN_314,
     ADDED_IN_321,
     DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
 )
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
 from ..core.enums import LanguageCodeEnum, ReportingPeriod
@@ -175,9 +172,7 @@ class ProductQueries(graphene.ObjectType):
     categories = FilterConnectionField(
         CategoryCountableConnection,
         filter=CategoryFilterInput(description="Filtering options for categories."),
-        where=CategoryWhereInput(
-            description="Where filtering options." + ADDED_IN_314 + PREVIEW_FEATURE
-        ),
+        where=CategoryWhereInput(description="Where filtering options."),
         sort_by=CategorySortingInput(description="Sort categories."),
         level=graphene.Argument(
             graphene.Int,
@@ -224,9 +219,7 @@ class ProductQueries(graphene.ObjectType):
     collections = FilterConnectionField(
         CollectionCountableConnection,
         filter=CollectionFilterInput(description="Filtering options for collections."),
-        where=CollectionWhereInput(
-            description="Where filtering options." + ADDED_IN_314 + PREVIEW_FEATURE
-        ),
+        where=CollectionWhereInput(description="Where filtering options."),
         sort_by=CollectionSortingInput(description="Sort collections."),
         description=(
             "List of the shop's collections. Requires one of the following permissions "
@@ -251,7 +244,7 @@ class ProductQueries(graphene.ObjectType):
             + ADDED_IN_321,
         ),
         external_reference=graphene.Argument(
-            graphene.String, description=f"External ID of the product. {ADDED_IN_310}"
+            graphene.String, description="External ID of the product."
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
@@ -266,11 +259,9 @@ class ProductQueries(graphene.ObjectType):
     products = FilterConnectionField(
         ProductCountableConnection,
         filter=ProductFilterInput(description="Filtering options for products."),
-        where=ProductWhereInput(
-            description="Where filtering options." + ADDED_IN_314 + PREVIEW_FEATURE
-        ),
+        where=ProductWhereInput(description="Where filtering options."),
         sort_by=ProductOrder(description="Sort products."),
-        search=graphene.String(description="Search products." + ADDED_IN_314),
+        search=graphene.String(description="Search products."),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
@@ -308,7 +299,7 @@ class ProductQueries(graphene.ObjectType):
             graphene.String, description="SKU of the product variant."
         ),
         external_reference=graphene.Argument(
-            graphene.String, description=f"External ID of the product. {ADDED_IN_310}"
+            graphene.String, description="External ID of the product."
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
@@ -331,9 +322,7 @@ class ProductQueries(graphene.ObjectType):
         filter=ProductVariantFilterInput(
             description="Filtering options for product variant."
         ),
-        where=ProductVariantWhereInput(
-            description="Where filtering options." + ADDED_IN_314 + PREVIEW_FEATURE
-        ),
+        where=ProductVariantWhereInput(description="Where filtering options."),
         sort_by=ProductVariantSortingInput(description="Sort products variants."),
         description=(
             "List of product variants. Requires one of the following permissions to "

--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -21,7 +21,7 @@ from ...product.models import (
     Product,
     ProductChannelListing,
 )
-from ..core.descriptions import ADDED_IN_38, CHANNEL_REQUIRED, DEPRECATED_IN_3X_INPUT
+from ..core.descriptions import CHANNEL_REQUIRED, DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
 from ..core.types import BaseEnum, ChannelSortInputObjectType, SortInputObjectType
 
@@ -192,7 +192,7 @@ class ProductOrderField(BaseEnum):
             ),
             ProductOrderField.LAST_MODIFIED_AT.name: "update date.",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
             ProductOrderField.RATING.name: "rating.",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
-            ProductOrderField.CREATED_AT.name: "creation date." + ADDED_IN_38,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+            ProductOrderField.CREATED_AT.name: "creation date.",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
         }
         if self.name in descriptions:
             return f"Sort products by {descriptions[self.name]}"

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -52,11 +52,7 @@ type Query {
     """ID of a warehouse."""
     id: ID
 
-    """
-    External ID of a warehouse. 
-    
-    Added in Saleor 3.10.
-    """
+    """External ID of a warehouse."""
     externalReference: String
   ): Warehouse @doc(category: "Products")
 
@@ -128,8 +124,6 @@ type Query {
   """
   Look up a tax configuration.
   
-  Added in Saleor 3.9.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfiguration(
@@ -139,8 +133,6 @@ type Query {
 
   """
   List of tax configurations.
-  
-  Added in Saleor 3.9.
   
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
@@ -168,8 +160,6 @@ type Query {
   """
   Look up a tax class.
   
-  Added in Saleor 3.9.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass(
@@ -179,8 +169,6 @@ type Query {
 
   """
   List of tax classes.
-  
-  Added in Saleor 3.9.
   
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
@@ -353,13 +341,7 @@ type Query {
     """Filtering options for categories."""
     filter: CategoryFilterInput
 
-    """
-    Where filtering options.
-    
-    Added in Saleor 3.14.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
-    """
+    """Where filtering options."""
     where: CategoryWhereInput
 
     """Sort categories."""
@@ -429,13 +411,7 @@ type Query {
     """Filtering options for collections."""
     filter: CollectionFilterInput
 
-    """
-    Where filtering options.
-    
-    Added in Saleor 3.14.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
-    """
+    """Where filtering options."""
     where: CollectionWhereInput
 
     """Sort collections."""
@@ -478,11 +454,7 @@ type Query {
     """
     slugLanguageCode: LanguageCodeEnum
 
-    """
-    External ID of the product. 
-    
-    Added in Saleor 3.10.
-    """
+    """External ID of the product."""
     externalReference: String
 
     """Slug of a channel for which the data should be returned."""
@@ -496,23 +468,13 @@ type Query {
     """Filtering options for products."""
     filter: ProductFilterInput
 
-    """
-    Where filtering options.
-    
-    Added in Saleor 3.14.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
-    """
+    """Where filtering options."""
     where: ProductWhereInput
 
     """Sort products."""
     sortBy: ProductOrder
 
-    """
-    Search products.
-    
-    Added in Saleor 3.14.
-    """
+    """Search products."""
     search: String
 
     """Slug of a channel for which the data should be returned."""
@@ -576,11 +538,7 @@ type Query {
     """SKU of the product variant."""
     sku: String
 
-    """
-    External ID of the product. 
-    
-    Added in Saleor 3.10.
-    """
+    """External ID of the product."""
     externalReference: String
 
     """Slug of a channel for which the data should be returned."""
@@ -600,13 +558,7 @@ type Query {
     """Filtering options for product variant."""
     filter: ProductVariantFilterInput
 
-    """
-    Where filtering options.
-    
-    Added in Saleor 3.14.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
-    """
+    """Where filtering options."""
     where: ProductVariantWhereInput
 
     """Sort products variants."""
@@ -696,10 +648,6 @@ type Query {
 
   """
   Look up a transaction by ID.
-  
-  Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
@@ -1003,26 +951,14 @@ type Query {
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCards(
-    """
-    Sort gift cards.
-    
-    Added in Saleor 3.1.
-    """
+    """Sort gift cards."""
     sortBy: GiftCardSortingInput
 
-    """
-    Filtering options for gift cards.
-    
-    Added in Saleor 3.1.
-    """
+    """Filtering options for gift cards."""
     filter: GiftCardFilterInput
 
     """
     Search gift cards by email and name of user, who created or used the gift card, and by code.
-    
-    Added in Saleor 3.15.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     search: String
 
@@ -1046,16 +982,12 @@ type Query {
   """
   List of gift card currencies.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardCurrencies: [String!]! @doc(category: "Gift cards")
 
   """
   List of gift card tags.
-  
-  Added in Saleor 3.1.
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -1381,11 +1313,7 @@ type Query {
     """ID of the channel."""
     id: ID
 
-    """
-    Slug of the channel.
-    
-    Added in Saleor 3.6.
-    """
+    """Slug of the channel."""
     slug: String
   ): Channel @doc(category: "Channels")
 
@@ -3791,11 +3719,7 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
   """Warehouse company name."""
   companyName: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `Address.companyName` instead.")
 
-  """
-  Click and collect options: local, all or disabled.
-  
-  Added in Saleor 3.1.
-  """
+  """Click and collect options: local, all or disabled."""
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum!
 
   """Shipping zones supported by the warehouse."""
@@ -3842,11 +3766,7 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
     last: Int
   ): StockCountableConnection
 
-  """
-  External ID of this warehouse. 
-  
-  Added in Saleor 3.10.
-  """
+  """External ID of this warehouse."""
   externalReference: String
 }
 
@@ -4234,11 +4154,7 @@ type ShippingMethodTranslation implements Node @doc(category: "Shipping") {
   """
   description: JSONString
 
-  """
-  Represents the shipping method fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the shipping method fields to translate."""
   translatableContent: ShippingMethodTranslatableContent
 }
 
@@ -5039,11 +4955,7 @@ type ShippingMethodTranslatableContent implements Node @doc(category: "Shipping"
   """The ID of the shipping method translatable content."""
   id: ID!
 
-  """
-  The ID of the shipping method to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the shipping method to translate."""
   shippingMethodId: ID!
 
   """Shipping method name to translate."""
@@ -5093,11 +5005,7 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   """The ID of the channel."""
   id: ID!
 
-  """
-  List of private metadata items. Requires staff permissions to access.
-  
-  Added in Saleor 3.15.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
 
   """
@@ -5105,22 +5013,18 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
 
-  """
-  List of public metadata items. Can be accessed without permissions.
-  
-  Added in Saleor 3.15.
-  """
+  """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
 
   """
@@ -5128,14 +5032,14 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
 
@@ -5173,8 +5077,6 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   """
   Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   defaultCountry: CountryDisplay!
@@ -5182,30 +5084,18 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   """
   List of warehouses assigned to this channel.
   
-  Added in Saleor 3.5.
-  
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   warehouses: [Warehouse!]!
 
-  """
-  List of shippable countries for the channel.
-  
-  Added in Saleor 3.6.
-  """
+  """List of shippable countries for the channel."""
   countries: [CountryDisplay!]
 
-  """
-  Shipping methods that are available for the channel.
-  
-  Added in Saleor 3.6.
-  """
+  """Shipping methods that are available for the channel."""
   availableShippingMethodsPerCountry(countries: [CountryCode!]): [ShippingMethodsPerCountry!]
 
   """
   Define the stock setting for this channel.
-  
-  Added in Saleor 3.7.
   
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
@@ -5214,8 +5104,6 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   """
   Channel-specific order settings.
   
-  Added in Saleor 3.12.
-  
   Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_ORDERS.
   """
   orderSettings: OrderSettings!
@@ -5223,20 +5111,12 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   """
   Channel-specific checkout settings.
   
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_CHECKOUTS.
   """
   checkoutSettings: CheckoutSettings!
 
   """
   Channel-specific payment settings.
-  
-  Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_CHANNELS, HANDLE_PAYMENTS.
   """
@@ -5252,11 +5132,7 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   taxConfiguration: TaxConfiguration!
 }
 
-"""
-List of shipping methods available for the country.
-
-Added in Saleor 3.6.
-"""
+"""List of shipping methods available for the country."""
 type ShippingMethodsPerCountry @doc(category: "Shipping") {
   """The country code."""
   countryCode: CountryCode!
@@ -5624,11 +5500,7 @@ enum WeightUnitsEnum {
   TONNE
 }
 
-"""
-Represents the channel stock settings.
-
-Added in Saleor 3.7.
-"""
+"""Represents the channel stock settings."""
 type StockSettings @doc(category: "Products") {
   """
   Allocation strategy defines the preference of warehouses for allocations and reservations.
@@ -5663,10 +5535,6 @@ type OrderSettings {
 
   """
   Expiration time in minutes. Default null - means do not expire any orders.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   expireOrdersAfter: Minute
 
@@ -5674,28 +5542,14 @@ type OrderSettings {
   Determine what strategy will be used to mark the order as paid. Based on the chosen option, the proper object will be created and attached to the order when it's manually marked as paid.
   `PAYMENT_FLOW` - [default option] creates the `Payment` object.
   `TRANSACTION_FLOW` - creates the `TransactionItem` object.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   markAsPaidStrategy: MarkAsPaidStrategyEnum!
 
-  """
-  The time in days after expired orders will be deleted.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The time in days after expired orders will be deleted."""
   deleteExpiredOrdersAfter: Day!
 
   """
   Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   allowUnpaidOrders: Boolean!
 
@@ -5731,18 +5585,10 @@ enum MarkAsPaidStrategyEnum @doc(category: "Channels") {
 """The `Day` scalar type represents number of days by integer value."""
 scalar Day
 
-"""
-Represents the channel-specific checkout settings.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents the channel-specific checkout settings."""
 type CheckoutSettings {
   """
-  Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one.
-  
-  Added in Saleor 3.15.This field will be removed in Saleor 4.0.
+  Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one.This field will be removed in Saleor 4.0.
   """
   useLegacyErrorFlow: Boolean!
 
@@ -5758,10 +5604,6 @@ type CheckoutSettings {
 type PaymentSettings {
   """
   Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
-  
-  Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   defaultTransactionFlowStrategy: TransactionFlowStrategyEnum!
 }
@@ -5777,11 +5619,7 @@ enum TransactionFlowStrategyEnum @doc(category: "Payments") {
   CHARGE
 }
 
-"""
-Channel-specific tax configuration.
-
-Added in Saleor 3.9.
-"""
+"""Channel-specific tax configuration."""
 type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes") {
   """The ID of the object."""
   id: ID!
@@ -5857,11 +5695,7 @@ enum TaxCalculationStrategy @doc(category: "Taxes") {
   TAX_APP
 }
 
-"""
-Country-specific exceptions of a channel's tax configuration.
-
-Added in Saleor 3.9.
-"""
+"""Country-specific exceptions of a channel's tax configuration."""
 type TaxConfigurationPerCountry @doc(category: "Taxes") {
   """Country in which this configuration applies."""
   country: CountryDisplay!
@@ -6316,8 +6150,6 @@ type TaxType @doc(category: "Taxes") {
 
 """
 Tax class is a named object used to define tax rates per country. Tax class can be assigned to product types, products and shipping methods to define their tax rates.
-
-Added in Saleor 3.9.
 """
 type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
   """The ID of the object."""
@@ -6370,8 +6202,6 @@ type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
 
 """
 Tax rate for a country. When tax class is null, it represents the default tax rate for that country; otherwise it's a country tax rate specific to the given tax class.
-
-Added in Saleor 3.9.
 """
 type TaxClassCountryRate @doc(category: "Taxes") {
   """Country in which this tax rate applies."""
@@ -6721,11 +6551,7 @@ type AttributeValueTranslation implements Node @doc(category: "Attributes") {
   """Translated plain text attribute value ."""
   plainText: String
 
-  """
-  Represents the attribute value fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the attribute value fields to translate."""
   translatableContent: AttributeValueTranslatableContent
 }
 
@@ -6736,11 +6562,7 @@ type AttributeValueTranslatableContent implements Node @doc(category: "Attribute
   """The ID of the attribute value translatable content."""
   id: ID!
 
-  """
-  The ID of the attribute value to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the attribute value to translate."""
   attributeValueId: ID!
 
   """Name of the attribute value to translate."""
@@ -6765,11 +6587,7 @@ type AttributeValueTranslatableContent implements Node @doc(category: "Attribute
   """Represents a value of an attribute."""
   attributeValue: AttributeValue @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 
-  """
-  Associated attribute that can be translated.
-  
-  Added in Saleor 3.9.
-  """
+  """Associated attribute that can be translated."""
   attribute: AttributeTranslatableContent
 }
 
@@ -6780,11 +6598,7 @@ type AttributeTranslatableContent implements Node @doc(category: "Attributes") {
   """The ID of the attribute translatable content."""
   id: ID!
 
-  """
-  The ID of the attribute to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the attribute to translate."""
   attributeId: ID!
 
   """Name of the attribute to translate."""
@@ -6811,11 +6625,7 @@ type AttributeTranslation implements Node @doc(category: "Attributes") {
   """Translated attribute name."""
   name: String!
 
-  """
-  Represents the attribute fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the attribute fields to translate."""
   translatableContent: AttributeTranslatableContent
 }
 
@@ -7240,32 +7050,16 @@ input ProductFilterInput @doc(category: "Products") {
   search: String
   metadata: [MetadataFilter!]
 
-  """
-  Filter by the publication date. 
-  
-  Added in Saleor 3.8.
-  """
+  """Filter by the publication date."""
   publishedFrom: DateTime
 
-  """
-  Filter by availability for purchase. 
-  
-  Added in Saleor 3.8.
-  """
+  """Filter by availability for purchase."""
   isAvailable: Boolean
 
-  """
-  Filter by the date of availability for purchase. 
-  
-  Added in Saleor 3.8.
-  """
+  """Filter by the date of availability for purchase."""
   availableFrom: DateTime
 
-  """
-  Filter by visibility in product listings. 
-  
-  Added in Saleor 3.8.
-  """
+  """Filter by visibility in product listings."""
   isVisibleInListing: Boolean
   price: PriceRangeInput
 
@@ -7576,11 +7370,7 @@ enum ProductOrderField @doc(category: "Products") {
   """Sort products by rating."""
   RATING
 
-  """
-  Sort products by creation date.
-  
-  Added in Saleor 3.8.
-  """
+  """Sort products by creation date."""
   CREATED_AT
 }
 
@@ -7637,11 +7427,7 @@ type CategoryTranslation implements Node @doc(category: "Products") {
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
-  """
-  Represents the category fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the category fields to translate."""
   translatableContent: CategoryTranslatableContent
 }
 
@@ -7652,11 +7438,7 @@ type CategoryTranslatableContent implements Node @doc(category: "Products") {
   """The ID of the category translatable content."""
   id: ID!
 
-  """
-  The ID of the category to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the category to translate."""
   categoryId: ID!
 
   """SEO title to translate."""
@@ -8167,11 +7949,7 @@ type ProductVariantTranslation implements Node @doc(category: "Products") {
   """Translated product variant name."""
   name: String!
 
-  """
-  Represents the product variant fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the product variant fields to translate."""
   translatableContent: ProductVariantTranslatableContent
 }
 
@@ -8182,11 +7960,7 @@ type ProductVariantTranslatableContent implements Node @doc(category: "Products"
   """The ID of the product variant translatable content."""
   id: ID!
 
-  """
-  The ID of the product variant to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the product variant to translate."""
   productVariantId: ID!
 
   """Name of the product variant to translate."""
@@ -8645,11 +8419,7 @@ type CollectionTranslation implements Node @doc(category: "Products") {
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
-  """
-  Represents the collection fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the collection fields to translate."""
   translatableContent: CollectionTranslatableContent
 }
 
@@ -8660,11 +8430,7 @@ type CollectionTranslatableContent implements Node @doc(category: "Products") {
   """The ID of the collection translatable content."""
   id: ID!
 
-  """
-  The ID of the collection to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the collection to translate."""
   collectionId: ID!
 
   """SEO title to translate."""
@@ -8765,11 +8531,7 @@ type ProductTranslation implements Node @doc(category: "Products") {
   """
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 
-  """
-  Represents the product fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the product fields to translate."""
   translatableContent: ProductTranslatableContent
 }
 
@@ -8780,11 +8542,7 @@ type ProductTranslatableContent implements Node @doc(category: "Products") {
   """The ID of the product translatable content."""
   id: ID!
 
-  """
-  The ID of the product to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the product to translate."""
   productId: ID!
 
   """SEO title to translate."""
@@ -8913,11 +8671,7 @@ type PageTranslatableContent implements Node @doc(category: "Pages") {
   """The ID of the page translatable content."""
   id: ID!
 
-  """
-  The ID of the page to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the page to translate."""
   pageId: ID!
 
   """SEO title to translate."""
@@ -9003,11 +8757,7 @@ type PageTranslation implements Node @doc(category: "Pages") {
   """
   contentJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `content` field instead.")
 
-  """
-  Represents the page fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the page fields to translate."""
   translatableContent: PageTranslatableContent
 }
 
@@ -9073,11 +8823,7 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
   content: JSONString
   publicationDate: Date @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `publishedAt` field to fetch the publication date.")
 
-  """
-  The page publication date.
-  
-  Added in Saleor 3.3.
-  """
+  """The page publication date."""
   publishedAt: DateTime
 
   """Determines if the page is published."""
@@ -9204,11 +8950,7 @@ type VoucherTranslatableContent implements Node @doc(category: "Discounts") {
   """The ID of the voucher translatable content."""
   id: ID!
 
-  """
-  The ID of the voucher to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the voucher to translate."""
   voucherId: ID!
 
   """Voucher name to translate."""
@@ -9239,11 +8981,7 @@ type VoucherTranslation implements Node @doc(category: "Discounts") {
   """Translated voucher name."""
   name: String
 
-  """
-  Represents the voucher fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the voucher fields to translate."""
   translatableContent: VoucherTranslatableContent
 }
 
@@ -9590,11 +9328,7 @@ type MenuItemTranslatableContent implements Node @doc(category: "Menu") {
   """The ID of the menu item translatable content."""
   id: ID!
 
-  """
-  The ID of the menu item to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the menu item to translate."""
   menuItemId: ID!
 
   """Name of the menu item to translate."""
@@ -9623,11 +9357,7 @@ type MenuItemTranslation implements Node @doc(category: "Menu") {
   """Translated menu item name."""
   name: String!
 
-  """
-  Represents the menu item fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the menu item fields to translate."""
   translatableContent: MenuItemTranslatableContent
 }
 
@@ -9771,8 +9501,6 @@ type Menu implements Node & ObjectWithMetadata @doc(category: "Menu") {
 
 """
 Represents promotion's original translatable fields and related translations.
-
-Added in Saleor 3.17.
 """
 type PromotionTranslatableContent implements Node @doc(category: "Discounts") {
   """ID of the promotion translatable content."""
@@ -9798,11 +9526,7 @@ type PromotionTranslatableContent implements Node @doc(category: "Discounts") {
   ): PromotionTranslation
 }
 
-"""
-Represents promotion translations.
-
-Added in Saleor 3.17.
-"""
+"""Represents promotion translations."""
 type PromotionTranslation implements Node @doc(category: "Discounts") {
   """ID of the promotion translation."""
   id: ID!
@@ -9820,28 +9544,18 @@ type PromotionTranslation implements Node @doc(category: "Discounts") {
   """
   description: JSONString
 
-  """
-  Represents the promotion fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the promotion fields to translate."""
   translatableContent: PromotionTranslatableContent
 }
 
 """
 Represents promotion rule's original translatable fields and related translations.
-
-Added in Saleor 3.17.
 """
 type PromotionRuleTranslatableContent implements Node @doc(category: "Discounts") {
   """ID of the promotion rule translatable content."""
   id: ID!
 
-  """
-  ID of the promotion rule to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """ID of the promotion rule to translate."""
   promotionRuleId: ID!
 
   """Name of the promotion rule."""
@@ -9861,11 +9575,7 @@ type PromotionRuleTranslatableContent implements Node @doc(category: "Discounts"
   ): PromotionRuleTranslation
 }
 
-"""
-Represents promotion rule translations.
-
-Added in Saleor 3.17.
-"""
+"""Represents promotion rule translations."""
 type PromotionRuleTranslation implements Node @doc(category: "Discounts") {
   """ID of the promotion rule translation."""
   id: ID!
@@ -9883,11 +9593,7 @@ type PromotionRuleTranslation implements Node @doc(category: "Discounts") {
   """
   description: JSONString
 
-  """
-  Represents the promotion rule fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the promotion rule fields to translate."""
   translatableContent: PromotionRuleTranslatableContent
 }
 
@@ -9900,11 +9606,7 @@ type SaleTranslatableContent implements Node @doc(category: "Discounts") {
   """The ID of the sale translatable content."""
   id: ID!
 
-  """
-  The ID of the sale to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """The ID of the sale to translate."""
   saleId: ID!
 
   """Name of the sale to translate."""
@@ -9939,11 +9641,7 @@ type SaleTranslation implements Node @doc(category: "Discounts") {
   """Translated name of sale."""
   name: String
 
-  """
-  Represents the sale fields to translate.
-  
-  Added in Saleor 3.14.
-  """
+  """Represents the sale fields to translate."""
   translatableContent: SaleTranslatableContent
 }
 
@@ -10218,11 +9916,7 @@ input TaxClassFilterInput @doc(category: "Taxes") {
   countries: [CountryCode!]
 }
 
-"""
-Tax class rates grouped by country.
-
-Added in Saleor 3.9.
-"""
+"""Tax class rates grouped by country."""
 type TaxCountryConfiguration @doc(category: "Taxes") {
   """A country for which tax class rates are grouped."""
   country: CountryDisplay!
@@ -10301,8 +9995,6 @@ type Shop implements ObjectWithMetadata {
   """
   List of all currencies supported by shop's channels.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   channelCurrencies: [String!]!
@@ -10358,18 +10050,10 @@ type Shop implements ObjectWithMetadata {
   """Header text."""
   headerText: String
 
-  """
-  Automatically approve all new fulfillments.
-  
-  Added in Saleor 3.1.
-  """
+  """Automatically approve all new fulfillments."""
   fulfillmentAutoApprove: Boolean!
 
-  """
-  Allow to approve fulfillments which are unpaid.
-  
-  Added in Saleor 3.1.
-  """
+  """Allow to approve fulfillments which are unpaid."""
   fulfillmentAllowUnpaid: Boolean!
 
   """
@@ -10396,8 +10080,6 @@ type Shop implements ObjectWithMetadata {
   """
   Default number of minutes stock will be reserved for anonymous checkout or null when stock reservation is disabled.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   reserveStockDurationAnonymousUser: Int
@@ -10405,16 +10087,12 @@ type Shop implements ObjectWithMetadata {
   """
   Default number of minutes stock will be reserved for authenticated checkout or null when stock reservation is disabled.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   reserveStockDurationAuthenticatedUser: Int
 
   """
   Default number of maximum line quantity in single checkout (per single checkout line).
-  
-  Added in Saleor 3.1.
   
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
@@ -10450,16 +10128,12 @@ type Shop implements ObjectWithMetadata {
   """
   Determines if account confirmation by email is enabled.
   
-  Added in Saleor 3.14.
-  
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   enableAccountConfirmationByEmail: Boolean
 
   """
   Determines if user can login without confirmation when `enableAccountConfirmation` is enabled.
-  
-  Added in Saleor 3.15.
   
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
@@ -10479,11 +10153,7 @@ type Shop implements ObjectWithMetadata {
   """
   version: String!
 
-  """
-  Minor Saleor API version.
-  
-  Added in Saleor 3.5.
-  """
+  """Minor Saleor API version."""
   schemaVersion: String!
 
   """
@@ -11148,34 +10818,20 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   """Date and time when gift card was created."""
   created: DateTime!
 
-  """
-  The user who bought or issued a gift card.
-  
-  Added in Saleor 3.1.
-  """
+  """The user who bought or issued a gift card."""
   createdBy: User
 
-  """
-  The customer who used a gift card.
-  
-  Added in Saleor 3.1.
-  """
+  """The customer who used a gift card."""
   usedBy: User @deprecated(reason: "This field will be removed in Saleor 4.0.")
 
   """
   Email address of the user who bought or issued gift card.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: MANAGE_USERS, OWNER.
   """
   createdByEmail: String
 
-  """
-  Email address of the customer who used a gift card.
-  
-  Added in Saleor 3.1.
-  """
+  """Email address of the customer who used a gift card."""
   usedByEmail: String @deprecated(reason: "This field will be removed in Saleor 4.0.")
 
   """Date and time when gift card was last used."""
@@ -11187,23 +10843,15 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   """
   App which created the gift card.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   app: App
 
-  """
-  Related gift card product.
-  
-  Added in Saleor 3.1.
-  """
+  """Related gift card product."""
   product: Product
 
   """
   List of events associated with the gift card.
-  
-  Added in Saleor 3.1.
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -11215,17 +10863,11 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   """
   The gift card tag.
   
-  Added in Saleor 3.1.
-  
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   tags: [GiftCardTag!]!
 
-  """
-  Slug of the channel where the gift card was bought.
-  
-  Added in Saleor 3.1.
-  """
+  """Slug of the channel where the gift card was bought."""
   boughtInChannel: String
   isActive: Boolean!
   initialBalance: Money!
@@ -11241,11 +10883,7 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   startDate: DateTime @deprecated(reason: "This field will be removed in Saleor 4.0.")
 }
 
-"""
-History log of the gift card.
-
-Added in Saleor 3.1.
-"""
+"""History log of the gift card."""
 type GiftCardEvent implements Node @doc(category: "Gift cards") {
   """ID of the event associated with a gift card."""
   id: ID!
@@ -11328,11 +10966,7 @@ input GiftCardEventFilterInput @doc(category: "Gift cards") {
   orders: [ID!]
 }
 
-"""
-The gift card tag.
-
-Added in Saleor 3.1.
-"""
+"""The gift card tag."""
 type GiftCardTag implements Node @doc(category: "Gift cards") {
   """ID of the tag associated with a gift card."""
   id: ID!
@@ -11458,13 +11092,7 @@ Represents a delivery method chosen for the checkout. `Warehouse` type is used w
 """
 union DeliveryMethod = Warehouse | ShippingMethod
 
-"""
-Represents a payment transaction.
-
-Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents a payment transaction."""
 type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Payments") {
   """The ID of the object."""
   id: ID!
@@ -11507,11 +11135,7 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   """
   metafields(keys: [String!]): Metadata
 
-  """
-  The transaction token.
-  
-  Added in Saleor 3.14.
-  """
+  """The transaction token."""
   token: UUID!
 
   """Date and time at which payment transaction was created."""
@@ -11528,96 +11152,50 @@ type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Paymen
   """Total amount authorized for this payment."""
   authorizedAmount: Money!
 
-  """
-  Total amount of ongoing authorization requests for the transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """Total amount of ongoing authorization requests for the transaction."""
   authorizePendingAmount: Money!
 
   """Total amount refunded for this payment."""
   refundedAmount: Money!
 
-  """
-  Total amount of ongoing refund requests for the transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """Total amount of ongoing refund requests for the transaction."""
   refundPendingAmount: Money!
 
-  """
-  Total amount canceled for this payment.
-  
-  Added in Saleor 3.13.
-  """
+  """Total amount canceled for this payment."""
   canceledAmount: Money!
 
-  """
-  Total amount of ongoing cancel requests for the transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """Total amount of ongoing cancel requests for the transaction."""
   cancelPendingAmount: Money!
 
   """Total amount charged for this payment."""
   chargedAmount: Money!
 
-  """
-  Total amount of ongoing charge requests for the transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """Total amount of ongoing charge requests for the transaction."""
   chargePendingAmount: Money!
 
-  """
-  Name of the transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """Name of the transaction."""
   name: String!
 
-  """
-  Message related to the transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """Message related to the transaction."""
   message: String!
 
-  """
-  PSP reference of transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """PSP reference of transaction."""
   pspReference: String!
 
-  """
-  The related order.
-  
-  Added in Saleor 3.6.
-  """
+  """The related order."""
   order: Order
 
-  """
-  The related checkout.
-  
-  Added in Saleor 3.14.
-  """
+  """The related checkout."""
   checkout: Checkout
 
   """List of all transaction's events."""
   events: [TransactionEvent!]!
 
-  """
-  User or App that created the transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """User or App that created the transaction."""
   createdBy: UserOrApp
 
   """
   The url that will allow to redirect user to payment provider page with transaction details.
-  
-  Added in Saleor 3.13.
   """
   externalUrl: String!
 }
@@ -12344,11 +11922,7 @@ type Invoice implements ObjectWithMetadata & Job & Node @doc(category: "Orders")
   """URL to view/download an invoice."""
   url: String
 
-  """
-  Order related to the invoice.
-  
-  Added in Saleor 3.10.
-  """
+  """Order related to the invoice."""
   order: Order
 }
 
@@ -12554,18 +12128,10 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
   """The details of the card used for this payment."""
   creditCard: CreditCard
 
-  """
-  Informs whether this is a partial payment.
-  
-  Added in Saleor 3.14.
-  """
+  """Informs whether this is a partial payment."""
   partial: Boolean!
 
-  """
-  PSP reference of the payment.
-  
-  Added in Saleor 3.14.
-  """
+  """PSP reference of the payment."""
   pspReference: String
 }
 
@@ -13011,53 +12577,27 @@ type TransactionEvent implements Node @doc(category: "Payments") {
   """Date and time at which a transaction event was created."""
   createdAt: DateTime!
 
-  """
-  PSP reference of transaction.
-  
-  Added in Saleor 3.13.
-  """
+  """PSP reference of transaction."""
   pspReference: String!
 
-  """
-  Message related to the transaction's event.
-  
-  Added in Saleor 3.13.
-  """
+  """Message related to the transaction's event."""
   message: String!
 
   """
   The url that will allow to redirect user to payment provider page with transaction details.
-  
-  Added in Saleor 3.13.
   """
   externalUrl: String!
 
-  """
-  The amount related to this event.
-  
-  Added in Saleor 3.13.
-  """
+  """The amount related to this event."""
   amount: Money!
 
-  """
-  The type of action related to this event.
-  
-  Added in Saleor 3.13.
-  """
+  """The type of action related to this event."""
   type: TransactionEventTypeEnum
 
-  """
-  User or App that created the transaction event.
-  
-  Added in Saleor 3.13.
-  """
+  """User or App that created the transaction event."""
   createdBy: UserOrApp
 
-  """
-  Idempotency key assigned to the event.
-  
-  Added in Saleor 3.14.
-  """
+  """Idempotency key assigned to the event."""
   idempotencyKey: String
 }
 
@@ -13156,10 +12696,6 @@ enum CheckoutChargeStatusEnum @doc(category: "Checkout") {
 
 """
 Represents a payment method stored for user (tokenized) in payment gateway.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type StoredPaymentMethod @doc(category: "Payments") {
   """Stored payment method ID."""
@@ -13377,8 +12913,6 @@ type PaymentSource @doc(category: "Payments") {
   """
   List of public metadata items.
   
-  Added in Saleor 3.1.
-  
   Can be accessed without permissions.
   """
   metadata: [MetadataItem!]!
@@ -13468,11 +13002,7 @@ input CategoryFilterInput @doc(category: "Products") {
   ids: [ID!]
   slugs: [String!]
 
-  """
-  Filter by when was the most recent update. 
-  
-  Added in Saleor 3.17.
-  """
+  """Filter by when was the most recent update."""
   updatedAt: DateTimeRangeInput
 }
 
@@ -13677,11 +13207,7 @@ type PaymentCountableEdge @doc(category: "Payments") {
 }
 
 input PaymentFilterInput @doc(category: "Payments") {
-  """
-  Filter by ids. 
-  
-  Added in Saleor 3.8.
-  """
+  """Filter by ids."""
   ids: [ID!]
   checkouts: [ID!]
 }
@@ -13989,11 +13515,7 @@ enum GiftCardSortField @doc(category: "Gift cards") {
   """Sort gift cards by current balance."""
   CURRENT_BALANCE
 
-  """
-  Sort gift cards by created at.
-  
-  Added in Saleor 3.8.
-  """
+  """Sort gift cards by created at."""
   CREATED_AT
 }
 
@@ -20527,11 +20049,7 @@ input WarehouseCreateInput @doc(category: "Products") {
   """The email address of the warehouse."""
   email: String
 
-  """
-  External ID of the warehouse.
-  
-  Added in Saleor 3.10.
-  """
+  """External ID of the warehouse."""
   externalReference: String
 
   """Warehouse name."""
@@ -20566,11 +20084,7 @@ input WarehouseUpdateInput @doc(category: "Products") {
   """The email address of the warehouse."""
   email: String
 
-  """
-  External ID of the warehouse.
-  
-  Added in Saleor 3.10.
-  """
+  """External ID of the warehouse."""
   externalReference: String
 
   """Warehouse name."""
@@ -20579,18 +20093,10 @@ input WarehouseUpdateInput @doc(category: "Products") {
   """Address of the warehouse."""
   address: AddressInput
 
-  """
-  Click and collect options: local, all or disabled.
-  
-  Added in Saleor 3.1.
-  """
+  """Click and collect options: local, all or disabled."""
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum
 
-  """
-  Visibility of warehouse stocks.
-  
-  Added in Saleor 3.1.
-  """
+  """Visibility of warehouse stocks."""
   isPrivate: Boolean
 }
 

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -22,7 +22,7 @@ from ..channel.types import (
 )
 from ..core.connection import CountableConnection, create_connection_slice
 from ..core.context import get_database_connection_name
-from ..core.descriptions import ADDED_IN_36, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.doc_category import DOC_CATEGORY_SHIPPING
 from ..core.fields import ConnectionField, JSONString, PermissionsField
 from ..core.tracing import traced_resolver
@@ -433,6 +433,4 @@ class ShippingMethodsPerCountry(BaseObjectType):
 
     class Meta:
         doc_category = DOC_CATEGORY_SHIPPING
-        description = (
-            "List of shipping methods available for the country." + ADDED_IN_36
-        )
+        description = "List of shipping methods available for the country."

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -186,7 +186,7 @@ class Shop(graphene.ObjectType):
     )
     channel_currencies = PermissionsField(
         NonNullList(graphene.String),
-        description=("List of all currencies supported by shop's channels."),
+        description="List of all currencies supported by shop's channels.",
         required=True,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
@@ -307,7 +307,7 @@ class Shop(graphene.ObjectType):
     )
     enable_account_confirmation_by_email = PermissionsField(
         graphene.Boolean,
-        description=("Determines if account confirmation by email is enabled."),
+        description="Determines if account confirmation by email is enabled.",
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )
     allow_login_without_confirmation = PermissionsField(

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -19,10 +19,6 @@ from ..app.types import App
 from ..core import ResolveInfo
 from ..core.context import get_database_connection_name
 from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_35,
-    ADDED_IN_314,
-    ADDED_IN_315,
     ADDED_IN_319,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
@@ -190,9 +186,7 @@ class Shop(graphene.ObjectType):
     )
     channel_currencies = PermissionsField(
         NonNullList(graphene.String),
-        description=(
-            "List of all currencies supported by shop's channels." + ADDED_IN_31
-        ),
+        description=("List of all currencies supported by shop's channels."),
         required=True,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
@@ -244,11 +238,11 @@ class Shop(graphene.ObjectType):
     )
     header_text = graphene.String(description="Header text.")
     fulfillment_auto_approve = graphene.Boolean(
-        description="Automatically approve all new fulfillments." + ADDED_IN_31,
+        description="Automatically approve all new fulfillments.",
         required=True,
     )
     fulfillment_allow_unpaid = graphene.Boolean(
-        description="Allow to approve fulfillments which are unpaid." + ADDED_IN_31,
+        description="Allow to approve fulfillments which are unpaid.",
         required=True,
     )
     track_inventory_by_default = graphene.Boolean(
@@ -269,7 +263,6 @@ class Shop(graphene.ObjectType):
         description=(
             "Default number of minutes stock will be reserved for "
             "anonymous checkout or null when stock reservation is disabled."
-            + ADDED_IN_31
         ),
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )
@@ -278,7 +271,6 @@ class Shop(graphene.ObjectType):
         description=(
             "Default number of minutes stock will be reserved for "
             "authenticated checkout or null when stock reservation is disabled."
-            + ADDED_IN_31
         ),
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )
@@ -286,7 +278,7 @@ class Shop(graphene.ObjectType):
         graphene.Int,
         description=(
             "Default number of maximum line quantity in single checkout "
-            "(per single checkout line)." + ADDED_IN_31
+            "(per single checkout line)."
         ),
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )
@@ -315,16 +307,14 @@ class Shop(graphene.ObjectType):
     )
     enable_account_confirmation_by_email = PermissionsField(
         graphene.Boolean,
-        description=(
-            "Determines if account confirmation by email is enabled." + ADDED_IN_314
-        ),
+        description=("Determines if account confirmation by email is enabled."),
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )
     allow_login_without_confirmation = PermissionsField(
         graphene.Boolean,
         description=(
             "Determines if user can login without confirmation when "
-            "`enableAccountConfirmation` is enabled." + ADDED_IN_315
+            "`enableAccountConfirmation` is enabled."
         ),
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )
@@ -345,7 +335,7 @@ class Shop(graphene.ObjectType):
         ],
     )
     schema_version = graphene.String(
-        description="Minor Saleor API version." + ADDED_IN_35,
+        description="Minor Saleor API version.",
         required=True,
     )
     available_tax_apps = PermissionsField(

--- a/saleor/graphql/tax/schema.py
+++ b/saleor/graphql/tax/schema.py
@@ -9,7 +9,6 @@ from ..account.enums import CountryCodeEnum
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.context import get_database_connection_name
-from ..core.descriptions import ADDED_IN_39
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import NonNullList
@@ -37,7 +36,7 @@ from .types import (
 class TaxQueries(graphene.ObjectType):
     tax_configuration = PermissionsField(
         TaxConfiguration,
-        description="Look up a tax configuration." + ADDED_IN_39,
+        description="Look up a tax configuration.",
         id=graphene.Argument(
             graphene.ID, description="ID of a tax configuration.", required=True
         ),
@@ -49,7 +48,7 @@ class TaxQueries(graphene.ObjectType):
     )
     tax_configurations = FilterConnectionField(
         TaxConfigurationCountableConnection,
-        description="List of tax configurations." + ADDED_IN_39,
+        description="List of tax configurations.",
         filter=TaxConfigurationFilterInput(
             description="Filtering options for tax configurations."
         ),
@@ -61,7 +60,7 @@ class TaxQueries(graphene.ObjectType):
     )
     tax_class = PermissionsField(
         TaxClass,
-        description="Look up a tax class." + ADDED_IN_39,
+        description="Look up a tax class.",
         id=graphene.Argument(
             graphene.ID, description="ID of a tax class.", required=True
         ),
@@ -73,7 +72,7 @@ class TaxQueries(graphene.ObjectType):
     )
     tax_classes = FilterConnectionField(
         TaxClassCountableConnection,
-        description="List of tax classes." + ADDED_IN_39,
+        description="List of tax classes.",
         sort_by=TaxClassSortingInput(description="Sort tax classes."),
         filter=TaxClassFilterInput(description="Filtering options for tax classes."),
         permissions=[

--- a/saleor/graphql/tax/types.py
+++ b/saleor/graphql/tax/types.py
@@ -5,7 +5,7 @@ from ..channel.dataloaders import ChannelByIdLoader
 from ..channel.types import Channel
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
-from ..core.descriptions import ADDED_IN_39, ADDED_IN_319
+from ..core.descriptions import ADDED_IN_319
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.types import BaseObjectType, CountryDisplay, ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
@@ -63,7 +63,7 @@ class TaxConfiguration(ModelObjectType[models.TaxConfiguration]):
     )
 
     class Meta:
-        description = "Channel-specific tax configuration." + ADDED_IN_39
+        description = "Channel-specific tax configuration."
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
         model = models.TaxConfiguration
 
@@ -119,10 +119,7 @@ class TaxConfigurationPerCountry(ModelObjectType[models.TaxConfigurationPerCount
     )
 
     class Meta:
-        description = (
-            "Country-specific exceptions of a channel's tax configuration."
-            + ADDED_IN_39
-        )
+        description = "Country-specific exceptions of a channel's tax configuration."
         interface = [graphene.relay.Node]
         model = models.TaxConfigurationPerCountry
 
@@ -143,7 +140,7 @@ class TaxClass(ModelObjectType[models.TaxClass]):
         description = (
             "Tax class is a named object used to define tax rates per country. Tax "
             "class can be assigned to product types, products and shipping methods to "
-            "define their tax rates." + ADDED_IN_39
+            "define their tax rates."
         )
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
         model = models.TaxClass
@@ -174,7 +171,7 @@ class TaxClassCountryRate(ModelObjectType[models.TaxClassCountryRate]):
         description = (
             "Tax rate for a country. When tax class is null, it represents the default "
             "tax rate for that country; otherwise it's a country tax rate specific to "
-            "the given tax class." + ADDED_IN_39
+            "the given tax class."
         )
         model = models.TaxClassCountryRate
 
@@ -202,7 +199,7 @@ class TaxCountryConfiguration(BaseObjectType):
     )
 
     class Meta:
-        description = "Tax class rates grouped by country." + ADDED_IN_39
+        description = "Tax class rates grouped by country."
         doc_category = DOC_CATEGORY_TAXES
 
     @staticmethod

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -23,9 +23,6 @@ from ..attribute.dataloaders import AttributesByAttributeId, AttributeValueByIdL
 from ..channel import ChannelContext
 from ..core.context import get_database_connection_name
 from ..core.descriptions import (
-    ADDED_IN_39,
-    ADDED_IN_314,
-    ADDED_IN_317,
     ADDED_IN_321,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_TYPE,
@@ -116,8 +113,7 @@ class AttributeValueTranslation(
     plain_text = graphene.String(description="Translated plain text attribute value .")
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.AttributeValueTranslatableContent",
-        description="Represents the attribute value fields to translate."
-        + ADDED_IN_314,
+        description="Represents the attribute value fields to translate.",
     )
 
     class Meta:
@@ -139,7 +135,7 @@ class AttributeTranslation(BaseTranslationType[attribute_models.AttributeTransla
     name = graphene.String(required=True, description="Translated attribute name.")
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.AttributeTranslatableContent",
-        description="Represents the attribute fields to translate." + ADDED_IN_314,
+        description="Represents the attribute fields to translate.",
     )
 
     class Meta:
@@ -157,8 +153,7 @@ class AttributeTranslatableContent(ModelObjectType[attribute_models.Attribute]):
         required=True, description="The ID of the attribute translatable content."
     )
     attribute_id = graphene.ID(
-        required=True,
-        description="The ID of the attribute to translate." + ADDED_IN_314,
+        required=True, description="The ID of the attribute to translate."
     )
     name = graphene.String(
         required=True, description="Name of the attribute to translate."
@@ -197,7 +192,7 @@ class AttributeValueTranslatableContent(
     )
     attribute_value_id = graphene.ID(
         required=True,
-        description="The ID of the attribute value to translate." + ADDED_IN_314,
+        description="The ID of the attribute value to translate.",
     )
     name = graphene.String(
         required=True,
@@ -217,7 +212,7 @@ class AttributeValueTranslatableContent(
     )
     attribute = graphene.Field(
         AttributeTranslatableContent,
-        description="Associated attribute that can be translated." + ADDED_IN_39,
+        description="Associated attribute that can be translated.",
     )
 
     class Meta:
@@ -252,8 +247,7 @@ class ProductVariantTranslation(
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.ProductVariantTranslatableContent",
-        description="Represents the product variant fields to translate."
-        + ADDED_IN_314,
+        description="Represents the product variant fields to translate.",
     )
 
     class Meta:
@@ -273,8 +267,7 @@ class ProductVariantTranslatableContent(ModelObjectType[product_models.ProductVa
         required=True, description="The ID of the product variant translatable content."
     )
     product_variant_id = graphene.ID(
-        required=True,
-        description="The ID of the product variant to translate." + ADDED_IN_314,
+        required=True, description="The ID of the product variant to translate."
     )
     name = graphene.String(
         required=True,
@@ -342,7 +335,7 @@ class ProductTranslation(BaseTranslationType[product_models.ProductTranslation])
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.ProductTranslatableContent",
-        description="Represents the product fields to translate." + ADDED_IN_314,
+        description="Represents the product fields to translate.",
     )
 
     class Meta:
@@ -366,7 +359,7 @@ class ProductTranslatableContent(ModelObjectType[product_models.Product]):
     )
     product_id = graphene.ID(
         required=True,
-        description="The ID of the product to translate." + ADDED_IN_314,
+        description="The ID of the product to translate.",
     )
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
@@ -456,7 +449,7 @@ class CollectionTranslation(BaseTranslationType[product_models.CollectionTransla
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.CollectionTranslatableContent",
-        description="Represents the collection fields to translate." + ADDED_IN_314,
+        description="Represents the collection fields to translate.",
     )
 
     class Meta:
@@ -479,8 +472,7 @@ class CollectionTranslatableContent(ModelObjectType[product_models.Collection]):
         required=True, description="The ID of the collection translatable content."
     )
     collection_id = graphene.ID(
-        required=True,
-        description="The ID of the collection to translate." + ADDED_IN_314,
+        required=True, description="The ID of the collection to translate."
     )
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
@@ -555,7 +547,7 @@ class CategoryTranslation(BaseTranslationType[product_models.CategoryTranslation
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.CategoryTranslatableContent",
-        description="Represents the category fields to translate." + ADDED_IN_314,
+        description="Represents the category fields to translate.",
     )
 
     class Meta:
@@ -579,7 +571,7 @@ class CategoryTranslatableContent(ModelObjectType[product_models.Category]):
     )
     category_id = graphene.ID(
         required=True,
-        description="The ID of the category to translate." + ADDED_IN_314,
+        description="The ID of the category to translate.",
     )
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
@@ -639,7 +631,7 @@ class PageTranslation(BaseTranslationType[page_models.PageTranslation]):
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.PageTranslatableContent",
-        description="Represents the page fields to translate." + ADDED_IN_314,
+        description="Represents the page fields to translate.",
     )
 
     class Meta:
@@ -661,9 +653,7 @@ class PageTranslatableContent(ModelObjectType[page_models.Page]):
     id = graphene.GlobalID(
         required=True, description="The ID of the page translatable content."
     )
-    page_id = graphene.ID(
-        required=True, description="The ID of the page to translate." + ADDED_IN_314
-    )
+    page_id = graphene.ID(required=True, description="The ID of the page to translate.")
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
     slug = graphene.String(description="Slug to translate." + ADDED_IN_321)
@@ -743,7 +733,7 @@ class VoucherTranslation(BaseTranslationType[discount_models.VoucherTranslation]
     name = graphene.String(description="Translated voucher name.")
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.VoucherTranslatableContent",
-        description="Represents the voucher fields to translate." + ADDED_IN_314,
+        description="Represents the voucher fields to translate.",
     )
 
     class Meta:
@@ -761,8 +751,7 @@ class VoucherTranslatableContent(ModelObjectType[discount_models.Voucher]):
         required=True, description="The ID of the voucher translatable content."
     )
     voucher_id = graphene.ID(
-        required=True,
-        description="The ID of the voucher to translate." + ADDED_IN_314,
+        required=True, description="The ID of the voucher to translate."
     )
     name = graphene.String(description="Voucher name to translate.")
     translation = TranslationField(VoucherTranslation, type_name="voucher")
@@ -801,7 +790,7 @@ class SaleTranslation(BaseTranslationType[discount_models.PromotionTranslation])
     name = graphene.String(description="Translated name of sale.")
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.SaleTranslatableContent",
-        description="Represents the sale fields to translate." + ADDED_IN_314,
+        description="Represents the sale fields to translate.",
     )
 
     class Meta:
@@ -822,10 +811,7 @@ class SaleTranslatableContent(ModelObjectType[discount_models.Promotion]):
     id = graphene.GlobalID(
         required=True, description="The ID of the sale translatable content."
     )
-    sale_id = graphene.ID(
-        required=True,
-        description="The ID of the sale to translate." + ADDED_IN_314,
-    )
+    sale_id = graphene.ID(required=True, description="The ID of the sale to translate.")
     name = graphene.String(required=True, description="Name of the sale to translate.")
     translation = TranslationField(SaleTranslation, type_name="sale")
     sale = PermissionsField(
@@ -880,7 +866,7 @@ class MenuItemTranslation(BaseTranslationType[menu_models.MenuItemTranslation]):
     name = graphene.String(required=True, description="Translated menu item name.")
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.MenuItemTranslatableContent",
-        description="Represents the menu item fields to translate." + ADDED_IN_314,
+        description="Represents the menu item fields to translate.",
     )
 
     class Meta:
@@ -898,8 +884,7 @@ class MenuItemTranslatableContent(ModelObjectType[menu_models.MenuItem]):
         required=True, description="The ID of the menu item translatable content."
     )
     menu_item_id = graphene.ID(
-        required=True,
-        description="The ID of the menu item to translate." + ADDED_IN_314,
+        required=True, description="The ID of the menu item to translate."
     )
     name = graphene.String(
         required=True, description="Name of the menu item to translate."
@@ -945,8 +930,7 @@ class ShippingMethodTranslation(
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.ShippingMethodTranslatableContent",
-        description="Represents the shipping method fields to translate."
-        + ADDED_IN_314,
+        description="Represents the shipping method fields to translate.",
     )
 
     class Meta:
@@ -968,8 +952,7 @@ class ShippingMethodTranslatableContent(
         required=True, description="The ID of the shipping method translatable content."
     )
     shipping_method_id = graphene.ID(
-        required=True,
-        description="The ID of the shipping method to translate." + ADDED_IN_314,
+        required=True, description="The ID of the shipping method to translate."
     )
     name = graphene.String(
         required=True, description="Shipping method name to translate."
@@ -1021,13 +1004,13 @@ class PromotionTranslation(BaseTranslationType[discount_models.PromotionTranslat
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.PromotionTranslatableContent",
-        description="Represents the promotion fields to translate." + ADDED_IN_314,
+        description="Represents the promotion fields to translate.",
     )
 
     class Meta:
         model = discount_models.Promotion
         interfaces = [graphene.relay.Node]
-        description = "Represents promotion translations." + ADDED_IN_317
+        description = "Represents promotion translations."
 
     @staticmethod
     def resolve_translatable_content(root: discount_models.PromotionTranslation, info):
@@ -1050,7 +1033,7 @@ class PromotionTranslatableContent(ModelObjectType[discount_models.Promotion]):
         interfaces = [graphene.relay.Node]
         description = (
             "Represents promotion's original translatable fields "
-            "and related translations." + ADDED_IN_317
+            "and related translations."
         )
 
     @staticmethod
@@ -1070,13 +1053,13 @@ class PromotionRuleTranslation(
     )
     translatable_content = graphene.Field(
         "saleor.graphql.translations.types.PromotionRuleTranslatableContent",
-        description="Represents the promotion rule fields to translate." + ADDED_IN_314,
+        description="Represents the promotion rule fields to translate.",
     )
 
     class Meta:
         model = discount_models.PromotionRule
         interfaces = [graphene.relay.Node]
-        description = "Represents promotion rule translations." + ADDED_IN_317
+        description = "Represents promotion rule translations."
 
     @staticmethod
     def resolve_translatable_content(
@@ -1090,8 +1073,7 @@ class PromotionRuleTranslatableContent(ModelObjectType[discount_models.Promotion
         required=True, description="ID of the promotion rule translatable content."
     )
     promotion_rule_id = graphene.ID(
-        required=True,
-        description="ID of the promotion rule to translate." + ADDED_IN_314,
+        required=True, description="ID of the promotion rule to translate."
     )
     name = graphene.String(description="Name of the promotion rule.")
     description = JSONString(
@@ -1104,7 +1086,7 @@ class PromotionRuleTranslatableContent(ModelObjectType[discount_models.Promotion
         interfaces = [graphene.relay.Node]
         description = (
             "Represents promotion rule's original translatable fields "
-            "and related translations." + ADDED_IN_317
+            "and related translations."
         )
 
     @staticmethod

--- a/saleor/graphql/warehouse/schema.py
+++ b/saleor/graphql/warehouse/schema.py
@@ -8,7 +8,6 @@ from ...permission.enums import (
 from ...warehouse import models
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_310
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.utils import from_global_id_or_error
@@ -38,7 +37,7 @@ class WarehouseQueries(graphene.ObjectType):
         description="Look up a warehouse by ID.",
         id=graphene.Argument(graphene.ID, description="ID of a warehouse."),
         external_reference=graphene.Argument(
-            graphene.String, description=f"External ID of a warehouse. {ADDED_IN_310}"
+            graphene.String, description="External ID of a warehouse."
         ),
         permissions=[
             ProductPermissions.MANAGE_PRODUCTS,

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -12,8 +12,6 @@ from ..core import ResolveInfo
 from ..core.connection import CountableConnection, create_connection_slice
 from ..core.context import get_database_connection_name
 from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_310,
     ADDED_IN_320,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
@@ -37,7 +35,7 @@ class WarehouseInput(BaseInputObjectType):
     slug = graphene.String(description="Warehouse slug.")
     email = graphene.String(description="The email address of the warehouse.")
     external_reference = graphene.String(
-        description="External ID of the warehouse." + ADDED_IN_310, required=False
+        description="External ID of the warehouse.", required=False
     )
 
     class Meta:
@@ -70,13 +68,11 @@ class WarehouseUpdateInput(WarehouseInput):
         required=False,
     )
     click_and_collect_option = WarehouseClickAndCollectOptionEnum(
-        description=(
-            "Click and collect options: local, all or disabled." + ADDED_IN_31
-        ),
+        description=("Click and collect options: local, all or disabled."),
         required=False,
     )
     is_private = graphene.Boolean(
-        description="Visibility of warehouse stocks." + ADDED_IN_31,
+        description="Visibility of warehouse stocks.",
         required=False,
     )
 
@@ -105,9 +101,7 @@ class Warehouse(ModelObjectType[models.Warehouse]):
         ),
     )
     click_and_collect_option = WarehouseClickAndCollectOptionEnum(
-        description=(
-            "Click and collect options: local, all or disabled." + ADDED_IN_31
-        ),
+        description=("Click and collect options: local, all or disabled."),
         required=True,
     )
     shipping_zones = ConnectionField(
@@ -124,7 +118,7 @@ class Warehouse(ModelObjectType[models.Warehouse]):
         ],
     )
     external_reference = graphene.String(
-        description=f"External ID of this warehouse. {ADDED_IN_310}", required=False
+        description="External ID of this warehouse.", required=False
     )
 
     class Meta:

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -101,7 +101,7 @@ class Warehouse(ModelObjectType[models.Warehouse]):
         ),
     )
     click_and_collect_option = WarehouseClickAndCollectOptionEnum(
-        description=("Click and collect options: local, all or disabled."),
+        description="Click and collect options: local, all or disabled.",
         required=True,
     )
     shipping_zones = ConnectionField(


### PR DESCRIPTION
I want to merge this change because it drops ADDED_IN and FEATURE_PREVIEW for versions < 3.18 in modules:
- channel
- giftcard
- invoice
- page
- payment
- product
- shipping
- shop
- tax
- translations
- warehouse

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
