### PR TITLE
Add add-index-concurently rule

### DIFF
--- a/.semgrep/best-practice/add-index-concurrently.py
+++ b/.semgrep/best-practice/add-index-concurrently.py
@@ -1,0 +1,20 @@
+import django.contrib.postgres.indexes
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0001_initial"),
+    ]
+
+    operations = [
+        # ruleid: add-index-concurrently
+        migrations.AddIndex(
+            model_name="user",
+            index=django.contrib.postgres.indexes.GinIndex(
+                fields=["search_document"],
+                name="user_search_gin",
+                opclasses=["gin_trgm_ops"],
+            ),
+        ),
+    ]

--- a/.semgrep/best-practice/add-index-concurrently.yaml
+++ b/.semgrep/best-practice/add-index-concurrently.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: add-index-concurrently
+    metadata:
+      category: best-practice
+      technology:
+        - django
+    languages:
+      - python
+    severity: ERROR
+    message: Adding an index in migrations should be done concurrently; use
+      `django.contrib.postgres.operations.AddIndexConcurrently` instead of
+      `migrations.AddIndex`.
+    pattern: django.db.migrations.AddIndex(...)

--- a/saleor/account/migrations/0048_auto_20210308_1135.py
+++ b/saleor/account/migrations/0048_auto_20210308_1135.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="user",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="user_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="user",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/account/migrations/0050_auto_20210506_1058.py
+++ b/saleor/account/migrations/0050_auto_20210506_1058.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="user",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/account/migrations/0053_auto_20210719_1048.py
+++ b/saleor/account/migrations/0053_auto_20210719_1048.py
@@ -23,6 +23,7 @@ class Migration(migrations.Migration):
                 blank=True, db_index=True, default="", max_length=128, region=None
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="address",
             index=django.contrib.postgres.indexes.GinIndex(
@@ -36,6 +37,7 @@ class Migration(migrations.Migration):
                 ],
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="user",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/account/migrations/0057_user_search_document.py
+++ b/saleor/account/migrations/0057_user_search_document.py
@@ -19,6 +19,7 @@ class Migration(migrations.Migration):
             model_name="user",
             name="user_search_gin",
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="user",
             index=django.contrib.postgres.indexes.GinIndex(
@@ -27,6 +28,7 @@ class Migration(migrations.Migration):
                 opclasses=["gin_trgm_ops", "gin_trgm_ops", "gin_trgm_ops"],
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="user",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/account/migrations/0063_user_user_p_meta_jsonb_path_idx.py
+++ b/saleor/account/migrations/0063_user_user_p_meta_jsonb_path_idx.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="user",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/account/migrations/0065_address_warehouse_address_search_gin.py
+++ b/saleor/account/migrations/0065_address_warehouse_address_search_gin.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="address",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/account/migrations/0075_add_address_metadata.py
+++ b/saleor/account/migrations/0075_add_address_metadata.py
@@ -32,12 +32,14 @@ class Migration(migrations.Migration):
                 null=True,
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="address",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="address_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="address",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/app/migrations/0004_auto_20210308_1135.py
+++ b/saleor/app/migrations/0004_auto_20210308_1135.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="app",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="app_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="app",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/attribute/migrations/0007_auto_20210308_1135.py
+++ b/saleor/attribute/migrations/0007_auto_20210308_1135.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="attribute",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="attribute_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="attribute",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/attribute/migrations/0011_attributevalue_attribute_a_name_9f3448_gin.py
+++ b/saleor/attribute/migrations/0011_attributevalue_attribute_a_name_9f3448_gin.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="attributevalue",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/attribute/migrations/0016_auto_20210827_0938.py
+++ b/saleor/attribute/migrations/0016_auto_20210827_0938.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
             model_name="attributevalue",
             name="attribute_a_name_9f3448_gin",
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="attributevalue",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/attribute/migrations/0028_attribute_attribute_gin.py
+++ b/saleor/attribute/migrations/0028_attribute_attribute_gin.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="attribute",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/checkout/migrations/0032_auto_20210308_1135.py
+++ b/saleor/checkout/migrations/0032_auto_20210308_1135.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkout",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="checkout_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkout",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/checkout/migrations/0049_auto_20220621_0850.py
+++ b/saleor/checkout/migrations/0049_auto_20220621_0850.py
@@ -32,12 +32,14 @@ class Migration(migrations.Migration):
                 null=True,
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkoutline",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="checkoutline_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkoutline",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/checkout/migrations/0055_create_checkout_metadata_model.py
+++ b/saleor/checkout/migrations/0055_create_checkout_metadata_model.py
@@ -53,12 +53,14 @@ class Migration(migrations.Migration):
                 "abstract": False,
             },
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkoutmetadata",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="checkoutmetadata_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkoutmetadata",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/discount/migrations/0025_auto_20210506_0831.py
+++ b/saleor/discount/migrations/0025_auto_20210506_0831.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="orderdiscount",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/discount/migrations/0074_auto_20240119_1029.py
+++ b/saleor/discount/migrations/0074_auto_20240119_1029.py
@@ -185,18 +185,21 @@ class Migration(migrations.Migration):
                 "ordering": ("created_at", "id"),
             },
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkoutdiscount",
             index=django.contrib.postgres.indexes.BTreeIndex(
                 fields=["promotion_rule"], name="checkoutdiscount_rule_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkoutdiscount",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["name", "translated_name"], name="discount_ch_name_64e096_gin"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="checkoutdiscount",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/giftcard/migrations/0005_auto_20210719_1116.py
+++ b/saleor/giftcard/migrations/0005_auto_20210719_1116.py
@@ -144,18 +144,21 @@ class Migration(migrations.Migration):
             model_name="giftcard",
             name="start_date",
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="giftcard",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="giftcard_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="giftcard",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="giftcard_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="giftcard",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/giftcard/migrations/0010_auto_20211007_0546.py
+++ b/saleor/giftcard/migrations/0010_auto_20211007_0546.py
@@ -45,6 +45,7 @@ class Migration(migrations.Migration):
                 related_name="gift_cards", to="giftcard.GiftCardTag"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="giftcardtag",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/giftcard/migrations/0018_metadata_index.py
+++ b/saleor/giftcard/migrations/0018_metadata_index.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="giftcard",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="giftcard_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="giftcard",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/invoice/migrations/0005_auto_20210308_1135.py
+++ b/saleor/invoice/migrations/0005_auto_20210308_1135.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="invoice",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="invoice_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="invoice",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/menu/migrations/0021_auto_20210308_1135.py
+++ b/saleor/menu/migrations/0021_auto_20210308_1135.py
@@ -10,24 +10,28 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="menu",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="menu_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="menu",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="menu_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="menuitem",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="menuitem_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="menuitem",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/order/migrations/0101_auto_20210308_1213.py
+++ b/saleor/order/migrations/0101_auto_20210308_1213.py
@@ -10,24 +10,28 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="fulfillment",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="fulfillment_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="fulfillment",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="fulfillment_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="order",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="order_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="order",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/order/migrations/0104_auto_20210506_0835.py
+++ b/saleor/order/migrations/0104_auto_20210506_0835.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="order",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/order/migrations/0121_order_search_document.py
+++ b/saleor/order/migrations/0121_order_search_document.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
             model_name="order",
             name="order_order_user_em_bda05b_gin",
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="order",
             index=django.contrib.postgres.indexes.GinIndex(
@@ -26,6 +27,7 @@ class Migration(migrations.Migration):
                 opclasses=["gin_trgm_ops"],
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="order",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/order/migrations/0151_auto_20220606_1431.py
+++ b/saleor/order/migrations/0151_auto_20220606_1431.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
                 blank=True, null=True
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="order",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/order/migrations/0154_auto_20220621_0850.py
+++ b/saleor/order/migrations/0154_auto_20220621_0850.py
@@ -32,12 +32,14 @@ class Migration(migrations.Migration):
                 null=True,
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="orderline",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="orderline_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="orderline",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/page/migrations/0021_auto_20210308_1135.py
+++ b/saleor/page/migrations/0021_auto_20210308_1135.py
@@ -10,24 +10,28 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="page",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="page_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="page",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="page_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="pagetype",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="pagetype_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="pagetype",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/page/migrations/0023_auto_20210526_0835.py
+++ b/saleor/page/migrations/0023_auto_20210526_0835.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="page",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["title", "slug"], name="page_page_title_964714_gin"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="pagetype",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/payment/migrations/0025_auto_20210506_0750.py
+++ b/saleor/payment/migrations/0025_auto_20210506_0750.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="payment",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/payment/migrations/0030_auto_20210908_1346.py
+++ b/saleor/payment/migrations/0030_auto_20210908_1346.py
@@ -45,12 +45,14 @@ class Migration(migrations.Migration):
                 max_length=11,
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="payment",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="payment_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="payment",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/payment/migrations/0035_auto_20220421_0615.py
+++ b/saleor/payment/migrations/0035_auto_20220421_0615.py
@@ -156,18 +156,21 @@ class Migration(migrations.Migration):
                 "ordering": ("pk",),
             },
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="transactionitem",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="transactionitem_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="transactionitem",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="transactionitem_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="transactionitem",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0040_auto_20171205_0428.py
+++ b/saleor/product/migrations/0040_auto_20171205_0428.py
@@ -8,6 +8,7 @@ class Migration(migrations.Migration):
     dependencies = [("product", "0039_merge_20171130_0727")]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="product",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0130_create_product_description_search_vector.py
+++ b/saleor/product/migrations/0130_create_product_description_search_vector.py
@@ -47,6 +47,7 @@ class Migration(migrations.Migration):
                 blank=True, null=True
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="product",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0142_auto_20210308_1135.py
+++ b/saleor/product/migrations/0142_auto_20210308_1135.py
@@ -10,72 +10,84 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="category",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="category_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="category",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="category_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="collection",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="collection_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="collection",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="collection_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="digitalcontent",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="digitalcontent_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="digitalcontent",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="digitalcontent_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="product",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="product_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="product",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="product_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="producttype",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="producttype_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="producttype",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="producttype_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="productvariant",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="productvariant_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="productvariant",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0145_auto_20210511_1043.py
+++ b/saleor/product/migrations/0145_auto_20210511_1043.py
@@ -9,6 +9,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="productchannellisting",
             index=models.Index(

--- a/saleor/product/migrations/0148_producttype_product_type_search_gin.py
+++ b/saleor/product/migrations/0148_producttype_product_type_search_gin.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="producttype",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0149_auto_20211004_1636.py
+++ b/saleor/product/migrations/0149_auto_20211004_1636.py
@@ -41,6 +41,7 @@ class Migration(migrations.Migration):
             name="description_plaintext",
             field=models.TextField(blank=True),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="category",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0150_collection_collection_search_gin.py
+++ b/saleor/product/migrations/0150_collection_collection_search_gin.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="collection",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0151_productchannellisting_product_pro_discoun_3145f3_btree.py
+++ b/saleor/product/migrations/0151_productchannellisting_product_pro_discoun_3145f3_btree.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="productchannellisting",
             index=django.contrib.postgres.indexes.BTreeIndex(

--- a/saleor/product/migrations/0156_product_search_document.py
+++ b/saleor/product/migrations/0156_product_search_document.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
             name="search_document",
             field=models.TextField(blank=True, default=""),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="product",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0164_auto_20220311_1430.py
+++ b/saleor/product/migrations/0164_auto_20220311_1430.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
                 blank=True, null=True
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="product",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/product/migrations/0166_update_publication_date_and_available_for_purchase.py
+++ b/saleor/product/migrations/0166_update_publication_date_and_available_for_purchase.py
@@ -43,6 +43,7 @@ class Migration(migrations.Migration):
             old_name="publication_date",
             new_name="published_at",
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="productchannellisting",
             index=models.Index(

--- a/saleor/product/migrations/0180_productmedia_metadata.py
+++ b/saleor/product/migrations/0180_productmedia_metadata.py
@@ -32,12 +32,14 @@ class Migration(migrations.Migration):
                 null=True,
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="productmedia",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="productmedia_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="productmedia",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/shipping/migrations/0028_auto_20210308_1135.py
+++ b/saleor/shipping/migrations/0028_auto_20210308_1135.py
@@ -10,24 +10,28 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="shippingmethod",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="shippingmethod_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="shippingmethod",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["metadata"], name="shippingmethod_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="shippingzone",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="shippingzone_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="shippingzone",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/warehouse/migrations/0013_auto_20210308_1135.py
+++ b/saleor/warehouse/migrations/0013_auto_20210308_1135.py
@@ -10,12 +10,14 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="warehouse",
             index=django.contrib.postgres.indexes.GinIndex(
                 fields=["private_metadata"], name="warehouse_p_meta_idx"
             ),
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="warehouse",
             index=django.contrib.postgres.indexes.GinIndex(

--- a/saleor/warehouse/migrations/0018_auto_20210323_2116.py
+++ b/saleor/warehouse/migrations/0018_auto_20210323_2116.py
@@ -46,6 +46,7 @@ class Migration(migrations.Migration):
                 "ordering": ("pk",),
             },
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="reservation",
             index=models.Index(

--- a/saleor/warehouse/migrations/0019_auto_20211019_1438.py
+++ b/saleor/warehouse/migrations/0019_auto_20211019_1438.py
@@ -47,6 +47,7 @@ class Migration(migrations.Migration):
                 "ordering": ("pk",),
             },
         ),
+        # nosemgrep: add-index-concurrently
         migrations.AddIndex(
             model_name="preorderreservation",
             index=models.Index(


### PR DESCRIPTION
Add Semgrep rule to require adding indexes concurrently.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
