### PR TITLE
Split fixtures in the Site module

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -40,6 +40,7 @@ pytest_plugins = [
     "saleor.thumbnail.tests.fixtures",
     "saleor.order.tests.fixtures",
     "saleor.product.tests.fixtures",
+    "saleor.site.tests.fixtures",
 ]
 
 

--- a/saleor/site/tests/fixtures/__init__.py
+++ b/saleor/site/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+from .site_settings import *  # noqa: F401, F403

--- a/saleor/site/tests/fixtures/site_settings.py
+++ b/saleor/site/tests/fixtures/site_settings.py
@@ -1,0 +1,43 @@
+import pytest
+
+from ....menu.models import Menu
+from ...models import Site, SiteSettings
+
+
+@pytest.fixture(autouse=True)
+def site_settings(db, settings) -> SiteSettings:
+    """Create a site and matching site settings.
+
+    This fixture is autouse because django.contrib.sites.models.Site and
+    saleor.site.models.SiteSettings have a one-to-one relationship and a site
+    should never exist without a matching settings object.
+    """
+    site = Site.objects.get_or_create(name="mirumee.com", domain="mirumee.com")[0]
+    obj = SiteSettings.objects.get_or_create(
+        site=site,
+        default_mail_sender_name="Mirumee Labs",
+        default_mail_sender_address="mirumee@example.com",
+    )[0]
+    settings.SITE_ID = site.pk
+    settings.ALLOWED_HOSTS += [site.domain]
+
+    main_menu = Menu.objects.get_or_create(
+        name=settings.DEFAULT_MENUS["top_menu_name"],
+        slug=settings.DEFAULT_MENUS["top_menu_name"],
+    )[0]
+    secondary_menu = Menu.objects.get_or_create(
+        name=settings.DEFAULT_MENUS["bottom_menu_name"],
+        slug=settings.DEFAULT_MENUS["bottom_menu_name"],
+    )[0]
+    obj.top_menu = main_menu
+    obj.bottom_menu = secondary_menu
+    obj.save()
+    return obj
+
+
+@pytest.fixture
+def site_settings_with_reservations(site_settings):
+    site_settings.reserve_stock_duration_anonymous_user = 5
+    site_settings.reserve_stock_duration_authenticated_user = 5
+    site_settings.save()
+    return site_settings

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 import graphene
 import pytest
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.template.defaultfilters import truncatechars
@@ -70,7 +69,6 @@ from ..discount.models import (
 )
 from ..giftcard import GiftCardEvents
 from ..giftcard.models import GiftCard, GiftCardEvent, GiftCardTag
-from ..menu.models import Menu
 from ..payment import ChargeStatus, TransactionKind
 from ..payment.interface import AddressData, GatewayConfig, GatewayResponse, PaymentData
 from ..payment.models import Payment, TransactionEvent, TransactionItem
@@ -95,7 +93,6 @@ from ..shipping.models import (
     ShippingZone,
 )
 from ..shipping.utils import convert_to_shipping_method_data
-from ..site.models import SiteSettings
 from ..tax import TaxCalculationStrategy
 from ..warehouse.models import (
     PreorderReservation,
@@ -203,45 +200,6 @@ def _sample_gateway(settings):
     settings.PLUGINS += [
         "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway"
     ]
-
-
-@pytest.fixture(autouse=True)
-def site_settings(db, settings) -> SiteSettings:
-    """Create a site and matching site settings.
-
-    This fixture is autouse because django.contrib.sites.models.Site and
-    saleor.site.models.SiteSettings have a one-to-one relationship and a site
-    should never exist without a matching settings object.
-    """
-    site = Site.objects.get_or_create(name="mirumee.com", domain="mirumee.com")[0]
-    obj = SiteSettings.objects.get_or_create(
-        site=site,
-        default_mail_sender_name="Mirumee Labs",
-        default_mail_sender_address="mirumee@example.com",
-    )[0]
-    settings.SITE_ID = site.pk
-    settings.ALLOWED_HOSTS += [site.domain]
-
-    main_menu = Menu.objects.get_or_create(
-        name=settings.DEFAULT_MENUS["top_menu_name"],
-        slug=settings.DEFAULT_MENUS["top_menu_name"],
-    )[0]
-    secondary_menu = Menu.objects.get_or_create(
-        name=settings.DEFAULT_MENUS["bottom_menu_name"],
-        slug=settings.DEFAULT_MENUS["bottom_menu_name"],
-    )[0]
-    obj.top_menu = main_menu
-    obj.bottom_menu = secondary_menu
-    obj.save()
-    return obj
-
-
-@pytest.fixture
-def site_settings_with_reservations(site_settings):
-    site_settings.reserve_stock_duration_anonymous_user = 5
-    site_settings.reserve_stock_duration_authenticated_user = 5
-    site_settings.save()
-    return site_settings
 
 
 @pytest.fixture


### PR DESCRIPTION
I want to merge this change because of splitting fixtures in the Site module
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
