### PR TITLE
Split fixtures in the Permission module

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,7 @@ pytest_plugins = [
     "saleor.product.tests.fixtures",
     "saleor.site.tests.fixtures",
     "saleor.shipping.tests.fixtures",
+    "saleor.permission.tests.fixtures",
 ]
 
 

--- a/saleor/permission/tests/fixtures/__init__.py
+++ b/saleor/permission/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+from .permission import *  # noqa: F403

--- a/saleor/permission/tests/fixtures/permission.py
+++ b/saleor/permission/tests/fixtures/permission.py
@@ -1,0 +1,128 @@
+import pytest
+
+from ...models import Permission
+
+
+@pytest.fixture
+def permission_manage_discounts():
+    return Permission.objects.get(codename="manage_discounts")
+
+
+@pytest.fixture
+def permission_manage_gift_card():
+    return Permission.objects.get(codename="manage_gift_card")
+
+
+@pytest.fixture
+def permission_manage_orders():
+    return Permission.objects.get(codename="manage_orders")
+
+
+@pytest.fixture
+def permission_manage_orders_import():
+    return Permission.objects.get(codename="manage_orders_import")
+
+
+@pytest.fixture
+def permission_manage_checkouts():
+    return Permission.objects.get(codename="manage_checkouts")
+
+
+@pytest.fixture
+def permission_handle_checkouts():
+    return Permission.objects.get(codename="handle_checkouts")
+
+
+@pytest.fixture
+def permission_manage_plugins():
+    return Permission.objects.get(codename="manage_plugins")
+
+
+@pytest.fixture
+def permission_manage_apps():
+    return Permission.objects.get(codename="manage_apps")
+
+
+@pytest.fixture
+def permission_handle_taxes():
+    return Permission.objects.get(codename="handle_taxes")
+
+
+@pytest.fixture
+def permission_manage_observability():
+    return Permission.objects.get(codename="manage_observability")
+
+
+@pytest.fixture
+def permission_manage_taxes():
+    return Permission.objects.get(codename="manage_taxes")
+
+
+@pytest.fixture
+def permission_manage_staff():
+    return Permission.objects.get(codename="manage_staff")
+
+
+@pytest.fixture
+def permission_manage_products():
+    return Permission.objects.get(codename="manage_products")
+
+
+@pytest.fixture
+def permission_manage_product_types_and_attributes():
+    return Permission.objects.get(codename="manage_product_types_and_attributes")
+
+
+@pytest.fixture
+def permission_manage_shipping():
+    return Permission.objects.get(codename="manage_shipping")
+
+
+@pytest.fixture
+def permission_manage_users():
+    return Permission.objects.get(codename="manage_users")
+
+
+@pytest.fixture
+def permission_impersonate_user():
+    return Permission.objects.get(codename="impersonate_user")
+
+
+@pytest.fixture
+def permission_manage_settings():
+    return Permission.objects.get(codename="manage_settings")
+
+
+@pytest.fixture
+def permission_manage_menus():
+    return Permission.objects.get(codename="manage_menus")
+
+
+@pytest.fixture
+def permission_manage_pages():
+    return Permission.objects.get(codename="manage_pages")
+
+
+@pytest.fixture
+def permission_manage_page_types_and_attributes():
+    return Permission.objects.get(codename="manage_page_types_and_attributes")
+
+
+@pytest.fixture
+def permission_manage_translations():
+    return Permission.objects.get(codename="manage_translations")
+
+
+@pytest.fixture
+def permission_manage_webhooks():
+    return Permission.objects.get(codename="manage_webhooks")
+
+
+@pytest.fixture
+def permission_manage_channels():
+    return Permission.objects.get(codename="manage_channels")
+
+
+@pytest.fixture
+def permission_manage_payments():
+    return Permission.objects.get(codename="handle_payments")

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -74,7 +74,6 @@ from ..payment.models import Payment, TransactionEvent, TransactionItem
 from ..payment.transaction_item_calculations import recalculate_transaction_amounts
 from ..payment.utils import create_manual_adjustment_events
 from ..permission.enums import get_permissions
