### PR TITLE
Clean up feature preview label from account, app, attributes modules

### DIFF
--- a/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
@@ -17,7 +17,6 @@ from ....order.utils import match_orders_with_new_user
 from ....permission.enums import AccountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
-from ...core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_USERS
 from ...core.enums import CustomerBulkUpdateErrorCode, ErrorPolicyEnum
 from ...core.mutations import BaseMutation, ModelMutation
@@ -94,7 +93,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
         )
 
     class Meta:
-        description = "Updates customers." + ADDED_IN_313 + PREVIEW_FEATURE
+        description = "Updates customers."
         doc_category = DOC_CATEGORY_USERS
         permissions = (AccountPermissions.MANAGE_USERS,)
         error_type_class = CustomerBulkUpdateError

--- a/saleor/graphql/account/mutations/account/send_confirmation_email.py
+++ b/saleor/graphql/account/mutations/account/send_confirmation_email.py
@@ -15,7 +15,6 @@ from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel.utils import clean_channel
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import BaseMutation
 from ....core.types import SendConfirmationEmailError
@@ -39,9 +38,7 @@ class SendConfirmationEmail(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Sends a notification confirmation." + ADDED_IN_315 + PREVIEW_FEATURE
-        )
+        description = "Sends a notification confirmation."
         doc_category = DOC_CATEGORY_USERS
         error_type_class = SendConfirmationEmailError
         permissions = (AuthorizationFilters.AUTHENTICATED_USER,)

--- a/saleor/graphql/account/mutations/permission_group/permission_group_create.py
+++ b/saleor/graphql/account/mutations/permission_group/permission_group_create.py
@@ -15,7 +15,6 @@ from .....webhook.event_types import WebhookEventAsyncType
 from ....account.utils import get_out_of_scope_permissions, get_user_accessible_channels
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_314, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.enums import PermissionEnum
 from ....core.mutations import ModelMutation
@@ -37,10 +36,7 @@ class PermissionGroupInput(BaseInputObjectType):
         required=False,
     )
     add_channels = NonNullList(
-        graphene.ID,
-        description="List of channels to assign to this group."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        graphene.ID, description="List of channels to assign to this group."
     )
 
     class Meta:
@@ -52,9 +48,7 @@ class PermissionGroupCreateInput(PermissionGroupInput):
     restricted_access_to_channels = graphene.Boolean(
         description=(
             "Determine if the group has restricted access to channels.  DEFAULT: False"
-        )
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        ),
         default_value=False,
         required=False,
     )

--- a/saleor/graphql/account/mutations/permission_group/permission_group_update.py
+++ b/saleor/graphql/account/mutations/permission_group/permission_group_update.py
@@ -19,7 +19,6 @@ from ....account.utils import (
     get_out_of_scope_users,
 )
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_314, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.enums import PermissionEnum
 from ....core.types import NonNullList, PermissionGroupError
