### PR TITLE
Enable logging lint rules in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ target-version = "py39"
     "I",
     "ISC001",
     "ISC002",
+    "LOG",
     "PIE",
     "PT",
     "T20",

--- a/saleor/attribute/management/commands/update_attribute_file_urls.py
+++ b/saleor/attribute/management/commands/update_attribute_file_urls.py
@@ -40,16 +40,17 @@ class Command(BaseCommand):
                 )
             except ClientError as exc:
                 if exc.response["Error"]["Code"] == "NoSuchKey":
-                    logger.info(f"No object found: {old_file_url}")
+                    logger.info("No object found: %s", old_file_url)
                 else:
                     raise
             else:
                 storage.bucket.Object(old_file_url).delete()
-                logger.info(f"File {old_file_url} moved to {new_file_url}.")
+                logger.info("File %s moved to %s.", old_file_url, new_file_url)
 
                 value.file_url = new_file_name
                 value.save(update_fields=["file_url"])
                 logger.info(
-                    f"File url for AttributeValue {value} with id {value.id} "
-                    "has been updated."
+                    "File URL for AttributeValue %s with ID %s has been updated.",
+                    value,
+                    value.id,
                 )

--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -40,8 +40,8 @@ class RestrictWriterDBTask(Task):
             wrapper_fun = import_string(func_path)
         except ImportError:
             task_logger.error(
-                f"Could not import the function {func_path}. "
-                f"Check if the path is correct."
+                "Could not import the function %s. Check if the path is correct.",
+                func_path,
             )
             return super().__call__(*args, **kwargs)
 

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -112,8 +112,8 @@ def generate_payload_promise_from_subscription(
     ):
         if hasattr(results, "errors"):
             logger.warning(
-                "Unable to build a payload for subscription. \n"
-                f"error: {str(results.errors)}",
+                "Unable to build a payload for subscription.\nerror: %s",
+                str(results.errors),
                 extra={"query": subscription_query, "app": app_id},
             )
             return None