-from ..permission.models import Permission
 from ..plugins.manager import get_plugins_manager
 from ..product.models import (
     CategoryTranslation,
@@ -1887,61 +1886,6 @@ def image_list():
 
 
 @pytest.fixture
-def permission_manage_discounts():
-    return Permission.objects.get(codename="manage_discounts")
-
-
-@pytest.fixture
-def permission_manage_gift_card():
-    return Permission.objects.get(codename="manage_gift_card")
-
-
-@pytest.fixture
-def permission_manage_orders():
-    return Permission.objects.get(codename="manage_orders")
-
-
-@pytest.fixture
-def permission_manage_orders_import():
-    return Permission.objects.get(codename="manage_orders_import")
-
-
-@pytest.fixture
-def permission_manage_checkouts():
-    return Permission.objects.get(codename="manage_checkouts")
-
-
-@pytest.fixture
-def permission_handle_checkouts():
-    return Permission.objects.get(codename="handle_checkouts")
-
-
-@pytest.fixture
-def permission_manage_plugins():
-    return Permission.objects.get(codename="manage_plugins")
-
-
-@pytest.fixture
-def permission_manage_apps():
-    return Permission.objects.get(codename="manage_apps")
-
-
-@pytest.fixture
-def permission_handle_taxes():
-    return Permission.objects.get(codename="handle_taxes")
-
-
-@pytest.fixture
-def permission_manage_observability():
-    return Permission.objects.get(codename="manage_observability")
-
-
-@pytest.fixture
-def permission_manage_taxes():
-    return Permission.objects.get(codename="manage_taxes")
-
-
-@pytest.fixture
 def voucher_without_channel(db):
     voucher = Voucher.objects.create()
     VoucherCode.objects.create(code="mirumee", voucher=voucher)
@@ -2831,76 +2775,6 @@ def promotion_events(catalogue_promotion, staff_user):
         ]
     )
     return events
-
-
-@pytest.fixture
-def permission_manage_staff():
-    return Permission.objects.get(codename="manage_staff")
-
-
-@pytest.fixture
-def permission_manage_products():
-    return Permission.objects.get(codename="manage_products")
-
-
-@pytest.fixture
-def permission_manage_product_types_and_attributes():
-    return Permission.objects.get(codename="manage_product_types_and_attributes")
-
-
-@pytest.fixture
-def permission_manage_shipping():
-    return Permission.objects.get(codename="manage_shipping")
-
-
-@pytest.fixture
-def permission_manage_users():
-    return Permission.objects.get(codename="manage_users")
-
-
-@pytest.fixture
-def permission_impersonate_user():
-    return Permission.objects.get(codename="impersonate_user")
-
-
-@pytest.fixture
-def permission_manage_settings():
-    return Permission.objects.get(codename="manage_settings")
-
-
-@pytest.fixture
-def permission_manage_menus():
-    return Permission.objects.get(codename="manage_menus")
-
-
-@pytest.fixture
-def permission_manage_pages():
-    return Permission.objects.get(codename="manage_pages")
-
-
-@pytest.fixture
-def permission_manage_page_types_and_attributes():
-    return Permission.objects.get(codename="manage_page_types_and_attributes")
-
-
-@pytest.fixture
-def permission_manage_translations():
-    return Permission.objects.get(codename="manage_translations")
-
-
-@pytest.fixture
-def permission_manage_webhooks():
-    return Permission.objects.get(codename="manage_webhooks")
-
-
-@pytest.fixture
-def permission_manage_channels():
-    return Permission.objects.get(codename="manage_channels")
-
-
-@pytest.fixture
-def permission_manage_payments():
-    return Permission.objects.get(codename="handle_payments")
 
 
 @pytest.fixture


### PR DESCRIPTION
I want to merge this change because splitting fixtures in the Permission module.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
