### PR TITLE
Allow fixtures to be split into smaller files.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import os
+from glob import glob
 
 import dj_database_url
 import django.test
@@ -36,6 +37,9 @@ pytest_plugins = [
     "saleor.graphql.webhook.tests.benchmark.fixtures",
     "saleor.tax.tests.fixtures",
     "saleor.webhook.tests.subscription_webhooks.fixtures",
+] + [
+    fixture_file.replace("/", ".").replace(".py", "")
+    for fixture_file in glob("saleor/**/tests/fixtures/[!__]*.py", recursive=True)
 ]
 
 


### PR DESCRIPTION
I want to merge this change because allowing fixtures to be split into smaller files.

We want to split fixtures into smaller files e.g:
``` 
saleor/checkouts/tests/fixtures/checkout.py
saleor/checkouts/tests/fixtures/checkout_line.py
saleor/checkouts/tests/fixtures/checkout_tax_response.py
...
```
Those changes allow to automatically import fixtures for all folders inside `/tests/fixtures`



<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
