### PR TITLE
Split fixtures in the the Menu module

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,6 +36,7 @@ pytest_plugins = [
     "saleor.tax.tests.fixtures",
     "saleor.channel.tests.fixtures",
     "saleor.page.tests.fixtures",
+    "saleor.menu.tests.fixtures",
 ]
 
 

--- a/saleor/menu/tests/fixtures/__init__.py
+++ b/saleor/menu/tests/fixtures/__init__.py
@@ -1,0 +1,3 @@
+from .menu import *  # noqa: F403
+from .menu_item import *  # noqa: F403
+from .menu_item_translation import *  # noqa: F403

--- a/saleor/menu/tests/fixtures/menu.py
+++ b/saleor/menu/tests/fixtures/menu.py
@@ -1,0 +1,21 @@
+import pytest
+
+from ...models import Menu
+
+
+@pytest.fixture
+def menu(db):
+    return Menu.objects.get_or_create(name="test-navbar", slug="test-navbar")[0]
+
+
+@pytest.fixture
+def menu_with_items(menu, category, published_collection):
+    menu.items.create(name="Link 1", url="http://example.com/")
+    menu_item = menu.items.create(name="Link 2", url="http://example.com/")
+    menu.items.create(name=category.name, category=category, parent=menu_item)
+    menu.items.create(
+        name=published_collection.name,
+        collection=published_collection,
+        parent=menu_item,
+    )
+    return menu

--- a/saleor/menu/tests/fixtures/menu_item.py
+++ b/saleor/menu/tests/fixtures/menu_item.py
@@ -1,0 +1,16 @@
+import pytest
+
+from ...models import MenuItem
+
+
+@pytest.fixture
+def menu_item(menu):
+    return MenuItem.objects.create(menu=menu, name="Link 1", url="http://example.com/")
+
+
+@pytest.fixture
+def menu_item_list(menu):
+    menu_item_1 = MenuItem.objects.create(menu=menu, name="Link 1")
+    menu_item_2 = MenuItem.objects.create(menu=menu, name="Link 2")
+    menu_item_3 = MenuItem.objects.create(menu=menu, name="Link 3")
+    return menu_item_1, menu_item_2, menu_item_3

--- a/saleor/menu/tests/fixtures/menu_item_translation.py
+++ b/saleor/menu/tests/fixtures/menu_item_translation.py
@@ -1,0 +1,10 @@
+import pytest
+
+from ...models import MenuItemTranslation
+
+
+@pytest.fixture
+def menu_item_translation_fr(menu_item):
+    return MenuItemTranslation.objects.create(
+        language_code="fr", menu_item=menu_item, name="French manu item name"
+    )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -86,7 +86,7 @@ from ..discount.utils.voucher import (
 from ..giftcard import GiftCardEvents
 from ..giftcard.models import GiftCard, GiftCardEvent, GiftCardTag
 from ..graphql.core.utils import to_global_id_or_none
-from ..menu.models import Menu, MenuItem, MenuItemTranslation
+from ..menu.models import Menu
 from ..order import OrderOrigin, OrderStatus
 from ..order.actions import cancel_fulfillment, fulfill_order_lines
 from ..order.base_calculations import base_order_subtotal
@@ -6750,37 +6750,6 @@ def collection_list(db, channel_USD):
 
 
 @pytest.fixture
-def menu(db):
-    return Menu.objects.get_or_create(name="test-navbar", slug="test-navbar")[0]
-
-
-@pytest.fixture
-def menu_item(menu):
-    return MenuItem.objects.create(menu=menu, name="Link 1", url="http://example.com/")
-
-
-@pytest.fixture
-def menu_item_list(menu):
-    menu_item_1 = MenuItem.objects.create(menu=menu, name="Link 1")
-    menu_item_2 = MenuItem.objects.create(menu=menu, name="Link 2")
-    menu_item_3 = MenuItem.objects.create(menu=menu, name="Link 3")
-    return menu_item_1, menu_item_2, menu_item_3
-
-
-@pytest.fixture
-def menu_with_items(menu, category, published_collection):
-    menu.items.create(name="Link 1", url="http://example.com/")
-    menu_item = menu.items.create(name="Link 2", url="http://example.com/")
-    menu.items.create(name=category.name, category=category, parent=menu_item)
-    menu.items.create(
-        name=published_collection.name,
-        collection=published_collection,
-        parent=menu_item,
-    )
-    return menu
-
-
-@pytest.fixture
 def translated_attribute(product):
     attribute = product.product_type.product_attributes.first()
     return AttributeTranslation.objects.create(
@@ -6934,13 +6903,6 @@ def promotion_rule_translation_fr(promotion_rule):
         promotion_rule=promotion_rule,
         name="French promotion rule name",
         description=dummy_editorjs("French promotion rule description."),
-    )
-
-
-@pytest.fixture
-def menu_item_translation_fr(menu_item):
-    return MenuItemTranslation.objects.create(
-        language_code="fr", menu_item=menu_item, name="French manu item name"
     )
 
 


### PR DESCRIPTION
I want to merge this change because of splitting fixtures in the Menu module

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
