### PR TITLE
Add unit_discount fields to order bulk create

### DIFF
--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -25,6 +25,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....core.weight import zero_weight
 from ....discount.models import OrderDiscount, VoucherCode
+from ....discount.utils import apply_discount_to_value
 from ....giftcard.models import GiftCard
 from ....invoice.models import Invoice
 from ....order import (
@@ -48,7 +49,12 @@ from ....warehouse.models import Stock, Warehouse
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_314, ADDED_IN_318, PREVIEW_FEATURE
+from ...core.descriptions import (
+    ADDED_IN_314,
+    ADDED_IN_318,
+    ADDED_IN_319,
+    PREVIEW_FEATURE,
+)
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.enums import ErrorPolicy, ErrorPolicyEnum, LanguageCodeEnum
 from ...core.mutations import BaseMutation
@@ -56,6 +62,7 @@ from ...core.scalars import DateTime, PositiveDecimal, WeightScalar
 from ...core.types import BaseInputObjectType, BaseObjectType, NonNullList
 from ...core.types.common import OrderBulkCreateError
 from ...core.utils import from_global_id_or_error
+from ...discount.enums import DiscountValueTypeEnum
 from ...meta.inputs import MetadataInput
 from ...payment.mutations.transaction.transaction_create import (
     TransactionCreate,
@@ -274,6 +281,9 @@ class LineAmounts:
     total_net: Decimal
     unit_gross: Decimal
     unit_net: Decimal
+    unit_discount_value: Decimal
+    unit_discount_type: Optional[str]
+    unit_discount_reason: Optional[str]
     undiscounted_total_gross: Decimal
     undiscounted_total_net: Decimal
     undiscounted_unit_gross: Decimal
@@ -455,6 +465,20 @@ class OrderBulkCreateOrderLineInput(BaseInputObjectType):
         TaxedMoneyInput,
         required=True,
         description="Price of the order line excluding applied discount.",
+    )
+    unit_discount_reason = graphene.String(
+        required=False,
+        description="Reason of the discount on order line." + ADDED_IN_319,
+    )
+    unit_discount_type = graphene.Field(
+        DiscountValueTypeEnum,
+        required=False,
+        description="Type of the discount: fixed or percent" + ADDED_IN_319,
+    )
+    unit_discount_value = PositiveDecimal(
+        description="Value of the discount. Can store fixed value or percent value"
+        + ADDED_IN_319,
+        required=False,
     )
     warehouse = graphene.ID(
         required=True,
@@ -1056,6 +1080,11 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
         net_amount = line_input["total_price"]["net"]
         undiscounted_gross_amount = line_input["undiscounted_total_price"]["gross"]
         undiscounted_net_amount = line_input["undiscounted_total_price"]["net"]
+
+        unit_discount_reason = line_input.get("unit_discount_reason")
+        unit_discount_type = line_input.get("unit_discount_type")
+        unit_discount_value = line_input.get("unit_discount_value", Decimal(0))
+
         quantity = line_input["quantity"]
         tax_rate = line_input.get("tax_rate", None)
 
@@ -1122,11 +1151,35 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             undiscounted_unit_price_net_amount - unit_price_net_amount
         )
 
+        if (
+            unit_discount_value
+            and unit_discount_type
+            and Money(unit_price_net_amount, currency)
+            != apply_discount_to_value(
+                unit_discount_value,
+                unit_discount_type,
+                currency,
+                Money(undiscounted_unit_price_net_amount, currency),
+            )
+        ):
+            order_data.errors.append(
+                OrderBulkError(
+                    message=(
+                        "Provided discount value doesn't match with provided line amounts."
+                    ),
+                    path=f"lines.{index}.unit_discount_value",
+                    code=OrderBulkCreateErrorCode.PRICE_ERROR,
+                )
+            )
+
         return LineAmounts(
             total_gross=gross_amount,
             total_net=net_amount,
             unit_gross=unit_price_gross_amount,
             unit_net=unit_price_net_amount,
+            unit_discount_reason=unit_discount_reason,
+            unit_discount_type=unit_discount_type,
+            unit_discount_value=unit_discount_value,
             undiscounted_total_gross=undiscounted_gross_amount,
             undiscounted_total_net=undiscounted_net_amount,
             undiscounted_unit_gross=undiscounted_unit_price_gross_amount,
@@ -1608,6 +1661,9 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             is_gift_card=order_line_input["is_gift_card"],
             currency=order_input["currency"],
             quantity=line_amounts.quantity,
+            unit_discount_reason=line_amounts.unit_discount_reason,
+            unit_discount_type=line_amounts.unit_discount_type,
+            unit_discount_value=line_amounts.unit_discount_value,
             unit_price_net_amount=line_amounts.unit_net,
             unit_price_gross_amount=line_amounts.unit_gross,
             total_price_net_amount=line_amounts.total_net,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26781,6 +26781,27 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   """Price of the order line excluding applied discount."""
   undiscountedTotalPrice: TaxedMoneyInput!
 
+  """
+  Reason of the discount on order line.
+  
+  Added in Saleor 3.19.
+  """
+  unitDiscountReason: String
+
+  """
+  Type of the discount: fixed or percent
+  
+  Added in Saleor 3.19.
+  """
+  unitDiscountType: DiscountValueTypeEnum
+
+  """
+  Value of the discount. Can store fixed value or percent value
+  
+  Added in Saleor 3.19.
+  """
+  unitDiscountValue: PositiveDecimal
+
   """The ID of the warehouse, where the line will be allocated."""
   warehouse: ID!
 


### PR DESCRIPTION
Add `unit_discount_type`, `unit_discount_value` and `unit_discount_reason` to `OrderBulkCreate`

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
