### PR TITLE
Drop obsolete comment

### DIFF
--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -87,8 +87,6 @@ def to_enum(enum_cls, *, type_name=None, **options) -> graphene.Enum:
     :return:
     """
 
-    # note this won't work until
-    # https://github.com/graphql-python/graphene/issues/956 is fixed
     deprecation_reason = getattr(enum_cls, "__deprecation_reason__", None)
     if deprecation_reason:
         options.setdefault("deprecation_reason", deprecation_reason)


### PR DESCRIPTION
Said fix landed in graphql-core 2.1.4, we're on 2.3.2.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