@@ -44,15 +43,10 @@ class PermissionGroupUpdateInput(PermissionGroupInput):
         required=False,
     )
     remove_channels = NonNullList(
-        graphene.ID,
-        description="List of channels to unassign from this group."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        graphene.ID, description="List of channels to unassign from this group."
     )
     restricted_access_to_channels = graphene.Boolean(
-        description="Determine if the group has restricted access to channels."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        description="Determine if the group has restricted access to channels.",
         required=False,
     )
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -36,10 +36,6 @@ from ..core import ResolveInfo
 from ..core.connection import CountableConnection, create_connection_slice
 from ..core.context import get_database_connection_name
 from ..core.descriptions import (
-    ADDED_IN_38,
-    ADDED_IN_310,
-    ADDED_IN_314,
-    ADDED_IN_315,
     ADDED_IN_319,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
@@ -99,7 +95,7 @@ class AddressInput(BaseInputObjectType):
     )
     metadata = graphene.List(
         graphene.NonNull(MetadataInput),
-        description="Address public metadata." + ADDED_IN_315,
+        description="Address public metadata.",
         required=False,
     )
     skip_validation = graphene.Boolean(
@@ -161,7 +157,6 @@ class Address(ModelObjectType[models.Address]):
         description = "Represents user address data."
         interfaces = [relay.Node, ObjectWithMetadata]
         model = models.Address
-        metadata_since = ADDED_IN_310
 
     @staticmethod
     def resolve_country(root: models.Address, _info: ResolveInfo):
@@ -333,7 +328,7 @@ class User(ModelObjectType[models.User]):
     )
     is_confirmed = graphene.Boolean(
         required=True,
-        description="Determines if user has confirmed email." + ADDED_IN_315,
+        description="Determines if user has confirmed email.",
     )
     addresses = NonNullList(
         Address, description="List of all user's addresses.", required=True
@@ -363,7 +358,7 @@ class User(ModelObjectType[models.User]):
     )
     checkouts = ConnectionField(
         CheckoutCountableConnection,
-        description="Returns checkouts assigned to this user." + ADDED_IN_38,
+        description="Returns checkouts assigned to this user.",
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
@@ -401,7 +396,7 @@ class User(ModelObjectType[models.User]):
         description=(
             "List of channels the user has access to. The sum of channels from all "
             "user groups. If at least one group has `restrictedAccessToChannels` "
-            "set to False - all channels are returned." + ADDED_IN_314 + PREVIEW_FEATURE
+            "set to False - all channels are returned."
         ),
     )
     restricted_access_to_channels = graphene.Boolean(
@@ -409,9 +404,7 @@ class User(ModelObjectType[models.User]):
         description=(
             "Determine if user have restricted access to channels. False if at least "
             "one user group has `restrictedAccessToChannels` set to False."
-        )
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        ),
     )
     avatar = ThumbnailField(description="The avatar of the user.")
     events = PermissionsField(
@@ -439,7 +432,7 @@ class User(ModelObjectType[models.User]):
         Address, description="The default billing address of the user."
     )
     external_reference = graphene.String(
-        description=f"External ID of this user. {ADDED_IN_310}", required=False
+        description="External ID of this user.", required=False
     )
 
     last_login = DateTime(
@@ -458,7 +451,7 @@ class User(ModelObjectType[models.User]):
             "Returns a list of user's stored payment methods that can be used in "
             "provided channel. The field returns a list of stored payment methods by "
             "payment apps. When `amount` is not provided, 0 will be used as default "
-            "value." + ADDED_IN_315 + PREVIEW_FEATURE
+            "value."
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned.",
@@ -943,16 +936,11 @@ class Group(ModelObjectType[models.Group]):
         ),
     )
     accessible_channels = NonNullList(
-        Channel,
-        description="List of channels the group has access to."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        Channel, description="List of channels the group has access to."
     )
     restricted_access_to_channels = graphene.Boolean(
         required=True,
-        description="Determine if the group have restricted access to channels."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        description="Determine if the group have restricted access to channels.",
     )
 
     class Meta:

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -24,14 +24,8 @@ from ..core import ResolveInfo, SaleorContext
 from ..core.connection import CountableConnection
 from ..core.context import get_database_connection_name
 from ..core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_35,
-    ADDED_IN_38,
-    ADDED_IN_313,
-    ADDED_IN_314,
     ADDED_IN_319,
     DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
 )
 from ..core.doc_category import DOC_CATEGORY_APPS
 from ..core.federation import federated_entity, resolve_federation_references
@@ -241,17 +235,11 @@ class AppManifestWebhook(BaseObjectType):
 class AppManifestRequiredSaleorVersion(BaseObjectType):
     constraint = graphene.String(
         required=True,
-        description=(
-            "Required Saleor version as semver range." + ADDED_IN_313 + PREVIEW_FEATURE
-        ),
+        description=("Required Saleor version as semver range."),
     )
     satisfied = graphene.Boolean(
         required=True,
-        description=(
-            "Informs if the Saleor version matches the required one."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
-        ),
+        description=("Informs if the Saleor version matches the required one."),
     )
 
     class Meta:
@@ -262,16 +250,12 @@ class AppManifestBrandLogo(BaseObjectType):
     default = IconThumbnailField(
         graphene.String,
         required=True,
-        description="Data URL with a base64 encoded logo image."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        description="Data URL with a base64 encoded logo image.",
     )
 
     class Meta:
         doc_category = DOC_CATEGORY_APPS
