### PR TITLE
Drop aniso8601 now that Python 3.11 supports ISO8601

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5165,4 +5165,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "fde023b061726d8726a5c15bcd877cc2d86e1afcbc31073edfc8f9d0689a71c1"
+content-hash = "c849e39ef4562d5258b7067b955fdf9976035749c4d3afba6600872679a59793"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ documentation = "https://docs.saleor.io/"
   [tool.poetry.dependencies]
   python = "~3.12"
   Adyen = "^4.0.0"
-  aniso8601 = "^7.0.0"
   asgiref = "^3.7.2"
   Authlib = "^1.3.1"
   authorizenet = "^1.1.5"

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 from typing import Any, Optional, Union, cast, overload
 
 import graphene
-from aniso8601 import parse_datetime
 from babel.numbers import get_currency_precision
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
@@ -899,16 +898,8 @@ def parse_transaction_event_data(
                 else None
             )
         except ValueError:
-            try:
-                # datetime.datetime.fromisoformat supports only formats of the objects that were
-                # created by date.isoformat() or datetime.isoformat(). It is fixed in
-                # 3.11
-                # This try except block can be removed after moving to python 3.11
-                # ref: https://docs.python.org/3/library/datetime.html#datetime.datetime.datetime.fromisoformat
-                parsed_event_data["time"] = parse_datetime(event_time_data)
-            except ValueError:
-                logger.warning(invalid_msg, "time", event_time_data)
-                error_field_msg.append(invalid_msg % ("time", event_time_data))
+            logger.warning(invalid_msg, "time", event_time_data)
+            error_field_msg.append(invalid_msg % ("time", event_time_data))
     else:
         parsed_event_data["time"] = timezone.now()
 


### PR DESCRIPTION
This library was used as a workaround for Python's lack of support for some ISO8601 formats, but that's no longer an issue in Python 3.11 and above.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
