### PR TITLE
Split fixtures in the Thumbnail module

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,7 @@ pytest_plugins = [
     "saleor.page.tests.fixtures",
     "saleor.menu.tests.fixtures",
     "saleor.warehouse.tests.fixtures",
+    "saleor.thumbnail.tests.fixtures",
 ]
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -147,7 +147,6 @@ from ..shipping.utils import convert_to_shipping_method_data
 from ..site.models import SiteSettings
 from ..tax import TaxCalculationStrategy
 from ..tax.utils import calculate_tax_rate, get_tax_class_kwargs_for_order_line
-from ..thumbnail.models import Thumbnail
 from ..warehouse.models import (
     Allocation,
     PreorderAllocation,
@@ -8401,43 +8400,6 @@ def product_media_image(product, image, media_root):
         alt="image",
         type=ProductMediaTypes.IMAGE,
         oembed_data="{}",
-    )
-
-
-@pytest.fixture
-def thumbnail_product_media(product_media_image, image_list, media_root):
-    return Thumbnail.objects.create(
-        product_media=product_media_image,
-        size=128,
-        image=image_list[1],
-    )
-
-
-@pytest.fixture
-def thumbnail_category(category_with_image, image_list, media_root):
-    return Thumbnail.objects.create(
-        category=category_with_image,
-        size=128,
-        image=image_list[1],
-    )
-
-
-@pytest.fixture
-def thumbnail_collection(collection_with_image, image_list, media_root):
-    return Thumbnail.objects.create(
-        collection=collection_with_image,
-        size=128,
-        image=image_list[1],
-    )
-
-
-@pytest.fixture
-def thumbnail_user(customer_user, image_list, media_root):
-    customer_user.avatar = image_list[0]
-    return Thumbnail.objects.create(
-        user=customer_user,
-        size=128,
-        image=image_list[1],
     )
 
 

--- a/saleor/thumbnail/tests/fixtures/__init__.py
+++ b/saleor/thumbnail/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+from .thumbnail import *  # noqa: F403

--- a/saleor/thumbnail/tests/fixtures/thumbnail.py
+++ b/saleor/thumbnail/tests/fixtures/thumbnail.py
@@ -1,0 +1,40 @@
+import pytest
+
+from ...models import Thumbnail
+
+
+@pytest.fixture
+def thumbnail_product_media(product_media_image, image_list, media_root):
+    return Thumbnail.objects.create(
+        product_media=product_media_image,
+        size=128,
+        image=image_list[1],
+    )
+
+
+@pytest.fixture
+def thumbnail_category(category_with_image, image_list, media_root):
+    return Thumbnail.objects.create(
+        category=category_with_image,
+        size=128,
+        image=image_list[1],
+    )
+
+
+@pytest.fixture
+def thumbnail_collection(collection_with_image, image_list, media_root):
+    return Thumbnail.objects.create(
+        collection=collection_with_image,
+        size=128,
+        image=image_list[1],
+    )
+
+
+@pytest.fixture
+def thumbnail_user(customer_user, image_list, media_root):
+    customer_user.avatar = image_list[0]
+    return Thumbnail.objects.create(
+        user=customer_user,
+        size=128,
+        image=image_list[1],
+    )


### PR DESCRIPTION
I want to merge this change because of splitting fixtures in the Thumbnail module.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
