### PR TITLE
Tag also apps added using django command as installed

### DIFF
--- a/saleor/app/management/commands/install_app.py
+++ b/saleor/app/management/commands/install_app.py
@@ -49,7 +49,9 @@ class Command(BaseCommand):
             app_job.permissions.set(permissions)
 
         try:
-            _, token = install_app(app_job, activate)
+            app, token = install_app(app_job, activate)
+            app.is_installed = True
+            app.save(update_fields=["is_installed"])
             app_job.delete()
         except Exception as e:
             app_job.status = JobStatus.FAILED


### PR DESCRIPTION
Saleor apps installed using django command 'manage.py install_app --activate <manifest_url>' do not show up in Saleor Dashboard under Apps / Installed Apps.

This is due to App.is_installed being False for app installed from command line.

Apps installed from Saleor dashboard end up handled in celery task install_app_task(), where this boolean gets set to True
https://github.com/saleor/saleor/blob/main/saleor/app/tasks.py#L34

This patch sets the same boolean also after completing installation in manage.py command.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
