### PR TITLE
Drop flush_post_commit_hooks from API clients

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -653,7 +653,6 @@ def test_checkout_complete_gift_card_bought(
     address,
     shipping_method,
     payment_txn_captured,
-    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_gift_card_items
@@ -693,8 +692,7 @@ def test_checkout_complete_gift_card_bought(
     variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1621,7 +1621,6 @@ def test_checkout_complete_gift_card_bought(
     shipping_method,
     transaction_events_generator,
     transaction_item_generator,
-    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = prepare_checkout_for_test(
@@ -1649,8 +1648,7 @@ def test_checkout_complete_gift_card_bought(
     variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -482,7 +482,6 @@ def test_order_from_checkout_gift_card_bought(
     address,
     shipping_method,
     payment_txn_captured,
-    django_capture_on_commit_callbacks,
 ):
     # given
     checkout = checkout_with_gift_card_items
@@ -526,12 +525,11 @@ def test_order_from_checkout_gift_card_bought(
     variables = {"id": graphene.Node.to_global_id("Checkout", checkout.pk)}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = app_api_client.post_graphql(
-            MUTATION_ORDER_CREATE_FROM_CHECKOUT,
-            variables,
-            permissions=[permission_handle_checkouts],
-        )
+    response = app_api_client.post_graphql(
+        MUTATION_ORDER_CREATE_FROM_CHECKOUT,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/meta/tests/mutations/test_order.py
+++ b/saleor/graphql/meta/tests/mutations/test_order.py
@@ -603,7 +603,6 @@ def test_change_in_public_metadata_triggers_webhooks(
     setup_order_webhooks,
     api_client,
     order_with_lines,
-    django_capture_on_commit_callbacks,
     settings,
 ):
     # given
@@ -622,10 +621,9 @@ def test_change_in_public_metadata_triggers_webhooks(
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        execute_update_public_metadata_for_item(
-            api_client, None, order_id, "Order", key="new-key"
-        )
+    execute_update_public_metadata_for_item(
+        api_client, None, order_id, "Order", key="new-key"
+    )
 
     # then
     order_metadata_updated_delivery = EventDelivery.objects.get(
@@ -681,7 +679,6 @@ def test_change_in_private_metadata_triggers_webhooks(
     staff_api_client,
     permission_manage_orders,
     order_with_lines,
-    django_capture_on_commit_callbacks,
     settings,
 ):
     # given
@@ -700,10 +697,9 @@ def test_change_in_private_metadata_triggers_webhooks(
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        execute_update_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, order_id, "Order", key="new-key"
-        )
+    execute_update_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, order_id, "Order", key="new-key"
+    )
 
     # then
     order_metadata_updated_delivery = EventDelivery.objects.get(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1524,7 +1524,6 @@ def test_draft_order_complete_triggers_webhooks(
     permission_group_manage_orders,
     draft_order,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -1552,10 +1551,7 @@ def test_draft_order_complete_triggers_webhooks(
     variables = {"id": order_id}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            DRAFT_ORDER_COMPLETE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -3643,7 +3643,6 @@ def test_draft_order_create_triggers_webhooks(
     channel_PLN,
     graphql_address_data,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -3682,10 +3681,9 @@ def test_draft_order_create_triggers_webhooks(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = app_api_client.post_graphql(
-            query, variables, permissions=(permission_manage_orders,)
-        )
+    response = app_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_orders,)
+    )
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -279,7 +279,6 @@ def test_draft_order_delete_do_not_trigger_sync_webhooks(
     wrapped_call_order_event,
     setup_order_webhooks,
     settings,
-    django_capture_on_commit_callbacks,
     staff_api_client,
     permission_group_manage_orders,
     draft_order,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -2272,7 +2272,6 @@ def test_draft_order_update_triggers_webhooks(
     app_api_client,
     permission_manage_orders,
     draft_order,
-    django_capture_on_commit_callbacks,
     settings,
 ):
     # given
@@ -2305,10 +2304,9 @@ def test_draft_order_update_triggers_webhooks(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = app_api_client.post_graphql(
-            query, variables, permissions=(permission_manage_orders,)
-        )
+    response = app_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_orders,)
+    )
 
     # then
     content = get_graphql_content(response)
@@ -2369,7 +2367,6 @@ def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
     app_api_client,
     permission_manage_orders,
     draft_order,
-    django_capture_on_commit_callbacks,
     settings,
 ):
     # given
@@ -2392,10 +2389,9 @@ def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = app_api_client.post_graphql(
-            query, variables, permissions=(permission_manage_orders,)
-        )
+    response = app_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_orders,)
+    )
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
@@ -995,7 +995,6 @@ def test_fulfillment_refund_products_calls_order_refunded(
     permission_group_manage_orders,
     fulfilled_order,
     payment_dummy,
-    django_capture_on_commit_callbacks,
 ):
     payment_dummy.total = fulfilled_order.total_gross_amount
     payment_dummy.captured_amount = payment_dummy.total
@@ -1048,8 +1047,7 @@ def test_fulfillment_refund_products_calls_order_refunded(
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
+    staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
 
     # then
     amount = fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
@@ -1070,7 +1070,6 @@ def test_fulfillment_return_products_calls_order_refunded(
     permission_group_manage_orders,
     fulfilled_order,
     payment_dummy,
-    django_capture_on_commit_callbacks,
 ):
     # given
     payment_dummy.total = fulfilled_order.total_gross_amount
@@ -1129,8 +1128,7 @@ def test_fulfillment_return_products_calls_order_refunded(
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
+    staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
 
     # then
     amount = order_line.unit_price_gross_amount * 2

--- a/saleor/graphql/order/tests/mutations/test_order_cancel.py
+++ b/saleor/graphql/order/tests/mutations/test_order_cancel.py
@@ -152,7 +152,6 @@ def test_order_cancel_skip_trigger_webhooks(
     permission_group_manage_orders,
     order_with_lines,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -174,8 +173,7 @@ def test_order_cancel_skip_trigger_webhooks(
     variables = {"id": order_id}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(MUTATION_ORDER_CANCEL, variables)
+    response = staff_api_client.post_graphql(MUTATION_ORDER_CANCEL, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -195,7 +195,6 @@ def test_order_capture_triggers_webhooks(
     payment_txn_preauth,
     staff_user,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -221,8 +220,7 @@ def test_order_capture_triggers_webhooks(
     variables = {"id": order_id, "amount": amount}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(ORDER_CAPTURE_MUTATION, variables)
+    response = staff_api_client.post_graphql(ORDER_CAPTURE_MUTATION, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -625,7 +625,6 @@ def test_order_confirm_triggers_webhooks(
     permission_group_manage_orders,
     payment_txn_preauth,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -655,11 +654,10 @@ def test_order_confirm_triggers_webhooks(
     assert not OrderEvent.objects.exists()
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            ORDER_CONFIRM_MUTATION,
-            {"id": graphene.Node.to_global_id("Order", order_unconfirmed.id)},
-        )
+    response = staff_api_client.post_graphql(
+        ORDER_CONFIRM_MUTATION,
+        {"id": graphene.Node.to_global_id("Order", order_unconfirmed.id)},
+    )
 
     # then
     assert not get_graphql_content(response)["data"]["orderConfirm"]["errors"]

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -659,7 +659,6 @@ def test_order_fulfill_with_gift_cards(
     gift_card_shippable_order_line,
     permission_group_manage_orders,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     # given
     query = ORDER_FULFILL_MUTATION
@@ -690,8 +689,7 @@ def test_order_fulfill_with_gift_cards(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(query, variables)
 
     content = get_graphql_content(response)
     data = content["data"]["orderFulfill"]
@@ -1513,7 +1511,6 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
     warehouse,
     site_settings,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -1545,8 +1542,7 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
         },
     }
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        staff_api_client.post_graphql(query, variables)
+    staff_api_client.post_graphql(query, variables)
 
     # then
     assert mocked_webhooks.call_count == 2
@@ -1620,12 +1616,7 @@ def test_order_fulfill_triggers_webhooks(
         },
     }
     # when
-    with django_capture_on_commit_callbacks(execute=False) as callbacks:
-        response = staff_api_client.post_graphql(query, variables)
-
-    with django_capture_on_commit_callbacks(execute=True):
-        for callback in callbacks:
-            callback()
+    response = staff_api_client.post_graphql(query, variables)
 
     # then
     assert not get_graphql_content(response)["data"]["orderFulfill"]["errors"]

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -331,7 +331,6 @@ def test_order_line_delete_triggers_webhooks(
     permission_group_manage_orders,
     staff_api_client,
     settings,
-    django_capture_on_commit_callbacks,
     status,
     webhook_event,
 ):
@@ -356,8 +355,7 @@ def test_order_line_delete_triggers_webhooks(
     variables = {"id": line_id}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(query, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_line_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_update.py
@@ -59,7 +59,6 @@ def test_order_line_update_with_out_of_stock_webhook_for_two_lines_success_scena
     order_with_lines,
     permission_group_manage_orders,
     staff_api_client,
-    django_capture_on_commit_callbacks,
 ):
     # given
     Stock.objects.update(quantity=5)
@@ -76,11 +75,10 @@ def test_order_line_update_with_out_of_stock_webhook_for_two_lines_success_scena
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        variables = {"lineId": first_line_id, "quantity": new_quantity}
-        staff_api_client.post_graphql(query, variables)
-        variables = {"lineId": second_line_id, "quantity": new_quantity}
-        staff_api_client.post_graphql(query, variables)
+    variables = {"lineId": first_line_id, "quantity": new_quantity}
+    staff_api_client.post_graphql(query, variables)
+    variables = {"lineId": second_line_id, "quantity": new_quantity}
+    staff_api_client.post_graphql(query, variables)
 
     # then
     assert out_of_stock_mock.call_count == 2
@@ -608,7 +606,6 @@ def test_order_line_update_triggers_webhooks(
     permission_group_manage_orders,
     staff_api_client,
     settings,
-    django_capture_on_commit_callbacks,
     status,
     webhook_event,
 ):
@@ -635,8 +632,7 @@ def test_order_line_update_triggers_webhooks(
     variables = {"lineId": first_line_id, "quantity": new_quantity}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(query, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -1269,7 +1269,6 @@ def test_order_lines_create_triggers_webhooks(
     permission_group_manage_orders,
     staff_api_client,
     settings,
-    django_capture_on_commit_callbacks,
     status,
     webhook_event,
 ):
@@ -1295,8 +1294,7 @@ def test_order_lines_create_triggers_webhooks(
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(query, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_note_add.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_add.py
@@ -201,7 +201,6 @@ def test_order_note_add_user_triggers_webhooks(
     permission_group_manage_orders,
     order_with_lines,
     settings,
-    django_capture_on_commit_callbacks,
     status,
     webhook_event,
 ):
@@ -224,8 +223,7 @@ def test_order_note_add_user_triggers_webhooks(
     variables = {"id": order_id, "message": message}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(ORDER_NOTE_ADD_MUTATION, variables)
+    response = staff_api_client.post_graphql(ORDER_NOTE_ADD_MUTATION, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_note_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_update.py
@@ -234,7 +234,6 @@ def test_order_note_update_user_triggers_webhooks(
     order_with_lines,
     staff_user,
     settings,
-    django_capture_on_commit_callbacks,
     status,
     webhook_event,
 ):
@@ -264,12 +263,11 @@ def test_order_note_update_user_triggers_webhooks(
     variables = {"id": note_id, "message": message}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            ORDER_NOTE_UPDATE_MUTATION,
-            variables,
-            permissions=[permission_manage_orders],
-        )
+    response = staff_api_client.post_graphql(
+        ORDER_NOTE_UPDATE_MUTATION,
+        variables,
+        permissions=[permission_manage_orders],
+    )
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_refund.py
+++ b/saleor/graphql/order/tests/mutations/test_order_refund.py
@@ -38,7 +38,6 @@ def test_order_refund(
     staff_api_client,
     permission_group_manage_orders,
     payment_txn_captured,
-    django_capture_on_commit_callbacks,
 ):
     # given
     permission_group_manage_orders.user_set.add(staff_api_client.user)
@@ -49,8 +48,7 @@ def test_order_refund(
     variables = {"id": order_id, "amount": amount}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(query, variables)
 
     # then
     content = get_graphql_content(response)
@@ -92,7 +90,6 @@ def test_order_fully_refunded(
     staff_api_client,
     permission_group_manage_orders,
     payment_txn_captured,
-    django_capture_on_commit_callbacks,
 ):
     # given
     permission_group_manage_orders.user_set.add(staff_api_client.user)
@@ -107,8 +104,7 @@ def test_order_fully_refunded(
     variables = {"id": order_id, "amount": amount}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(query, variables)
 
     # then
     content = get_graphql_content(response)
@@ -171,7 +167,6 @@ def test_order_refund_by_app(
     app_api_client,
     permission_manage_orders,
     payment_txn_captured,
-    django_capture_on_commit_callbacks,
 ):
     # given
     order = payment_txn_captured.order
@@ -181,10 +176,9 @@ def test_order_refund_by_app(
     variables = {"id": order_id, "amount": amount}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = app_api_client.post_graphql(
-            query, variables, permissions=(permission_manage_orders,)
-        )
+    response = app_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_orders,)
+    )
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update.py
@@ -535,7 +535,6 @@ def test_order_update_triggers_webhooks(
     order_with_lines,
     graphql_address_data,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -557,8 +556,7 @@ def test_order_update_triggers_webhooks(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(ORDER_UPDATE_MUTATION, variables)
+    response = staff_api_client.post_graphql(ORDER_UPDATE_MUTATION, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -561,7 +561,6 @@ def test_order_update_shipping_triggers_webhooks(
     order_with_lines,
     shipping_method,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -583,8 +582,7 @@ def test_order_update_shipping_triggers_webhooks(
     variables = {"order": order_id, "shippingMethod": method_id}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(query, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/payment/tests/mutations/test_payment_refund.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_refund.py
@@ -35,7 +35,6 @@ def test_payment_refund_success(
     permission_group_manage_orders,
     payment_txn_captured,
     order_with_lines,
-    django_capture_on_commit_callbacks,
 ):
     # given
     permission_group_manage_orders.user_set.add(staff_api_client.user)
@@ -49,8 +48,7 @@ def test_payment_refund_success(
     variables = {"paymentId": payment_id, "amount": str(payment.total)}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(REFUND_QUERY, variables)
+    response = staff_api_client.post_graphql(REFUND_QUERY, variables)
 
     # then
     content = get_graphql_content(response)
@@ -105,7 +103,6 @@ def test_payment_refund_success_by_app(
     app_api_client,
     permission_manage_orders,
     payment_txn_captured,
-    django_capture_on_commit_callbacks,
 ):
     # given
     payment = payment_txn_captured
@@ -117,10 +114,9 @@ def test_payment_refund_success_by_app(
     variables = {"paymentId": payment_id, "amount": str(payment.total)}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = app_api_client.post_graphql(
-            REFUND_QUERY, variables, permissions=(permission_manage_orders,)
-        )
+    response = app_api_client.post_graphql(
+        REFUND_QUERY, variables, permissions=(permission_manage_orders,)
+    )
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/product/tests/deprecated/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/deprecated/test_product_variant_bulk_create.py
@@ -73,7 +73,6 @@ def test_product_variant_bulk_create_by_name(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -100,10 +99,9 @@ def test_product_variant_bulk_create_by_name(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkCreate"]
 
@@ -133,7 +131,6 @@ def test_product_variant_bulk_create_by_attribute_id(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -155,10 +152,9 @@ def test_product_variant_bulk_create_by_attribute_id(
 
     variables = {"productId": product_id, "variants": variants}
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkCreate"]
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -114,7 +114,6 @@ def test_product_variant_bulk_create_by_name(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -152,10 +151,9 @@ def test_product_variant_bulk_create_by_name(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
     content = get_graphql_content(response, ignore_errors=True)
     data = content["data"]["productVariantBulkCreate"]
 
@@ -191,7 +189,6 @@ def test_product_variant_bulk_create_by_attribute_id(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -216,10 +213,9 @@ def test_product_variant_bulk_create_by_attribute_id(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkCreate"]
 
@@ -242,7 +238,6 @@ def test_product_variant_bulk_create_by_attribute_external_ref(
     product,
     color_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     product_variant_count = ProductVariant.objects.count()
@@ -272,10 +267,9 @@ def test_product_variant_bulk_create_by_attribute_external_ref(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkCreate"]
 
@@ -298,7 +292,6 @@ def test_product_variant_bulk_create_return_error_when_attribute_external_ref_an
     product,
     color_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     product.product_type.variant_attributes.add(color_attribute)
@@ -327,10 +320,9 @@ def test_product_variant_bulk_create_return_error_when_attribute_external_ref_an
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkCreate"]
 
@@ -348,7 +340,6 @@ def test_product_variant_bulk_create_will_create_new_attr_value_and_external_ref
     product,
     color_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     product.product_type.variant_attributes.add(color_attribute)
@@ -381,10 +372,9 @@ def test_product_variant_bulk_create_will_create_new_attr_value_and_external_ref
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkCreate"]
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -98,7 +98,6 @@ def test_product_variant_bulk_update(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -124,10 +123,9 @@ def test_product_variant_bulk_update(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
     product_with_single_variant.refresh_from_db(fields=["search_index_dirty"])
@@ -166,7 +164,6 @@ def test_product_variant_bulk_create_stock_thread_race(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -215,10 +212,9 @@ def test_product_variant_bulk_create_stock_thread_race(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
 
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
@@ -244,7 +240,6 @@ def test_product_variant_bulk_update_stocks(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -288,10 +283,9 @@ def test_product_variant_bulk_update_stocks(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
 
@@ -359,7 +353,6 @@ def test_product_variant_bulk_update_and_remove_stock(
     warehouse,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     variant = variant_with_many_stocks
@@ -382,10 +375,9 @@ def test_product_variant_bulk_update_and_remove_stock(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
 
@@ -401,7 +393,6 @@ def test_product_variant_bulk_update_and_remove_stock_when_stock_not_exists(
     warehouse,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     variant = variant_with_many_stocks
@@ -421,10 +412,9 @@ def test_product_variant_bulk_update_and_remove_stock_when_stock_not_exists(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
 
@@ -444,7 +434,6 @@ def test_product_variant_bulk_update_stocks_with_invalid_warehouse(
     warehouse,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     variant = variant_with_many_stocks
@@ -468,10 +457,9 @@ def test_product_variant_bulk_update_stocks_with_invalid_warehouse(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
     stock_to_update.refresh_from_db()
@@ -681,7 +669,6 @@ def test_product_variant_bulk_update_with_already_existing_sku(
     product_with_two_variants,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     variants = product_with_two_variants.variants.all()
@@ -696,10 +683,9 @@ def test_product_variant_bulk_update_with_already_existing_sku(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
 
@@ -714,7 +700,6 @@ def test_product_variant_bulk_update_when_variant_not_exists(
     staff_api_client,
     product_with_two_variants,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     product_id = graphene.Node.to_global_id("Product", product_with_two_variants.pk)
@@ -726,10 +711,9 @@ def test_product_variant_bulk_update_when_variant_not_exists(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
 
@@ -754,7 +738,6 @@ def test_product_variant_bulk_update_attributes(
     settings,
     multiselect_attribute,
     color_attribute,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -794,10 +777,9 @@ def test_product_variant_bulk_update_attributes(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantBulkUpdate"]
 
@@ -818,7 +800,6 @@ def test_generate_pre_save_payloads(
     variant,
     permission_manage_products,
     webhook_app,
-    django_capture_on_commit_callbacks,
 ):
     # given
     SUBSCRIPTION_QUERY = """
@@ -848,8 +829,7 @@ def test_generate_pre_save_payloads(
 
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    with django_capture_on_commit_callbacks(execute=True):
-        staff_api_client.post_graphql(PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables)
+    staff_api_client.post_graphql(PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables)
 
     # then
     payload_key = get_pre_save_payload_key(webhook, variant)

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -87,7 +87,6 @@ def test_create_variant_with_name(
     product_type,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     # given
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -125,10 +124,9 @@ def test_create_variant_with_name(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            CREATE_VARIANT_MUTATION, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        CREATE_VARIANT_MUTATION, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     # then
@@ -165,7 +163,6 @@ def test_create_variant_without_name(
     product_type,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     # given
     query = CREATE_VARIANT_MUTATION
@@ -196,10 +193,9 @@ def test_create_variant_without_name(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     # then
@@ -273,7 +269,6 @@ def test_create_variant_preorder(
     product,
     product_type,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -302,10 +297,9 @@ def test_create_variant_preorder(
         }
     }
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]
@@ -328,7 +322,6 @@ def test_create_variant_no_required_attributes(
     product_type,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -356,10 +349,9 @@ def test_create_variant_no_required_attributes(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]
@@ -386,7 +378,6 @@ def test_create_variant_with_file_attribute(
     permission_manage_products,
     warehouse,
     site_settings,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -419,10 +410,9 @@ def test_create_variant_with_file_attribute(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]
@@ -454,7 +444,6 @@ def test_create_variant_with_boolean_attribute(
     boolean_attribute,
     size_attribute,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(
         boolean_attribute, through_defaults={"variant_selection": True}
@@ -483,10 +472,9 @@ def test_create_variant_with_boolean_attribute(
         }
     }
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     data = content["productVariant"]
 
@@ -523,7 +511,6 @@ def test_create_variant_with_file_attribute_new_value(
     permission_manage_products,
     warehouse,
     site_settings,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -555,10 +542,9 @@ def test_create_variant_with_file_attribute_new_value(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]
@@ -588,7 +574,6 @@ def test_create_variant_with_file_attribute_no_file_url_given(
     file_attribute,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -618,10 +603,9 @@ def test_create_variant_with_file_attribute_no_file_url_given(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     errors = content["errors"]
@@ -653,7 +637,6 @@ def test_create_variant_with_page_reference_attribute(
     page_list,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -686,10 +669,9 @@ def test_create_variant_with_page_reference_attribute(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]
@@ -749,7 +731,6 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
     permission_manage_products,
     warehouse,
     site_settings,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -783,10 +764,9 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     errors = content["errors"]
     data = content["productVariant"]
@@ -814,7 +794,6 @@ def test_create_variant_with_product_reference_attribute(
     product_list,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -852,10 +831,9 @@ def test_create_variant_with_product_reference_attribute(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]
@@ -915,7 +893,6 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
     permission_manage_products,
     warehouse,
     site_settings,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -949,10 +926,9 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     errors = content["errors"]
     data = content["productVariant"]
@@ -980,7 +956,6 @@ def test_create_variant_with_variant_reference_attribute(
     product_list,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     # given
     query = CREATE_VARIANT_MUTATION
@@ -1023,10 +998,9 @@ def test_create_variant_with_variant_reference_attribute(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
 
     # then
     content = get_graphql_content(response)["data"]["productVariantCreate"]
@@ -1088,7 +1062,6 @@ def test_create_variant_with_variant_reference_attribute_no_references_given(
     permission_manage_products,
     warehouse,
     site_settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     query = CREATE_VARIANT_MUTATION
@@ -1125,10 +1098,9 @@ def test_create_variant_with_variant_reference_attribute_no_references_given(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
 
     # then
     content = get_graphql_content(response)["data"]["productVariantCreate"]
@@ -1493,7 +1465,6 @@ def test_create_variant_with_rich_text_attribute(
     staff_api_client,
     rich_text_attribute,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(rich_text_attribute)
     query = CREATE_VARIANT_MUTATION
@@ -1521,10 +1492,9 @@ def test_create_variant_with_rich_text_attribute(
         }
     }
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     data = content["productVariant"]
 
@@ -1544,7 +1514,6 @@ def test_create_variant_with_plain_text_attribute(
     staff_api_client,
     plain_text_attribute,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     # given
     product_type.variant_attributes.add(plain_text_attribute)
@@ -1574,10 +1543,9 @@ def test_create_variant_with_plain_text_attribute(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
 
     # then
     content = get_graphql_content(response)["data"]["productVariantCreate"]
@@ -1600,7 +1568,6 @@ def test_create_variant_with_date_attribute(
     staff_api_client,
     date_attribute,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(date_attribute)
 
@@ -1623,10 +1590,9 @@ def test_create_variant_with_date_attribute(
         }
     }
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     data = content["productVariant"]
     variant = product.variants.last()
@@ -1664,7 +1630,6 @@ def test_create_variant_with_date_time_attribute(
     staff_api_client,
     date_time_attribute,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     product_type.variant_attributes.add(date_time_attribute)
 
@@ -1688,10 +1653,9 @@ def test_create_variant_with_date_time_attribute(
         }
     }
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     data = content["productVariant"]
     variant = product.variants.last()
@@ -1729,7 +1693,6 @@ def test_create_variant_with_empty_string_for_sku(
     product_type,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1757,10 +1720,9 @@ def test_create_variant_with_empty_string_for_sku(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]
@@ -1788,7 +1750,6 @@ def test_create_variant_without_sku(
     product_type,
     permission_manage_products,
     warehouse,
-    django_capture_on_commit_callbacks,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1814,10 +1775,9 @@ def test_create_variant_without_sku(
             "trackInventory": True,
         }
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)["data"]["productVariantCreate"]
 
     assert not content["errors"]

--- a/saleor/graphql/product/tests/mutations/test_product_variant_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_delete.py
@@ -30,7 +30,6 @@ def test_delete_variant_by_sku(
     staff_api_client,
     product,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     variant = product.variants.first()
@@ -38,12 +37,11 @@ def test_delete_variant_by_sku(
     variables = {"sku": variant_sku}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            DELETE_VARIANT_BY_SKU_MUTATION,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        DELETE_VARIANT_BY_SKU_MUTATION,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantDelete"]
 
@@ -77,17 +75,15 @@ def test_delete_variant(
     staff_api_client,
     product,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     query = DELETE_VARIANT_MUTATION
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     variant_sku = variant.sku
     variables = {"id": variant_id}
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantDelete"]
 
@@ -104,17 +100,15 @@ def test_delete_variant_remove_checkout_lines(
     staff_api_client,
     checkout_with_items,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     query = DELETE_VARIANT_MUTATION
     line = checkout_with_items.lines.first()
     variant = line.variant
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     variables = {"id": variant_id}
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantDelete"]
 
@@ -136,7 +130,6 @@ def test_delete_variant_with_image(
     variant_with_image,
     permission_manage_products,
     media_root,
-    django_capture_on_commit_callbacks,
 ):
     """Ensure deleting variant doesn't delete linked product image."""
 
@@ -145,10 +138,9 @@ def test_delete_variant_with_image(
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     variables = {"id": variant_id}
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantDelete"]
 
@@ -381,7 +373,6 @@ def test_delete_variant_delete_product_channel_listing_without_available_channel
     staff_api_client,
     product,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     """Test that the product is unlisted if all listed variants are removed."""
     # given
@@ -397,10 +388,9 @@ def test_delete_variant_delete_product_channel_listing_without_available_channel
     assert product.channel_listings.count() == 1
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
 
     # then
     content = get_graphql_content(response)
@@ -423,7 +413,6 @@ def test_delete_variant_delete_product_channel_listing_not_deleted(
     staff_api_client,
     product_with_two_variants,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     """Test that the product listing persists if any variant listings remain."""
     # given
@@ -437,10 +426,9 @@ def test_delete_variant_delete_product_channel_listing_not_deleted(
     product_channel_listing_count = product.channel_listings.count()
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
 
     # then
     content = get_graphql_content(response)
@@ -479,7 +467,6 @@ def test_delete_variant_by_external_reference(
     staff_api_client,
     product,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     query = DELETE_VARIANT_BY_EXTERNAL_REFERENCE
@@ -490,12 +477,11 @@ def test_delete_variant_by_external_reference(
     variables = {"externalReference": ext_ref}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariantDelete"]
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_preorder_deactivate.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_preorder_deactivate.py
@@ -39,7 +39,6 @@ def test_product_variant_deactivate_preorder(
     permission_manage_products,
     preorder_variant_global_and_channel_threshold,
     preorder_allocation,
-    django_capture_on_commit_callbacks,
 ):
     variant = preorder_variant_global_and_channel_threshold
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
@@ -48,12 +47,11 @@ def test_product_variant_deactivate_preorder(
         stock__product_variant_id=variant.pk
     ).count()
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            QUERY_VARIANT_DEACTIVATE_PREORDER,
-            {"id": variant_id},
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        QUERY_VARIANT_DEACTIVATE_PREORDER,
+        {"id": variant_id},
+        permissions=[permission_manage_products],
+    )
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content["data"]["productVariantPreorderDeactivate"]["productVariant"]

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -99,7 +99,6 @@ def test_update_product_variant_by_id(
     product,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     query = """
         mutation updateVariant (
@@ -149,10 +148,9 @@ def test_update_product_variant_by_id(
         "externalReference": external_reference,
     }
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content["data"]["productVariantUpdate"]["productVariant"]
@@ -173,7 +171,6 @@ def test_update_product_variant_marks_prices_as_dirty(
     size_attribute,
     permission_manage_products,
     catalogue_promotion,
-    django_capture_on_commit_callbacks,
 ):
     # given
     query = """
@@ -202,10 +199,9 @@ def test_update_product_variant_marks_prices_as_dirty(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
 
     # then
     variant.refresh_from_db()
@@ -259,7 +255,6 @@ def test_update_product_variant_by_sku(
     product,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     #   given
     variant = product.variants.first()
@@ -277,10 +272,9 @@ def test_update_product_variant_by_sku(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            UPDATE_VARIANT_BY_SKU, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        UPDATE_VARIANT_BY_SKU, variables, permissions=[permission_manage_products]
+    )
 
     variant.refresh_from_db()
     content = get_graphql_content(response)
@@ -301,7 +295,6 @@ def test_update_product_variant_by_sku_return_error_when_sku_dont_exists(
     product,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     # given
     variant = product.variants.first()
@@ -319,10 +312,9 @@ def test_update_product_variant_by_sku_return_error_when_sku_dont_exists(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            UPDATE_VARIANT_BY_SKU, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        UPDATE_VARIANT_BY_SKU, variables, permissions=[permission_manage_products]
+    )
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content["data"]["productVariantUpdate"]
@@ -365,7 +357,6 @@ def test_update_product_variant_by_external_reference(
     product,
     size_attribute,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     #   given
     query = UPDATE_VARIANT_BY_EXTERNAL_REFERENCE
@@ -382,10 +373,9 @@ def test_update_product_variant_by_external_reference(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content["data"]["productVariantUpdate"]
@@ -2266,7 +2256,6 @@ def test_update_product_variant_change_preorder_data(
     staff_api_client,
     permission_manage_products,
     preorder_variant_global_threshold,
-    django_capture_on_commit_callbacks,
 ):
     variant = preorder_variant_global_threshold
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
@@ -2289,12 +2278,11 @@ def test_update_product_variant_change_preorder_data(
         },
     }
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            QUERY_UPDATE_VARIANT_PREORDER,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_PREORDER,
+        variables,
+        permissions=[permission_manage_products],
+    )
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content["data"]["productVariantUpdate"]["productVariant"]
@@ -2308,7 +2296,6 @@ def test_update_product_variant_can_not_turn_off_preorder(
     staff_api_client,
     permission_manage_products,
     preorder_variant_global_threshold,
-    django_capture_on_commit_callbacks,
 ):
     """Test that preorder cannot be disabled through updating the `preorder` field directly."""
     variant = preorder_variant_global_threshold
@@ -2317,12 +2304,11 @@ def test_update_product_variant_can_not_turn_off_preorder(
 
     variables = {"id": variant_id, "sku": sku, "preorder": None}
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            QUERY_UPDATE_VARIANT_PREORDER,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_PREORDER,
+        variables,
+        permissions=[permission_manage_products],
+    )
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content["data"]["productVariantUpdate"]["productVariant"]

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -115,7 +115,6 @@ def test_delete_categories_trigger_webhook(
     category_list,
     permission_manage_products,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -129,12 +128,11 @@ def test_delete_categories_trigger_webhook(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            MUTATION_CATEGORY_BULK_DELETE,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        MUTATION_CATEGORY_BULK_DELETE,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
 
     # then
@@ -196,7 +194,6 @@ def test_delete_categories_trigger_product_updated_webhook(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -216,12 +213,11 @@ def test_delete_categories_trigger_product_updated_webhook(
             for category in category_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            MUTATION_CATEGORY_BULK_DELETE,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        MUTATION_CATEGORY_BULK_DELETE,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["categoryBulkDelete"]["count"] == 3
@@ -401,7 +397,6 @@ def test_delete_collections_trigger_collection_deleted_webhook(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -412,12 +407,11 @@ def test_delete_collections_trigger_collection_deleted_webhook(
             for collection in collection_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            MUTATION_COLLECTION_BULK_DELETE,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        MUTATION_COLLECTION_BULK_DELETE,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["collectionBulkDelete"]["count"] == 3
@@ -441,7 +435,6 @@ def test_delete_collections_trigger_product_updated_webhook(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -454,12 +447,11 @@ def test_delete_collections_trigger_product_updated_webhook(
             for collection in collection_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            MUTATION_COLLECTION_BULK_DELETE,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        MUTATION_COLLECTION_BULK_DELETE,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["collectionBulkDelete"]["count"] == 3
@@ -490,7 +482,6 @@ def test_delete_products(
     permission_manage_products,
     order_list,
     channel_USD,
-    django_capture_on_commit_callbacks,
 ):
     # given
     query = DELETE_PRODUCTS_MUTATION
@@ -547,10 +538,9 @@ def test_delete_products(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
 
     # then
     content = get_graphql_content(response)
@@ -639,7 +629,6 @@ def test_delete_products_trigger_webhook(
     permission_manage_products,
     channel_USD,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -652,10 +641,9 @@ def test_delete_products_trigger_webhook(
             for product in product_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["productBulkDelete"]["count"] == 3
@@ -677,7 +665,6 @@ def test_delete_products_without_variants(
     permission_manage_products,
     channel_USD,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -693,10 +680,9 @@ def test_delete_products_without_variants(
             for product in product_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["productBulkDelete"]["count"] == 3
@@ -980,7 +966,6 @@ def test_delete_product_variants_by_sku(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -998,12 +983,11 @@ def test_delete_product_variants_by_sku(
     variables = {"skus": [variant.sku for variant in product_variant_list]}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
 
     # then
@@ -1033,7 +1017,6 @@ def test_delete_product_variants_by_sku_task_for_recalculate_product_prices_call
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1046,12 +1029,11 @@ def test_delete_product_variants_by_sku_task_for_recalculate_product_prices_call
     variables = {"skus": [variant.sku for variant in variants]}
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
-            variables,
-            permissions=[permission_manage_products],
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION,
+        variables,
+        permissions=[permission_manage_products],
+    )
     content = get_graphql_content(response)
 
     # then
@@ -1096,7 +1078,6 @@ def test_delete_product_variants(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1119,10 +1100,9 @@ def test_delete_product_variants(
             for variant in product_variant_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 4
@@ -1151,7 +1131,6 @@ def test_delete_product_variants_task_for_recalculate_product_prices_called(
     permission_manage_products,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1169,10 +1148,9 @@ def test_delete_product_variants_task_for_recalculate_product_prices_called(
             for variant in variants
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["productVariantBulkDelete"]["count"] == len(variants)
@@ -1220,7 +1198,6 @@ def test_delete_product_variants_removes_checkout_lines(
     checkout,
     product_list,
     permission_manage_products,
-    django_capture_on_commit_callbacks,
 ):
     query = PRODUCT_VARIANT_BULK_DELETE_MUTATION
 
@@ -1245,10 +1222,9 @@ def test_delete_product_variants_removes_checkout_lines(
             for variant in variant_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 2
@@ -1281,7 +1257,6 @@ def test_delete_product_variants_with_images(
     media_root,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1308,10 +1283,9 @@ def test_delete_product_variants_with_images(
             for variant in product_variant_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 4
@@ -1508,7 +1482,6 @@ def test_delete_product_variants_with_file_attribute(
     file_attribute,
     any_webhook,
     settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -1534,10 +1507,9 @@ def test_delete_product_variants_with_file_attribute(
             for variant in product_variant_list
         ]
     }
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            query, variables, permissions=[permission_manage_products]
-        )
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
     content = get_graphql_content(response)
 
     assert content["data"]["productVariantBulkDelete"]["count"] == 4

--- a/saleor/graphql/product/tests/test_variant_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_variant_channel_listing_update.py
@@ -187,7 +187,6 @@ def test_variant_channel_listing_update_as_staff_user(
     permission_manage_products,
     channel_USD,
     channel_PLN,
-    django_capture_on_commit_callbacks,
 ):
     # given
     product_pln_channel_listing = ProductChannelListing.objects.create(
@@ -214,12 +213,11 @@ def test_variant_channel_listing_update_as_staff_user(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_CHANNEL_LISTING_UPDATE_MUTATION,
-            variables=variables,
-            permissions=(permission_manage_products,),
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_CHANNEL_LISTING_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_products,),
+    )
     content = get_graphql_content(response)
 
     # then
@@ -321,7 +319,6 @@ def test_variant_channel_listing_update_trigger_webhook_product_variant_updated(
     permission_manage_products,
     channel_USD,
     channel_PLN,
-    django_capture_on_commit_callbacks,
 ):
     # given
     ProductChannelListing.objects.create(
@@ -348,12 +345,11 @@ def test_variant_channel_listing_update_trigger_webhook_product_variant_updated(
     }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        response = staff_api_client.post_graphql(
-            PRODUCT_VARIANT_CHANNEL_LISTING_UPDATE_MUTATION,
-            variables=variables,
-            permissions=(permission_manage_products,),
-        )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_CHANNEL_LISTING_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_products,),
+    )
     get_graphql_content(response)
 
     # then

--- a/saleor/product/tests/test_category.py
+++ b/saleor/product/tests/test_category.py
@@ -19,17 +19,14 @@ def test_collect_categories_tree_products(categories_tree):
     )
 
 
-def test_delete_categories(
-    categories_tree_with_published_products, django_capture_on_commit_callbacks
-):
+def test_delete_categories(categories_tree_with_published_products):
     # given
     parent = categories_tree_with_published_products
     child = parent.children.first()
     product_list = [child.products.first(), parent.products.first()]
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        delete_categories([parent.pk], manager=get_plugins_manager(allow_replica=False))
+    delete_categories([parent.pk], manager=get_plugins_manager(allow_replica=False))
 
     assert not Category.objects.filter(
         id__in=[category.id for category in [parent, child]]

--- a/saleor/tests/e2e/conftest.py
+++ b/saleor/tests/e2e/conftest.py
@@ -2,12 +2,12 @@ import json
 
 import pytest
 from django.core.serializers.json import DjangoJSONEncoder
+from django.test import TestCase
 from django.test.client import MULTIPART_CONTENT, Client
 
 from ...account.models import User
 from ...app.models import App
 from ...graphql.tests.fixtures import BaseApiClient
-from ...tests.utils import flush_post_commit_hooks
 
 
 class E2eApiClient(BaseApiClient):
@@ -28,8 +28,8 @@ class E2eApiClient(BaseApiClient):
         data = json.dumps(data, cls=DjangoJSONEncoder)
         kwargs["content_type"] = "application/json"
 
-        result = super(Client, self).post(self.api_path, data, **kwargs)
-        flush_post_commit_hooks()
+        with TestCase.captureOnCommitCallbacks(execute=True):
+            result = super(Client, self).post(self.api_path, data, **kwargs)
         return result
 
     def post_multipart(self, *args, **kwargs):
@@ -40,8 +40,8 @@ class E2eApiClient(BaseApiClient):
         """
         kwargs["content_type"] = MULTIPART_CONTENT
 
-        result = super(Client, self).post(self.api_path, *args, **kwargs)
-        flush_post_commit_hooks()
+        with TestCase.captureOnCommitCallbacks(execute=True):
+            result = super(Client, self).post(self.api_path, *args, **kwargs)
         return result
 
 

--- a/saleor/tests/utils.py
+++ b/saleor/tests/utils.py
@@ -3,7 +3,7 @@ import math
 from decimal import Decimal
 
 from django.conf import settings
-from django.db import connections, transaction
+from django.db import connections
 
 from ..core.db.connection import allow_writer
 
@@ -53,20 +53,6 @@ def prepare_test_db_connections():
     """
     replica = settings.DATABASE_CONNECTION_REPLICA_NAME
     connections[replica] = FakeDbReplicaConnection(connections[replica])  # type: ignore
-
-
-def flush_post_commit_hooks():
-    """Run all pending `transaction.on_commit()` callbacks.
-
-    Forces all `on_commit()` hooks to run even if the transaction was not committed yet.
-    """
-    connection = transaction.get_connection(settings.DATABASE_CONNECTION_DEFAULT_NAME)
-    was_atomic = connection.in_atomic_block
-    was_commit_on_exit = connection.commit_on_exit
-    connection.in_atomic_block = False
-    connection.run_and_clear_commit_hooks()
-    connection.in_atomic_block = was_atomic
-    connection.commit_on_exit = was_commit_on_exit
 
 
 def dummy_editorjs(text, json_format=False):


### PR DESCRIPTION
This PR entirely removes `flush_post_commit_hooks` also from API clients in tests. Requests to Saleor made in tests are now automatically wrapped with `TestCase.captureOnCommitCallbacks` - a function that is internally used in fixture `django_capture_on_commit_callbacks`. 

The fixture `django_capture_on_commit_callbacks` still needs to be used manually when testing callbacks from internal functions (not API requests).

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
