### PR TITLE
Enable comprehension lint rules in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ target-version = "py39"
   select = [
     "ASYNC",
     "B",
+    "C4",
     "D",
     "E",
     "F",

--- a/saleor/channel/tests/test_utils.py
+++ b/saleor/channel/tests/test_utils.py
@@ -15,7 +15,7 @@ def test_get_default_channel_with_one_channels(channel_USD):
     with warnings.catch_warnings(record=True) as warns:
         get_default_channel()
         assert any(
-            [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
+            str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns
         )
 
 

--- a/saleor/checkout/migrations/0001_initial.py
+++ b/saleor/checkout/migrations/0001_initial.py
@@ -128,6 +128,6 @@ class Migration(migrations.Migration):
             options={"db_table": "cart_cartline"},
         ),
         migrations.AlterUniqueTogether(
-            name="cartline", unique_together=set([("cart", "product", "data")])
+            name="cartline", unique_together={("cart", "product", "data")}
         ),
     ]

--- a/saleor/checkout/migrations/0002_auto_20161014_1221.py
+++ b/saleor/checkout/migrations/0002_auto_20161014_1221.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
             model_name="cartline", old_name="product", new_name="variant"
         ),
         migrations.AlterUniqueTogether(
-            name="cartline", unique_together=set([("cart", "variant", "data")])
+            name="cartline", unique_together={("cart", "variant", "data")}
         ),
     ]

--- a/saleor/core/notification/mutation_handler.py
+++ b/saleor/core/notification/mutation_handler.py
@@ -8,12 +8,12 @@ def get_external_notification_payload(objects, extra_payload, payload_function):
 def send_notification(
     manager, external_event_type, payloads, channel_slug=None, plugin_id=None
 ):
-    method_kwargs = dict(
-        manager=manager,
-        external_event_type=external_event_type,
-        channel_slug=channel_slug,
-        plugin_id=plugin_id,
-    )
+    method_kwargs = {
+        "manager": manager,
+        "external_event_type": external_event_type,
+        "channel_slug": channel_slug,
+        "plugin_id": plugin_id,
+    }
     if isinstance(payloads, list):
         for payload in payloads:
             trigger_notifications(**method_kwargs, payload=payload)