--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -83,8 +83,8 @@ def _bulk_release_voucher_usage(order_ids):
     suspected_codes = [code.code for code in codes if code.used < code.order_count]
     if suspected_codes:
         logger.error(
-            f"Voucher codes: [{','.join(suspected_codes)}] have been used more times "
-            f"than indicated by `code.used` field."
+            "Voucher codes: [%s] have been used more times than indicated by `code.used` field.",
+            ",".join(suspected_codes),
         )
 
     codes.update(used=Greatest(F("used") - F("order_count"), 0))

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -87,7 +87,7 @@ def api_call(
     try:
         return method(request_data, **kwargs)
     except (Adyen.AdyenError, ValueError, TypeError, ConnectTimeout) as e:
-        logger.warning(f"Unable to process the payment: {e}")
+        logger.warning("Unable to process the payment: %s", e)
         raise PaymentError(f"Unable to process the payment request: {e}.") from e
 
 

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -302,8 +302,9 @@ def handle_authorization(notification: dict[str, Any], gateway_config: GatewayCo
         # a partial payment so we create an order in separate webhook (order_closed)
         # after payment finished.
         logger.info(
-            f"This is a partial payment notification. We can't create an order. "
-            f"pspReference: {transaction_id}, payment_id: {payment.pk}"
+            "This is a partial payment notification. We can't create an order. pspReference: %s, paymentId: %x",
+            transaction_id,
+            payment.pk,
         )
         return
 
@@ -673,7 +674,7 @@ def handle_order_opened(notification: dict[str, Any], gateway_config: GatewayCon
     # order has been created.
     #
     # In this case we just logging here that we received the webhook properly.
-    logger.info(f"First payment request as a partial payment. {notification}")
+    logger.info("First payment request as a partial payment. %s", notification)
 
 
 def get_or_create_adyen_partial_payments(
@@ -811,8 +812,9 @@ def handle_order_closed(notification: dict[str, Any], gateway_config: GatewayCon
     is_success = True if notification.get("success") == "true" else False
     psp_reference = notification.get("pspReference")
     logger.info(
-        f"Partial payment has been finished with result: {is_success}."
-        f"psp: {psp_reference}"
+        "Partial payment has been finished with result: %s. pspReference: %s",
+        is_success,
+        psp_reference,
     )
 
     if not is_success:
@@ -828,11 +830,11 @@ def handle_order_closed(notification: dict[str, Any], gateway_config: GatewayCon
 
     if not payment:
         # We don't know anything about that payment
-        logger.info(f"There is no payment with psp: {psp_reference}")
+        logger.info("There is no payment with pspReference: %s", psp_reference)
         return
 
     if payment.order:
-        logger.info(f"Order already created for payment: {payment.pk}")
+        logger.info("Order already created for payment: %s", payment.pk)
         return
 
     adyen_partial_payments = get_or_create_adyen_partial_payments(notification, payment)

--- a/saleor/payment/gateways/np_atobarai/__init__.py
+++ b/saleor/payment/gateways/np_atobarai/__init__.py
@@ -88,8 +88,9 @@ def tracking_number_updated(fulfillment: Fulfillment, config: ApiConfig) -> None
         elif errors:
             error = ", ".join(errors)
             logger.warning(
-                f"Could not capture payment with id {payment_graphql_id} "
-                f"in NP Atobarai: {error}"
+                "Could not capture payment with id %s in NP Atobarai: %s",
+                payment_graphql_id,
+                error,
             )
             msg = (
                 f"Error: Cannot capture payment with id {payment_graphql_id} ({error})"

--- a/saleor/plugins/sendgrid/plugin.py
+++ b/saleor/plugins/sendgrid/plugin.py
@@ -234,7 +234,7 @@ class SendgridEmailPlugin(BasePlugin):
         event_in_notify_event = event in UserNotifyEvent.CHOICES
 
         if not event_in_notify_event:
-            logger.info(f"Send email with event {event} as dynamic template ID.")
+            logger.info("Send email with event %s as dynamic template ID.", event)
             payload = payload_func()
             send_email_with_dynamic_template_id.delay(
                 payload, event, asdict(self.config)
@@ -242,7 +242,7 @@ class SendgridEmailPlugin(BasePlugin):
             return previous_value
 
         if event not in EVENT_MAP:
-            logger.warning(f"Missing handler for event {event}")
+            logger.warning("Missing handler for event %s", event)
             return previous_value
 
         configuration = {item["name"]: item["value"] for item in self.configuration}

--- a/saleor/plugins/user_email/plugin.py
+++ b/saleor/plugins/user_email/plugin.py
@@ -401,7 +401,7 @@ class UserEmailPlugin(BasePlugin):
             return previous_value
 
         if event not in event_map:
-            logger.warning(f"Missing handler for event {event}")
+            logger.warning("Missing handler for event %s", event)
             return previous_value
 
         event_func = event_map[event]

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1976,7 +1976,9 @@ class WebhookPlugin(BasePlugin):
                 }
             )
             if event not in NotifyEventType.CHOICES:
-                logger.info(f"Webhook {event_type} triggered for {event} notify event.")
+                logger.info(
+                    "Webhook %s triggered for %s notify event.", event_type, event
+                )
             self.trigger_webhooks_async(data, event_type, webhooks)
 
     def page_created(self, page: "Page", previous_value: Any) -> Any:
@@ -2694,17 +2696,15 @@ class WebhookPlugin(BasePlugin):
                 transaction_data.transaction, transaction_data.event
             )
             logger.warning(
-                f"Transaction request skipped for "
-                f"{transaction_data.transaction.psp_reference}. "
-                f"Missing relation to App."
+                "Transaction request skipped for %s. Missing relation to App.",
+                transaction_data.transaction.psp_reference,
             )
             return None
 
         if not transaction_data.event:
             logger.warning(
-                f"Transaction request skipped for "
-                f"{transaction_data.transaction.psp_reference}. "
-                f"Missing relation to TransactionEvent."
+                "Transaction request skipped for %s. Missing relation to TransactionEvent.",
+                transaction_data.transaction.psp_reference,
             )
             return None
 

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -90,7 +90,7 @@ def update_variants_names(product_type_pk: int, saved_attributes_ids: list[int])
             settings.DATABASE_CONNECTION_REPLICA_NAME
         ).get(pk=product_type_pk)
     except ObjectDoesNotExist:
-        logging.warning(f"Cannot find product type with id: {product_type_pk}.")
+        logging.warning("Cannot find product type with id: %s.", product_type_pk)
         return
     saved_attributes = Attribute.objects.using(
         settings.DATABASE_CONNECTION_REPLICA_NAME

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -99,7 +99,7 @@ def put_event(generate_payload: Callable[[], bytes]):
     except TruncationError as err:
         logger.warning("Observability event dropped. %s", err, extra=err.extra)
     except Exception:
-        logger.error("Observability event dropped.", exc_info=True)
+        logger.exception("Observability event dropped.")
 
 
 def pop_events_with_remaining_size() -> tuple[list[bytes], int]:
@@ -109,7 +109,7 @@ def pop_events_with_remaining_size() -> tuple[list[bytes], int]:
             events, remaining = buffer.pop_events_get_size()
             batch_count = buffer.in_batches(remaining)
         except Exception:
-            logger.error("Could not pop observability events batch.", exc_info=True)
+            logger.exception("Could not pop observability events batch.")
             events, batch_count = [], 0
     return events, batch_count
 

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -63,16 +63,16 @@ def handle_transaction_request_task(self, delivery_id, request_event_id):
     request_event = TransactionEvent.objects.filter(id=request_event_id).first()
     if not request_event:
         logger.error(
-            f"Cannot find the request event with id: {request_event_id} "
-            f"for transaction-request webhook."
+            "Cannot find the request event with id: %s for transaction-request webhook.",
+            request_event_id,
         )
         return None
     delivery = get_delivery_for_webhook(delivery_id)
     if not delivery:
         recalculate_refundable_for_checkout(request_event.transaction, request_event)
         logger.error(
-            f"Cannot find the delivery with id: {delivery_id} "
-            f"for transaction-request webhook."
+            "Cannot find the delivery with id: %s for transaction-request webhook.",
+            delivery_id,
         )
         return None
     attempt = create_attempt(delivery, self.request.id)


### PR DESCRIPTION
Replaced all f-strings in logs with proper logging string interpolation. Log handlers like Sentry and Datadog need to receive message templates and variables separately to be able to tell which events are related.


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
