### PR TITLE
Split fixtures in the Plugin module

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -234,7 +234,7 @@ def test_checkout_available_payment_gateways_currency_specified_USD(
     api_client,
     checkout_with_item,
     expected_dummy_gateway,
-    _sample_gateway,
+    sample_gateway,
 ):
     checkout_with_item.currency = "USD"
     checkout_with_item.save(update_fields=["currency"])
@@ -253,7 +253,7 @@ def test_checkout_available_payment_gateways_currency_specified_USD(
 
 
 def test_checkout_available_payment_gateways_currency_specified_EUR(
-    api_client, checkout_with_item, expected_dummy_gateway, _sample_gateway
+    api_client, checkout_with_item, expected_dummy_gateway, sample_gateway
 ):
     checkout_with_item.currency = "EUR"
     checkout_with_item.save(update_fields=["currency"])

--- a/saleor/graphql/shop/tests/queries/test_shop.py
+++ b/saleor/graphql/shop/tests/queries/test_shop.py
@@ -557,9 +557,7 @@ AVAILABLE_PAYMENT_GATEWAYS_QUERY = """
 """
 
 
-def test_query_available_payment_gateways(
-    user_api_client, _sample_gateway, channel_USD
-):
+def test_query_available_payment_gateways(user_api_client, sample_gateway, channel_USD):
     # given
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
 
@@ -580,7 +578,7 @@ def test_query_available_payment_gateways(
 
 
 def test_query_available_payment_gateways_specified_currency_USD(
-    user_api_client, _sample_gateway, channel_USD
+    user_api_client, sample_gateway, channel_USD
 ):
     # given
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
@@ -602,7 +600,7 @@ def test_query_available_payment_gateways_specified_currency_USD(
 
 
 def test_query_available_payment_gateways_specified_currency_EUR(
-    user_api_client, _sample_gateway, channel_USD
+    user_api_client, sample_gateway, channel_USD
 ):
     # given
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY

--- a/saleor/plugins/tests/fixtures/__init__.py
+++ b/saleor/plugins/tests/fixtures/__init__.py
@@ -1,0 +1,3 @@
+from .gateway import *  # noqa: F403
+from .plugin_configuration import *  # noqa: F403
+from .plugin_manager import *  # noqa: F403

--- a/saleor/plugins/tests/fixtures/gateway.py
+++ b/saleor/plugins/tests/fixtures/gateway.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup_dummy_gateways(settings):
+    settings.PLUGINS = [
+        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+        "saleor.payment.gateways.dummy_credit_card.plugin.DummyCreditCardGatewayPlugin",
+    ]
+    return settings
+
+
+@pytest.fixture
+def sample_gateway(settings):
+    settings.PLUGINS += [
+        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway"
+    ]
+    return settings

--- a/saleor/plugins/tests/fixtures/plugin_configuration.py
+++ b/saleor/plugins/tests/fixtures/plugin_configuration.py
@@ -2,11 +2,9 @@ import copy
 
 import pytest
 
-from ..base_plugin import ConfigurationTypeField
-from ..manager import PluginsManager
-from ..models import PluginConfiguration
-from .sample_plugins import (
-    ALL_PLUGINS,
+from ...base_plugin import ConfigurationTypeField
+from ...models import PluginConfiguration
+from ..sample_plugins import (
     ChannelPluginSample,
     PluginInactive,
     PluginSample,
@@ -91,14 +89,3 @@ def new_config():
 @pytest.fixture
 def new_config_structure():
     return {"type": ConfigurationTypeField.STRING, "help_text": "foo", "label": "foo"}
-
-
-@pytest.fixture
-def plugins_manager():
-    return PluginsManager(plugins=[])
-
-
-@pytest.fixture
-def all_plugins_manager():
-    plugins_as_module_paths = [p.__module__ + "." + p.__name__ for p in ALL_PLUGINS]
-    return PluginsManager(plugins=plugins_as_module_paths)

--- a/saleor/plugins/tests/fixtures/plugin_manager.py
+++ b/saleor/plugins/tests/fixtures/plugin_manager.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ...manager import PluginsManager
+from ..sample_plugins import ALL_PLUGINS
+
+
+@pytest.fixture
+def plugins_manager():
+    return PluginsManager(plugins=[])
+
+
+@pytest.fixture
+def all_plugins_manager():
+    plugins_as_module_paths = [p.__module__ + "." + p.__name__ for p in ALL_PLUGINS]
+    return PluginsManager(plugins=plugins_as_module_paths)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -173,22 +173,6 @@ def assert_max_num_queries(capture_queries):
     return partial(capture_queries, exact=False)
 
 
-@pytest.fixture(autouse=True)
-def setup_dummy_gateways(settings):
-    settings.PLUGINS = [
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
-        "saleor.payment.gateways.dummy_credit_card.plugin.DummyCreditCardGatewayPlugin",
-    ]
-    return settings
-
-
-@pytest.fixture
-def _sample_gateway(settings):
-    settings.PLUGINS += [
-        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway"
-    ]
-
-
 @pytest.fixture
 def checkout(db, channel_USD, settings):
     checkout = Checkout.objects.create(


### PR DESCRIPTION
I want to merge this change because of splitting fixtures in the Plugin module

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
