### PR TITLE
Drop flush_post_commit_hooks

### DIFF
--- a/saleor/account/tests/test_utils.py
+++ b/saleor/account/tests/test_utils.py
@@ -5,7 +5,6 @@ from django.test import override_settings
 
 from ...checkout import AddressType
 from ...plugins.manager import get_plugins_manager
-from ...tests.utils import flush_post_commit_hooks
 from ..models import Address, User
 from ..utils import (
     get_user_groups_permissions,
@@ -251,12 +250,13 @@ def test_send_user_event_no_webhook_sent(
     mock_customer_created_webhook,
     mock_customer_updated_webhook,
     customer_user,
+    django_capture_on_commit_callbacks,
 ):
     # when
-    send_user_event(customer_user, False, False)
+    with django_capture_on_commit_callbacks(execute=True):
+        send_user_event(customer_user, False, False)
 
     # then
-    flush_post_commit_hooks()
     mock_staff_created_webhook.assert_not_called()
     mock_staff_updated_webhook.assert_not_called()
     mock_customer_created_webhook.assert_not_called()
@@ -273,12 +273,13 @@ def test_send_user_event_customer_created_event(
     mock_customer_created_webhook,
     mock_customer_updated_webhook,
     customer_user,
+    django_capture_on_commit_callbacks,
 ):
     # when
-    send_user_event(customer_user, True, True)
+    with django_capture_on_commit_callbacks(execute=True):
+        send_user_event(customer_user, True, True)
 
     # then
-    flush_post_commit_hooks()
     mock_customer_created_webhook.assert_called_once_with(customer_user)
     mock_customer_updated_webhook.assert_not_called()
     mock_staff_created_webhook.assert_not_called()
@@ -295,12 +296,13 @@ def test_send_user_event_customer_updated_event(
     mock_customer_created_webhook,
     mock_customer_updated_webhook,
     customer_user,
+    django_capture_on_commit_callbacks,
 ):
     # when
-    send_user_event(customer_user, False, True)
+    with django_capture_on_commit_callbacks(execute=True):
+        send_user_event(customer_user, False, True)
 
     # then
-    flush_post_commit_hooks()
     mock_customer_updated_webhook.assert_called_once_with(customer_user)
     mock_customer_created_webhook.assert_not_called()
     mock_staff_created_webhook.assert_not_called()
@@ -317,12 +319,13 @@ def test_send_user_event_staff_created_event(
     mock_customer_created_webhook,
     mock_customer_updated_webhook,
     staff_user,
+    django_capture_on_commit_callbacks,
 ):
     # when
-    send_user_event(staff_user, True, True)
+    with django_capture_on_commit_callbacks(execute=True):
+        send_user_event(staff_user, True, True)
 
     # then
-    flush_post_commit_hooks()
     mock_staff_created_webhook.assert_called_once_with(staff_user)
     mock_staff_updated_webhook.assert_not_called()
     mock_customer_created_webhook.assert_not_called()
@@ -339,12 +342,13 @@ def test_send_user_event_staff_updated_event(
     mock_customer_created_webhook,
     mock_customer_updated_webhook,
     staff_user,
+    django_capture_on_commit_callbacks,
 ):
     # when
-    send_user_event(staff_user, False, True)
+    with django_capture_on_commit_callbacks(execute=True):
+        send_user_event(staff_user, False, True)
 
     # then
-    flush_post_commit_hooks()
     mock_staff_updated_webhook.assert_called_once_with(staff_user)
     mock_staff_created_webhook.assert_not_called()
     mock_customer_created_webhook.assert_not_called()

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -28,7 +28,6 @@ from ...payment.interface import GatewayResponse
 from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
 from ...product.models import ProductTranslation, ProductVariantTranslation
-from ...tests.utils import flush_post_commit_hooks
 from .. import calculations
 from ..complete_checkout import (
     _complete_checkout_fail_handler,
@@ -54,6 +53,7 @@ def test_create_order_captured_payment_creates_expected_events(
     payment_txn_captured,
     channel_USD,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     checkout = checkout_with_item
     checkout_user = customer_user
@@ -76,20 +76,20 @@ def test_create_order_captured_payment_creates_expected_events(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    order = _create_order(
-        checkout_info=checkout_info,
-        checkout_lines=lines,
-        order_data=_prepare_order_data(
-            manager=manager,
+    with django_capture_on_commit_callbacks(execute=True):
+        order = _create_order(
             checkout_info=checkout_info,
-            lines=lines,
-            prices_entered_with_tax=True,
-        ),
-        user=customer_user,
-        app=None,
-        manager=manager,
-    )
-    flush_post_commit_hooks()
+            checkout_lines=lines,
+            order_data=_prepare_order_data(
+                manager=manager,
+                checkout_info=checkout_info,
+                lines=lines,
+                prices_entered_with_tax=True,
+            ),
+            user=customer_user,
+            app=None,
+            manager=manager,
+        )
 
     (
         order_placed_event,
@@ -216,6 +216,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     payment_txn_captured,
     channel_USD,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     checkout = checkout_with_item
     checkout_user = None
@@ -239,20 +240,20 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    order = _create_order(
-        checkout_info=checkout_info,
-        checkout_lines=lines,
-        order_data=_prepare_order_data(
-            manager=manager,
+    with django_capture_on_commit_callbacks(execute=True):
+        order = _create_order(
             checkout_info=checkout_info,
-            lines=lines,
-            prices_entered_with_tax=True,
-        ),
-        user=None,
-        app=None,
-        manager=manager,
-    )
-    flush_post_commit_hooks()
+            checkout_lines=lines,
+            order_data=_prepare_order_data(
+                manager=manager,
+                checkout_info=checkout_info,
+                lines=lines,
+                prices_entered_with_tax=True,
+            ),
+            user=None,
+            app=None,
+            manager=manager,
+        )
 
     (
         order_placed_event,
@@ -375,6 +376,7 @@ def test_create_order_preauth_payment_creates_expected_events(
     payment_txn_preauth,
     channel_USD,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     checkout = checkout_with_item
     checkout_user = customer_user
@@ -397,20 +399,20 @@ def test_create_order_preauth_payment_creates_expected_events(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    order = _create_order(
-        checkout_info=checkout_info,
-        checkout_lines=lines,
-        order_data=_prepare_order_data(
-            manager=manager,
+    with django_capture_on_commit_callbacks(execute=True):
+        order = _create_order(
             checkout_info=checkout_info,
-            lines=lines,
-            prices_entered_with_tax=True,
-        ),
-        user=customer_user,
-        app=None,
-        manager=manager,
-    )
-    flush_post_commit_hooks()
+            checkout_lines=lines,
+            order_data=_prepare_order_data(
+                manager=manager,
+                checkout_info=checkout_info,
+                lines=lines,
+                prices_entered_with_tax=True,
+            ),
+            user=customer_user,
+            app=None,
+            manager=manager,
+        )
 
     (
         order_placed_event,
@@ -489,6 +491,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     payment_txn_preauth,
     channel_USD,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     checkout = checkout_with_item
     checkout_user = None
@@ -512,20 +515,20 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    order = _create_order(
-        checkout_info=checkout_info,
-        checkout_lines=lines,
-        order_data=_prepare_order_data(
-            manager=manager,
+    with django_capture_on_commit_callbacks(execute=True):
+        order = _create_order(
             checkout_info=checkout_info,
-            lines=lines,
-            prices_entered_with_tax=True,
-        ),
-        user=None,
-        app=None,
-        manager=manager,
-    )
-    flush_post_commit_hooks()
+            checkout_lines=lines,
+            order_data=_prepare_order_data(
+                manager=manager,
+                checkout_info=checkout_info,
+                lines=lines,
+                prices_entered_with_tax=True,
+            ),
+            user=None,
+            app=None,
+            manager=manager,
+        )
 
     (
         order_placed_event,
@@ -845,6 +848,7 @@ def test_create_order_gift_card_bought(
     shipping_method,
     is_anonymous_user,
     non_shippable_gift_card_product,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout_user = None if is_anonymous_user else customer_user
@@ -892,24 +896,23 @@ def test_create_order_gift_card_bought(
     total_gross = subtotal.gross + shipping_price.gross - checkout.discount
 
     # when
-    order = _create_order(
-        checkout_info=checkout_info,
-        checkout_lines=lines,
-        order_data=_prepare_order_data(
-            manager=manager,
+    with django_capture_on_commit_callbacks(execute=True):
+        order = _create_order(
             checkout_info=checkout_info,
-            lines=lines,
-            prices_entered_with_tax=True,
-        ),
-        user=customer_user if not is_anonymous_user else None,
-        app=None,
-        manager=manager,
-    )
+            checkout_lines=lines,
+            order_data=_prepare_order_data(
+                manager=manager,
+                checkout_info=checkout_info,
+                lines=lines,
+                prices_entered_with_tax=True,
+            ),
+            user=customer_user if not is_anonymous_user else None,
+            app=None,
+            manager=manager,
+        )
 
     # then
-    flush_post_commit_hooks()
     assert order.total.gross == total_gross
-    flush_post_commit_hooks()
     gift_card = GiftCard.objects.get()
     assert (
         gift_card.initial_balance
@@ -918,7 +921,6 @@ def test_create_order_gift_card_bought(
         ).unit_price_gross
     )
     assert GiftCardEvent.objects.filter(gift_card=gift_card, type=GiftCardEvents.BOUGHT)
-    flush_post_commit_hooks()
     send_notification_mock.assert_called_once_with(
         checkout_user,
         None,
@@ -939,6 +941,7 @@ def test_create_order_gift_card_bought_order_not_captured_gift_cards_not_sent(
     customer_user,
     shipping_method,
     is_anonymous_user,
+    django_capture_on_commit_callbacks,
 ):
     """Check that digital gift cards are not issued if the payment is not captured."""
     # given
@@ -971,23 +974,22 @@ def test_create_order_gift_card_bought_order_not_captured_gift_cards_not_sent(
     total_gross = subtotal.gross + shipping_price.gross - checkout.discount
 
     # when
-    order = _create_order(
-        checkout_info=checkout_info,
-        checkout_lines=lines,
-        order_data=_prepare_order_data(
-            manager=manager,
+    with django_capture_on_commit_callbacks(execute=True):
+        order = _create_order(
             checkout_info=checkout_info,
-            lines=lines,
-            prices_entered_with_tax=True,
-        ),
-        user=customer_user if not is_anonymous_user else None,
-        app=None,
-        manager=manager,
-    )
+            checkout_lines=lines,
+            order_data=_prepare_order_data(
+                manager=manager,
+                checkout_info=checkout_info,
+                lines=lines,
+                prices_entered_with_tax=True,
+            ),
+            user=customer_user if not is_anonymous_user else None,
+            app=None,
+            manager=manager,
+        )
 
     # then
-    flush_post_commit_hooks()
-    flush_post_commit_hooks()
     assert order.total.gross == total_gross
     assert not GiftCard.objects.exists()
     send_notification_mock.assert_not_called()
@@ -1223,6 +1225,7 @@ def test_complete_checkout_0_total_with_transaction_for_mark_as_paid(
     checkout_with_item_total_0,
     customer_user,
     app,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_item_total_0
@@ -1243,19 +1246,18 @@ def test_complete_checkout_0_total_with_transaction_for_mark_as_paid(
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when
-    order, _, _ = complete_checkout(
-        checkout_info=checkout_info,
-        manager=manager,
-        lines=lines,
-        payment_data={},
-        store_source=False,
-        user=customer_user,
-        app=app,
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order, _, _ = complete_checkout(
+            checkout_info=checkout_info,
+            manager=manager,
+            lines=lines,
+            payment_data={},
+            store_source=False,
+            user=customer_user,
+            app=app,
+        )
 
     # then
-    flush_post_commit_hooks()
-
     assert order
     assert order.authorize_status == OrderAuthorizeStatus.FULL
     assert order.charge_status == OrderChargeStatus.FULL
@@ -1269,6 +1271,7 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
     channel_USD,
     app,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     checkout = checkout_with_item_total_0
     checkout_user = customer_user
@@ -1291,17 +1294,17 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    order, action_required, action_data = complete_checkout(
-        checkout_info=checkout_info,
-        lines=lines,
-        manager=manager,
-        payment_data={},
-        store_source=False,
-        user=customer_user,
-        app=app,
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order, action_required, action_data = complete_checkout(
+            checkout_info=checkout_info,
+            lines=lines,
+            manager=manager,
+            payment_data={},
+            store_source=False,
+            user=customer_user,
+            app=app,
+        )
 
-    flush_post_commit_hooks()
     (
         order_marked_as_paid,
         order_placed_event,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -30,7 +30,6 @@ from .....payment.gateways.dummy_credit_card import TOKEN_VALIDATION_MAPPING
 from .....payment.interface import GatewayResponse
 from .....payment.model_helpers import get_subtotal
 from .....plugins.manager import PluginsManager, get_plugins_manager
-from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.models import Reservation, Stock, WarehouseClickAndCollectOption
 from .....warehouse.tests.utils import get_available_quantity_for_stock
 from ....core.utils import to_global_id_or_none
@@ -654,6 +653,7 @@ def test_checkout_complete_gift_card_bought(
     address,
     shipping_method,
     payment_txn_captured,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_gift_card_items
@@ -693,19 +693,18 @@ def test_checkout_complete_gift_card_bought(
     variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
 
     # when
-    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
 
     # then
     content = get_graphql_content(response)
     data = content["data"]["checkoutComplete"]
     assert not data["errors"]
 
-    flush_post_commit_hooks()
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert order.status == OrderStatus.PARTIALLY_FULFILLED
 
-    flush_post_commit_hooks()
     gift_card = GiftCard.objects.get()
     assert GiftCardEvent.objects.filter(gift_card=gift_card, type=GiftCardEvents.BOUGHT)
     send_notification_mock.assert_called_once_with(

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
@@ -12,7 +12,6 @@ from .....order.fetch import OrderLineInfo
 from .....order.models import FulfillmentLine, FulfillmentStatus
 from .....payment import ChargeStatus, PaymentError
 from .....payment.interface import RefundData
-from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.models import Allocation, Stock
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -996,6 +995,7 @@ def test_fulfillment_refund_products_calls_order_refunded(
     permission_group_manage_orders,
     fulfilled_order,
     payment_dummy,
+    django_capture_on_commit_callbacks,
 ):
     payment_dummy.total = fulfilled_order.total_gross_amount
     payment_dummy.captured_amount = payment_dummy.total
@@ -1048,10 +1048,10 @@ def test_fulfillment_refund_products_calls_order_refunded(
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
+    with django_capture_on_commit_callbacks(execute=True):
+        staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
 
     # then
-    flush_post_commit_hooks()
     amount = fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2
     amount += order_line.unit_price_gross_amount * 2
     amount = amount.quantize(Decimal("0.001"))

--- a/saleor/graphql/product/tests/deprecated/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/deprecated/test_product_variant_bulk_create.py
@@ -7,7 +7,6 @@ import graphene
 from .....attribute import AttributeInputType
 from .....product.error_codes import ProductVariantBulkErrorCode
 from .....product.models import ProductChannelListing, ProductVariant
-from .....tests.utils import flush_post_commit_hooks
 from ....tests.utils import get_graphql_content
 
 PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
@@ -74,6 +73,7 @@ def test_product_variant_bulk_create_by_name(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -100,11 +100,11 @@ def test_product_variant_bulk_create_by_name(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkCreate"]
 
     # then
@@ -133,6 +133,7 @@ def test_product_variant_bulk_create_by_attribute_id(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -154,11 +155,11 @@ def test_product_variant_bulk_create_by_attribute_id(
 
     variables = {"productId": product_id, "variants": variants}
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkCreate"]
 
     assert not data["errors"]

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -16,7 +16,7 @@ from .....product.models import (
     ProductVariant,
     ProductVariantChannelListing,
 )
-from .....tests.utils import dummy_editorjs, flush_post_commit_hooks
+from .....tests.utils import dummy_editorjs
 from ....core.enums import ErrorPolicyEnum
 from ....tests.utils import get_graphql_content
 
@@ -114,6 +114,7 @@ def test_product_variant_bulk_create_by_name(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -151,11 +152,11 @@ def test_product_variant_bulk_create_by_name(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+        )
     content = get_graphql_content(response, ignore_errors=True)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkCreate"]
 
     # then
@@ -190,6 +191,7 @@ def test_product_variant_bulk_create_by_attribute_id(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -214,11 +216,11 @@ def test_product_variant_bulk_create_by_attribute_id(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkCreate"]
 
     # then
@@ -240,6 +242,7 @@ def test_product_variant_bulk_create_by_attribute_external_ref(
     product,
     color_attribute,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     product_variant_count = ProductVariant.objects.count()
@@ -269,11 +272,11 @@ def test_product_variant_bulk_create_by_attribute_external_ref(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkCreate"]
 
     # then
@@ -295,6 +298,7 @@ def test_product_variant_bulk_create_return_error_when_attribute_external_ref_an
     product,
     color_attribute,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     product.product_type.variant_attributes.add(color_attribute)
@@ -323,11 +327,11 @@ def test_product_variant_bulk_create_return_error_when_attribute_external_ref_an
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkCreate"]
 
     # then
@@ -344,6 +348,7 @@ def test_product_variant_bulk_create_will_create_new_attr_value_and_external_ref
     product,
     color_attribute,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     product.product_type.variant_attributes.add(color_attribute)
@@ -376,11 +381,11 @@ def test_product_variant_bulk_create_will_create_new_attr_value_and_external_ref
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkCreate"]
 
     # then

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -14,7 +14,6 @@ from .....graphql.product.bulk_mutations.product_variant_bulk_update import (
 from .....graphql.webhook.subscription_payload import get_pre_save_payload_key
 from .....product.error_codes import ProductVariantBulkErrorCode
 from .....product.models import ProductChannelListing
-from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.models import Stock
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.models import Webhook
@@ -99,6 +98,7 @@ def test_product_variant_bulk_update(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -124,11 +124,11 @@ def test_product_variant_bulk_update(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
     product_with_single_variant.refresh_from_db(fields=["search_index_dirty"])
 
@@ -166,6 +166,7 @@ def test_product_variant_bulk_create_stock_thread_race(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -214,12 +215,12 @@ def test_product_variant_bulk_create_stock_thread_race(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
 
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
 
     # then
@@ -243,6 +244,7 @@ def test_product_variant_bulk_update_stocks(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -286,11 +288,11 @@ def test_product_variant_bulk_update_stocks(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
 
     # then
@@ -357,6 +359,7 @@ def test_product_variant_bulk_update_and_remove_stock(
     warehouse,
     size_attribute,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     variant = variant_with_many_stocks
@@ -379,11 +382,11 @@ def test_product_variant_bulk_update_and_remove_stock(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
 
     # then
@@ -398,6 +401,7 @@ def test_product_variant_bulk_update_and_remove_stock_when_stock_not_exists(
     warehouse,
     size_attribute,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     variant = variant_with_many_stocks
@@ -417,11 +421,11 @@ def test_product_variant_bulk_update_and_remove_stock_when_stock_not_exists(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
 
     # then
@@ -440,6 +444,7 @@ def test_product_variant_bulk_update_stocks_with_invalid_warehouse(
     warehouse,
     size_attribute,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     variant = variant_with_many_stocks
@@ -463,11 +468,11 @@ def test_product_variant_bulk_update_stocks_with_invalid_warehouse(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
     stock_to_update.refresh_from_db()
 
@@ -676,6 +681,7 @@ def test_product_variant_bulk_update_with_already_existing_sku(
     product_with_two_variants,
     size_attribute,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     variants = product_with_two_variants.variants.all()
@@ -690,11 +696,11 @@ def test_product_variant_bulk_update_with_already_existing_sku(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
 
     # then
@@ -708,6 +714,7 @@ def test_product_variant_bulk_update_when_variant_not_exists(
     staff_api_client,
     product_with_two_variants,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     # given
     product_id = graphene.Node.to_global_id("Product", product_with_two_variants.pk)
@@ -719,11 +726,11 @@ def test_product_variant_bulk_update_when_variant_not_exists(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
 
     # then
@@ -747,6 +754,7 @@ def test_product_variant_bulk_update_attributes(
     settings,
     multiselect_attribute,
     color_attribute,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -786,11 +794,11 @@ def test_product_variant_bulk_update_attributes(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
 
     # then
@@ -810,6 +818,7 @@ def test_generate_pre_save_payloads(
     variant,
     permission_manage_products,
     webhook_app,
+    django_capture_on_commit_callbacks,
 ):
     # given
     SUBSCRIPTION_QUERY = """
@@ -839,8 +848,8 @@ def test_generate_pre_save_payloads(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    staff_api_client.post_graphql(PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables)
-    flush_post_commit_hooks()
+    with django_capture_on_commit_callbacks(execute=True):
+        staff_api_client.post_graphql(PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables)
 
     # then
     payload_key = get_pre_save_payload_key(webhook, variant)

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 
 from .....discount.utils.promotion import get_active_catalogue_promotion_rules
 from .....product.error_codes import ProductErrorCode
-from .....tests.utils import dummy_editorjs, flush_post_commit_hooks
+from .....tests.utils import dummy_editorjs
 from ....core.enums import WeightUnitsEnum
 from ....tests.utils import get_graphql_content
 
@@ -87,6 +87,7 @@ def test_create_variant_with_name(
     product_type,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     # given
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -124,11 +125,11 @@ def test_create_variant_with_name(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        CREATE_VARIANT_MUTATION, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            CREATE_VARIANT_MUTATION, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     # then
     assert not content["errors"]
@@ -164,6 +165,7 @@ def test_create_variant_without_name(
     product_type,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     # given
     query = CREATE_VARIANT_MUTATION
@@ -194,11 +196,11 @@ def test_create_variant_without_name(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     # then
     assert not content["errors"]
@@ -271,6 +273,7 @@ def test_create_variant_preorder(
     product,
     product_type,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -299,11 +302,11 @@ def test_create_variant_preorder(
         }
     }
 
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -325,6 +328,7 @@ def test_create_variant_no_required_attributes(
     product_type,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -352,11 +356,11 @@ def test_create_variant_no_required_attributes(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -382,6 +386,7 @@ def test_create_variant_with_file_attribute(
     permission_manage_products,
     warehouse,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -414,11 +419,11 @@ def test_create_variant_with_file_attribute(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -449,6 +454,7 @@ def test_create_variant_with_boolean_attribute(
     boolean_attribute,
     size_attribute,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(
         boolean_attribute, through_defaults={"variant_selection": True}
@@ -477,11 +483,11 @@ def test_create_variant_with_boolean_attribute(
         }
     }
 
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     data = content["productVariant"]
 
     assert not content["errors"]
@@ -517,6 +523,7 @@ def test_create_variant_with_file_attribute_new_value(
     permission_manage_products,
     warehouse,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -548,11 +555,11 @@ def test_create_variant_with_file_attribute_new_value(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -581,6 +588,7 @@ def test_create_variant_with_file_attribute_no_file_url_given(
     file_attribute,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -610,11 +618,11 @@ def test_create_variant_with_file_attribute_no_file_url_given(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     errors = content["errors"]
     data = content["productVariant"]
@@ -645,6 +653,7 @@ def test_create_variant_with_page_reference_attribute(
     page_list,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -677,11 +686,11 @@ def test_create_variant_with_page_reference_attribute(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -740,6 +749,7 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
     permission_manage_products,
     warehouse,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -773,11 +783,11 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     errors = content["errors"]
     data = content["productVariant"]
 
@@ -804,6 +814,7 @@ def test_create_variant_with_product_reference_attribute(
     product_list,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -841,11 +852,11 @@ def test_create_variant_with_product_reference_attribute(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -904,6 +915,7 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
     permission_manage_products,
     warehouse,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -937,11 +949,11 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     errors = content["errors"]
     data = content["productVariant"]
 
@@ -968,6 +980,7 @@ def test_create_variant_with_variant_reference_attribute(
     product_list,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     # given
     query = CREATE_VARIANT_MUTATION
@@ -1010,13 +1023,13 @@ def test_create_variant_with_variant_reference_attribute(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
 
     # then
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -1075,6 +1088,7 @@ def test_create_variant_with_variant_reference_attribute_no_references_given(
     permission_manage_products,
     warehouse,
     site_settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     query = CREATE_VARIANT_MUTATION
@@ -1111,13 +1125,13 @@ def test_create_variant_with_variant_reference_attribute_no_references_given(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
 
     # then
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     errors = content["errors"]
     data = content["productVariant"]
 
@@ -1479,6 +1493,7 @@ def test_create_variant_with_rich_text_attribute(
     staff_api_client,
     rich_text_attribute,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(rich_text_attribute)
     query = CREATE_VARIANT_MUTATION
@@ -1506,11 +1521,11 @@ def test_create_variant_with_rich_text_attribute(
         }
     }
 
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     data = content["productVariant"]
 
     assert not content["errors"]
@@ -1529,6 +1544,7 @@ def test_create_variant_with_plain_text_attribute(
     staff_api_client,
     plain_text_attribute,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     # given
     product_type.variant_attributes.add(plain_text_attribute)
@@ -1558,13 +1574,13 @@ def test_create_variant_with_plain_text_attribute(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
 
     # then
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     data = content["productVariant"]
 
     assert not content["errors"]
@@ -1584,6 +1600,7 @@ def test_create_variant_with_date_attribute(
     staff_api_client,
     date_attribute,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(date_attribute)
 
@@ -1606,11 +1623,11 @@ def test_create_variant_with_date_attribute(
         }
     }
 
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     data = content["productVariant"]
     variant = product.variants.last()
     expected_attributes_data = {
@@ -1647,6 +1664,7 @@ def test_create_variant_with_date_time_attribute(
     staff_api_client,
     date_time_attribute,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(date_time_attribute)
 
@@ -1670,11 +1688,11 @@ def test_create_variant_with_date_time_attribute(
         }
     }
 
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
     data = content["productVariant"]
     variant = product.variants.last()
     expected_attributes_data = {
@@ -1711,6 +1729,7 @@ def test_create_variant_with_empty_string_for_sku(
     product_type,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1738,11 +1757,11 @@ def test_create_variant_with_empty_string_for_sku(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]
@@ -1769,6 +1788,7 @@ def test_create_variant_without_sku(
     product_type,
     permission_manage_products,
     warehouse,
+    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1794,11 +1814,11 @@ def test_create_variant_without_sku(
             "trackInventory": True,
         }
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
-    flush_post_commit_hooks()
 
     assert not content["errors"]
     data = content["productVariant"]

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -26,7 +26,6 @@ from ....product.models import (
     ProductVariantChannelListing,
     VariantMedia,
 )
-from ....tests.utils import flush_post_commit_hooks
 from ....thumbnail.models import Thumbnail
 from ...tests.utils import get_graphql_content
 
@@ -116,6 +115,7 @@ def test_delete_categories_trigger_webhook(
     category_list,
     permission_manage_products,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -129,11 +129,12 @@ def test_delete_categories_trigger_webhook(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        MUTATION_CATEGORY_BULK_DELETE,
-        variables,
-        permissions=[permission_manage_products],
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            MUTATION_CATEGORY_BULK_DELETE,
+            variables,
+            permissions=[permission_manage_products],
+        )
     content = get_graphql_content(response)
 
     # then
@@ -195,6 +196,7 @@ def test_delete_categories_trigger_product_updated_webhook(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -214,11 +216,12 @@ def test_delete_categories_trigger_product_updated_webhook(
             for category in category_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        MUTATION_CATEGORY_BULK_DELETE,
-        variables,
-        permissions=[permission_manage_products],
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            MUTATION_CATEGORY_BULK_DELETE,
+            variables,
+            permissions=[permission_manage_products],
+        )
     content = get_graphql_content(response)
 
     assert content["data"]["categoryBulkDelete"]["count"] == 3
@@ -398,6 +401,7 @@ def test_delete_collections_trigger_collection_deleted_webhook(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -408,11 +412,12 @@ def test_delete_collections_trigger_collection_deleted_webhook(
             for collection in collection_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        MUTATION_COLLECTION_BULK_DELETE,
-        variables,
-        permissions=[permission_manage_products],
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            MUTATION_COLLECTION_BULK_DELETE,
+            variables,
+            permissions=[permission_manage_products],
+        )
     content = get_graphql_content(response)
 
     assert content["data"]["collectionBulkDelete"]["count"] == 3
@@ -436,6 +441,7 @@ def test_delete_collections_trigger_product_updated_webhook(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -448,11 +454,12 @@ def test_delete_collections_trigger_product_updated_webhook(
             for collection in collection_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        MUTATION_COLLECTION_BULK_DELETE,
-        variables,
-        permissions=[permission_manage_products],
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            MUTATION_COLLECTION_BULK_DELETE,
+            variables,
+            permissions=[permission_manage_products],
+        )
     content = get_graphql_content(response)
 
     assert content["data"]["collectionBulkDelete"]["count"] == 3
@@ -483,6 +490,7 @@ def test_delete_products(
     permission_manage_products,
     order_list,
     channel_USD,
+    django_capture_on_commit_callbacks,
 ):
     # given
     query = DELETE_PRODUCTS_MUTATION
@@ -539,9 +547,10 @@ def test_delete_products(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
 
     # then
     content = get_graphql_content(response)
@@ -630,6 +639,7 @@ def test_delete_products_trigger_webhook(
     permission_manage_products,
     channel_USD,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -642,9 +652,10 @@ def test_delete_products_trigger_webhook(
             for product in product_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)
 
     assert content["data"]["productBulkDelete"]["count"] == 3
@@ -666,6 +677,7 @@ def test_delete_products_without_variants(
     permission_manage_products,
     channel_USD,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -681,9 +693,10 @@ def test_delete_products_without_variants(
             for product in product_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)
 
     assert content["data"]["productBulkDelete"]["count"] == 3
@@ -967,6 +980,7 @@ def test_delete_product_variants_by_sku(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -984,13 +998,13 @@ def test_delete_product_variants_by_sku(
     variables = {"skus": [variant.sku for variant in product_variant_list]}
 
     # when
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
-        variables,
-        permissions=[permission_manage_products],
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
+            variables,
+            permissions=[permission_manage_products],
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
 
     # then
     assert content["data"]["productVariantBulkDelete"]["count"] == 4
@@ -1019,6 +1033,7 @@ def test_delete_product_variants_by_sku_task_for_recalculate_product_prices_call
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1031,13 +1046,13 @@ def test_delete_product_variants_by_sku_task_for_recalculate_product_prices_call
     variables = {"skus": [variant.sku for variant in variants]}
 
     # when
-    response = staff_api_client.post_graphql(
-        PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
-        variables,
-        permissions=[permission_manage_products],
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
+            variables,
+            permissions=[permission_manage_products],
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
 
     # then
     assert content["data"]["productVariantBulkDelete"]["count"] == len(variants)
@@ -1081,6 +1096,7 @@ def test_delete_product_variants(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1103,11 +1119,11 @@ def test_delete_product_variants(
             for variant in product_variant_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 4
     assert not ProductVariant.objects.filter(
@@ -1135,6 +1151,7 @@ def test_delete_product_variants_task_for_recalculate_product_prices_called(
     permission_manage_products,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1152,11 +1169,11 @@ def test_delete_product_variants_task_for_recalculate_product_prices_called(
             for variant in variants
         ]
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
 
     assert content["data"]["productVariantBulkDelete"]["count"] == len(variants)
     assert not ProductVariant.objects.filter(
@@ -1203,6 +1220,7 @@ def test_delete_product_variants_removes_checkout_lines(
     checkout,
     product_list,
     permission_manage_products,
+    django_capture_on_commit_callbacks,
 ):
     query = PRODUCT_VARIANT_BULK_DELETE_MUTATION
 
@@ -1227,11 +1245,11 @@ def test_delete_product_variants_removes_checkout_lines(
             for variant in variant_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 2
     assert not ProductVariant.objects.filter(
@@ -1263,6 +1281,7 @@ def test_delete_product_variants_with_images(
     media_root,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1289,11 +1308,11 @@ def test_delete_product_variants_with_images(
             for variant in product_variant_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 4
     assert not ProductVariant.objects.filter(
@@ -1489,6 +1508,7 @@ def test_delete_product_variants_with_file_attribute(
     file_attribute,
     any_webhook,
     settings,
+    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1514,11 +1534,11 @@ def test_delete_product_variants_with_file_attribute(
             for variant in product_variant_list
         ]
     }
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        response = staff_api_client.post_graphql(
+            query, variables, permissions=[permission_manage_products]
+        )
     content = get_graphql_content(response)
-    flush_post_commit_hooks()
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 4
     assert not ProductVariant.objects.filter(

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -16,7 +16,6 @@ from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
 from ...product.models import DigitalContent
 from ...product.tests.utils import create_image
-from ...tests.utils import flush_post_commit_hooks
 from ...warehouse.models import Allocation, Stock
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...webhook.utils import get_webhooks_for_multiple_events
@@ -766,6 +765,7 @@ def test_order_refunded_by_user(
     order_refunded_mock,
     order,
     checkout_with_item,
+    django_capture_on_commit_callbacks,
 ):
     # given
     payment = Payment.objects.create(
@@ -776,10 +776,10 @@ def test_order_refunded_by_user(
 
     # when
     manager = get_plugins_manager(allow_replica=False)
-    order_refunded(order, order.user, app, amount, payment, manager)
+    with django_capture_on_commit_callbacks(execute=True):
+        order_refunded(order, order.user, app, amount, payment, manager)
 
     # then
-    flush_post_commit_hooks()
     order_event = order.events.last()
     assert order_event.type == OrderEvents.PAYMENT_REFUNDED
 
@@ -800,6 +800,7 @@ def test_order_refunded_by_app(
     order,
     checkout_with_item,
     app,
+    django_capture_on_commit_callbacks,
 ):
     # given
     payment = Payment.objects.create(
@@ -809,10 +810,10 @@ def test_order_refunded_by_app(
 
     # when
     manager = get_plugins_manager(allow_replica=False)
-    order_refunded(order, None, app, amount, payment, manager)
+    with django_capture_on_commit_callbacks(execute=True):
+        order_refunded(order, None, app, amount, payment, manager)
 
     # then
-    flush_post_commit_hooks()
     order_event = order.events.last()
     assert order_event.type == OrderEvents.PAYMENT_REFUNDED
 
@@ -1670,7 +1671,11 @@ def test_fulfill_digital_lines_no_allocation(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_order_transaction_updated_order_fully_paid(
-    order_fully_paid, order_updated, order_with_lines, transaction_item_generator
+    order_fully_paid,
+    order_updated,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -1683,19 +1688,19 @@ def test_order_transaction_updated_order_fully_paid(
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     order_fully_paid.assert_called_once_with(order_with_lines, webhooks=set())
     order_updated.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2084,7 +2089,11 @@ def test_order_transaction_updated_for_refunded_triggers_webhooks(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_order_transaction_updated_order_partially_paid(
-    order_fully_paid, order_updated, order_with_lines, transaction_item_generator
+    order_fully_paid,
+    order_updated,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2097,19 +2106,19 @@ def test_order_transaction_updated_order_partially_paid(
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     assert not order_fully_paid.called
     order_updated.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2117,7 +2126,11 @@ def test_order_transaction_updated_order_partially_paid(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_order_transaction_updated_order_partially_paid_and_multiple_transactions(
-    order_fully_paid, order_updated, order_with_lines, transaction_item_generator
+    order_fully_paid,
+    order_updated,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2133,19 +2146,19 @@ def test_order_transaction_updated_order_partially_paid_and_multiple_transaction
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     assert not order_fully_paid.called
     order_updated.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2153,7 +2166,11 @@ def test_order_transaction_updated_order_partially_paid_and_multiple_transaction
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_order_transaction_updated_with_the_same_transaction_charged_amount(
-    order_fully_paid, order_updated, order_with_lines, transaction_item_generator
+    order_fully_paid,
+    order_updated,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2168,19 +2185,19 @@ def test_order_transaction_updated_with_the_same_transaction_charged_amount(
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=charged_value,
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=charged_value,
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     assert not order_fully_paid.called
     assert not order_updated.called
 
@@ -2188,7 +2205,11 @@ def test_order_transaction_updated_with_the_same_transaction_charged_amount(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_order_transaction_updated_order_authorized(
-    order_fully_paid, order_updated, order_with_lines, transaction_item_generator
+    order_fully_paid,
+    order_updated,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2202,19 +2223,19 @@ def test_order_transaction_updated_order_authorized(
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     assert not order_fully_paid.called
     order_updated.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2222,7 +2243,11 @@ def test_order_transaction_updated_order_authorized(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_order_transaction_updated_order_partially_authorized_and_multiple_transactions(
-    order_fully_paid, order_updated, order_with_lines, transaction_item_generator
+    order_fully_paid,
+    order_updated,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2238,19 +2263,19 @@ def test_order_transaction_updated_order_partially_authorized_and_multiple_trans
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     assert not order_fully_paid.called
     order_updated.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2258,7 +2283,11 @@ def test_order_transaction_updated_order_partially_authorized_and_multiple_trans
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
 def test_order_transaction_updated_with_the_same_transaction_authorized_amount(
-    order_fully_paid, order_updated, order_with_lines, transaction_item_generator
+    order_fully_paid,
+    order_updated,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2273,19 +2302,19 @@ def test_order_transaction_updated_with_the_same_transaction_authorized_amount(
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=authorized_value,
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=authorized_value,
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     assert not order_fully_paid.called
     assert not order_updated.called
 
@@ -2293,7 +2322,11 @@ def test_order_transaction_updated_with_the_same_transaction_authorized_amount(
 @patch("saleor.plugins.manager.PluginsManager.order_refunded")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_refunded")
 def test_order_transaction_updated_order_fully_refunded(
-    order_fully_refunded, order_refunded, order_with_lines, transaction_item_generator
+    order_fully_refunded,
+    order_refunded,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2306,19 +2339,19 @@ def test_order_transaction_updated_order_fully_refunded(
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     order_fully_refunded.assert_called_once_with(order_with_lines, webhooks=set())
     order_refunded.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2326,7 +2359,11 @@ def test_order_transaction_updated_order_fully_refunded(
 @patch("saleor.plugins.manager.PluginsManager.order_refunded")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_refunded")
 def test_order_transaction_updated_order_partially_refunded(
-    order_fully_refunded, order_refunded, order_with_lines, transaction_item_generator
+    order_fully_refunded,
+    order_refunded,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2339,19 +2376,19 @@ def test_order_transaction_updated_order_partially_refunded(
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     assert not order_fully_refunded.called
     order_refunded.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2359,7 +2396,11 @@ def test_order_transaction_updated_order_partially_refunded(
 @patch("saleor.plugins.manager.PluginsManager.order_refunded")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_refunded")
 def test_order_transaction_updated_order_fully_refunded_and_multiple_transactions(
-    order_fully_refunded, order_refunded, order_with_lines, transaction_item_generator
+    order_fully_refunded,
+    order_refunded,
+    order_with_lines,
+    transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order_info = fetch_order_info(order_with_lines)
@@ -2376,19 +2417,19 @@ def test_order_transaction_updated_order_fully_refunded_and_multiple_transaction
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     order_fully_refunded.assert_called_once_with(order_with_lines, webhooks=set())
     order_refunded.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2401,6 +2442,7 @@ def test_order_transaction_updated_order_fully_refunded_with_transaction_and_pay
     order_with_lines,
     transaction_item_generator,
     payment_dummy,
+    django_capture_on_commit_callbacks,
 ):
     # given
     payment = payment_dummy
@@ -2429,19 +2471,19 @@ def test_order_transaction_updated_order_fully_refunded_with_transaction_and_pay
     )
 
     # when
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction_item,
-        manager=manager,
-        user=None,
-        app=None,
-        previous_authorized_value=Decimal(0),
-        previous_charged_value=Decimal(0),
-        previous_refunded_value=Decimal(0),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        order_transaction_updated(
+            order_info=order_info,
+            transaction_item=transaction_item,
+            manager=manager,
+            user=None,
+            app=None,
+            previous_authorized_value=Decimal(0),
+            previous_charged_value=Decimal(0),
+            previous_refunded_value=Decimal(0),
+        )
 
     # then
-    flush_post_commit_hooks()
     order_refunded.assert_called_once_with(order_with_lines, webhooks=set())
     order_fully_refunded.assert_called_once_with(order_with_lines, webhooks=set())
 

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -4,7 +4,6 @@ from unittest.mock import ANY, patch
 from ...payment import ChargeStatus
 from ...payment.interface import RefundData
 from ...plugins.manager import get_plugins_manager
-from ...tests.utils import flush_post_commit_hooks
 from ...warehouse.models import Allocation
 from .. import FulfillmentLineData, FulfillmentStatus
 from ..actions import create_refund_fulfillment
@@ -15,7 +14,11 @@ from ..models import FulfillmentLine
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_only_order_lines(
-    mocked_refund, mocked_order_updated, order_with_lines, payment_dummy
+    mocked_refund,
+    mocked_order_updated,
+    order_with_lines,
+    payment_dummy,
+    django_capture_on_commit_callbacks,
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -36,17 +39,17 @@ def test_create_refund_fulfillment_only_order_lines(
     order_refund_lines = [
         OrderLineInfo(line=line, quantity=2) for line in order_lines_to_refund
     ]
-    returned_fulfillemnt = create_refund_fulfillment(
-        user=None,
-        app=None,
-        order=order_with_lines,
-        payment=payment,
-        order_lines_to_refund=order_refund_lines,
-        fulfillment_lines_to_refund=[],
-        manager=get_plugins_manager(allow_replica=False),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        returned_fulfillemnt = create_refund_fulfillment(
+            user=None,
+            app=None,
+            order=order_with_lines,
+            payment=payment,
+            order_lines_to_refund=order_refund_lines,
+            fulfillment_lines_to_refund=[],
+            manager=get_plugins_manager(allow_replica=False),
+        )
 
-    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == lines_count
@@ -85,7 +88,11 @@ def test_create_refund_fulfillment_only_order_lines(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_included_shipping_costs(
-    mocked_refund, mocked_order_updated, order_with_lines, payment_dummy
+    mocked_refund,
+    mocked_order_updated,
+    order_with_lines,
+    payment_dummy,
+    django_capture_on_commit_callbacks,
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -102,18 +109,18 @@ def test_create_refund_fulfillment_included_shipping_costs(
     order_refund_lines = [
         OrderLineInfo(line=line, quantity=2) for line in order_lines_to_refund
     ]
-    returned_fulfillemnt = create_refund_fulfillment(
-        user=None,
-        app=None,
-        order=order_with_lines,
-        payment=payment,
-        order_lines_to_refund=order_refund_lines,
-        fulfillment_lines_to_refund=[],
-        manager=get_plugins_manager(allow_replica=False),
-        refund_shipping_costs=True,
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        returned_fulfillemnt = create_refund_fulfillment(
+            user=None,
+            app=None,
+            order=order_with_lines,
+            payment=payment,
+            order_lines_to_refund=order_refund_lines,
+            fulfillment_lines_to_refund=[],
+            manager=get_plugins_manager(allow_replica=False),
+            refund_shipping_costs=True,
+        )
 
-    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == lines_count
@@ -147,7 +154,11 @@ def test_create_refund_fulfillment_included_shipping_costs(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_only_fulfillment_lines(
-    mocked_refund, mocked_order_updated, fulfilled_order, payment_dummy
+    mocked_refund,
+    mocked_order_updated,
+    fulfilled_order,
+    payment_dummy,
+    django_capture_on_commit_callbacks,
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -163,17 +174,17 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
         FulfillmentLineData(line=line, quantity=2)
         for line in fulfillment_lines_to_refund
     ]
-    returned_fulfillemnt = create_refund_fulfillment(
-        user=None,
-        app=None,
-        order=fulfilled_order,
-        payment=payment,
-        order_lines_to_refund=[],
-        fulfillment_lines_to_refund=fulfillment_refund_lines,
-        manager=get_plugins_manager(allow_replica=False),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        returned_fulfillemnt = create_refund_fulfillment(
+            user=None,
+            app=None,
+            order=fulfilled_order,
+            payment=payment,
+            order_lines_to_refund=[],
+            fulfillment_lines_to_refund=fulfillment_refund_lines,
+            manager=get_plugins_manager(allow_replica=False),
+        )
 
-    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == len(order_line_ids)
@@ -204,7 +215,11 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_custom_amount(
-    mocked_refund, mocked_order_updated, fulfilled_order, payment_dummy
+    mocked_refund,
+    mocked_order_updated,
+    fulfilled_order,
+    payment_dummy,
+    django_capture_on_commit_callbacks,
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -221,18 +236,18 @@ def test_create_refund_fulfillment_custom_amount(
         FulfillmentLineData(line=line, quantity=2)
         for line in fulfillment_lines_to_refund
     ]
-    returned_fulfillemnt = create_refund_fulfillment(
-        user=None,
-        app=None,
-        order=fulfilled_order,
-        payment=payment,
-        order_lines_to_refund=[],
-        fulfillment_lines_to_refund=fulfillment_refund_lines,
-        manager=get_plugins_manager(allow_replica=False),
-        amount=amount,
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        returned_fulfillemnt = create_refund_fulfillment(
+            user=None,
+            app=None,
+            order=fulfilled_order,
+            payment=payment,
+            order_lines_to_refund=[],
+            fulfillment_lines_to_refund=fulfillment_refund_lines,
+            manager=get_plugins_manager(allow_replica=False),
+            amount=amount,
+        )
 
-    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == len(order_line_ids)

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -11,7 +11,6 @@ from ...checkout import CheckoutAuthorizeStatus
 from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...order import OrderAuthorizeStatus, OrderChargeStatus, OrderGrantedRefundStatus
 from ...plugins.manager import get_plugins_manager
-from ...tests.utils import flush_post_commit_hooks
 from .. import TransactionEventType
 from ..interface import (
     PaymentLineData,
@@ -678,6 +677,7 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_fully_paid
     transaction_item_generator,
     app,
     order_with_lines,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order = order_with_lines
@@ -701,12 +701,12 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_fully_paid
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     order.refresh_from_db()
     assert order.charge_status == OrderChargeStatus.FULL
     mock_order_fully_paid.assert_called_once_with(order, webhooks=set())
@@ -725,6 +725,7 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_partially_
     transaction_item_generator,
     app,
     order_with_lines,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order = order_with_lines
@@ -748,12 +749,12 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_partially_
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     order.refresh_from_db()
     assert order_with_lines.charge_status == OrderChargeStatus.PARTIAL
     assert not mock_order_fully_paid.called
@@ -772,6 +773,7 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_fully_refu
     transaction_item_generator,
     app,
     order_with_lines,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order = order_with_lines
@@ -795,12 +797,12 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_fully_refu
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     order.refresh_from_db()
 
     mock_order_fully_refunded.assert_called_once_with(order, webhooks=set())
@@ -819,6 +821,7 @@ def test_create_transaction_event_from_request_triggers_webhooks_partially_refun
     transaction_item_generator,
     app,
     order_with_lines,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order = order_with_lines
@@ -842,12 +845,12 @@ def test_create_transaction_event_from_request_triggers_webhooks_partially_refun
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     order.refresh_from_db()
 
     assert not mock_order_fully_refunded.called
@@ -864,6 +867,7 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_authorized
     transaction_item_generator,
     app,
     order_with_lines,
+    django_capture_on_commit_callbacks,
 ):
     # given
     order = order_with_lines
@@ -887,12 +891,12 @@ def test_create_transaction_event_from_request_triggers_webhooks_when_authorized
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     order.refresh_from_db()
     assert order_with_lines.authorize_status == OrderAuthorizeStatus.FULL
     assert not mock_order_fully_paid.called
@@ -996,6 +1000,7 @@ def test_create_transaction_event_from_request_when_paid(
     transaction_item_generator,
     app,
     checkout_with_prices,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_prices
@@ -1020,12 +1025,12 @@ def test_create_transaction_event_from_request_when_paid(
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
@@ -1040,6 +1045,7 @@ def test_create_transaction_event_from_request_when_authorized(
     transaction_item_generator,
     app,
     checkout_with_prices,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_prices
@@ -1067,12 +1073,12 @@ def test_create_transaction_event_from_request_when_authorized(
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_checkout_fully_paid.assert_not_called()
@@ -1088,6 +1094,7 @@ def test_create_transaction_event_from_request_when_paid_triggers_checkout_compl
     app,
     checkout_with_prices,
     plugins_manager,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_prices
@@ -1118,12 +1125,12 @@ def test_create_transaction_event_from_request_when_paid_triggers_checkout_compl
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
@@ -1141,6 +1148,7 @@ def test_create_transaction_event_from_request_when_authorized_triggers_checkout
     app,
     checkout_with_prices,
     plugins_manager,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_prices
@@ -1171,12 +1179,12 @@ def test_create_transaction_event_from_request_when_authorized_triggers_checkout
     }
 
     # when
-    create_transaction_event_from_request_and_webhook_response(
-        request_event, app, response_data
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_from_request_and_webhook_response(
+            request_event, app, response_data
+        )
 
     # then
-    flush_post_commit_hooks()
     checkout.refresh_from_db()
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_checkout_fully_paid.assert_not_called()
@@ -2135,6 +2143,7 @@ def test_create_transaction_event_for_transaction_session_call_webhook_order_upd
     webhook_app,
     plugins_manager,
     order_with_lines,
+    django_capture_on_commit_callbacks,
 ):
     # given
     expected_amount = Decimal("15")
@@ -2146,16 +2155,16 @@ def test_create_transaction_event_for_transaction_session_call_webhook_order_upd
         transaction=transaction, include_in_calculations=False
     )
     # when
-    create_transaction_event_for_transaction_session(
-        request_event,
-        webhook_app,
-        manager=plugins_manager,
-        transaction_webhook_response=response,
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_for_transaction_session(
+            request_event,
+            webhook_app,
+            manager=plugins_manager,
+            transaction_webhook_response=response,
+        )
 
     # then
     order_with_lines.refresh_from_db()
-    flush_post_commit_hooks()
     assert not mock_order_fully_paid.called
     mock_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
 
@@ -2170,6 +2179,7 @@ def test_create_transaction_event_for_transaction_session_call_webhook_for_fully
     webhook_app,
     plugins_manager,
     order_with_lines,
+    django_capture_on_commit_callbacks,
 ):
     # given
     response = transaction_session_response.copy()
@@ -2181,16 +2191,16 @@ def test_create_transaction_event_for_transaction_session_call_webhook_for_fully
     )
 
     # when
-    create_transaction_event_for_transaction_session(
-        request_event,
-        webhook_app,
-        manager=plugins_manager,
-        transaction_webhook_response=response,
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        create_transaction_event_for_transaction_session(
+            request_event,
+            webhook_app,
+            manager=plugins_manager,
+            transaction_webhook_response=response,
+        )
 
     # then
     order_with_lines.refresh_from_db()
-    flush_post_commit_hooks()
     mock_order_fully_paid.assert_called_once_with(order_with_lines, webhooks=set())
     mock_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
 

--- a/saleor/tests/e2e/conftest.py
+++ b/saleor/tests/e2e/conftest.py
@@ -7,7 +7,7 @@ from django.test.client import MULTIPART_CONTENT, Client
 from ...account.models import User
 from ...app.models import App
 from ...graphql.tests.fixtures import BaseApiClient
-from ..utils import flush_post_commit_hooks
+from ...tests.utils import flush_post_commit_hooks
 
 
 class E2eApiClient(BaseApiClient):

--- a/saleor/webhook/tests/test_tasks.py
+++ b/saleor/webhook/tests/test_tasks.py
@@ -14,7 +14,6 @@ from ...payment import TransactionEventType
 from ...payment.interface import TransactionActionData
 from ...payment.models import TransactionEvent
 from ...payment.transaction_item_calculations import recalculate_transaction_amounts
-from ...tests.utils import flush_post_commit_hooks
 from ..event_types import WebhookEventSyncType
 from ..payloads import generate_transaction_action_request_payload
 from ..transport.synchronous.transport import handle_transaction_request_task
@@ -44,6 +43,7 @@ def test_trigger_transaction_request(
     staff_user,
     permission_manage_payments,
     app,
+    django_capture_on_commit_callbacks,
 ):
     # given
     event = transaction_item_created_by_app.events.create(
@@ -65,12 +65,14 @@ def test_trigger_transaction_request(
     )
 
     # when
-    trigger_transaction_request(
-        transaction_data, WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED, staff_user
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        trigger_transaction_request(
+            transaction_data,
+            WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED,
+            staff_user,
+        )
 
     # then
-    flush_post_commit_hooks()
     generated_payload = EventPayload.objects.first()
     generated_delivery = EventDelivery.objects.first()
 
@@ -100,6 +102,7 @@ def test_trigger_transaction_request_with_webhook_subscription(
     staff_user,
     permission_manage_payments,
     app,
+    django_capture_on_commit_callbacks,
 ):
     # given
     subscription = """
@@ -139,12 +142,14 @@ def test_trigger_transaction_request_with_webhook_subscription(
     )
 
     # when
-    trigger_transaction_request(
-        transaction_data, WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED, staff_user
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        trigger_transaction_request(
+            transaction_data,
+            WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED,
+            staff_user,
+        )
 
     # then
-    flush_post_commit_hooks()
     generated_payload = EventPayload.objects.first()
     generated_delivery = EventDelivery.objects.first()
 


### PR DESCRIPTION
Drop `flush_post_commit_hooks` usages in favor of `django_capture_on_commit_callbacks` fixture.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