-        description = (
-            "Represents the app's manifest brand data." + ADDED_IN_314 + PREVIEW_FEATURE
-        )
+        description = "Represents the app's manifest brand data."
 
     @staticmethod
     def resolve_default(
@@ -300,16 +284,12 @@ class AppManifestBrandLogo(BaseObjectType):
 
 class AppBrandLogo(BaseObjectType):
     default = IconThumbnailField(
-        graphene.String,
-        required=True,
-        description="URL to the default logo image." + ADDED_IN_314 + PREVIEW_FEATURE,
+        graphene.String, required=True, description="URL to the default logo image."
     )
 
     class Meta:
         doc_category = DOC_CATEGORY_APPS
-        description = (
-            "Represents the app's brand logo data." + ADDED_IN_314 + PREVIEW_FEATURE
-        )
+        description = "Represents the app's brand logo data."
 
     @staticmethod
     def resolve_default(
@@ -351,15 +331,11 @@ class AppBrandLogo(BaseObjectType):
 
 class AppBrand(BaseObjectType):
     logo = graphene.Field(
-        AppBrandLogo,
-        required=True,
-        description="App's logos details." + ADDED_IN_314 + PREVIEW_FEATURE,
+        AppBrandLogo, required=True, description="App's logos details."
     )
 
     class Meta:
-        description = (
-            "Represents the app's brand data." + ADDED_IN_314 + PREVIEW_FEATURE
-        )
+        description = "Represents the app's brand data."
         doc_category = DOC_CATEGORY_APPS
 
     @staticmethod
@@ -371,15 +347,11 @@ class AppBrand(BaseObjectType):
 
 class AppManifestBrand(BaseObjectType):
     logo = graphene.Field(
-        AppManifestBrandLogo,
-        required=True,
-        description="App's logos details." + ADDED_IN_314 + PREVIEW_FEATURE,
+        AppManifestBrandLogo, required=True, description="App's logos details."
     )
 
     class Meta:
-        description = (
-            "Represents the app's manifest brand data." + ADDED_IN_314 + PREVIEW_FEATURE
-        )
+        description = "Represents the app's manifest brand data."
         doc_category = DOC_CATEGORY_APPS
 
 
@@ -430,29 +402,20 @@ class Manifest(BaseObjectType):
     )
     webhooks = NonNullList(
         AppManifestWebhook,
-        description="List of the app's webhooks." + ADDED_IN_35,
+        description="List of the app's webhooks.",
         required=True,
     )
     audience = graphene.String(
-        description=(
-            "The audience that will be included in all JWT tokens for the app."
-            + ADDED_IN_38
-        )
+        description="The audience that will be included in all JWT tokens for the app."
     )
     required_saleor_version = graphene.Field(
         AppManifestRequiredSaleorVersion,
-        description=(
-            "Determines the app's required Saleor version as semver range."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
-        ),
+        description="Determines the app's required Saleor version as semver range.",
     )
-    author = graphene.String(
-        description=("The App's author name." + ADDED_IN_313 + PREVIEW_FEATURE)
-    )
+    author = graphene.String(description="The App's author name.")
     brand = graphene.Field(
         AppManifestBrand,
-        description="App's brand data." + ADDED_IN_314 + PREVIEW_FEATURE,
+        description="App's brand data.",
     )
 
     class Meta:
@@ -540,23 +503,19 @@ class App(ModelObjectType[models.App]):
     )
     app_url = graphene.String(description="URL to iframe with the app.")
     manifest_url = graphene.String(
-        description="URL to manifest used during app's installation." + ADDED_IN_35
+        description="URL to manifest used during app's installation."
     )
     version = graphene.String(description="Version number of the app.")
     access_token = graphene.String(
         description="JWT token used to authenticate by third-party app."
     )
-    author = graphene.String(
-        description=("The App's author name." + ADDED_IN_313 + PREVIEW_FEATURE)
-    )
+    author = graphene.String(description="The App's author name.")
     extensions = NonNullList(
         AppExtension,
-        description="App's dashboard extensions." + ADDED_IN_31,
+        description="App's dashboard extensions.",
         required=True,
     )
-    brand = graphene.Field(
-        AppBrand, description="App's brand data." + ADDED_IN_314 + PREVIEW_FEATURE
-    )
+    brand = graphene.Field(AppBrand, description="App's brand data.")
 
     class Meta:
         description = "Represents app data."
@@ -645,9 +604,7 @@ class AppInstallation(ModelObjectType[models.AppInstallation]):
         required=True,
         description="The URL address of manifest for the app installation.",
     )
-    brand = graphene.Field(
-        AppBrand, description="App's brand data." + ADDED_IN_314 + PREVIEW_FEATURE
-    )
+    brand = graphene.Field(AppBrand, description="App's brand data.")
 
     class Meta:
         model = models.AppInstallation

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -9,7 +9,6 @@ from ...permission.utils import has_one_of_permissions
 from ...product import models
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ..channel.filters import get_channel_slug_from_filter_data
-from ..core.descriptions import ADDED_IN_311, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.enums import MeasurementUnitsEnum
 from ..core.filters import (
@@ -293,5 +292,5 @@ class AttributeWhere(MetadataWhereFilterBase):
 class AttributeWhereInput(WhereInputObjectType):
     class Meta:
         filterset_class = AttributeWhere
-        description = "Where filtering options." + ADDED_IN_311 + PREVIEW_FEATURE
+        description = "Where filtering options."
         doc_category = DOC_CATEGORY_ATTRIBUTES

--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -14,7 +14,6 @@ from ....core.utils import prepare_unique_slug
 from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ...core.enums import ErrorPolicyEnum
 from ...core.mutations import BaseMutation, ModelMutation
@@ -233,7 +232,7 @@ class AttributeBulkCreate(BaseMutation):
         )
 
     class Meta:
-        description = "Creates attributes." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Creates attributes."
         doc_category = DOC_CATEGORY_ATTRIBUTES
         error_type_class = AttributeBulkCreateError
         webhook_events_info = [

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -15,7 +15,6 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.utils import get_webhooks_for_event
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ...core.enums import ErrorPolicyEnum
 from ...core.mutations import BaseMutation, ModelMutation
@@ -99,7 +98,7 @@ class AttributeBulkUpdate(BaseMutation):
         )
 
     class Meta:
-        description = "Updates attributes." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Updates attributes."
         doc_category = DOC_CATEGORY_ATTRIBUTES
         error_type_class = AttributeBulkUpdateError
         webhook_events_info = [

--- a/saleor/graphql/attribute/schema.py
+++ b/saleor/graphql/attribute/schema.py
@@ -3,7 +3,6 @@ import graphene
 from ...attribute import models
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_310, ADDED_IN_311, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.fields import BaseField, FilterConnectionField
 from ..core.utils.resolvers import resolve_by_global_id_slug_or_ext_ref
@@ -36,12 +35,8 @@ class AttributeQueries(graphene.ObjectType):
         AttributeCountableConnection,
         description="List of the shop's attributes.",
         filter=AttributeFilterInput(description="Filtering options for attributes."),
-        where=AttributeWhereInput(
-            description="Filtering options for attributes." + ADDED_IN_311
-        ),
-        search=graphene.String(
-            description="Search attributes." + ADDED_IN_311 + PREVIEW_FEATURE
-        ),
+        where=AttributeWhereInput(description="Filtering options for attributes."),
+        search=graphene.String(description="Search attributes."),
         sort_by=AttributeSortingInput(description="Sorting options for attributes."),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
@@ -53,7 +48,7 @@ class AttributeQueries(graphene.ObjectType):
         id=graphene.Argument(graphene.ID, description="ID of the attribute."),
         slug=graphene.Argument(graphene.String, description="Slug of the attribute."),
         external_reference=graphene.Argument(
-            graphene.String, description=f"External ID of the attribute. {ADDED_IN_310}"
+            graphene.String, description="External ID of the attribute."
         ),
         description="Look up an attribute by ID, slug or external reference.",
         doc_category=DOC_CATEGORY_ATTRIBUTES,

--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -9,14 +9,6 @@ from ....webhook.event_types import WebhookEventAsyncType
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
 from ...core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_35,
-    ADDED_IN_37,
-    ADDED_IN_312,
-    ADDED_IN_313,
-    ADDED_IN_314,
-    ADDED_IN_315,
-    ADDED_IN_316,
     ADDED_IN_318,
     ADDED_IN_320,
     DEPRECATED_IN_3X_INPUT,
@@ -73,7 +65,6 @@ class CheckoutSettingsInput(BaseInputObjectType):
             "Some of the `problems` can block the finalizing checkout process. "
             "The legacy flow will be removed in Saleor 4.0. "
             "The flow with `checkout.problems` will be the default one. "
-            + ADDED_IN_315
             + DEPRECATED_IN_3X_INPUT
         )
     )
@@ -111,14 +102,14 @@ class OrderSettingsInput(BaseInputObjectType):
         description=(
             "Expiration time in minutes. "
             "Default null - means do not expire any orders. "
-            "Enter 0 or null to disable." + ADDED_IN_313 + PREVIEW_FEATURE
+            "Enter 0 or null to disable."
         ),
     )
     delete_expired_orders_after = Day(
         required=False,
         description=(
             "The time in days after expired orders will be deleted."
-            "Allowed range is from 1 to 120." + ADDED_IN_314 + PREVIEW_FEATURE
+            "Allowed range is from 1 to 120."
         ),
     )
     mark_as_paid_strategy = MarkAsPaidStrategyEnum(
@@ -129,15 +120,13 @@ class OrderSettingsInput(BaseInputObjectType):
             "and attached to the order when it's manually marked as paid."
             "\n`PAYMENT_FLOW` - [default option] creates the `Payment` object."
             "\n`TRANSACTION_FLOW` - creates the `TransactionItem` object."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
         ),
     )
     allow_unpaid_orders = graphene.Boolean(
         required=False,
         description=(
             "Determine if it is possible to place unpaid order by calling "
-            "`checkoutComplete` mutation." + ADDED_IN_315 + PREVIEW_FEATURE
+            "`checkoutComplete` mutation."
         ),
     )
     include_draft_order_in_voucher_usage = graphene.Boolean(
@@ -162,7 +151,7 @@ class PaymentSettingsInput(BaseInputObjectType):
         description=(
             "Determine the transaction flow strategy to be used. "
             "Include the selected option in the payload sent to the payment app, as a "
-            "requested action for the transaction." + ADDED_IN_316 + PREVIEW_FEATURE
+            "requested action for the transaction."
         ),
     )
 