@@ -24,7 +24,7 @@ def send_notification(
 def trigger_notifications(
     manager, external_event_type, payload, channel_slug=None, plugin_id=None
 ):
-    method_kwargs = dict(event=external_event_type, payload_func=lambda: payload)
+    method_kwargs = {"event": external_event_type, "payload_func": lambda: payload}
     manager.notify(**method_kwargs, plugin_id=plugin_id, channel_slug=channel_slug)
 
 

--- a/saleor/core/tests/test_jwt.py
+++ b/saleor/core/tests/test_jwt.py
@@ -76,9 +76,11 @@ def test_create_access_token_for_app_extension_staff_user_with_more_permissions(
         decoded_token["app_extension"]
     )
     _, decode_app_id = graphene.Node.from_global_id(decoded_token["app"])
-    assert set(decoded_token["user_permissions"]) == set(
-        ["MANAGE_CHANNELS", "MANAGE_APPS", "MANAGE_PRODUCTS"]
-    )
+    assert set(decoded_token["user_permissions"]) == {
+        "MANAGE_CHANNELS",
+        "MANAGE_APPS",
+        "MANAGE_PRODUCTS",
+    }
     assert int(decode_extension_id) == extension.id
     assert int(decode_app_id) == app.id
     assert decoded_token["aud"] == audience

--- a/saleor/core/utils/events.py
+++ b/saleor/core/utils/events.py
@@ -14,10 +14,8 @@ def any_webhook_has_subscription(
     event_has_subscription = False
     for event in events:
         event_has_subscription = any(
-            [
-                bool(webhook.subscription_query)
-                for webhook in webhook_event_map.get(event, [])
-            ]
+            bool(webhook.subscription_query)
+            for webhook in webhook_event_map.get(event, [])
         )
         if event_has_subscription:
             break
@@ -29,9 +27,9 @@ def any_webhook_is_active_for_events(
 ) -> bool:
     """Check if any webhook is active for given events."""
 
-    active_webhook_events = set(
-        [event for event, webhooks in webhook_event_map.items() if webhooks]
-    )
+    active_webhook_events = {
+        event for event, webhooks in webhook_event_map.items() if webhooks
+    }
     if not active_webhook_events.intersection(events):
         return False
     return True
@@ -113,10 +111,7 @@ def call_event(func_obj, *func_args, **func_kwargs):
     Ensures that in atomic transaction event is called on_commit.
     """
     is_protected_instance = any(
-        [
-            isinstance(arg, (Checkout, CheckoutInfo, Order, OrderInfo))
-            for arg in func_args
-        ]
+        isinstance(arg, (Checkout, CheckoutInfo, Order, OrderInfo)) for arg in func_args
     )
     func_obj_self = getattr(func_obj, "__self__", None)
     is_plugin_manager_method = "PluginsManager" in str(

--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -41,12 +41,12 @@ def test_get_products_data(product, product_with_image, collection, image, chann
     variant_without_sku.save()
 
     products = Product.objects.all()
-    export_fields = set(
+    export_fields = {
         value
         for mapping in ProductExportFields.HEADERS_TO_FIELDS_MAPPING.values()
         for value in mapping.values()
         if value
-    )
+    }
     warehouse_ids = [str(warehouse.pk) for warehouse in Warehouse.objects.all()]
     attribute_ids = [str(attr.pk) for attr in Attribute.objects.all()]
     channel_ids = [str(channel.pk) for channel in Channel.objects.all()]

--- a/saleor/discount/interface.py
+++ b/saleor/discount/interface.py
@@ -31,10 +31,10 @@ class VoucherInfo:
 def fetch_voucher_info(
     voucher: Voucher, voucher_code: Optional[str] = None
 ) -> VoucherInfo:
-    variant_pks = list(variant.id for variant in voucher.variants.all())
-    product_pks = list(product.id for product in voucher.products.all())
-    category_pks = list(category.id for category in voucher.categories.all())
-    collection_pks = list(collection.id for collection in voucher.collections.all())
+    variant_pks = [variant.id for variant in voucher.variants.all()]
+    product_pks = [product.id for product in voucher.products.all()]
+    category_pks = [category.id for category in voucher.categories.all()]
+    collection_pks = [collection.id for collection in voucher.collections.all()]
 
     return VoucherInfo(
         voucher=voucher,

--- a/saleor/discount/migrations/0063_basediscount_voucher_code.py
+++ b/saleor/discount/migrations/0063_basediscount_voucher_code.py
@@ -52,9 +52,7 @@ def get_discount_voucher_id_to_code_map(Voucher, model_discounts):
     vouchers = Voucher.objects.filter(
         Exists(model_discounts.filter(voucher_id=OuterRef("pk")))
     )
-    voucher_id_to_code_map = {
-        voucher_id: code for voucher_id, code in vouchers.values_list("id", "code")
-    }
+    voucher_id_to_code_map = dict(vouchers.values_list("id", "code"))
     return voucher_id_to_code_map
 
 

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -188,7 +188,7 @@ def test_handle_promotion_toggle(
     assert PromotionRule.objects.filter(variants_dirty=True).count() == 2
 
     mock_mark_catalogue_promotion_rules_as_dirty.assert_called_once_with(
-        set([promotions[index].id for index in indexes_of_toggle_sales])
+        {promotions[index].id for index in indexes_of_toggle_sales}
     )
 
     mock_clear_promotion_rule_variants_task.assert_called_once()
@@ -268,7 +268,7 @@ def test_decrease_voucher_code_usage_task_multiple_use(
     order_list = draft_order_list_with_multiple_use_voucher
     voucher = voucher_multiple_use
     voucher_codes = voucher.codes.all()[: len(order_list)]
-    assert all([voucher_code.used == 1 for voucher_code in voucher_codes])
+    assert all(voucher_code.used == 1 for voucher_code in voucher_codes)
     voucher_code_ids = [voucher_code.pk for voucher_code in voucher_codes]
 
     # when
@@ -276,7 +276,7 @@ def test_decrease_voucher_code_usage_task_multiple_use(
 
     # then
     voucher_codes = voucher.codes.all()[: len(order_list)]
-    assert all([voucher_code.used == 0 for voucher_code in voucher_codes])
+    assert all(voucher_code.used == 0 for voucher_code in voucher_codes)
 
 
 def test_decrease_voucher_code_usage_task_single_use(
@@ -286,7 +286,7 @@ def test_decrease_voucher_code_usage_task_single_use(
     order_list = draft_order_list_with_single_use_voucher
     voucher = voucher_single_use
     voucher_codes = voucher.codes.all()[: len(order_list)]
-    assert all([voucher_code.is_active is False for voucher_code in voucher_codes])
+    assert all(voucher_code.is_active is False for voucher_code in voucher_codes)
     voucher_code_ids = [voucher_code.pk for voucher_code in voucher_codes]
 
     # when
@@ -294,7 +294,7 @@ def test_decrease_voucher_code_usage_task_single_use(
 
     # then
     voucher_codes = voucher.codes.all()[: len(order_list)]
-    assert all([voucher_code.is_active is True for voucher_code in voucher_codes])
+    assert all(voucher_code.is_active is True for voucher_code in voucher_codes)
 
 
 def test_disconnect_voucher_codes_from_draft_orders(
@@ -306,11 +306,11 @@ def test_disconnect_voucher_codes_from_draft_orders(
     order.lines.add(order_line)
 
     order_list_ids = [order.id for order in order_list]
-    assert all([order.voucher_code for order in order_list])
+    assert all(order.voucher_code for order in order_list)
     for order in order_list:
         order.should_refresh_prices = False
     Order.objects.bulk_update(order_list, ["should_refresh_prices"])
-    assert all([order.should_refresh_prices is False for order in order_list])
+    assert all(order.should_refresh_prices is False for order in order_list)
 
     voucher_code = order.voucher_code
     order_discount = OrderDiscount.objects.create(
@@ -325,8 +325,8 @@ def test_disconnect_voucher_codes_from_draft_orders(
 
     # then
     order_list = Order.objects.filter(id__in=order_list_ids).all()
-    assert all([order.voucher_code is None for order in order_list])
-    assert all([order.should_refresh_prices is True for order in order_list])
+    assert all(order.voucher_code is None for order in order_list)
+    assert all(order.should_refresh_prices is True for order in order_list)
 
     with pytest.raises(line_discount._meta.model.DoesNotExist):
         line_discount.refresh_from_db()

--- a/saleor/discount/tests/test_utils/test_update_rule_variant_relation.py
+++ b/saleor/discount/tests/test_utils/test_update_rule_variant_relation.py
@@ -48,5 +48,5 @@ def test_update_rule_variant_relation(
         related_variants = PromotionRuleVariant.objects.filter(
             promotionrule_id=rule.id
         ).values_list("productvariant_id", flat=True)
-        assert all([variant in new_variant_ids for variant in related_variants])
+        assert all(variant in new_variant_ids for variant in related_variants)
         assert len(related_variants) == len(new_variants)

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -715,12 +715,12 @@ def update_rule_variant_relation(
     existing_rules_variants = PromotionRuleVariant.objects.filter(
         Exists(rules.filter(pk=OuterRef("promotionrule_id")))
     ).all()
-    new_rule_variant_set = set(
+    new_rule_variant_set = {
         (rv.promotionrule_id, rv.productvariant_id) for rv in new_rules_variants
-    )
-    existing_rule_variant_set = set(
+    }
+    existing_rule_variant_set = {
         (rv.promotionrule_id, rv.productvariant_id) for rv in existing_rules_variants
-    )
+    }
     # Assign new variants to promotion rules
     rules_variants_to_add = [
         rv

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -207,9 +207,9 @@ def get_discounted_lines(
             if not line_variant or not line_product:
                 continue
             line_category = line_product.category
-            line_collections = set(
-                [collection.pk for collection in line_info.collections if collection]
-            )
+            line_collections = {
+                collection.pk for collection in line_info.collections if collection
+            }
             if line_info.variant and (
                 line_variant.pk in voucher_info.variant_pks
                 or line_product.pk in voucher_info.product_pks

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
@@ -362,7 +362,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
     @classmethod
     def update_address(cls, info, instance, data, field):
         address = getattr(instance, field) or models.Address()
-        address_metadata = data.pop("metadata", list())
+        address_metadata = data.pop("metadata", [])
         cls.update_metadata(address, address_metadata)
         address = cls.construct_instance(address, data)
         cls.clean_instance(info, address)
@@ -671,7 +671,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
             info, cleaned_inputs_map, index_error_map
         )
 
-        if any([bool(error) for error in index_error_map.values()]):
+        if any(index_error_map.values()):
             if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
                 results = cls.get_results(instances_data_with_errors_list, True)
                 return CustomerBulkUpdate(count=0, results=results)

--- a/saleor/graphql/account/dataloaders.py
+++ b/saleor/graphql/account/dataloaders.py
@@ -169,12 +169,9 @@ class RestrictedChannelAccessByUserIdLoader(DataLoader):
             id__in=user_groups.values("group_id")
         )
 
-        group_id_to_restricted_access = {
-            group_id: restricted_access
-            for group_id, restricted_access in groups.values_list(
-                "id", "restricted_access_to_channels"
-            )
-        }
+        group_id_to_restricted_access = dict(
+            groups.values_list("id", "restricted_access_to_channels")
+        )
 
         user_to_restricted_access: defaultdict[int, bool] = defaultdict(lambda: True)
         for user_id, group_id in user_groups.values_list("user_id", "group_id"):

--- a/saleor/graphql/account/mixins.py
+++ b/saleor/graphql/account/mixins.py
@@ -10,7 +10,7 @@ from ..utils import get_user_or_app_from_context
 class AddressMetadataMixin:
     @classmethod
     def construct_instance(cls, instance, cleaned_data):
-        cls.update_metadata(instance, cleaned_data.pop("metadata", list()))  # type: ignore[attr-defined] # noqa: E501
+        cls.update_metadata(instance, cleaned_data.pop("metadata", []))  # type: ignore[attr-defined] # noqa: E501
         return super().construct_instance(instance, cleaned_data)  # type: ignore[misc] # noqa: E501
 
 

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -95,7 +95,7 @@ class BaseAddressUpdate(ModelMutation, I18nMixin):
         cleaned_input = cls.clean_input(
             info=info, instance=instance, data=data.get("input")
         )
-        cls.update_metadata(instance, cleaned_input.pop("metadata", list()))
+        cls.update_metadata(instance, cleaned_input.pop("metadata", []))
         address = cls.validate_address(cleaned_input, instance=instance, info=info)
         cls.clean_instance(info, address)
         cls.save(info, address, cleaned_input)
@@ -270,7 +270,7 @@ class BaseCustomerCreate(ModelMutation, I18nMixin):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 
         if shipping_address_data:
-            address_metadata = shipping_address_data.pop("metadata", list())
+            address_metadata = shipping_address_data.pop("metadata", [])
             shipping_address = cls.validate_address(
                 shipping_address_data,
                 address_type=AddressType.SHIPPING,
@@ -281,7 +281,7 @@ class BaseCustomerCreate(ModelMutation, I18nMixin):
             cleaned_input[SHIPPING_ADDRESS_FIELD] = shipping_address
 
         if billing_address_data:
-            address_metadata = billing_address_data.pop("metadata", list())
+            address_metadata = billing_address_data.pop("metadata", [])
             billing_address = cls.validate_address(
                 billing_address_data,
                 address_type=AddressType.BILLING,

--- a/saleor/graphql/account/mutations/permission_group/permission_group_update.py
+++ b/saleor/graphql/account/mutations/permission_group/permission_group_update.py
@@ -303,7 +303,7 @@ class PermissionGroupUpdate(PermissionGroupCreate):
 
         # check if user with manage staff will be added to the group
         if add_users:
-            if any([user.has_perm(manage_staff_permission) for user in add_users]):
+            if any(user.has_perm(manage_staff_permission) for user in add_users):
                 return True
 
         permissions = get_not_manageable_permissions_after_removing_users_from_group(

--- a/saleor/graphql/account/mutations/staff/staff_create.py
+++ b/saleor/graphql/account/mutations/staff/staff_create.py
@@ -167,7 +167,7 @@ class StaffCreate(ModelMutation):
         send_notification=True,
         redirect_url=None,
     ):
-        if any([field in cleaned_input for field in USER_SEARCH_FIELDS]):
+        if any(field in cleaned_input for field in USER_SEARCH_FIELDS):
             user.search_document = prepare_user_search_document_value(
                 user, attach_addresses_data=False
             )

--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -196,7 +196,7 @@ def test_customer_register_no_redirect_url(mocked_notify, api_client, site_setti
     errors = response.json()["data"]["accountRegister"]["errors"]
 
     # then
-    assert "redirectUrl" in map(lambda error: error["field"], errors)
+    assert "redirectUrl" in (error["field"] for error in errors)
     mocked_notify.assert_not_called()
 
 

--- a/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_create.py
+++ b/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_create.py
@@ -94,7 +94,7 @@ def test_permission_group_create_mutation(
     assert (
         set(group.permissions.all().values_list("codename", flat=True))
         == permissions_codes
-        == set(perm.lower() for perm in variables["input"]["addPermissions"])
+        == {perm.lower() for perm in variables["input"]["addPermissions"]}
     )
     assert (
         {user["email"] for user in permission_group_data["users"]}
@@ -359,7 +359,7 @@ def test_permission_group_create_mutation_lack_of_permission(
     assert (
         set(group.permissions.all().values_list("codename", flat=True))
         == permissions_codes
-        == set(perm.lower() for perm in variables["input"]["addPermissions"])
+        == {perm.lower() for perm in variables["input"]["addPermissions"]}
     )
 
 
@@ -547,7 +547,7 @@ def test_permission_group_create_mutation_requestor_does_not_have_all_users_perm
     assert (
         set(group.permissions.all().values_list("codename", flat=True))
         == permissions_codes
-        == set(perm.lower() for perm in variables["input"]["addPermissions"])
+        == {perm.lower() for perm in variables["input"]["addPermissions"]}
     )
     assert (
         {user["email"] for user in data["group"]["users"]}

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_create.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_create.py
@@ -191,7 +191,7 @@ def test_customer_create(
 
     mocked_customer_metadata_updated.assert_called_once_with(new_user)
 
-    assert set([shipping_address, billing_address]) == set(new_user.addresses.all())
+    assert {shipping_address, billing_address} == set(new_user.addresses.all())
     customer_creation_event = account_events.CustomerEvent.objects.get()
     assert customer_creation_event.type == account_events.CustomerEvents.ACCOUNT_CREATED
     assert customer_creation_event.user == new_customer
@@ -314,7 +314,7 @@ def test_customer_create_as_app(
 
     mocked_customer_metadata_updated.assert_called_once_with(new_user)
 
-    assert set([shipping_address, billing_address]) == set(new_user.addresses.all())
+    assert {shipping_address, billing_address} == set(new_user.addresses.all())
     customer_creation_event = account_events.CustomerEvent.objects.get()
     assert customer_creation_event.type == account_events.CustomerEvents.ACCOUNT_CREATED
     assert customer_creation_event.user == new_customer

--- a/saleor/graphql/account/tests/queries/test_users.py
+++ b/saleor/graphql/account/tests/queries/test_users.py
@@ -23,7 +23,7 @@ def test_query_customers(staff_api_client, user_api_client, permission_manage_us
     content = get_graphql_content(response)
     users = content["data"]["customers"]["edges"]
     assert users
-    assert all([not user["node"]["isStaff"] for user in users])
+    assert all(not user["node"]["isStaff"] for user in users)
 
     # check permissions
     response = user_api_client.post_graphql(query, variables)
@@ -54,7 +54,7 @@ def test_query_staff(
     assert len(data) == 2
     staff_emails = [user["node"]["email"] for user in data]
     assert sorted(staff_emails) == [admin_user.email, staff_user.email]
-    assert all([user["node"]["isStaff"] for user in data])
+    assert all(user["node"]["isStaff"] for user in data)
 
     # check permissions
     response = user_api_client.post_graphql(query, variables)

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -219,7 +219,7 @@ def get_not_manageable_permissions_after_removing_users_from_group(
     # if True, all group permissions can be managed
     group_remaining_users = set(group_users) - set(users)
     manage_staff_permission = AccountPermissions.MANAGE_STAFF.value
-    if any([user.has_perm(manage_staff_permission) for user in group_remaining_users]):
+    if any(user.has_perm(manage_staff_permission) for user in group_remaining_users):
         return set()
 
     # if group and any of remaining group user doesn't have manage staff permission

--- a/saleor/graphql/app/mutations/app_token_verify.py
+++ b/saleor/graphql/app/mutations/app_token_verify.py
@@ -32,5 +32,5 @@ class AppTokenVerify(BaseMutation):
         tokens = models.AppToken.objects.filter(
             Q(token_last_4=token[-4:]), Exists(apps.filter(pk=OuterRef("app_id")))
         ).values_list("auth_token", flat=True)
-        valid = any([check_password(token, auth_token) for auth_token in tokens])
+        valid = any(check_password(token, auth_token) for auth_token in tokens)
         return AppTokenVerify(valid=valid)

--- a/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
+++ b/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
@@ -95,7 +95,7 @@ def test_app_fetch_manifest(staff_api_client, staff_user, permission_manage_apps
     assert manifest["dataPrivacyUrl"] == "http://localhost:8888/app-data-privacy"
     assert manifest["homepageUrl"] == "http://localhost:8888/homepage"
     assert manifest["supportUrl"] == "http://localhost:8888/support"
-    assert set([perm["code"] for perm in manifest["permissions"]]) == {
+    assert {perm["code"] for perm in manifest["permissions"]} == {
         "MANAGE_ORDERS",
         "MANAGE_USERS",
     }

--- a/saleor/graphql/app/tests/queries/test_app_extension.py
+++ b/saleor/graphql/app/tests/queries/test_app_extension.py
@@ -198,9 +198,7 @@ def test_app_extension_staff_user_fetching_access_token(
 
     assert extension_data["accessToken"]
     decoded_token = jwt_decode(extension_data["accessToken"])
-    assert set(decoded_token["permissions"]) == set(
-        ["MANAGE_PRODUCTS", "MANAGE_ORDERS"]
-    )
+    assert set(decoded_token["permissions"]) == {"MANAGE_PRODUCTS", "MANAGE_ORDERS"}
 
 
 def test_app_extension_access_token_with_audience(

--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -57,7 +57,7 @@ def validate_value(
         )
 
     if not is_swatch_attr and any(
-        [value_data.get(field) for field in ONLY_SWATCH_FIELDS]
+        value_data.get(field) for field in ONLY_SWATCH_FIELDS
     ):
         message = (
             "Cannot define value, file and contentType fields for not "

--- a/saleor/graphql/attribute/mutations/mixins.py
+++ b/saleor/graphql/attribute/mutations/mixins.py
@@ -98,7 +98,7 @@ class AttributeMixin:
 
     @classmethod
     def validate_non_swatch_attr_value(cls, value_data: dict):
-        if any([value_data.get(field) for field in cls.ONLY_SWATCH_FIELDS]):
+        if any(value_data.get(field) for field in cls.ONLY_SWATCH_FIELDS):
             raise ValidationError(
                 {
                     cls.ATTRIBUTE_VALUES_FIELD: ValidationError(

--- a/saleor/graphql/attribute/tests/deprecated/test_attributes.py
+++ b/saleor/graphql/attribute/tests/deprecated/test_attributes.py
@@ -68,6 +68,4 @@ def test_attributes_query_with_filter(
     expected_flat_attributes_data = list(expected_qs.values_list("slug", flat=True))
 
     assert flat_attributes_data == expected_flat_attributes_data
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -456,7 +456,7 @@ class AttributeAssignmentMixin:
         attr_values: AttrValuesInput,
     ):
         if not attr_values.dropdown:
-            return tuple()
+            return ()
 
         attr_value = attr_values.dropdown.value
         external_ref = attr_values.dropdown.external_reference
@@ -484,7 +484,7 @@ class AttributeAssignmentMixin:
         if attr_value:
             return cls._prepare_attribute_values(attribute, [attr_value])
 
-        return tuple()
+        return ()
 
     @classmethod
     def _pre_save_swatch_value(
@@ -494,7 +494,7 @@ class AttributeAssignmentMixin:
         attr_values: AttrValuesInput,
     ):
         if not attr_values.swatch:
-            return tuple()
+            return ()
 
         attr_value = attr_values.swatch.value
         external_ref = attr_values.swatch.external_reference
@@ -535,7 +535,7 @@ class AttributeAssignmentMixin:
         if attr_value := attr_values.swatch.value:
             return cls._prepare_attribute_values(attribute, [attr_value])
 
-        return tuple()
+        return ()
 
     @classmethod
     def _pre_save_multiselect_values(
@@ -545,7 +545,7 @@ class AttributeAssignmentMixin:
         attr_values_input: AttrValuesInput,
     ):
         if not attr_values_input.multiselect:
-            return tuple()
+            return ()
 
         attribute_values: list[attribute_models.AttributeValue] = []
         for attr_value in attr_values_input.multiselect:
@@ -602,7 +602,7 @@ class AttributeAssignmentMixin:
         elif attr_values.numeric:
             value = attr_values.numeric
         else:
-            return tuple()
+            return ()
 
         defaults = {
             "name": value,
@@ -619,7 +619,7 @@ class AttributeAssignmentMixin:
         """
 
         if not attr_values.values:
-            return tuple()
+            return ()
 
         return cls._prepare_attribute_values(attribute, attr_values.values)
 
@@ -631,7 +631,7 @@ class AttributeAssignmentMixin:
         attr_values: AttrValuesInput,
     ):
         if not attr_values.rich_text:
-            return tuple()
+            return ()
         defaults = {
             "rich_text": attr_values.rich_text,
             "name": truncatechars(
@@ -648,7 +648,7 @@ class AttributeAssignmentMixin:
         attr_values: AttrValuesInput,
     ):
         if not attr_values.plain_text:
-            return tuple()
+            return ()
         defaults = {
             "plain_text": attr_values.plain_text,
             "name": truncatechars(attr_values.plain_text, 200),
@@ -663,7 +663,7 @@ class AttributeAssignmentMixin:
         attr_values: AttrValuesInput,
     ):
         if attr_values.boolean is None:
-            return tuple()
+            return ()
 
         boolean = bool(attr_values.boolean)
         value = {
@@ -732,7 +732,7 @@ class AttributeAssignmentMixin:
         Slug value is generated based on instance and reference entity id.
         """
         if not attr_values.references or not attribute.entity_type:
-            return tuple()
+            return ()
 
         entity_data = cls.ENTITY_TYPE_MAPPING[attribute.entity_type]
         field_name = entity_data.name_field
@@ -774,7 +774,7 @@ class AttributeAssignmentMixin:
         """
         file_url = attr_value.file_url
         if not file_url:
-            return tuple()
+            return ()
         name = file_url.split("/")[-1]
         # don't create new value when assignment already exists
         value = cls._get_assigned_attribute_value_if_exists(

--- a/saleor/graphql/channel/dataloaders.py
+++ b/saleor/graphql/channel/dataloaders.py
@@ -36,7 +36,7 @@ class ChannelByOrderIdLoader(DataLoader):
                     for order in orders
                 ]
 
-            channel_ids = set(order.channel_id for order in orders if order)
+            channel_ids = {order.channel_id for order in orders if order}
             return (
                 ChannelByIdLoader(self.context)
                 .load_many(channel_ids)

--- a/saleor/graphql/channel/tests/queries/test_channel.py
+++ b/saleor/graphql/channel/tests/queries/test_channel.py
@@ -205,12 +205,16 @@ def test_query_channel_returns_countries_attached_to_shipping_zone(
     # then
     content = get_graphql_content(response)
     channel_data = content["data"]["channel"]
-    assert set([country["code"] for country in channel_data["countries"]]) == set(
-        ["PL", "DE", "FR"]
-    )
-    assert set([country["country"] for country in channel_data["countries"]]) == set(
-        ["Poland", "Germany", "France"]
-    )
+    assert {country["code"] for country in channel_data["countries"]} == {
+        "PL",
+        "DE",
+        "FR",
+    }
+    assert {country["country"] for country in channel_data["countries"]} == {
+        "Poland",
+        "Germany",
+        "France",
+    }
 
 
 def test_query_channel_returns_supported_shipping_methods(

--- a/saleor/graphql/checkout/dataloaders/models.py
+++ b/saleor/graphql/checkout/dataloaders/models.py
@@ -88,7 +88,7 @@ class ChannelByCheckoutIDLoader(DataLoader):
                     for checkout in checkouts
                 ]
 
-            channel_ids = set(checkout.channel_id for checkout in checkouts if checkout)
+            channel_ids = {checkout.channel_id for checkout in checkouts if checkout}
             return (
                 ChannelByIdLoader(self.context)
                 .load_many(channel_ids)

--- a/saleor/graphql/checkout/dataloaders/problems.py
+++ b/saleor/graphql/checkout/dataloaders/problems.py
@@ -119,15 +119,7 @@ class CheckoutLinesProblemsByCheckoutIdLoader(
             product_channel_listings = (
                 ProductChannelListingByProductIdAndChannelSlugLoader(
                     self.context
-                ).load_many(
-                    [
-                        (
-                            product_id,
-                            channel_slug,
-                        )
-                        for product_id, channel_slug in product_data_list
-                    ]
-                )
+                ).load_many(product_data_list)
             )
 
             return Promise.all([variant_stocks, product_channel_listings]).then(

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -292,12 +292,12 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         cleaned_input["channel"] = channel
         cleaned_input["currency"] = channel.currency_code
         shipping_address_metadata = (
-            data.get("shipping_address", {}).pop("metadata", list())
+            data.get("shipping_address", {}).pop("metadata", [])
             if data.get("shipping_address")
             else None
         )
         billing_address_metadata = (
-            data.get("billing_address", {}).pop("metadata", list())
+            data.get("billing_address", {}).pop("metadata", [])
             if data.get("billing_address")
             else None
         )

--- a/saleor/graphql/checkout/mutations/checkout_create_from_order.py
+++ b/saleor/graphql/checkout/mutations/checkout_create_from_order.py
@@ -232,9 +232,7 @@ class CheckoutCreateFromOrder(BaseMutation):
         global_quantity_limit: Optional[int],
     ) -> tuple[set[int], list[order_models.OrderLine], list[dict[str, Any]]]:
         variant_errors: list[dict[str, Any]] = []
-        variant_ids_set = set(
-            [line.variant_id for line in order_lines if line.variant_id]
-        )
+        variant_ids_set = {line.variant_id for line in order_lines if line.variant_id}
         channel_id = (order.channel_id,)
         channel_id = cast(int, channel_id)
 
@@ -335,7 +333,7 @@ class CheckoutCreateFromOrder(BaseMutation):
                 item.variant.pk: item for item in e.items if item.variant
             }
             variant_ids_set = variant_ids_set - set(
-                list(variants_with_insufficient_stock.keys())
+                variants_with_insufficient_stock.keys()
             )
             error_codes = CheckoutCreateFromOrderUnavailableVariantErrorCode
             for line in available_order_lines:

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -142,10 +142,8 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
         # if the requestor is not app, the quantity is required for all lines
         if not app:
             if any(
-                [
-                    line_data.quantity_to_update is False
-                    for line_data in checkout_lines_data
-                ]
+                line_data.quantity_to_update is False
+                for line_data in checkout_lines_data
             ):
                 raise ValidationError(
                     {

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -484,7 +484,7 @@ def check_permissions_for_custom_prices(app, lines):
     Checkout line custom price can be changed only by app with
     handle checkout permission.
     """
-    if any(["price" in line for line in lines]) and (
+    if any("price" in line for line in lines) and (
         not app or not app.has_perm(CheckoutPermissions.HANDLE_CHECKOUTS)
     ):
         raise PermissionDenied(permissions=[CheckoutPermissions.HANDLE_CHECKOUTS])

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -125,9 +125,7 @@ def test_checkout_create_with_default_channel(
     assert new_checkout.channel == channel_USD
     assert calculate_checkout_quantity(lines) == quantity
 
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_checkout_create_with_inactive_channel(
@@ -266,9 +264,7 @@ def test_checkout_create_with_inactive_default_channel(
 
     assert new_checkout.channel == channel_USD
 
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_checkout_create_with_inactive_and_active_default_channel(
@@ -298,9 +294,7 @@ def test_checkout_create_with_inactive_and_active_default_channel(
 
     assert new_checkout.channel == channel_USD
 
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_checkout_create_with_inactive_and_two_active_default_channel(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2564,7 +2564,7 @@ def test_query_checkout_lines(
     ]
     assert expected_lines_ids == checkout_lines_ids
     is_gift_flags = [line["node"]["isGift"] for line in lines]
-    assert all([item is False for item in is_gift_flags])
+    assert all(item is False for item in is_gift_flags)
 
 
 def test_query_checkout_lines_with_meta(
@@ -2590,7 +2590,7 @@ def test_query_checkout_lines_with_meta(
     }
     """
     checkout = checkout_with_item
-    items = [item for item in checkout]
+    items = list(checkout)
 
     metadata_key = "md key"
     metadata_value = "md value"

--- a/saleor/graphql/checkout/tests/test_checkout_line_problems.py
+++ b/saleor/graphql/checkout/tests/test_checkout_line_problems.py
@@ -230,7 +230,7 @@ def test_lines_with_same_variant(api_client, checkout_with_items_and_shipping):
     assert len(content["data"]["checkout"]["problems"]) == 2
     problems = content["data"]["checkout"]["problems"]
     assert all(
-        [problem["availableQuantity"] == available_quantity for problem in problems]
+        problem["availableQuantity"] == available_quantity for problem in problems
     )
     problem_line_ids = [problem["line"]["id"] for problem in problems]
     problem_variant_ids = [problem["variant"]["id"] for problem in problems]

--- a/saleor/graphql/checkout/tests/test_checkout_problems.py
+++ b/saleor/graphql/checkout/tests/test_checkout_problems.py
@@ -268,7 +268,7 @@ def test_checkout_with_multiple_same_variant_and_out_of_stock(
     assert len(content["data"]["checkout"]["problems"]) == 2
     problems = content["data"]["checkout"]["problems"]
     assert all(
-        [problem["availableQuantity"] == available_quantity for problem in problems]
+        problem["availableQuantity"] == available_quantity for problem in problems
     )
     problem_line_ids = [problem["line"]["id"] for problem in problems]
     problem_variant_ids = [problem["variant"]["id"] for problem in problems]

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -1012,7 +1012,7 @@ class Checkout(ModelObjectType[models.Checkout]):
             product_ids = [line_info.product.id for line_info in lines]
 
             def with_product_types(product_types):
-                return any([pt.is_shipping_required for pt in product_types])
+                return any(pt.is_shipping_required for pt in product_types)
 
             return (
                 ProductTypeByProductIdLoader(info.context)

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -610,7 +610,7 @@ def where_filter_qs(
 
 
 def contains_filter_operator(input: dict[str, Union[dict, str]]):
-    return any([operator in input for operator in ["AND", "OR", "NOT"]])
+    return any(operator in input for operator in ["AND", "OR", "NOT"])
 
 
 def _handle_and_filter_input(

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -167,7 +167,7 @@ class VoucherInfoByVoucherCodeLoader(DataLoader[str, Optional[VoucherInfo]]):
             .in_bulk(field_name="code")
         )
 
-        vouchers = set([code.voucher for code in voucher_codes_map.values()])
+        vouchers = {code.voucher for code in voucher_codes_map.values()}
         voucher_products = (
             Voucher.products.through.objects.using(self.database_connection_name)
             .filter(voucher__in=vouchers)

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -41,7 +41,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):
         channel_to_products_map = cls.get_product_and_channel_map(queryset)
-        promotions = [promotion for promotion in queryset]
+        promotions = list(queryset)
         queryset.delete()
         manager = get_plugin_manager_promise(info.context).get()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.PROMOTION_DELETED)

--- a/saleor/graphql/discount/mutations/promotion/validators.py
+++ b/saleor/graphql/discount/mutations/promotion/validators.py
@@ -63,7 +63,7 @@ def clean_promotion_rule(
 def _get_gift_ids(cleaned_input, instance):
     """Return the set of gift ids for promotion rule valid after performing mutation."""
     if not instance and not any(
-        [field in cleaned_input for field in ["gifts", "add_gifts", "remove_gifts"]]
+        field in cleaned_input for field in ["gifts", "add_gifts", "remove_gifts"]
     ):
         return
 
@@ -533,7 +533,7 @@ def clean_predicate(predicate, error_class, index=None):
 
 
 def _contains_operator(input: dict[str, Union[dict, str]]):
-    return any([operator in input for operator in ["AND", "OR"]])
+    return any(operator in input for operator in ["AND", "OR"])
 
 
 def clean_fixed_discount_value(

--- a/saleor/graphql/discount/mutations/sale/sale_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_update.py
@@ -147,7 +147,7 @@ class SaleUpdate(ModelMutation):
             for rule in rules:
                 rule.reward_value_type = type
 
-        if any([key in CATALOGUE_FIELDS for key in input.keys()]):
+        if any(key in CATALOGUE_FIELDS for key in input.keys()):
             predicate = cls.create_predicate(input)
             for rule in rules:
                 rule.catalogue_predicate = predicate

--- a/saleor/graphql/discount/tests/deprecated/test_discount.py
+++ b/saleor/graphql/discount/tests/deprecated/test_discount.py
@@ -45,11 +45,9 @@ def test_sales_with_sorting_and_without_channel(
             promotion_converted_from_sale_with_empty_predicate,
         ]
     ]
-    assert all([node["node"]["name"] in promotion_names for node in sales_nodes])
+    assert all(node["node"]["name"] in promotion_names for node in sales_nodes)
 
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 QUERY_VOUCHERS_WITH_SORT = """
@@ -84,9 +82,7 @@ def test_query_vouchers_with_sort(
         voucher_percentage.name,
         voucher_with_high_min_spent_amount.name,
     ]
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_filter_sales_by_query(staff_api_client, permission_manage_discounts):

--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -959,10 +959,10 @@ def test_promotion_create_missing_reward_value_type(
 
     assert not data["promotion"]
     assert len(errors) == 2
-    error_fields = set([error["field"] for error in errors])
+    error_fields = {error["field"] for error in errors}
     assert len(error_fields) == 1
     assert "rewardValueType" in error_fields
-    error_codes = set([error["code"] for error in errors])
+    error_codes = {error["code"] for error in errors}
     assert len(error_codes) == 1
     assert PromotionCreateErrorCode.REQUIRED.name in error_codes
 
@@ -1713,7 +1713,7 @@ def test_promotion_create_events_by_staff_user(
 
     rule_ids = [event["ruleId"] for event in events if event.get("ruleId")]
     rules = data["promotion"]["rules"]
-    assert all([rule["id"] in rule_ids for rule in rules])
+    assert all(rule["id"] in rule_ids for rule in rules)
 
 
 def test_promotion_create_events_by_app(
@@ -1786,7 +1786,7 @@ def test_promotion_create_events_by_app(
 
     rule_ids = [event["ruleId"] for event in events if event.get("ruleId")]
     rules = data["promotion"]["rules"]
-    assert all([rule["id"] in rule_ids for rule in rules])
+    assert all(rule["id"] in rule_ids for rule in rules)
 
 
 @patch("saleor.product.tasks.update_products_discounted_prices_of_promotion_task.delay")
@@ -1847,7 +1847,7 @@ def test_promotion_create_gift_promotion(
     promotion = Promotion.objects.filter(name=promotion_name).get()
     rules = promotion.rules.all()
     assert len(rules) == 1
-    assert all([gift in product_variant_list for gift in rules[0].gifts.all()])
+    assert all(gift in product_variant_list for gift in rules[0].gifts.all())
     assert rules[0].reward_type == RewardTypeEnum.GIFT.value
 
 

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
@@ -1640,7 +1640,7 @@ def test_promotion_rule_create_gift_promotion(
     assert sorted(rule_data["giftIds"]) == sorted(gift_ids)
     assert promotion.rules.count() == rules_count + 1
     rule = promotion.rules.last()
-    assert all([gift in product_variant_list for gift in rule.gifts.all()])
+    assert all(gift in product_variant_list for gift in rule.gifts.all())
     assert rule.reward_type == RewardTypeEnum.GIFT.value
     promotion_rule_created_mock.assert_called_once_with(rule)
 

--- a/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
@@ -73,7 +73,7 @@ def test_sale_add_catalogues(
     assert collection_id in current_catalogue["collections"]
     assert category_id in current_catalogue["categories"]
     assert product_id in current_catalogue["products"]
-    assert all([variant in current_catalogue["variants"] for variant in variant_ids])
+    assert all(variant in current_catalogue["variants"] for variant in variant_ids)
 
     updated_webhook_mock.assert_called_once_with(
         promotion, previous_catalogue, current_catalogue

--- a/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
@@ -77,7 +77,7 @@ def test_sale_channel_listing_add_channels(
         len({(rule.reward_value_type, str(rule.catalogue_predicate)) for rule in rules})
         == 1
     )
-    assert all([rule.old_channel_listing_id for rule in rules])
+    assert all(rule.old_channel_listing_id for rule in rules)
 
     for rule in promotion.rules.all():
         assert rule.variants_dirty is True
@@ -327,12 +327,10 @@ def test_sale_channel_listing_add_update_remove_channels(
     channel_listings = data["channelListings"]
     assert len(channel_listings) == 2
     assert all(
-        [
-            listing["channel"]["slug"] in [channel_USD.slug, channel_JPY.slug]
-            for listing in channel_listings
-        ]
+        listing["channel"]["slug"] in [channel_USD.slug, channel_JPY.slug]
+        for listing in channel_listings
     )
-    assert all([listing["discountValue"] == discounted for listing in channel_listings])
+    assert all(listing["discountValue"] == discounted for listing in channel_listings)
 
     promotion.refresh_from_db()
     rules = promotion.rules.all()

--- a/saleor/graphql/discount/tests/queries/test_promotion.py
+++ b/saleor/graphql/discount/tests/queries/test_promotion.py
@@ -206,12 +206,10 @@ def test_query_order_promotion_with_gift_rule(
     content = get_graphql_content(response)
     rule = content["data"]["promotion"]["rules"][0]
     rule_db = promotion.rules.first()
-    assert set(rule["giftIds"]) == set(
-        [
-            graphene.Node.to_global_id("ProductVariant", gift.pk)
-            for gift in rule_db.gifts.all()
-        ]
-    )
+    assert set(rule["giftIds"]) == {
+        graphene.Node.to_global_id("ProductVariant", gift.pk)
+        for gift in rule_db.gifts.all()
+    }
     assert rule["giftsLimit"] == 1
     assert rule["rewardType"] == RewardType.GIFT.upper()
 

--- a/saleor/graphql/discount/types/promotion_events.py
+++ b/saleor/graphql/discount/types/promotion_events.py
@@ -163,7 +163,7 @@ PROMOTION_EVENT_MAP = {
 
 class PromotionEvent(graphene.Union):
     class Meta:
-        types = [v for v in PROMOTION_EVENT_MAP.values()]
+        types = list(PROMOTION_EVENT_MAP.values())
 
     @classmethod
     def resolve_type(cls, instance: models.PromotionEvent, _info):

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -271,7 +271,7 @@ def _handle_or_data(
 
 
 def contains_filter_operator(input: dict[str, Union[dict, str, list, bool]]) -> bool:
-    return any([operator in input for operator in ["AND", "OR", "NOT"]])
+    return any(operator in input for operator in ["AND", "OR", "NOT"])
 
 
 def _handle_predicate(

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
@@ -34,7 +34,7 @@ class GiftCardBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):
-        instances = [card for card in queryset]
+        instances = list(queryset)
         queryset.delete()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.GIFT_CARD_DELETED)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/invoice/utils.py
+++ b/saleor/graphql/invoice/utils.py
@@ -1,4 +1,4 @@
 def is_event_active_for_any_plugin(event: str, plugins_list):
     return any(
-        [plugin.is_event_active(event) for plugin in plugins_list if plugin.active]
+        plugin.is_event_active(event) for plugin in plugins_list if plugin.active
     )

--- a/saleor/graphql/menu/tests/deprecated/test_menu.py
+++ b/saleor/graphql/menu/tests/deprecated/test_menu.py
@@ -46,7 +46,7 @@ def test_menu_items_collection_without_providing_channel(
         response = user_api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert any(
-            [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
+            str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns
         )
 
     data = content["data"]["menuItem"]

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -259,18 +259,16 @@ class BaseMetadataMutation(BaseMutation):
         """Return a success response."""
         # Wrap the instance with ChannelContext for models that use it.
         use_channel_context = any(
-            [
-                isinstance(instance, Model)
-                for Model in [
-                    discount_models.Voucher,
-                    menu_models.Menu,
-                    menu_models.MenuItem,
-                    product_models.Collection,
-                    product_models.Product,
-                    product_models.ProductVariant,
-                    shipping_models.ShippingMethod,
-                    shipping_models.ShippingZone,
-                ]
+            isinstance(instance, Model)
+            for Model in [
+                discount_models.Voucher,
+                menu_models.Menu,
+                menu_models.MenuItem,
+                product_models.Collection,
+                product_models.Product,
+                product_models.ProductVariant,
+                shipping_models.ShippingMethod,
+                shipping_models.ShippingZone,
             ]
         )
         if use_channel_context:

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -182,11 +182,11 @@ class OrderBulkCreateData:
 
     @property
     def all_invoices(self) -> list[Invoice]:
-        return [invoice for invoice in self.invoices]
+        return list(self.invoices)
 
     @property
     def all_discounts(self) -> list[OrderDiscount]:
-        return [discount for discount in self.discounts]
+        return list(self.discounts)
 
     @property
     def orderline_fulfillmentlines_map(
@@ -216,18 +216,16 @@ class OrderBulkCreateData:
     @property
     def unique_variant_ids(self) -> list[int]:
         return list(
-            set(
-                [
-                    order_line.line.variant.id
-                    for order_line in self.lines
-                    if order_line.line.variant
-                ]
-            )
+            {
+                order_line.line.variant.id
+                for order_line in self.lines
+                if order_line.line.variant
+            }
         )
 
     @property
     def unique_warehouse_ids(self) -> list[UUID]:
-        return list(set([order_line.warehouse.id for order_line in self.lines]))
+        return list({order_line.warehouse.id for order_line in self.lines})
 
     @property
     def total_order_quantity(self):
@@ -1351,7 +1349,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             "user_email": "email",
             "user_external_reference": "external_reference",
         }
-        if any([note_input.get(key) for key in user_key_map.keys()]):
+        if any(note_input.get(key) for key in user_key_map.keys()):
             user = cls.get_instance_with_errors(
                 input=note_input,
                 errors=order_data.errors,
@@ -2128,7 +2126,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             if not order_data.is_critical_error:
                 stocks_map = stocks_map_copy
 
-        return [stock for stock in stocks_map.values()]
+        return list(stocks_map.values())
 
     @classmethod
     def handle_error_policy(

--- a/saleor/graphql/order/tests/deprecated/test_order.py
+++ b/saleor/graphql/order/tests/deprecated/test_order.py
@@ -63,9 +63,7 @@ def test_orders_total(
     # then
     amount = str(content["data"]["ordersTotal"]["gross"]["amount"])
     assert Money(amount, "USD") == order.total.gross
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 ORDER_LINE_DELETE_MUTATION = """

--- a/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
@@ -119,7 +119,7 @@ def test_fail_to_delete_non_draft_order_lines(
 ):
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_with_lines
-    order_lines = [line for line in order.lines.all()]
+    order_lines = list(order.lines.all())
     # Ensure we cannot delete a non-draft order
     order.status = OrderStatus.CANCELED
     order.save()
@@ -142,7 +142,7 @@ def test_delete_draft_order_lines(
 ):
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_with_lines
-    order_lines = [line for line in order.lines.all()]
+    order_lines = list(order.lines.all())
     # Only lines in draft order can be deleted
     order.status = OrderStatus.DRAFT
     order.save()
@@ -172,7 +172,7 @@ def test_delete_draft_order_lines_by_user_no_channel_access(
     # given
     permission_group_all_perms_channel_USD_only.user_set.add(staff_api_client.user)
     order = order_with_lines
-    order_lines = [line for line in order.lines.all()]
+    order_lines = list(order.lines.all())
     # Only lines in draft order can be deleted
     order.status = OrderStatus.DRAFT
     order.channel = channel_PLN
@@ -197,7 +197,7 @@ def test_delete_draft_order_lines_by_app(
 ):
     # given
     order = order_with_lines
-    order_lines = [line for line in order.lines.all()]
+    order_lines = list(order.lines.all())
     # Only lines in draft order can be deleted
     order.status = OrderStatus.DRAFT
     order.save()

--- a/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
@@ -475,12 +475,12 @@ def test_grant_refund_without_lines_and_amount_and_grant_for_shipping(
     data = content["data"]["orderGrantRefundCreate"]
     errors = data["errors"]
     assert len(errors) == 3
-    assert set([error["field"] for error in errors]) == {
+    assert {error["field"] for error in errors} == {
         "amount",
         "lines",
         "grantRefundForShipping",
     }
-    assert set([error["code"] for error in errors]) == {"REQUIRED"}
+    assert {error["code"] for error in errors} == {"REQUIRED"}
 
 
 def test_grant_refund_with_incorrect_line_id(

--- a/saleor/graphql/order/tests/queries/test_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_filter.py
@@ -1371,7 +1371,7 @@ def test_order_query_with_filter_checkout_tokens(
     channel_USD,
 ):
     assert not order.checkout_token
-    assert all([order.checkout_token for order in orders_from_checkout])
+    assert all(order.checkout_token for order in orders_from_checkout)
     # given
     variables = {
         "filter": {
@@ -1402,7 +1402,7 @@ def test_order_query_with_filter_checkout_tokens_empty_list(
     channel_USD,
 ):
     assert not order.checkout_token
-    assert all([order.checkout_token for order in orders_from_checkout])
+    assert all(order.checkout_token for order in orders_from_checkout)
     # given
     variables = {
         "filter": {

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1849,7 +1849,7 @@ class Order(ModelObjectType[models.Order]):
     def resolve_total_balance(root: models.Order, info):
         def _resolve_total_balance(data):
             granted_refunds, transactions, payments = data
-            if any([p.is_active for p in payments]):
+            if any(p.is_active for p in payments):
                 return root.total_balance
             else:
                 total_granted_refund = sum(

--- a/saleor/graphql/page/dataloaders.py
+++ b/saleor/graphql/page/dataloaders.py
@@ -72,7 +72,7 @@ class BasePageAttributesByPageTypeIdLoader(DataLoader):
 
         return (
             AttributesByAttributeId(self.context)
-            .load_many(set(attr_id for _, attr_id in page_type_attribute_pairs))
+            .load_many({attr_id for _, attr_id in page_type_attribute_pairs})
             .then(map_attributes)
         )
 

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -748,15 +748,14 @@ def test_transaction_event_report_event_already_exists_updates_available_actions
     response = get_graphql_content(response)
     transaction_report_data = response["data"]["transactionEventReport"]
     assert transaction_report_data["alreadyProcessed"] is True
-    assert set(transaction_report_data["transaction"]["actions"]) == set(
-        [
-            TransactionActionEnum.REFUND.name,
-            TransactionActionEnum.CHARGE.name,
-        ]
-    )
-    assert set(transaction.available_actions) == set(
-        [TransactionActionEnum.REFUND.value, TransactionActionEnum.CHARGE.value]
-    )
+    assert set(transaction_report_data["transaction"]["actions"]) == {
+        TransactionActionEnum.REFUND.name,
+        TransactionActionEnum.CHARGE.name,
+    }
+    assert set(transaction.available_actions) == {
+        TransactionActionEnum.REFUND.value,
+        TransactionActionEnum.CHARGE.value,
+    }
 
 
 def test_event_already_exists_do_not_overwrite_actions_when_not_provided_in_input(
@@ -827,15 +826,14 @@ def test_event_already_exists_do_not_overwrite_actions_when_not_provided_in_inpu
     response = get_graphql_content(response)
     transaction_report_data = response["data"]["transactionEventReport"]
     assert transaction_report_data["alreadyProcessed"] is True
-    assert set(transaction_report_data["transaction"]["actions"]) == set(
-        [
-            TransactionActionEnum.REFUND.name,
-            TransactionActionEnum.CHARGE.name,
-        ]
-    )
-    assert set(transaction.available_actions) == set(
-        [TransactionActionEnum.REFUND.value, TransactionActionEnum.CHARGE.value]
-    )
+    assert set(transaction_report_data["transaction"]["actions"]) == {
+        TransactionActionEnum.REFUND.name,
+        TransactionActionEnum.CHARGE.name,
+    }
+    assert set(transaction.available_actions) == {
+        TransactionActionEnum.REFUND.value,
+        TransactionActionEnum.CHARGE.value,
+    }
 
 
 def test_transaction_event_report_incorrect_amount_for_already_existing(
@@ -2710,9 +2708,7 @@ def test_transaction_event_report_updates_granted_refund_status_when_needed(
     assert granted_refund.status == expected_status
 
 
-@pytest.mark.parametrize(
-    "event_type", [event_type for event_type in OPTIONAL_AMOUNT_EVENTS]
-)
+@pytest.mark.parametrize("event_type", list(OPTIONAL_AMOUNT_EVENTS))
 def test_transaction_event_report_missing_amount(
     event_type,
     transaction_item_generator,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_request_refund_for_granted_refund.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_request_refund_for_granted_refund.py
@@ -212,9 +212,9 @@ def test_transaction_belongs_to_different_order_than_granted_refund_order(
     error_class = TransactionRequestRefundForGrantedRefundErrorCode
     data = content["data"]["transactionRequestRefundForGrantedRefund"]
     assert len(data["errors"]) == 2
-    assert any([err["field"] == "grantedRefundId" for err in data["errors"]])
-    assert any([err["field"] == "id" for err in data["errors"]])
-    assert all([err["code"] == error_class.INVALID.name for err in data["errors"]])
+    assert any(err["field"] == "grantedRefundId" for err in data["errors"])
+    assert any(err["field"] == "id" for err in data["errors"])
+    assert all(err["code"] == error_class.INVALID.name for err in data["errors"])
 
 
 @patch("saleor.payment.gateway.get_webhooks_for_event")

--- a/saleor/graphql/payment/utils.py
+++ b/saleor/graphql/payment/utils.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 def metadata_contains_empty_key(metadata_list: list[dict]) -> bool:
-    return not all([data["key"].strip() for data in metadata_list])
+    return not all(data["key"].strip() for data in metadata_list)
 
 
 def check_if_requestor_has_access(

--- a/saleor/graphql/plugins/filters.py
+++ b/saleor/graphql/plugins/filters.py
@@ -26,10 +26,8 @@ def filter_plugin_status_in_channels(
         else:
             for channel in channels:
                 if any(
-                    [
-                        (config.channel.id == channel.id and config.active is is_active)
-                        for config in plugin.channel_configurations
-                    ]
+                    (config.channel.id == channel.id and config.active is is_active)
+                    for config in plugin.channel_configurations
                 ):
                     filtered_plugins.append(plugin)
                     break
@@ -51,10 +49,8 @@ def filter_plugin_search(plugins: list[Plugin], value: Optional[str]) -> list[Pl
             plugin
             for plugin in plugins
             if any(
-                [
-                    value.lower() in getattr(plugin, field).lower()
-                    for field in plugin_fields
-                ]
+                value.lower() in getattr(plugin, field).lower()
+                for field in plugin_fields
             )
         ]
     return plugins

--- a/saleor/graphql/plugins/sorters.py
+++ b/saleor/graphql/plugins/sorters.py
@@ -13,9 +13,7 @@ def sort_active_key(plugin: Plugin, sort_reverse: bool):
         name = plugin.name
     else:
         active = False
-        if any(
-            [configuration.active for configuration in plugin.channel_configurations]
-        ):
+        if any(configuration.active for configuration in plugin.channel_configurations):
             active = True
         name = plugin.name
     return not active if sort_reverse else active, name

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -878,7 +878,7 @@ class ProductBulkCreate(BaseMutation):
             cls.call_event(manager.product_variant_created, variant, webhooks=webhooks)
 
         if products:
-            channel_ids = set([channel.id for channel in channels])
+            channel_ids = {channel.id for channel in channels}
             cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
 
     @classmethod
@@ -894,7 +894,7 @@ class ProductBulkCreate(BaseMutation):
         )
 
         # check error policy
-        if any([True if error else False for error in index_error_map.values()]):
+        if any(index_error_map.values()):
             if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
                 results = get_results(instances_data_with_errors_list, True)
                 return ProductBulkCreate(count=0, results=results)

--- a/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
@@ -102,7 +102,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         for product, variant in product_to_variant:
             product_variant_map[product].append(variant)
 
-        products = [product for product in queryset]
+        products = list(queryset)
         with transaction.atomic():
             variants_ids = tuple(
                 models.ProductVariant.objects.order_by("pk")

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -843,9 +843,7 @@ class ProductVariantBulkCreate(BaseMutation):
                 attribute_data[0].type == AttributeType.PRODUCT_TYPE
                 and attribute_data[0].variant_selection
             ):
-                attributes_display.append(
-                    ", ".join([value for value in attribute_data[1].values])
-                )
+                attributes_display.append(", ".join(list(attribute_data[1].values)))
 
         name = " / ".join(sorted(attributes_display))
         if not name:
@@ -917,7 +915,7 @@ class ProductVariantBulkCreate(BaseMutation):
 
     @classmethod
     def post_save_actions(cls, info, instances, product):
-        variant_ids = set([instance.node.id for instance in instances])
+        variant_ids = {instance.node.id for instance in instances}
         channel_ids = set(
             models.ProductVariantChannelListing.objects.filter(
                 variant_id__in=variant_ids

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -815,7 +815,7 @@ class ProductVariantBulkUpdate(BaseMutation):
         )
 
         # check error policy
-        if any([bool(error) for error in index_error_map.values()]):
+        if any(bool(error) for error in index_error_map.values()):
             if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
                 results = get_results(instances_data_with_errors_list, True)
                 return ProductVariantBulkUpdate(count=0, results=results)

--- a/saleor/graphql/product/dataloaders/attributes.py
+++ b/saleor/graphql/product/dataloaders/attributes.py
@@ -58,7 +58,7 @@ class BaseProductAttributesByProductTypeIdLoader(DataLoader):
 
         return (
             AttributesByAttributeId(self.context)
-            .load_many(set(attr_id for _, attr_id, *_ in product_type_attribute_pairs))
+            .load_many({attr_id for _, attr_id, *_ in product_type_attribute_pairs})
             .then(map_attributes)
         )
 

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -517,7 +517,7 @@ class ImagesByProductVariantIdLoader(DataLoader):
 
         return (
             ProductMediaByIdLoader(self.context)
-            .load_many(set(media_id for variant_id, media_id in variant_media))
+            .load_many({media_id for variant_id, media_id in variant_media})
             .then(map_variant_media)
         )
 
@@ -557,7 +557,7 @@ class CollectionsByProductIdLoader(DataLoader):
 
         return (
             CollectionByIdLoader(self.context)
-            .load_many(set(cid for pid, cid in product_collection_pairs))
+            .load_many({cid for pid, cid in product_collection_pairs})
             .then(map_collections)
         )
 

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -414,9 +414,9 @@ class ProductAttributeAssignmentUpdate(BaseMutation, VariantAssignmentValidation
         )
 
         if len(variant_attrs_pks) != len(assigned_attributes):
-            invalid_attrs = set(variant_attrs_pks) - set(
+            invalid_attrs = set(variant_attrs_pks) - {
                 str(pk) for pk in assigned_attributes
-            )
+            }
             invalid_attrs = [
                 graphene.Node.to_global_id("Attribute", pk) for pk in invalid_attrs
             ]
@@ -438,9 +438,9 @@ class ProductAttributeAssignmentUpdate(BaseMutation, VariantAssignmentValidation
         ).values_list("attribute_id", flat=True)
 
         if len(variant_attrs_pks) != len(assigned_attributes):
-            invalid_attrs = set(variant_attrs_pks) - set(
+            invalid_attrs = set(variant_attrs_pks) - {
                 str(pk) for pk in assigned_attributes
-            )
+            }
             invalid_attrs = [
                 graphene.Node.to_global_id("Attribute", pk) for pk in invalid_attrs
             ]
@@ -482,7 +482,7 @@ class ProductAttributeAssignmentUpdate(BaseMutation, VariantAssignmentValidation
             id__in=variant_attrs_pks
         ).values_list("pk", flat=True)
         if len(variant_attrs_pks) != len(attributes):
-            invalid_attrs = set(variant_attrs_pks) - set(str(pk) for pk in attributes)
+            invalid_attrs = set(variant_attrs_pks) - {str(pk) for pk in attributes}
             invalid_attrs = [
                 graphene.Node.to_global_id("Attribute", pk) for pk in invalid_attrs
             ]

--- a/saleor/graphql/product/tests/deprecated/test_collection.py
+++ b/saleor/graphql/product/tests/deprecated/test_collection.py
@@ -45,6 +45,4 @@ def test_collections_query_with_default_channel_slug(
         collection_data["products"]["totalCount"]
         == published_collection.products.count()
     )
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)

--- a/saleor/graphql/product/tests/deprecated/test_product.py
+++ b/saleor/graphql/product/tests/deprecated/test_product.py
@@ -81,9 +81,7 @@ def test_product_query_by_id_with_default_channel(user_api_client, product):
     collection_data = content["data"]["product"]
     assert collection_data is not None
     assert collection_data["name"] == product.name
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_product_query_by_slug_with_default_channel(user_api_client, product):
@@ -94,9 +92,7 @@ def test_product_query_by_slug_with_default_channel(user_api_client, product):
     collection_data = content["data"]["product"]
     assert collection_data is not None
     assert collection_data["name"] == product.name
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_fetch_all_products(user_api_client, product):
@@ -114,9 +110,7 @@ def test_fetch_all_products(user_api_client, product):
         product_channel_listing.available_for_purchase_at.date()
     )
     assert len(content["data"]["products"]["edges"]) == num_products
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_products_query_with_price_filter(
@@ -141,9 +135,7 @@ def test_products_query_with_price_filter(
     products = content["data"]["products"]["edges"]
 
     assert len(products) == 3
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_sort_products_product_type_name(
@@ -160,9 +152,7 @@ def test_sort_products_product_type_name(
     product_type_name_0 = edges[0]["node"]["productType"]["name"]
     product_type_name_1 = edges[1]["node"]["productType"]["name"]
     assert product_type_name_0 < product_type_name_1
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
     # Test sorting by PUBLISHED, descending
     desc_published_query = SORT_PRODUCTS_QUERY % {
@@ -174,9 +164,7 @@ def test_sort_products_product_type_name(
     product_type_name_0 = edges[0]["node"]["productType"]["name"]
     product_type_name_1 = edges[1]["node"]["productType"]["name"]
     assert product_type_name_0 < product_type_name_1
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 QUERY_COLLECTION_FROM_PRODUCT = """
@@ -241,9 +229,7 @@ def test_get_collections_from_product_as_customer(
     collections = content["data"]["product"]["collections"]
     assert len(collections) == 1
     assert {"name": published_collection.name} in collections
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_get_collections_from_product_as_anonymous(
@@ -267,9 +253,7 @@ def test_get_collections_from_product_as_anonymous(
     collections = content["data"]["product"]["collections"]
     assert len(collections) == 1
     assert {"name": published_collection.name} in collections
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_collections_query_with_filter(
@@ -323,9 +307,7 @@ def test_collections_query_with_filter(
     collections = content["data"]["collections"]["edges"]
 
     assert len(collections) == 2
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_collections_query_with_sort(
@@ -360,9 +342,7 @@ def test_collections_query_with_sort(
     collections = content["data"]["collections"]["edges"]
     for order, collection_name in enumerate(["Coll2", "Coll3", "Coll1"]):
         assert collections[order]["node"]["name"] == collection_name
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 QUERY_FETCH_ALL_VARIANTS = """
@@ -403,6 +383,4 @@ def test_fetch_all_variants(api_client, product_variant_list, channel_PLN):
     content = get_graphql_content(response)
     data = content["data"]["productVariants"]
     assert data["totalCount"] == len(product_variant_list)
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)

--- a/saleor/graphql/product/tests/deprecated/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/deprecated/test_product_variant_bulk_create.py
@@ -462,7 +462,7 @@ def test_product_variant_bulk_create_stocks_input(
         assert variant_data["sku"] in expected_result
         expected_variant = expected_result[variant_data["sku"]]
         expected_stocks = expected_variant["stocks"]
-        assert all([stock in expected_stocks for stock in variant_data["stocks"]])
+        assert all(stock in expected_stocks for stock in variant_data["stocks"])
 
 
 def test_product_variant_bulk_create_duplicated_warehouses(
@@ -627,10 +627,8 @@ def test_product_variant_bulk_create_channel_listings_input(
         expected_variant = expected_result[variant_data["sku"]]
         expected_channel_listing = expected_variant["channelListings"]
         assert all(
-            [
-                channelListing in expected_channel_listing
-                for channelListing in variant_data["channelListings"]
-            ]
+            channelListing in expected_channel_listing
+            for channelListing in variant_data["channelListings"]
         )
 
 
@@ -743,11 +741,9 @@ def test_product_variant_bulk_create_preorder_channel_listings_input(
             for channel_listing in expected_variant["channelListings"]
         ]
         assert all(
-            [
-                channel_listing["preorderThreshold"]["quantity"]
-                in expected_channel_listing_thresholds
-                for channel_listing in variant_data["channelListings"]
-            ]
+            channel_listing["preorderThreshold"]["quantity"]
+            in expected_channel_listing_thresholds
+            for channel_listing in variant_data["channelListings"]
         )
         preorder_data = variant_data["preorder"]
         assert preorder_data["globalThreshold"] == global_threshold

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -1139,7 +1139,7 @@ def test_product_variant_bulk_create_stocks_input(
         assert variant_data["sku"] in expected_result
         expected_variant = expected_result[variant_data["sku"]]
         expected_stocks = expected_variant["stocks"]
-        assert all([stock in expected_stocks for stock in variant_data["stocks"]])
+        assert all(stock in expected_stocks for stock in variant_data["stocks"])
 
 
 def test_product_variant_bulk_create_duplicated_warehouses(
@@ -1374,10 +1374,8 @@ def test_product_variant_bulk_create_channel_listings_input(
         expected_variant = expected_result[variant_data["sku"]]
         expected_channel_listing = expected_variant["channelListings"]
         assert all(
-            [
-                channelListing in expected_channel_listing
-                for channelListing in variant_data["channelListings"]
-            ]
+            channelListing in expected_channel_listing
+            for channelListing in variant_data["channelListings"]
         )
 
     # ensure all variants channel listings has discounted_price_amount set
@@ -1506,11 +1504,9 @@ def test_product_variant_bulk_create_preorder_channel_listings_input(
             for channel_listing in expected_variant["channelListings"]
         ]
         assert all(
-            [
-                channel_listing["preorderThreshold"]["quantity"]
-                in expected_channel_listing_thresholds
-                for channel_listing in variant_data["channelListings"]
-            ]
+            channel_listing["preorderThreshold"]["quantity"]
+            in expected_channel_listing_thresholds
+            for channel_listing in variant_data["channelListings"]
         )
         preorder_data = variant_data["preorder"]
         assert preorder_data["globalThreshold"] == global_threshold

--- a/saleor/graphql/product/tests/queries/test_product_variant_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_variant_query.py
@@ -408,10 +408,8 @@ def test_get_product_variant_stocks(
     assert len(data["stocksNoAddress"]) == all_stocks.count()
     no_address_stocks_ids = [stock["id"] for stock in data["stocksNoAddress"]]
     assert all(
-        [
-            graphene.Node.to_global_id("Stock", stock.pk) in no_address_stocks_ids
-            for stock in all_stocks
-        ]
+        graphene.Node.to_global_id("Stock", stock.pk) in no_address_stocks_ids
+        for stock in all_stocks
     )
 
     # When address is given, return only stocks from warehouse that ship to that
@@ -419,10 +417,8 @@ def test_get_product_variant_stocks(
     assert len(data["stocksWithAddress"]) == pl_stocks.count()
     with_address_stocks_ids = [stock["id"] for stock in data["stocksWithAddress"]]
     assert all(
-        [
-            graphene.Node.to_global_id("Stock", stock.pk) in with_address_stocks_ids
-            for stock in pl_stocks
-        ]
+        graphene.Node.to_global_id("Stock", stock.pk) in with_address_stocks_ids
+        for stock in pl_stocks
     )
 
 

--- a/saleor/graphql/product/tests/queries/test_products_query_with_filter.py
+++ b/saleor/graphql/product/tests/queries/test_products_query_with_filter.py
@@ -187,10 +187,10 @@ def test_products_query_with_filter_numeric_attributes(
     products = content["data"]["products"]["edges"]
 
     assert len(products) == len(expected_products_index)
-    assert set(product["node"]["id"] for product in products) == {
+    assert {product["node"]["id"] for product in products} == {
         products_ids[index] for index in expected_products_index
     }
-    assert set(product["node"]["name"] for product in products) == {
+    assert {product["node"]["name"] for product in products} == {
         products_instances[index].name for index in expected_products_index
     }
 
@@ -257,10 +257,10 @@ def test_products_query_with_filter_boolean_attributes(
     products = content["data"]["products"]["edges"]
 
     assert len(products) == len(expected_products_index)
-    assert set(product["node"]["id"] for product in products) == {
+    assert {product["node"]["id"] for product in products} == {
         products_ids[index] for index in expected_products_index
     }
-    assert set(product["node"]["name"] for product in products) == {
+    assert {product["node"]["name"] for product in products} == {
         products_instances[index].name for index in expected_products_index
     }
 

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -737,7 +737,7 @@ def test_delete_products_with_file_attributes(
     # given
     query = DELETE_PRODUCTS_MUTATION
 
-    values = [value for value in file_attribute.values.all()]
+    values = list(file_attribute.values.all())
     for i, product in enumerate(product_list[: len(values)]):
         product_type = product.product_type
         product_type.product_attributes.add(file_attribute)
@@ -909,7 +909,7 @@ def test_delete_product_types_with_file_attributes(
 ):
     query = PRODUCT_TYPE_BULK_DELETE_MUTATION
 
-    values = [value for value in file_attribute.values.all()]
+    values = list(file_attribute.values.all())
     for i, product_type in enumerate(product_type_list[: len(values)]):
         product_type.product_attributes.add(file_attribute)
         product = product_list[i]
@@ -1499,7 +1499,7 @@ def test_delete_product_variants_with_file_attribute(
         variant_id__in=[variant.id for variant in product_variant_list]
     ).exists()
 
-    values = [value for value in file_attribute.values.all()]
+    values = list(file_attribute.values.all())
     for i, variant in enumerate(product_variant_list[: len(values)]):
         product_type = variant.product.product_type
         product_type.variant_attributes.add(file_attribute)

--- a/saleor/graphql/product/tests/test_variant_availability.py
+++ b/saleor/graphql/product/tests/test_variant_availability.py
@@ -47,9 +47,7 @@ def test_variant_quantity_available_without_country_code_or_channel(
     content = get_graphql_content(response)
     variant_data = content["data"]["productVariant"]
     assert variant_data["quantityAvailable"] == 7
-    assert any(
-        [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
-    )
+    assert any(str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns)
 
 
 def test_variant_quantity_available_without_country_code_stock_only_in_cc_warehouse(

--- a/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
@@ -46,7 +46,7 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):
-        shipping_methods = [sm for sm in queryset]
+        shipping_methods = list(queryset)
         queryset.delete()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.SHIPPING_PRICE_DELETED)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
@@ -29,7 +29,7 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):
-        zones = [zone for zone in queryset]
+        zones = list(queryset)
         queryset.delete()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.SHIPPING_ZONE_DELETED)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/shipping/mutations/base.py
+++ b/saleor/graphql/shipping/mutations/base.py
@@ -270,9 +270,9 @@ class ShippingZoneMixin:
     def _extend_shipping_zone_countries(cls, data):
         countries = get_countries_without_shipping_zone()
         try:
-            data["countries"].extend([country for country in countries])
+            data["countries"].extend(list(countries))
         except (KeyError, AttributeError):
-            data["countries"] = [country for country in countries]
+            data["countries"] = list(countries)
 
 
 class ShippingPriceMixin:

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
@@ -259,10 +259,11 @@ def test_update_shipping_zone_add_second_warehouses(
     data = content["data"]["shippingZoneUpdate"]
     assert not data["errors"]
     data = content["data"]["shippingZoneUpdate"]["shippingZone"]
-    response_warehouses_slugs = set([wh["slug"] for wh in data["warehouses"]])
-    assert response_warehouses_slugs == set(
-        [warehouse.slug, warehouse_no_shipping_zone.slug]
-    )
+    response_warehouses_slugs = {wh["slug"] for wh in data["warehouses"]}
+    assert response_warehouses_slugs == {
+        warehouse.slug,
+        warehouse_no_shipping_zone.slug,
+    }
 
 
 def test_update_shipping_zone_remove_warehouses(

--- a/saleor/graphql/site/dataloaders.py
+++ b/saleor/graphql/site/dataloaders.py
@@ -24,7 +24,7 @@ class SiteByHostLoader(DataLoader):
 
     def batch_load(self, keys):
         # simulate non existing `domain__iexact__in`
-        q_list = map(lambda k: Q(domain__iexact=k), keys)
+        q_list = (Q(domain__iexact=k) for k in keys)
         q_list = reduce(lambda a, b: a | b, q_list)
         sites = Site.objects.using(self.database_connection_name).filter(q_list)
         sites_mapped = {s.domain.lower(): s for s in sites}

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -112,12 +112,10 @@ def test_tracing_query_hashing_different_vars_same_checksum(
         staff_api_client.post_graphql(query, {"first": i + 1})
 
     # then
-    fingerprints = list(
-        map(
-            lambda span: span.tags["graphql.query_fingerprint"],
-            _get_graphql_spans(tracer.finished_spans()),
-        )
-    )
+    fingerprints = [
+        span.tags["graphql.query_fingerprint"]
+        for span in _get_graphql_spans(tracer.finished_spans())
+    ]
     assert len(fingerprints) == QUERIES
     assert len(set(fingerprints)) == 1
 

--- a/saleor/graphql/tests/utils.py
+++ b/saleor/graphql/tests/utils.py
@@ -68,5 +68,5 @@ def get_multipart_request_body_with_multiple_files(query, variables, files, map_
             {"query": query, "variables": variables}, cls=DjangoJSONEncoder
         ),
         "map": json.dumps(map_dict, cls=DjangoJSONEncoder),
-        **{index: file for index, file in enumerate(files)},
+        **dict(enumerate(files)),
     }

--- a/saleor/graphql/translations/dataloaders.py
+++ b/saleor/graphql/translations/dataloaders.py
@@ -20,8 +20,8 @@ class BaseTranslationByIdAndLanguageCodeLoader(DataLoader):
         if not self.relation_name:
             raise ValueError("Provide a relation_name for this dataloader.")
 
-        ids = set([str(key[0]) for key in keys])
-        language_codes = set([key[1] for key in keys])
+        ids = {str(key[0]) for key in keys}
+        language_codes = {key[1] for key in keys}
 
         filters = {
             "language_code__in": language_codes,

--- a/saleor/graphql/translations/mutations/utils.py
+++ b/saleor/graphql/translations/mutations/utils.py
@@ -494,7 +494,7 @@ class BaseBulkTranslateMutation(BaseMutation):
             cleaned_inputs_map, index_error_map
         )
 
-        if any([bool(error) for error in index_error_map.values()]):
+        if any(bool(error) for error in index_error_map.values()):
             if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
                 results = cls.get_results(instances_data_with_errors_list, True)
                 return cls(count=0, results=results)

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -295,7 +295,7 @@ def format_error(error, handled_exceptions, query=None):
     # the API. This prevents from leaking internals that might be included in Python
     # exceptions' error messages.
     is_allowed_err = type(exc) in ALLOWED_ERRORS or any(
-        [isinstance(exc, allowed_err) for allowed_err in ALLOWED_ERRORS]
+        isinstance(exc, allowed_err) for allowed_err in ALLOWED_ERRORS
     )
     if not is_allowed_err and not settings.DEBUG:
         result["message"] = INTERNAL_ERROR_MESSAGE

--- a/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
+++ b/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
@@ -421,7 +421,7 @@ class StockBulkUpdate(BaseMutation):
             cleaned_inputs_map, warehouse_selector, variant_selector, index_error_map
         )
 
-        if any([bool(error) for error in index_error_map.values()]):
+        if any(bool(error) for error in index_error_map.values()):
             if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
                 results = cls.get_results(instances_data_with_errors_list, True)
                 return StockBulkUpdate(count=0, results=results)

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -439,7 +439,7 @@ class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
                         )
                     )
 
-                    variant_ids = list(set(key[0] for key in keys))
+                    variant_ids = list({key[0] for key in keys})
                     warehouse_ids = {
                         warehouse_id
                         for warehouse_ids in warehouse_ids_by_country_and_channel_map.values()  # noqa: E501
@@ -501,7 +501,7 @@ class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
                 self.context
             ).load_many(channel_ids)
 
-            country_codes = list(set(key[1] for key in keys if key[1]))
+            country_codes = list({key[1] for key in keys if key[1]})
             shipping_zones_by_country = ShippingZonesByCountryLoader(
                 self.context
             ).load_many(country_codes)
@@ -510,7 +510,7 @@ class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
                 [shipping_zones_by_channel, shipping_zones_by_country]
             ).then(with_shipping_zones)
 
-        channel_slugs = list(set(key[2] for key in keys if key[2]))
+        channel_slugs = list({key[2] for key in keys if key[2]})
         return (
             ChannelBySlugLoader(self.context)
             .load_many(channel_slugs)

--- a/saleor/graphql/webhook/subscription_query.py
+++ b/saleor/graphql/webhook/subscription_query.py
@@ -30,7 +30,7 @@ class SubscriptionQuery:
         self.events: list[str] = []
         self.error_code: Optional[str] = None
         self.errors = self.validate_query()
-        self.error_msg: str = ";".join(set([str(err.message) for err in self.errors]))
+        self.error_msg: str = ";".join({str(err.message) for err in self.errors})
 
     def get_filterable_channel_slugs(self) -> list[str]:
         """Get filterable channel slugs from the subscription.
@@ -157,7 +157,7 @@ class SubscriptionQuery:
                 code=WebhookErrorCode.MISSING_EVENT.value,
             )
 
-        return sorted(list(map(to_snake_case, events)))
+        return sorted(map(to_snake_case, events))
 
     @staticmethod
     def _get_subscription(ast: Document) -> Optional[OperationDefinition]:

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -1612,7 +1612,7 @@ def create_replace_order(
     """Create draft order with lines to replace."""
 
     replace_order = _populate_replace_order_fields(original_order)
-    order_line_to_create: dict[OrderLineIDType, OrderLine] = dict()
+    order_line_to_create: dict[OrderLineIDType, OrderLine] = {}
     # transaction is needed to ensure data consistency for order lines
     with traced_atomic_transaction():
         # iterate over lines without fulfillment to get the items for replace.
@@ -1772,7 +1772,7 @@ def create_return_fulfillment(
             shipping_refund_amount=shipping_refund_amount,
             manager=manager,
         )
-        returned_lines: dict[OrderLineIDType, tuple[QuantityType, OrderLine]] = dict()
+        returned_lines: dict[OrderLineIDType, tuple[QuantityType, OrderLine]] = {}
         order_lines_with_fulfillment = OrderLine.objects.in_bulk(
             [line_data.line.order_line_id for line_data in fulfillment_lines]
         )
@@ -1982,7 +1982,7 @@ def _process_refund(
     refund_shipping_costs: bool,
     manager: "PluginsManager",
 ):
-    lines_to_refund: dict[OrderLineIDType, tuple[QuantityType, OrderLine]] = dict()
+    lines_to_refund: dict[OrderLineIDType, tuple[QuantityType, OrderLine]] = {}
     refund_data = RefundData(
         order_lines_to_refund=order_lines_to_refund,
         fulfillment_lines_to_refund=fulfillment_lines_to_refund,

--- a/saleor/order/migrations/0111_auto_20210518_1357.py
+++ b/saleor/order/migrations/0111_auto_20210518_1357.py
@@ -24,10 +24,8 @@ def populate_refund_amounts_in_fulfillments(apps, schema_editor):
             [Decimal(event.parameters.get("amount", 0)) for event in refunded_events]
         )
         included_shipping_costs = any(
-            [
-                event.parameters.get("shipping_costs_included", False)
-                for event in refunded_events
-            ]
+            event.parameters.get("shipping_costs_included", False)
+            for event in refunded_events
         )
 
         fulfillment_count = fulfillments.count()

--- a/saleor/order/migrations/0177_set_order_voucher_code.py
+++ b/saleor/order/migrations/0177_set_order_voucher_code.py
@@ -43,9 +43,7 @@ def set_voucher_code(Order, Voucher, orders):
 
 def get_voucher_id_to_code_map(Voucher, orders):
     vouchers = Voucher.objects.filter(Exists(orders.filter(voucher_id=OuterRef("pk"))))
-    voucher_id_to_code_map = {
-        voucher_id: code for voucher_id, code in vouchers.values_list("id", "code")
-    }
+    voucher_id_to_code_map = dict(vouchers.values_list("id", "code"))
     return voucher_id_to_code_map
 
 

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -42,9 +42,7 @@ class AttributeData:
 
 
 def get_attribute_data_from_order_lines(lines: Iterable["OrderLine"]) -> AttributeData:
-    product_ids = set(
-        [line.variant.product_id for line in lines if line.variant_id]  # type: ignore
-    )
+    product_ids = {line.variant.product_id for line in lines if line.variant_id}  # type: ignore
     assigned_product_attribute_values = (
         AssignedProductAttributeValue.objects.using(
             settings.DATABASE_CONNECTION_REPLICA_NAME
@@ -62,13 +60,11 @@ def get_attribute_data_from_order_lines(lines: Iterable["OrderLine"]) -> Attribu
         settings.DATABASE_CONNECTION_REPLICA_NAME
     ).in_bulk(attribute_value_ids)
 
-    product_type_ids = set(
-        [
-            line.variant.product.product_type_id  # type: ignore
-            for line in lines
-            if line.variant_id
-        ]
-    )
+    product_type_ids = {
+        line.variant.product.product_type_id  # type: ignore
+        for line in lines
+        if line.variant_id
+    }
 
     attribute_products = AttributeProduct.objects.filter(
         product_type_id__in=product_type_ids

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -1570,7 +1570,7 @@ def test_fetch_order_data_plugin_tax_data_with_wrong_number_of_lines_no_shipping
 ):
     # given
     order = order_with_lines
-    lines = [line for line in order.lines.all()]
+    lines = list(order.lines.all())
     for line in lines:
         line.is_shipping_required = False
     OrderLine.objects.bulk_update(lines, ["is_shipping_required"])

--- a/saleor/order/tests/test_fulfillments_actions.py
+++ b/saleor/order/tests/test_fulfillments_actions.py
@@ -69,9 +69,10 @@ def test_create_fulfillments(
     event = events[0]
     assert event.type == OrderEvents.FULFILLMENT_FULFILLED_ITEMS
     assert event.user == staff_user
-    assert set(event.parameters["fulfilled_items"]) == set(
-        [fulfillment_lines[0].pk, fulfillment_lines[1].pk]
-    )
+    assert set(event.parameters["fulfilled_items"]) == {
+        fulfillment_lines[0].pk,
+        fulfillment_lines[1].pk,
+    }
 
     flush_post_commit_hooks()
     mock_email_fulfillment.assert_called_once_with(
@@ -142,9 +143,10 @@ def test_create_fulfillments_require_approval(
     event = events[0]
     assert event.type == OrderEvents.FULFILLMENT_AWAITS_APPROVAL
     assert event.user == staff_user
-    assert set(event.parameters["awaiting_fulfillments"]) == set(
-        [fulfillment_lines[0].pk, fulfillment_lines[1].pk]
-    )
+    assert set(event.parameters["awaiting_fulfillments"]) == {
+        fulfillment_lines[0].pk,
+        fulfillment_lines[1].pk,
+    }
 
     flush_post_commit_hooks()
     mock_email_fulfillment.assert_not_called()
@@ -212,9 +214,10 @@ def test_create_fulfillments_require_approval_as_app(
     assert event.type == OrderEvents.FULFILLMENT_AWAITS_APPROVAL
     assert event.user is None
     assert event.app == app
-    assert set(event.parameters["awaiting_fulfillments"]) == set(
-        [fulfillment_lines[0].pk, fulfillment_lines[1].pk]
-    )
+    assert set(event.parameters["awaiting_fulfillments"]) == {
+        fulfillment_lines[0].pk,
+        fulfillment_lines[1].pk,
+    }
 
     mock_email_fulfillment.assert_not_called()
 

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -466,7 +466,7 @@ def test_order_queryset_confirmed(draft_order, channel_USD):
     confirmed_orders = Order.objects.confirmed()
 
     assert draft_order not in confirmed_orders
-    assert all([order in confirmed_orders for order in other_orders])
+    assert all(order in confirmed_orders for order in other_orders)
 
 
 def test_order_queryset_drafts(draft_order, channel_USD):
@@ -482,7 +482,7 @@ def test_order_queryset_drafts(draft_order, channel_USD):
     draft_orders = Order.objects.drafts()
 
     assert draft_order in draft_orders
-    assert all([order not in draft_orders for order in other_orders])
+    assert all(order not in draft_orders for order in other_orders)
 
 
 def test_order_queryset_to_ship(settings, channel_USD):
@@ -530,8 +530,8 @@ def test_order_queryset_to_ship(settings, channel_USD):
 
     orders = Order.objects.ready_to_fulfill()
 
-    assert all([order in orders for order in orders_to_ship])
-    assert all([order not in orders for order in orders_not_to_ship])
+    assert all(order in orders for order in orders_to_ship)
+    assert all(order not in orders for order in orders_not_to_ship)
 
 
 def test_queryset_ready_to_capture(channel_USD):

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_get_or_create_adyen_partial_payments.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_get_or_create_adyen_partial_payments.py
@@ -35,9 +35,9 @@ def test_get_or_create_adyen_partial_payments_with_additional_actions_response(
     partial_payments = list(checkout.payments.exclude(id=payment_adyen_for_checkout.id))
 
     assert len(partial_payments) == 2
-    assert all([payment.is_active is False for payment in partial_payments])
-    assert all([payment.partial is True for payment in partial_payments])
-    assert all([payment.is_active is False for payment in partial_payments])
+    assert all(payment.is_active is False for payment in partial_payments)
+    assert all(payment.partial is True for payment in partial_payments)
+    assert all(payment.is_active is False for payment in partial_payments)
     assert any(payment.total == Decimal("14.71") for payment in partial_payments)
     assert any(payment.total == Decimal("16.29") for payment in partial_payments)
     assert any(
@@ -71,9 +71,9 @@ def test_get_or_create_adyen_partial_payments_with_notification_payload(
     partial_payments = list(checkout.payments.exclude(id=payment_adyen_for_checkout.id))
 
     assert len(partial_payments) == 2
-    assert all([payment.is_active is False for payment in partial_payments])
-    assert all([payment.partial is True for payment in partial_payments])
-    assert all([payment.is_active is False for payment in partial_payments])
+    assert all(payment.is_active is False for payment in partial_payments)
+    assert all(payment.partial is True for payment in partial_payments)
+    assert all(payment.is_active is False for payment in partial_payments)
     assert any(payment.total == Decimal("29.10") for payment in partial_payments)
     assert any(payment.total == Decimal("41.90") for payment in partial_payments)
     assert any(

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
@@ -333,9 +333,9 @@ def test_handle_additional_actions_with_adyen_partial_data(
 
     partial_payments = list(payment.order.payments.exclude(id=payment.id))
     assert len(partial_payments) == 2
-    assert all([payment.is_active is False for payment in partial_payments])
-    assert all([payment.partial is True for payment in partial_payments])
-    assert all([payment.is_active is False for payment in partial_payments])
+    assert all(payment.is_active is False for payment in partial_payments)
+    assert all(payment.partial is True for payment in partial_payments)
+    assert all(payment.is_active is False for payment in partial_payments)
     assert any(payment.total == Decimal("16.29") for payment in partial_payments)
     assert any(payment.total == Decimal("14.71") for payment in partial_payments)
     assert any(
@@ -428,9 +428,9 @@ def test_handle_additional_actions_with_adyen_partial_data_without_amount(
 
     partial_payments = list(payment.order.payments.exclude(id=payment.id))
     assert len(partial_payments) == 2
-    assert all([payment.is_active is False for payment in partial_payments])
-    assert all([payment.partial is True for payment in partial_payments])
-    assert all([payment.is_active is False for payment in partial_payments])
+    assert all(payment.is_active is False for payment in partial_payments)
+    assert all(payment.partial is True for payment in partial_payments)
+    assert all(payment.is_active is False for payment in partial_payments)
     assert any(payment.total == Decimal("65.29") for payment in partial_payments)
     assert any(payment.total == Decimal("14.71") for payment in partial_payments)
     assert any(

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -2011,9 +2011,9 @@ def test_handle_order_closed_with_adyen_partial_payments_success_true(
 
     partial_payments = list(payment.order.payments.exclude(id=payment.id))
     assert len(partial_payments) == 2
-    assert all([payment.is_active is False for payment in partial_payments])
-    assert all([payment.partial is True for payment in partial_payments])
-    assert all([payment.is_active is False for payment in partial_payments])
+    assert all(payment.is_active is False for payment in partial_payments)
+    assert all(payment.partial is True for payment in partial_payments)
+    assert all(payment.is_active is False for payment in partial_payments)
     assert any(payment.total == Decimal("29.10") for payment in partial_payments)
     assert any(payment.total == Decimal("41.90") for payment in partial_payments)
     assert any(
@@ -2095,9 +2095,9 @@ def test_handle_order_closed_with_adyen_partial_payments_success_true_without_am
 
     partial_payments = list(payment.order.payments.exclude(id=payment.id))
     assert len(partial_payments) == 2
-    assert all([payment.is_active is False for payment in partial_payments])
-    assert all([payment.partial is True for payment in partial_payments])
-    assert all([payment.is_active is False for payment in partial_payments])
+    assert all(payment.is_active is False for payment in partial_payments)
+    assert all(payment.partial is True for payment in partial_payments)
+    assert all(payment.is_active is False for payment in partial_payments)
     assert any(payment.total == Decimal("29.10") for payment in partial_payments)
     assert any(payment.total == Decimal("50.90") for payment in partial_payments)
     assert any(

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -1096,9 +1096,9 @@ def prepare_api_request_data(request: WSGIRequest, data: dict):
     params = data["parameters"]
     request_data: QueryDict = QueryDict("")
 
-    if all([param in request.GET for param in params]):
+    if all(param in request.GET for param in params):
         request_data = request.GET
-    elif all([param in request.POST for param in params]):
+    elif all(param in request.POST for param in params):
         request_data = request.POST
 
     if not request_data:

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -560,7 +560,7 @@ class StripeGatewayPlugin(BasePlugin):
         configuration = {item["name"]: item["value"] for item in configuration}
         required_fields = ["secret_api_key", "public_api_key"]
         all_required_fields_provided = all(
-            [configuration.get(field) for field in required_fields]
+            configuration.get(field) for field in required_fields
         )
         if plugin_configuration.active:
             if not all_required_fields_provided:

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -107,17 +107,13 @@ def test_pre_save_plugin_configuration_removes_webhook_when_disabled(
     plugin.pre_save_plugin_configuration(configuration)
 
     assert all(
-        [
-            c_field["value"] != "endpoint"
-            for c_field in configuration.configuration
-            if c_field["name"] == "webhook_endpoint_id"
-        ]
+        c_field["value"] != "endpoint"
+        for c_field in configuration.configuration
+        if c_field["name"] == "webhook_endpoint_id"
     )
     assert all(
-        [
-            c_field["name"] != "webhook_secret_key"
-            for c_field in configuration.configuration
-        ]
+        c_field["name"] != "webhook_secret_key"
+        for c_field in configuration.configuration
     )
     assert mocked_stripe.called
 

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -342,10 +342,8 @@ class Payment(ModelWithMetadata):
         # There is no authorized amount anymore when capture is succeeded
         # since capture can only be made once, even it is a partial capture
         if any(
-            [
-                txn.kind == TransactionKind.CAPTURE and txn.is_success
-                for txn in transactions
-            ]
+            txn.kind == TransactionKind.CAPTURE and txn.is_success
+            for txn in transactions
         ):
             return money
 
@@ -376,12 +374,10 @@ class Payment(ModelWithMetadata):
     @property
     def is_authorized(self):
         return any(
-            [
-                txn.kind == TransactionKind.AUTH
-                and txn.is_success
-                and not txn.action_required
-                for txn in self.transactions.all()
-            ]
+            txn.kind == TransactionKind.AUTH
+            and txn.is_success
+            and not txn.action_required
+            for txn in self.transactions.all()
         )
 
     @property

--- a/saleor/payment/tests/test_gateways_utils.py
+++ b/saleor/payment/tests/test_gateways_utils.py
@@ -47,7 +47,7 @@ def test_get_supported_currencies_not_configured(gateway_config):
             "Supported currencies not configured for Test, "
             "please configure supported currencies for this gateway."
         )
-        assert any([str(warning.message) == expected_warning for warning in warns])
+        assert any(str(warning.message) == expected_warning for warning in warns)
 
     # then
     assert currencies == []

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -975,7 +975,7 @@ def test_create_transaction_event_from_request_and_webhook_response_full_event(
     # then
     transaction.refresh_from_db()
     assert len(transaction.available_actions) == 2
-    assert set(transaction.available_actions) == set(["charge", "cancel"])
+    assert set(transaction.available_actions) == {"charge", "cancel"}
     assert transaction.events.count() == 2
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
@@ -2234,7 +2234,7 @@ def test_create_transaction_event_for_transaction_session_success_sets_actions(
     # then
     transaction.refresh_from_db()
     assert len(transaction.available_actions) == 3
-    assert set(transaction.available_actions) == set(["refund", "charge", "cancel"])
+    assert set(transaction.available_actions) == {"refund", "charge", "cancel"}
 
 
 @pytest.mark.parametrize(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -687,7 +687,7 @@ def get_payment_token(payment: Payment):
 def is_currency_supported(currency: str, gateway_id: str, manager: "PluginsManager"):
     """Return true if the given gateway supports given currency."""
     available_gateways = manager.list_payment_gateways(currency=currency)
-    return any([gateway.id == gateway_id for gateway in available_gateways])
+    return any(gateway.id == gateway_id for gateway in available_gateways)
 
 
 def price_from_minor_unit(value: str, currency: str):

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -925,7 +925,7 @@ class AvataxPlugin(BasePlugin):
         ]
 
         all_address_fields = all(
-            [configuration[field] for field in required_from_address_fields]
+            configuration[field] for field in required_from_address_fields
         )
         if not all_address_fields:
             missing_fields.extend(required_from_address_fields)

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -4933,7 +4933,7 @@ def test_get_order_request_data_checks_when_taxes_are_included_to_price(
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # then
-    assert all([line for line in lines_data if line["taxIncluded"] is True])
+    assert all(line for line in lines_data if line["taxIncluded"] is True)
 
 
 def test_get_order_request_data_uses_correct_address_for_cc(

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -1741,7 +1741,7 @@ class BasePlugin:
                 config_item.update([("value", new_value)])
 
         # Get new keys that don't exist in current_config and extend it.
-        current_config_keys = set(c_field["name"] for c_field in current_config)
+        current_config_keys = {c_field["name"] for c_field in current_config}
         missing_keys = set(configuration_to_update_dict.keys()) - current_config_keys
         for missing_key in missing_keys:
             if not config_structure.get(missing_key):
@@ -1850,7 +1850,7 @@ class BasePlugin:
                 continue
             updated_configuration.append(copy(config_field))
 
-        configured_keys = set(d["name"] for d in updated_configuration)
+        configured_keys = {d["name"] for d in updated_configuration}
         missing_keys = desired_config_keys - configured_keys
 
         if not missing_keys:

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2839,7 +2839,7 @@ class PluginsManager(PaymentInterface):
         self, plugin_id: str, data: dict, request: SaleorContext
     ) -> tuple[Optional["User"], dict]:
         """Verify the provided authentication data."""
-        default_data: dict[str, str] = dict()
+        default_data: dict[str, str] = {}
         default_user: Optional[User] = None
         default_value = default_user, default_data
         plugin = self.get_plugin(plugin_id)
@@ -2883,7 +2883,7 @@ class PluginsManager(PaymentInterface):
             self.plugins_per_channel[channel_slug] if channel_slug else self.all_plugins
         )
         only_active_plugins = [plugin for plugin in plugins if plugin.active]
-        return any([plugin.is_event_active(event) for plugin in only_active_plugins])
+        return any(plugin.is_event_active(event) for plugin in only_active_plugins)
 
 
 def get_plugins_manager(

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -700,9 +700,9 @@ def get_saleor_permissions_from_list(permissions: list) -> QuerySet[Permission]:
     if not saleor_permissions_str:
         return Permission.objects.none()
 
-    permission_codenames = list(
-        map(lambda perm: perm.replace("saleor:", ""), saleor_permissions_str)
-    )
+    permission_codenames = [
+        perm.replace("saleor:", "") for perm in saleor_permissions_str
+    ]
     permissions = get_permissions_from_codenames(permission_codenames)
     return permissions
 

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -78,10 +78,8 @@ def test_manager_with_default_configuration_for_channel_plugins(
     for _channel_slug, plugins in manager.plugins_per_channel.items():
         assert len(plugins) == 2
         assert all(
-            [
-                isinstance(plugin, (PluginSample, ChannelPluginSample))
-                for plugin in plugins
-            ]
+            isinstance(plugin, (PluginSample, ChannelPluginSample))
+            for plugin in plugins
         )
 
     # global plugin + plugins for each channel

--- a/saleor/plugins/tests/test_plugins.py
+++ b/saleor/plugins/tests/test_plugins.py
@@ -43,7 +43,7 @@ def test_update_config_items_skips_new_keys_when_doesnt_exsist_in_conf_structure
 
     plugin_sample._update_config_items(data_to_update, current_config)
     assert not all(
-        [config_field["name"] == "New-field" for config_field in current_config]
+        config_field["name"] == "New-field" for config_field in current_config
     )
 
 
@@ -74,7 +74,7 @@ def test_update_config_items_adds_new_keys(monkeypatch):
     ]
 
     plugin_sample._update_config_items(data_to_update, current_config)
-    assert any([config_field["name"] == "New-field" for config_field in current_config])
+    assert any(config_field["name"] == "New-field" for config_field in current_config)
 
 
 def test_update_configuration_structure_removes_old_keys(
@@ -89,7 +89,7 @@ def test_update_configuration_structure_removes_old_keys(
     configuration = PluginSample._update_configuration_structure(
         plugin_configuration.configuration
     )
-    assert all([config_field["name"] != "Username" for config_field in configuration])
+    assert all(config_field["name"] != "Username" for config_field in configuration)
 
 
 def test_save_plugin_configuration(plugin_configuration):

--- a/saleor/product/migrations/0001_initial.py
+++ b/saleor/product/migrations/0001_initial.py
@@ -330,6 +330,6 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.AlterUniqueTogether(
-            name="stock", unique_together=set([("variant", "location")])
+            name="stock", unique_together={("variant", "location")}
         ),
     ]

--- a/saleor/product/migrations/0016_auto_20161207_0843.py
+++ b/saleor/product/migrations/0016_auto_20161207_0843.py
@@ -8,6 +8,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterUniqueTogether(
-            name="stock", unique_together=set([("variant", "location_link")])
+            name="stock", unique_together={("variant", "location_link")}
         )
     ]

--- a/saleor/product/migrations/0018_auto_20161207_0844.py
+++ b/saleor/product/migrations/0018_auto_20161207_0844.py
@@ -11,6 +11,6 @@ class Migration(migrations.Migration):
             model_name="stock", old_name="location_link", new_name="location"
         ),
         migrations.AlterUniqueTogether(
-            name="stock", unique_together=set([("variant", "location")])
+            name="stock", unique_together={("variant", "location")}
         ),
     ]

--- a/saleor/product/migrations/0032_auto_20170216_0438.py
+++ b/saleor/product/migrations/0032_auto_20170216_0438.py
@@ -8,6 +8,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterUniqueTogether(
-            name="attributechoicevalue", unique_together=set([("display", "attribute")])
+            name="attributechoicevalue", unique_together={("display", "attribute")}
         )
     ]

--- a/saleor/product/migrations/0033_auto_20170227_0757.py
+++ b/saleor/product/migrations/0033_auto_20170227_0757.py
@@ -25,6 +25,6 @@ class Migration(migrations.Migration):
             model_name="productattribute", old_name="display", new_name="name"
         ),
         migrations.AlterUniqueTogether(
-            name="attributechoicevalue", unique_together=set([("name", "attribute")])
+            name="attributechoicevalue", unique_together={("name", "attribute")}
         ),
     ]

--- a/saleor/product/migrations/0104_fix_invalid_attributes_map.py
+++ b/saleor/product/migrations/0104_fix_invalid_attributes_map.py
@@ -18,7 +18,7 @@ def migrate_attributes_to_list(model_name):
                     # Fix a migration error where attributes were stored as repr(list)
                     loaded = json.loads(v.replace("'", '"'))
                     assert isinstance(loaded, list)
-                    assert all([isinstance(v_pk, str) for v_pk in loaded])
+                    assert all(isinstance(v_pk, str) for v_pk in loaded)
                     new_attributes[k] = loaded
                 elif not isinstance(v, list):
                     new_attributes[k] = [v]

--- a/saleor/product/migrations/0183_calculate_discounted_prices.py
+++ b/saleor/product/migrations/0183_calculate_discounted_prices.py
@@ -283,10 +283,7 @@ def _get_product_to_variant_channel_listings_per_channel_map(
     variant_channel_listings = variant_listing_model.objects.filter(
         Exists(variants.filter(id=OuterRef("variant_id"))), price_amount__isnull=False
     )
-    variant_to_product_id = {
-        variant_id: product_id
-        for variant_id, product_id in variants.values_list("id", "product_id")
-    }
+    variant_to_product_id = dict(variants.values_list("id", "product_id"))
 
     price_data = defaultdict(lambda: defaultdict(list))
     for variant_channel_listing in variant_channel_listings:

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -110,9 +110,9 @@ def update_products_discounted_prices_of_promotion_task(promotion_pk: UUID):
 
 
 def _get_channel_to_products_map(rule_to_variant_list):
-    variant_ids = set(
-        [rule_to_variant.productvariant_id for rule_to_variant in rule_to_variant_list]
-    )
+    variant_ids = {
+        rule_to_variant.productvariant_id for rule_to_variant in rule_to_variant_list
+    }
     variant_id_with_product_id_qs = (
         ProductVariant.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
         .filter(id__in=variant_ids)
@@ -122,9 +122,9 @@ def _get_channel_to_products_map(rule_to_variant_list):
     for variant_id, product_id in variant_id_with_product_id_qs:
         variant_id_to_product_id_map[variant_id] = product_id
 
-    rule_ids = set(
-        [rule_to_variant.promotionrule_id for rule_to_variant in rule_to_variant_list]
-    )
+    rule_ids = {
+        rule_to_variant.promotionrule_id for rule_to_variant in rule_to_variant_list
+    }
     PromotionChannel = PromotionRule.channels.through
     promotion_channel_qs = (
         PromotionChannel.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
@@ -246,8 +246,8 @@ def recalculate_discounted_price_for_products_task():
         "id",
         "product_id",
     )
-    products_ids = set([product_id for _, product_id in listing_details])
-    listing_ids = set([listing_id for listing_id, _ in listing_details])
+    products_ids = {product_id for _, product_id in listing_details}
+    listing_ids = {listing_id for listing_id, _ in listing_details}
     if products_ids:
         products = Product.objects.using(
             settings.DATABASE_CONNECTION_REPLICA_NAME

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -177,10 +177,8 @@ def test_available_products_only_published(product_list, channel_USD):
     available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 2
     assert all(
-        [
-            product.channel_listings.get(channel__slug=channel_USD).is_published
-            for product in available_products
-        ]
+        product.channel_listings.get(channel__slug=channel_USD).is_published
+        for product in available_products
     )
 
 
@@ -193,10 +191,8 @@ def test_available_products_only_available(product_list, channel_USD):
     available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 2
     assert all(
-        [
-            product.channel_listings.get(channel__slug=channel_USD).is_published
-            for product in available_products
-        ]
+        product.channel_listings.get(channel__slug=channel_USD).is_published
+        for product in available_products
     )
 
 
@@ -209,10 +205,8 @@ def test_available_products_available_from_yesterday(product_list, channel_USD):
     available_products = models.Product.objects.published(channel_USD)
     assert available_products.count() == 3
     assert all(
-        [
-            product.channel_listings.get(channel__slug=channel_USD).is_published
-            for product in available_products
-        ]
+        product.channel_listings.get(channel__slug=channel_USD).is_published
+        for product in available_products
     )
 
 

--- a/saleor/product/utils/__init__.py
+++ b/saleor/product/utils/__init__.py
@@ -55,7 +55,7 @@ def delete_categories(categories_ids: list[Union[str, int]], manager):
     product_channel_listing.update(is_published=False, published_at=None)
     products = list(products)
 
-    category_instances = [cat for cat in categories]
+    category_instances = list(categories)
     categories.delete()
     webhooks = get_webhooks_for_event(WebhookEventAsyncType.CATEGORY_DELETED)
     for category in category_instances:

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -188,12 +188,7 @@ def _get_product_to_variant_channel_listings_per_channel_map(
     variant_channel_listings = ProductVariantChannelListing.objects.filter(
         Exists(variants.filter(id=OuterRef("variant_id"))), price_amount__isnull=False
     )
-    variant_to_product_id = {
-        variant_id: product_id
-        for variant_id, product_id in variants.values_list(
-            "id", "product_id"
-        ).iterator()
-    }
+    variant_to_product_id = dict(variants.values_list("id", "product_id").iterator())
 
     price_data: dict[int, dict[int, list[Money]]] = defaultdict(
         lambda: defaultdict(list)

--- a/saleor/shipping/migrations/0001_initial.py
+++ b/saleor/shipping/migrations/0001_initial.py
@@ -316,6 +316,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name="shippingmethodcountry",
-            unique_together=set([("country_code", "shipping_method")]),
+            unique_together={("country_code", "shipping_method")},
         ),
     ]

--- a/saleor/shipping/postal_codes.py
+++ b/saleor/shipping/postal_codes.py
@@ -101,17 +101,13 @@ def is_shipping_method_applicable_for_postal_code(
     if not results:
         return True
     if all(
-        map(
-            lambda rule: rule.inclusion_type == PostalCodeRuleInclusionType.INCLUDE,
-            results.keys(),
-        )
+        rule.inclusion_type == PostalCodeRuleInclusionType.INCLUDE
+        for rule in results.keys()
     ):
         return any(results.values())
     if all(
-        map(
-            lambda rule: rule.inclusion_type == PostalCodeRuleInclusionType.EXCLUDE,
-            results.keys(),
-        )
+        rule.inclusion_type == PostalCodeRuleInclusionType.EXCLUDE
+        for rule in results.keys()
     ):
         return not any(results.values())
     # Shipping methods with complex rules are not supported for now

--- a/saleor/shipping/tests/test_shipping.py
+++ b/saleor/shipping/tests/test_shipping.py
@@ -56,7 +56,7 @@ def test_applicable_shipping_methods_price(
         country_code="PL",
         channel_id=channel_USD.id,
     )
-    result_ids = set([method.id for method in result])
+    result_ids = {method.id for method in result}
     assert len(result_ids) == len(result)
     assert (method in result) == shipping_included
 

--- a/saleor/site/migrations/0004_auto_20170221_0426.py
+++ b/saleor/site/migrations/0004_auto_20170221_0426.py
@@ -40,6 +40,6 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.AlterUniqueTogether(
-            name="authorizationkey", unique_together=set([("site_settings", "name")])
+            name="authorizationkey", unique_together={("site_settings", "name")}
         ),
     ]

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -468,7 +468,7 @@ def test_allocate_stock_insufficient_stocks_for_multiple_lines(
             manager=get_plugins_manager(allow_replica=False),
         )
 
-    assert set(item.variant for item in exc._excinfo[1].items) == {variant, variant_2}
+    assert {item.variant for item in exc._excinfo[1].items} == {variant, variant_2}
 
     assert not Allocation.objects.filter(
         order_line=order_line, stock__in=stocks

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -559,7 +559,7 @@ def test_category_deleted(category, subscription_category_deleted_webhook):
     webhooks = [subscription_category_deleted_webhook]
 
     category_query = Category.objects.filter(pk=category.id)
-    category_instances = [cat for cat in category_query]
+    category_instances = list(category_query)
     category_query.delete()
 
     event_type = WebhookEventAsyncType.CATEGORY_DELETED
@@ -615,7 +615,7 @@ def test_channel_deleted(channel_USD, subscription_channel_deleted_webhook):
     webhooks = [subscription_channel_deleted_webhook]
 
     channel_query = Channel.objects.filter(pk=channel_USD.id)
-    channel_instances = [channel for channel in channel_query]
+    channel_instances = list(channel_query)
     channel_query.delete()
 
     event_type = WebhookEventAsyncType.CHANNEL_DELETED
@@ -694,7 +694,7 @@ def test_gift_card_deleted(gift_card, subscription_gift_card_deleted_webhook):
     webhooks = [subscription_gift_card_deleted_webhook]
 
     gift_card_query = GiftCard.objects.filter(pk=gift_card.id)
-    gift_card_instances = [card for card in gift_card_query]
+    gift_card_instances = list(gift_card_query)
     gift_card_query.delete()
 
     event_type = WebhookEventAsyncType.GIFT_CARD_DELETED
@@ -718,7 +718,7 @@ def test_gift_card_sent(gift_card, channel_USD, subscription_gift_card_sent_webh
     webhooks = [subscription_gift_card_sent_webhook]
 
     gift_card_query = GiftCard.objects.filter(pk=gift_card.id)
-    gift_card_instances = [card for card in gift_card_query]
+    gift_card_instances = list(gift_card_query)
     gift_card_query.delete()
 
     event_type = WebhookEventAsyncType.GIFT_CARD_SENT
@@ -850,7 +850,7 @@ def test_menu_deleted(menu, subscription_menu_deleted_webhook):
     webhooks = [subscription_menu_deleted_webhook]
 
     menu_query = Menu.objects.filter(pk=menu.id)
-    menu_instances = [menu for menu in menu_query]
+    menu_instances = list(menu_query)
     menu_query.delete()
 
     event_type = WebhookEventAsyncType.MENU_DELETED
@@ -906,7 +906,7 @@ def test_menu_item_deleted(menu_item, subscription_menu_item_deleted_webhook):
     webhooks = [subscription_menu_item_deleted_webhook]
 
     menu_item_query = MenuItem.objects.filter(pk=menu_item.id)
-    menu_item_instances = [menu for menu in menu_item_query]
+    menu_item_instances = list(menu_item_query)
     menu_item_query.delete()
 
     event_type = WebhookEventAsyncType.MENU_ITEM_DELETED
@@ -973,7 +973,7 @@ def test_shipping_price_deleted(
     event_type = WebhookEventAsyncType.SHIPPING_PRICE_DELETED
 
     shipping_methods_query = ShippingMethod.objects.filter(pk=shipping_method.id)
-    method_instances = [method for method in shipping_methods_query]
+    method_instances = list(shipping_methods_query)
     shipping_methods_query.delete()
 
     shipping_method_id = graphene.Node.to_global_id(
@@ -1062,7 +1062,7 @@ def test_shipping_zone_deleted(
     event_type = WebhookEventAsyncType.SHIPPING_ZONE_DELETED
 
     shipping_zones_query = ShippingZone.objects.filter(pk=shipping_zone.id)
-    zones_instances = [zone for zone in shipping_zones_query]
+    zones_instances = list(shipping_zones_query)
     shipping_zones_query.delete()
 
     shipping_zone_id = graphene.Node.to_global_id("ShippingZone", zones_instances[0].id)

--- a/saleor/webhook/tests/test_tasks.py
+++ b/saleor/webhook/tests/test_tasks.py
@@ -1056,13 +1056,11 @@ def test_handle_transaction_request_task_with_available_actions(
     assert success_event.amount_value == event_amount
 
     transaction.refresh_from_db()
-    assert set(transaction.available_actions) == set(
-        [
-            "charge",
-            "refund",
-            "cancel",
-        ]
-    )
+    assert set(transaction.available_actions) == {
+        "charge",
+        "refund",
+        "cancel",
+    }
 
     mocked_post_request.assert_called_once_with(
         "POST",

--- a/saleor/webhook/tests/test_utils.py
+++ b/saleor/webhook/tests/test_utils.py
@@ -143,7 +143,7 @@ def test_truncation_error_extra_fields(
     error: type[TruncationError], event_type: ObservabilityEventTypes
 ):
     operation, bytes_limit, payload_size = "operation_name", 100, 102
-    kwargs = dict(extra_kwarg_a="a", extra_kwarg_b="b")
+    kwargs = {"extra_kwarg_a": "a", "extra_kwarg_b": "b"}
     err = error(operation, bytes_limit, payload_size, **kwargs)
     assert str(err)
     assert err.extra == {


### PR DESCRIPTION
This cleans up unnecessary calls to lists within sets and replaces unnecessary function calls with idiomatic comprehensions and literals.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
