### PR TITLE
Split fixtures in Shipping module

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -41,6 +41,7 @@ pytest_plugins = [
     "saleor.order.tests.fixtures",
     "saleor.product.tests.fixtures",
     "saleor.site.tests.fixtures",
+    "saleor.shipping.tests.fixtures",
 ]
 
 

--- a/saleor/shipping/tests/fixtures/__init__.py
+++ b/saleor/shipping/tests/fixtures/__init__.py
@@ -1,0 +1,4 @@
+from .shipping_method import *  # noqa: F401, F403
+from .shipping_method_data import *  # noqa: F401, F403
+from .shipping_method_translation import *  # noqa: F401, F403
+from .shipping_zone import *  # noqa: F401, F403

--- a/saleor/shipping/tests/fixtures/shipping_method.py
+++ b/saleor/shipping/tests/fixtures/shipping_method.py
@@ -1,0 +1,81 @@
+import pytest
+
+from ....core.prices import Money
+from ...models import ShippingMethod, ShippingMethodChannelListing, ShippingMethodType
+
+
+@pytest.fixture
+def shipping_method(shipping_zone, channel_USD, default_tax_class):
+    method = ShippingMethod.objects.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+        maximum_delivery_days=10,
+        minimum_delivery_days=5,
+        tax_class=default_tax_class,
+    )
+    ShippingMethodChannelListing.objects.create(
+        shipping_method=method,
+        channel=channel_USD,
+        minimum_order_price=Money(0, "USD"),
+        price=Money(10, "USD"),
+    )
+    return method
+
+
+@pytest.fixture
+def other_shipping_method(shipping_zone, channel_USD):
+    method = ShippingMethod.objects.create(
+        name="DPD",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    ShippingMethodChannelListing.objects.create(
+        channel=channel_USD,
+        shipping_method=method,
+        minimum_order_price=Money(0, "USD"),
+        price=Money(9, "USD"),
+    )
+    return method
+
+
+@pytest.fixture
+def shipping_method_weight_based(shipping_zone, channel_USD):
+    method = ShippingMethod.objects.create(
+        name="weight based method",
+        type=ShippingMethodType.WEIGHT_BASED,
+        shipping_zone=shipping_zone,
+        maximum_delivery_days=10,
+        minimum_delivery_days=5,
+    )
+    ShippingMethodChannelListing.objects.create(
+        shipping_method=method,
+        channel=channel_USD,
+        minimum_order_price=Money(0, "USD"),
+        price=Money(10, "USD"),
+    )
+    return method
+
+
+@pytest.fixture
+def shipping_method_excluded_by_postal_code(shipping_method):
+    shipping_method.postal_code_rules.create(start="HB2", end="HB6")
+    return shipping_method
+
+
+@pytest.fixture
+def shipping_method_channel_PLN(shipping_zone, channel_PLN):
+    shipping_zone.channels.add(channel_PLN)
+    method = ShippingMethod.objects.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    ShippingMethodChannelListing.objects.create(
+        shipping_method=method,
+        channel=channel_PLN,
+        minimum_order_price=Money(0, channel_PLN.currency_code),
+        price=Money(10, channel_PLN.currency_code),
+        currency=channel_PLN.currency_code,
+    )
+    return method

--- a/saleor/shipping/tests/fixtures/shipping_method_data.py
+++ b/saleor/shipping/tests/fixtures/shipping_method_data.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ...models import ShippingMethodChannelListing
+from ...utils import convert_to_shipping_method_data
+
+
+@pytest.fixture
+def shipping_method_data(shipping_method, channel_USD):
+    listing = ShippingMethodChannelListing.objects.filter(
+        channel=channel_USD, shipping_method=shipping_method
+    ).get()
+    return convert_to_shipping_method_data(shipping_method, listing)

--- a/saleor/shipping/tests/fixtures/shipping_method_translation.py
+++ b/saleor/shipping/tests/fixtures/shipping_method_translation.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ...models import ShippingMethodTranslation
+
+
+@pytest.fixture
+def shipping_method_translation_fr(shipping_method):
+    return ShippingMethodTranslation.objects.create(
+        language_code="fr",
+        shipping_method=shipping_method,
+        name="French shipping method name",
+    )

--- a/saleor/shipping/tests/fixtures/shipping_zone.py
+++ b/saleor/shipping/tests/fixtures/shipping_zone.py
@@ -1,0 +1,187 @@
+import pytest
+from django_countries import countries
+
+from ....core.prices import Money
+from ....warehouse.models import Warehouse
+from ...models import ShippingMethodChannelListing, ShippingMethodType, ShippingZone
+
+
+@pytest.fixture
+def shipping_zone(db, channel_USD, default_tax_class):  # pylint: disable=W0613
+    shipping_zone = ShippingZone.objects.create(
+        name="Europe", countries=[code for code, name in countries]
+    )
+    shipping_zone.channels.add(channel_USD)
+    method = shipping_zone.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+        tax_class=default_tax_class,
+    )
+    ShippingMethodChannelListing.objects.create(
+        channel=channel_USD,
+        currency=channel_USD.currency_code,
+        shipping_method=method,
+        minimum_order_price=Money(0, channel_USD.currency_code),
+        price=Money(10, channel_USD.currency_code),
+    )
+    return shipping_zone
+
+
+@pytest.fixture
+def shipping_zone_JPY(shipping_zone, channel_JPY):
+    shipping_zone.channels.add(channel_JPY)
+    method = shipping_zone.shipping_methods.get()
+    ShippingMethodChannelListing.objects.create(
+        channel=channel_JPY,
+        currency=channel_JPY.currency_code,
+        shipping_method=method,
+        minimum_order_price=Money(0, channel_JPY.currency_code),
+        price=Money(700, channel_JPY.currency_code),
+    )
+    return shipping_zone
+
+
+@pytest.fixture
+def shipping_zones(db, channel_USD, channel_PLN):
+    shipping_zone_poland, shipping_zone_usa = ShippingZone.objects.bulk_create(
+        [
+            ShippingZone(name="Poland", countries=["PL"]),
+            ShippingZone(name="USA", countries=["US"]),
+        ]
+    )
+
+    shipping_zone_poland.channels.add(channel_PLN, channel_USD)
+    shipping_zone_usa.channels.add(channel_PLN, channel_USD)
+
+    method = shipping_zone_poland.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    second_method = shipping_zone_usa.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    ShippingMethodChannelListing.objects.bulk_create(
+        [
+            ShippingMethodChannelListing(
+                channel=channel_USD,
+                shipping_method=method,
+                minimum_order_price=Money(0, "USD"),
+                price=Money(10, "USD"),
+                currency=channel_USD.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_USD,
+                shipping_method=second_method,
+                minimum_order_price=Money(0, "USD"),
+                currency=channel_USD.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_PLN,
+                shipping_method=method,
+                minimum_order_price=Money(0, "PLN"),
+                price=Money(40, "PLN"),
+                currency=channel_PLN.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_PLN,
+                shipping_method=second_method,
+                minimum_order_price=Money(0, "PLN"),
+                currency=channel_PLN.currency_code,
+            ),
+        ]
+    )
+    return [shipping_zone_poland, shipping_zone_usa]
+
+
+def chunks(it, n):
+    for i in range(0, len(it), n):
+        yield it[i : i + n]
+
+
+@pytest.fixture
+def shipping_zones_with_warehouses(address, channel_USD):
+    zones = [ShippingZone(name=f"{i}_zone") for i in range(10)]
+    warehouses = [Warehouse(slug=f"{i}_warehouse", address=address) for i in range(20)]
+    warehouses = Warehouse.objects.bulk_create(warehouses)
+    warehouses_in_batches = list(chunks(warehouses, 2))
+    for i, zone in enumerate(ShippingZone.objects.bulk_create(zones)):
+        zone.channels.add(channel_USD)
+        for warehouse in warehouses_in_batches[i]:
+            zone.warehouses.add(warehouse)
+    return zones
+
+
+@pytest.fixture
+def shipping_zones_with_different_channels(db, channel_USD, channel_PLN):
+    shipping_zone_poland, shipping_zone_usa = ShippingZone.objects.bulk_create(
+        [
+            ShippingZone(name="Poland", countries=["PL"]),
+            ShippingZone(name="USA", countries=["US"]),
+        ]
+    )
+
+    shipping_zone_poland.channels.add(channel_PLN, channel_USD)
+    shipping_zone_usa.channels.add(channel_USD)
+
+    method = shipping_zone_poland.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    second_method = shipping_zone_usa.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    ShippingMethodChannelListing.objects.bulk_create(
+        [
+            ShippingMethodChannelListing(
+                channel=channel_USD,
+                shipping_method=method,
+                minimum_order_price=Money(0, "USD"),
+                price=Money(10, "USD"),
+                currency=channel_USD.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_USD,
+                shipping_method=second_method,
+                minimum_order_price=Money(0, "USD"),
+                currency=channel_USD.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_PLN,
+                shipping_method=method,
+                minimum_order_price=Money(0, "PLN"),
+                price=Money(40, "PLN"),
+                currency=channel_PLN.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_PLN,
+                shipping_method=second_method,
+                minimum_order_price=Money(0, "PLN"),
+                currency=channel_PLN.currency_code,
+            ),
+        ]
+    )
+    return [shipping_zone_poland, shipping_zone_usa]
+
+
+@pytest.fixture
+def shipping_zone_without_countries(db, channel_USD):  # pylint: disable=W0613
+    shipping_zone = ShippingZone.objects.create(name="Europe", countries=[])
+    method = shipping_zone.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    ShippingMethodChannelListing.objects.create(
+        channel=channel_USD,
+        shipping_method=method,
+        minimum_order_price=Money(0, "USD"),
+        price=Money(10, "USD"),
+    )
+    return shipping_zone


### PR DESCRIPTION
I want to merge this change because of splitting fixtures in Shipping module

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