@@ -176,7 +165,7 @@ class ChannelInput(BaseInputObjectType):
     )
     stock_settings = graphene.Field(
         StockSettingsInput,
-        description=("The channel stock settings." + ADDED_IN_37),
+        description=("The channel stock settings."),
         required=False,
     )
     add_shipping_zones = NonNullList(
@@ -186,33 +175,33 @@ class ChannelInput(BaseInputObjectType):
     )
     add_warehouses = NonNullList(
         graphene.ID,
-        description="List of warehouses to assign to the channel." + ADDED_IN_35,
+        description="List of warehouses to assign to the channel.",
         required=False,
     )
     order_settings = graphene.Field(
         OrderSettingsInput,
-        description="The channel order settings" + ADDED_IN_312,
+        description="The channel order settings",
         required=False,
     )
     metadata = common_types.NonNullList(
         MetadataInput,
-        description="Channel public metadata." + ADDED_IN_315,
+        description="Channel public metadata.",
         required=False,
     )
     private_metadata = common_types.NonNullList(
         MetadataInput,
-        description="Channel private metadata." + ADDED_IN_315,
+        description="Channel private metadata.",
         required=False,
     )
 
     checkout_settings = graphene.Field(
         CheckoutSettingsInput,
-        description="The channel checkout settings" + ADDED_IN_315 + PREVIEW_FEATURE,
+        description="The channel checkout settings",
         required=False,
     )
     payment_settings = graphene.Field(
         PaymentSettingsInput,
-        description="The channel payment settings" + ADDED_IN_316 + PREVIEW_FEATURE,
+        description="The channel payment settings",
         required=False,
     )
 
@@ -230,7 +219,7 @@ class ChannelCreateInput(ChannelInput):
         description=(
             "Default country for the channel. Default country can be "
             "used in checkout to determine the stock quantities or calculate taxes "
-            "when the country was not explicitly provided." + ADDED_IN_31
+            "when the country was not explicitly provided."
         ),
         required=True,
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1329,20 +1329,10 @@ type Query {
     """Filtering options for attributes."""
     filter: AttributeFilterInput
 
-    """
-    Filtering options for attributes.
-    
-    Added in Saleor 3.11.
-    """
+    """Filtering options for attributes."""
     where: AttributeWhereInput
 
-    """
-    Search attributes.
-    
-    Added in Saleor 3.11.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
-    """
+    """Search attributes."""
     search: String
 
     """Sorting options for attributes."""
@@ -1376,11 +1366,7 @@ type Query {
     """Slug of the attribute."""
     slug: String
 
-    """
-    External ID of the attribute. 
-    
-    Added in Saleor 3.10.
-    """
+    """External ID of the attribute."""
     externalReference: String
   ): Attribute @doc(category: "Attributes")
 
@@ -3073,11 +3059,7 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
   """URL to iframe with the app."""
   appUrl: String
 
-  """
-  URL to manifest used during app's installation.
-  
-  Added in Saleor 3.5.
-  """
+  """URL to manifest used during app's installation."""
   manifestUrl: String
 
   """Version number of the app."""
@@ -3086,29 +3068,13 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
   """JWT token used to authenticate by third-party app."""
   accessToken: String
 
-  """
-  The App's author name.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The App's author name."""
   author: String
 
-  """
-  App's dashboard extensions.
-  
-  Added in Saleor 3.1.
-  """
+  """App's dashboard extensions."""
   extensions: [AppExtension!]!
 
-  """
-  App's brand data.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """App's brand data."""
   brand: AppBrand
 }
 
@@ -3290,39 +3256,15 @@ enum AppExtensionTargetEnum @doc(category: "Apps") {
   APP_PAGE
 }
 
-"""
-Represents the app's brand data.
-
-Added in Saleor 3.14.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents the app's brand data."""
 type AppBrand @doc(category: "Apps") {
-  """
-  App's logos details.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """App's logos details."""
   logo: AppBrandLogo!
 }
 
-"""
-Represents the app's brand logo data.
-
-Added in Saleor 3.14.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents the app's brand logo data."""
 type AppBrandLogo @doc(category: "Apps") {
-  """
-  URL to the default logo image.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """URL to the default logo image."""
   default(
     """
     Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
@@ -3775,11 +3717,7 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
   """The ID of the address."""
   id: ID!
 
-  """
-  List of private metadata items. Requires staff permissions to access.
-  
-  Added in Saleor 3.10.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
 
   """
@@ -3787,22 +3725,18 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.10.
+  Added in Saleor 3.3.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.10.
+  Added in Saleor 3.3.
   """
   privateMetafields(keys: [String!]): Metadata
 
-  """
-  List of public metadata items. Can be accessed without permissions.
-  
-  Added in Saleor 3.10.
-  """
+  """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
 
   """
@@ -3810,14 +3744,14 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.10.
+  Added in Saleor 3.3.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.10.
+  Added in Saleor 3.3.
   """
   metafields(keys: [String!]): Metadata
 
@@ -6752,13 +6686,7 @@ input MetadataFilter {
   value: String
 }
 
-"""
-Where filtering options.
-
-Added in Saleor 3.11.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Where filtering options."""
 input AttributeWhereInput @doc(category: "Attributes") {
   metadata: [MetadataFilter!]
   ids: [ID!]
@@ -7779,11 +7707,7 @@ input AddressInput {
   """
   phone: String
 
-  """
-  Address public metadata.
-  
-  Added in Saleor 3.15.
-  """
+  """Address public metadata."""
   metadata: [MetadataInput!]
 
   """
@@ -10319,11 +10243,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   """Determine if the user is active."""
   isActive: Boolean!
 
-  """
-  Determines if user has confirmed email.
-  
-  Added in Saleor 3.15.
-  """
+  """Determines if user has confirmed email."""
   isConfirmed: Boolean!
 
   """List of all user's addresses."""
@@ -10344,11 +10264,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
     channel: String
   ): [ID!]
 
-  """
-  Returns checkouts assigned to this user.
-  
-  Added in Saleor 3.8.
-  """
+  """Returns checkouts assigned to this user."""
   checkouts(
     """Slug of a channel for which the data should be returned."""
     channel: String
@@ -10428,19 +10344,11 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   List of channels the user has access to. The sum of channels from all user groups. If at least one group has `restrictedAccessToChannels` set to False - all channels are returned.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   accessibleChannels: [Channel!]
 
   """
   Determine if user have restricted access to channels. False if at least one user group has `restrictedAccessToChannels` set to False.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   restrictedAccessToChannels: Boolean!
 
@@ -10483,11 +10391,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   """The default billing address of the user."""
   defaultBillingAddress: Address
 
-  """
-  External ID of this user. 
-  
-  Added in Saleor 3.10.
-  """
+  """External ID of this user."""
   externalReference: String
 
   """The date when the user last time log in to the system."""
@@ -10501,10 +10405,6 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """
   Returns a list of user's stored payment methods that can be used in provided channel. The field returns a list of stored payment methods by payment apps. When `amount` is not provided, 0 will be used as default value.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   storedPaymentMethods(
     """Slug of a channel for which the data should be returned."""
@@ -12830,22 +12730,10 @@ type Group implements Node @doc(category: "Users") {
   """
   userCanManage: Boolean!
 
-  """
-  List of channels the group has access to.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """List of channels the group has access to."""
   accessibleChannels: [Channel!]
 
-  """
-  Determine if the group have restricted access to channels.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Determine if the group have restricted access to channels."""
   restrictedAccessToChannels: Boolean!
 }
 
@@ -14462,13 +14350,7 @@ type AppInstallation implements Node & Job @doc(category: "Apps") {
   """The URL address of manifest for the app installation."""
   manifestUrl: String!
 
-  """
-  App's brand data.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """App's brand data."""
   brand: AppBrand
 }
 
@@ -18767,10 +18649,6 @@ type Mutation {
   """
   Creates attributes.
   
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Triggers the following webhook events:
   - ATTRIBUTE_CREATED (async): An attribute was created.
   """
@@ -18784,10 +18662,6 @@ type Mutation {
 
   """
   Updates attributes.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Triggers the following webhook events:
   - ATTRIBUTE_UPDATED (async): An attribute was updated. Optionally called when new attribute value was created or deleted.
@@ -19221,11 +19095,7 @@ type Mutation {
   ): RequestPasswordReset @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_SET_PASSWORD_REQUESTED, STAFF_SET_PASSWORD_REQUESTED], syncEvents: [])
 
   """
-  Sends a notification confirmation.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Sends a notification confirmation. 
   
   Requires one of the following permissions: AUTHENTICATED_USER.
   
@@ -19604,11 +19474,7 @@ type Mutation {
   ): CustomerBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_DELETED], syncEvents: [])
 
   """
-  Updates customers.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Updates customers. 
   
   Requires one of the following permissions: MANAGE_USERS.
   
@@ -28851,60 +28717,28 @@ input ChannelCreateInput @doc(category: "Channels") {
   """Determine if channel will be set active or not."""
   isActive: Boolean
 
-  """
-  The channel stock settings.
-  
-  Added in Saleor 3.7.
-  """
+  """The channel stock settings."""
   stockSettings: StockSettingsInput
 
   """List of shipping zones to assign to the channel."""
   addShippingZones: [ID!]
 
-  """
-  List of warehouses to assign to the channel.
-  
-  Added in Saleor 3.5.
-  """
+  """List of warehouses to assign to the channel."""
   addWarehouses: [ID!]
 
-  """
-  The channel order settings
-  
-  Added in Saleor 3.12.
-  """
+  """The channel order settings"""
   orderSettings: OrderSettingsInput
 
-  """
-  Channel public metadata.
-  
-  Added in Saleor 3.15.
-  """
+  """Channel public metadata."""
   metadata: [MetadataInput!]
 
-  """
-  Channel private metadata.
-  
-  Added in Saleor 3.15.
-  """
+  """Channel private metadata."""
   privateMetadata: [MetadataInput!]
 
-  """
-  The channel checkout settings
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel checkout settings"""
   checkoutSettings: CheckoutSettingsInput
 
-  """
-  The channel payment settings
-  
-  Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel payment settings"""
   paymentSettings: PaymentSettingsInput
 
   """Name of the channel."""
@@ -28918,8 +28752,6 @@ input ChannelCreateInput @doc(category: "Channels") {
 
   """
   Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
-  
-  Added in Saleor 3.1.
   """
   defaultCountry: CountryCode!
 }
@@ -28944,19 +28776,11 @@ input OrderSettingsInput @doc(category: "Orders") {
 
   """
   Expiration time in minutes. Default null - means do not expire any orders. Enter 0 or null to disable.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   expireOrdersAfter: Minute
 
   """
   The time in days after expired orders will be deleted.Allowed range is from 1 to 120.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   deleteExpiredOrdersAfter: Day
 
@@ -28964,19 +28788,11 @@ input OrderSettingsInput @doc(category: "Orders") {
   Determine what strategy will be used to mark the order as paid. Based on the chosen option, the proper object will be created and attached to the order when it's manually marked as paid.
   `PAYMENT_FLOW` - [default option] creates the `Payment` object.
   `TRANSACTION_FLOW` - creates the `TransactionItem` object.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   markAsPaidStrategy: MarkAsPaidStrategyEnum
 
   """
   Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   allowUnpaidOrders: Boolean
 
@@ -28996,8 +28812,6 @@ input CheckoutSettingsInput @doc(category: "Checkout") {
   """
   Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one. 
   
-  Added in Saleor 3.15.
-  
   DEPRECATED: this field will be removed in Saleor 4.0.
   """
   useLegacyErrorFlow: Boolean
@@ -29013,10 +28827,6 @@ input CheckoutSettingsInput @doc(category: "Checkout") {
 input PaymentSettingsInput @doc(category: "Payments") {
   """
   Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
-  
-  Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   defaultTransactionFlowStrategy: TransactionFlowStrategyEnum
 }
@@ -29043,60 +28853,28 @@ input ChannelUpdateInput @doc(category: "Channels") {
   """Determine if channel will be set active or not."""
   isActive: Boolean
 
-  """
-  The channel stock settings.
-  
-  Added in Saleor 3.7.
-  """
+  """The channel stock settings."""
   stockSettings: StockSettingsInput
 
   """List of shipping zones to assign to the channel."""
   addShippingZones: [ID!]
 
-  """
-  List of warehouses to assign to the channel.
-  
-  Added in Saleor 3.5.
-  """
+  """List of warehouses to assign to the channel."""
   addWarehouses: [ID!]
 
-  """
-  The channel order settings
-  
-  Added in Saleor 3.12.
-  """
+  """The channel order settings"""
   orderSettings: OrderSettingsInput
 
-  """
-  Channel public metadata.
-  
-  Added in Saleor 3.15.
-  """
+  """Channel public metadata."""
   metadata: [MetadataInput!]
 
-  """
-  Channel private metadata.
-  
-  Added in Saleor 3.15.
-  """
+  """Channel private metadata."""
   privateMetadata: [MetadataInput!]
 
-  """
-  The channel checkout settings
-  
-  Added in Saleor 3.15.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel checkout settings"""
   checkoutSettings: CheckoutSettingsInput
 
-  """
-  The channel payment settings
-  
-  Added in Saleor 3.16.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel payment settings"""
   paymentSettings: PaymentSettingsInput
 
   """Name of the channel."""
@@ -29460,10 +29238,6 @@ input AttributeValueUpdateInput @doc(category: "Attributes") {
 """
 Creates attributes.
 
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-
 Triggers the following webhook events:
 - ATTRIBUTE_CREATED (async): An attribute was created.
 """
@@ -29511,10 +29285,6 @@ enum AttributeBulkCreateErrorCode @doc(category: "Attributes") {
 
 """
 Updates attributes.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
 Triggers the following webhook events:
 - ATTRIBUTE_UPDATED (async): An attribute was updated. Optionally called when new attribute value was created or deleted.
@@ -30064,45 +29834,19 @@ type Manifest @doc(category: "Apps") {
   """
   extensions: [AppManifestExtension!]!
 
-  """
-  List of the app's webhooks.
-  
-  Added in Saleor 3.5.
-  """
+  """List of the app's webhooks."""
   webhooks: [AppManifestWebhook!]!
 
-  """
-  The audience that will be included in all JWT tokens for the app.
-  
-  Added in Saleor 3.8.
-  """
+  """The audience that will be included in all JWT tokens for the app."""
   audience: String
 
-  """
-  Determines the app's required Saleor version as semver range.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Determines the app's required Saleor version as semver range."""
   requiredSaleorVersion: AppManifestRequiredSaleorVersion
 
-  """
-  The App's author name.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The App's author name."""
   author: String
 
-  """
-  App's brand data.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """App's brand data."""
   brand: AppManifestBrand
 }
 
@@ -30141,58 +29885,22 @@ type AppManifestWebhook @doc(category: "Apps") {
 }
 
 type AppManifestRequiredSaleorVersion @doc(category: "Apps") {
-  """
-  Required Saleor version as semver range.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Required Saleor version as semver range."""
   constraint: String!
 
-  """
-  Informs if the Saleor version matches the required one.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Informs if the Saleor version matches the required one."""
   satisfied: Boolean!
 }
 
-"""
-Represents the app's manifest brand data.
-
-Added in Saleor 3.14.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents the app's manifest brand data."""
 type AppManifestBrand @doc(category: "Apps") {
-  """
-  App's logos details.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """App's logos details."""
   logo: AppManifestBrandLogo!
 }
 
-"""
-Represents the app's manifest brand data.
-
-Added in Saleor 3.14.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
+"""Represents the app's manifest brand data."""
 type AppManifestBrandLogo @doc(category: "Apps") {
-  """
-  Data URL with a base64 encoded logo image.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Data URL with a base64 encoded logo image."""
   default(
     """
     Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
@@ -30433,11 +30141,7 @@ type RequestPasswordReset @doc(category: "Users") @webhookEventsInfo(asyncEvents
 }
 
 """
-Sends a notification confirmation.
-
-Added in Saleor 3.15.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Sends a notification confirmation. 
 
 Requires one of the following permissions: AUTHENTICATED_USER.
 
@@ -30968,11 +30672,7 @@ type CustomerBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: 
 }
 
 """
-Updates customers.
-
-Added in Saleor 3.13.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Updates customers. 
 
 Requires one of the following permissions: MANAGE_USERS.
 
@@ -31285,13 +30985,7 @@ input PermissionGroupCreateInput @doc(category: "Users") {
   """List of users to assign to this group."""
   addUsers: [ID!]
 
-  """
-  List of channels to assign to this group.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """List of channels to assign to this group."""
   addChannels: [ID!]
 
   """Group name."""
@@ -31299,10 +30993,6 @@ input PermissionGroupCreateInput @doc(category: "Users") {
 
   """
   Determine if the group has restricted access to channels.  DEFAULT: False
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   restrictedAccessToChannels: Boolean = false
 }
@@ -31328,13 +31018,7 @@ input PermissionGroupUpdateInput @doc(category: "Users") {
   """List of users to assign to this group."""
   addUsers: [ID!]
 
-  """
-  List of channels to assign to this group.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """List of channels to assign to this group."""
   addChannels: [ID!]
 
   """Group name."""
@@ -31346,22 +31030,10 @@ input PermissionGroupUpdateInput @doc(category: "Users") {
   """List of users to unassign from this group."""
   removeUsers: [ID!]
 
-  """
-  List of channels to unassign from this group.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """List of channels to unassign from this group."""
   removeChannels: [ID!]
 
-  """
-  Determine if the group has restricted access to channels.
-  
-  Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Determine if the group has restricted access to channels."""
   restrictedAccessToChannels: Boolean
 }
 


### PR DESCRIPTION
I want to merge this change because it drops ADDED_IN and FEATURE_PREVIEW (< 3.18) in saleor account, app ans attribute modules. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
