### PR TITLE
Make sure we never log URL credentials

### DIFF
--- a/saleor/core/utils/url.py
+++ b/saleor/core/utils/url.py
@@ -49,3 +49,15 @@ def get_default_storage_root_url():
     # `path` is stripped to get the actual root URL
     tmp_path = "path"
     return build_absolute_uri(default_storage.url(tmp_path)).rstrip(tmp_path)
+
+
+def sanitize_url_for_logging(url: str) -> str:
+    """Remove sensitive data from a URL to make it safe for logging."""
+    url_parts = urlparse(url)
+    if url_parts.username or url_parts.password:
+        url_parts = url_parts._replace(
+            netloc=f"***:***@{url_parts.hostname}:{url_parts.port}"
+            if url_parts.port
+            else f"***:***@{url_parts.hostname}"
+        )
+    return url_parts.geturl()

--- a/saleor/webhook/observability/obfuscation.py
+++ b/saleor/webhook/observability/obfuscation.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
-from urllib.parse import urlparse, urlunparse
 
 from graphql import (
     GraphQLError,
@@ -53,17 +52,6 @@ def filter_and_hide_headers(
             else:
                 filtered_headers[key] = val
     return filtered_headers
-
-
-def obfuscate_url(url: str) -> str:
-    parts = urlparse(url)
-    # If parts.username returns None there are no credentials in the URL
-    if parts.username is None:
-        return url
-    password = "" if parts.password is None else f":{MASK}"
-    port = "" if parts.port is None else f":{parts.port}"
-    netloc = f"{parts.username}{password}@{parts.hostname}{port}"
-    return urlunparse([parts[0], netloc, *parts[2:]])
 
 
 class SensitiveFieldError(GraphQLError):

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -12,6 +12,7 @@ from graphene.utils.str_converters import to_camel_case as str_to_camel_case
 from graphql import get_operation_ast
 
 from ...core.utils import build_absolute_uri
+from ...core.utils.url import sanitize_url_for_logging
 from .. import traced_payload_generator
 from ..event_types import WebhookEventSyncType
 from .exceptions import ApiCallTruncationError, EventDeliveryAttemptTruncationError
@@ -19,7 +20,6 @@ from .obfuscation import (
     anonymize_event_payload,
     anonymize_gql_operation_response,
     filter_and_hide_headers,
-    obfuscate_url,
 )
 from .payload_schema import (
     ApiCallPayload,
@@ -237,7 +237,7 @@ def generate_event_delivery_attempt_payload(
         webhook=Webhook(
             id=graphene.Node.to_global_id("Webhook", attempt.delivery.webhook.pk),
             name=attempt.delivery.webhook.name or "",
-            target_url=obfuscate_url(attempt.delivery.webhook.target_url),
+            target_url=sanitize_url_for_logging(attempt.delivery.webhook.target_url),
             subscription_query=TRUNC_PLACEHOLDER,
         ),
         app=App(

--- a/saleor/webhook/observability/tests/test_obfuscation.py
+++ b/saleor/webhook/observability/tests/test_obfuscation.py
@@ -7,7 +7,6 @@ from ..obfuscation import (
     anonymize_event_payload,
     anonymize_gql_operation_response,
     filter_and_hide_headers,
-    obfuscate_url,
     validate_sensitive_fields_map,
 )
 
@@ -37,30 +36,6 @@ def test_filter_and_hide_headers(headers, allowed, sensitive, expected):
         filter_and_hide_headers(headers, allowed=allowed, sensitive=sensitive)
         == expected
     )
-
-
-@pytest.mark.parametrize(
-    ("url", "expected"),
-    [
-        ("http://example.com/test", "http://example.com/test"),
-        (
-            "https://example.com:8000/test/path?q=val&k=val",
-            "https://example.com:8000/test/path?q=val&k=val",
-        ),
-        ("https://user@example.com/test", "https://user@example.com/test"),
-        ("https://:password@example.com/test", f"https://:{MASK}@example.com/test"),
-        (
-            "http://user:password@example.com:8000/test",
-            f"http://user:{MASK}@example.com:8000/test",
-        ),
-        (
-            "awssqs://key:secret@sqs.us-east-2.amazonaws.com/xxxx/myqueue.fifo",
-            f"awssqs://key:{MASK}@sqs.us-east-2.amazonaws.com/xxxx/myqueue.fifo",
-        ),
-    ],
-)
-def test_obfuscate_url(url, expected):
-    assert obfuscate_url(url) == expected
 
 
 def test_anonymize_gql_operation_response(gql_operation_factory):

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -488,4 +488,4 @@ def test_generate_event_delivery_attempt_payload_target_url_obfuscated(
     payload = generate_event_delivery_attempt_payload(event_attempt, None, 1024)
     payload = json.loads(payload)
 
-    assert payload["webhook"]["targetUrl"] == f"http://user:{MASK}@example.com/webhooks"
+    assert payload["webhook"]["targetUrl"] == "http://***:***@example.com/webhooks"

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -17,6 +17,7 @@ from ....core.db.connection import allow_writer
 from ....core.models import EventDelivery, EventPayload
 from ....core.tracing import webhooks_opentracing_trace
 from ....core.utils import get_domain
+from ....core.utils.url import sanitize_url_for_logging
 from ....graphql.core.dataloaders import DataLoader
 from ....graphql.webhook.subscription_payload import (
     generate_payload_from_subscription,
@@ -136,7 +137,7 @@ def create_deliveries_for_multiple_subscription_objects(
                         "[Webhook ID:%r] No data changes for event %r, skip delivery to %r",
                         webhook.id,
                         event_type,
-                        webhook.target_url,
+                        sanitize_url_for_logging(webhook.target_url),
                     )
                     continue
 
@@ -404,7 +405,7 @@ def send_webhook_request_async(self, event_delivery_id) -> None:
             task_logger.info(
                 "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",
                 webhook.id,
-                webhook.target_url,
+                sanitize_url_for_logging(webhook.target_url),
                 delivery.event_type,
                 delivery.id,
             )
@@ -461,7 +462,7 @@ def send_observability_events(webhooks: list[WebhookData], events: list[bytes]):
             logger.info(
                 "Webhook ID: %r failed request to %r (%s/%s events dropped): %r.",
                 webhook.id,
-                webhook.target_url,
+                sanitize_url_for_logging(webhook.target_url),
                 failed,
                 len(events),
                 response.content,
@@ -471,7 +472,7 @@ def send_observability_events(webhooks: list[WebhookData], events: list[bytes]):
         logger.debug(
             "Successful delivered %s events to %r.",
             len(events),
-            webhook.target_url,
+            sanitize_url_for_logging(webhook.target_url),
             extra={**extra, "dropped_events_count": 0},
         )
 

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -14,6 +14,7 @@ from ....core.db.connection import allow_writer
 from ....core.models import EventDelivery, EventPayload
 from ....core.tracing import webhooks_opentracing_trace
 from ....core.utils import get_domain
+from ....core.utils.url import sanitize_url_for_logging
 from ....graphql.webhook.subscription_payload import (
     generate_payload_from_subscription,
     initialize_request,
@@ -104,7 +105,7 @@ def _send_webhook_request_sync(
 
     logger.debug(
         "[Webhook] Sending payload to %r for event %r.",
-        webhook.target_url,
+        sanitize_url_for_logging(webhook.target_url),
         delivery.event_type,
     )
     if attempt is None:
@@ -131,7 +132,7 @@ def _send_webhook_request_sync(
         logger.info(
             "[Webhook] Failed parsing JSON response from %r: %r."
             "ID of failed DeliveryAttempt: %r . ",
-            webhook.target_url,
+            sanitize_url_for_logging(webhook.target_url),
             e,
             attempt.id,
         )
@@ -141,7 +142,7 @@ def _send_webhook_request_sync(
             logger.info(
                 "[Webhook] Failed request to %r: %r. "
                 "ID of failed DeliveryAttempt: %r . ",
-                webhook.target_url,
+                sanitize_url_for_logging(webhook.target_url),
                 response.content,
                 attempt.id,
             )
@@ -149,7 +150,7 @@ def _send_webhook_request_sync(
             logger.debug(
                 "[Webhook] Success response from %r."
                 "Successful DeliveryAttempt id: %r",
-                webhook.target_url,
+                sanitize_url_for_logging(webhook.target_url),
                 attempt.id,
             )
 

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -35,6 +35,7 @@ from ...core.tasks import delete_files_from_private_storage_task
 from ...core.taxes import TaxData, TaxLineData
 from ...core.utils import build_absolute_uri
 from ...core.utils.events import call_event
+from ...core.utils.url import sanitize_url_for_logging
 from ...payment import PaymentError
 from ...payment.interface import (
     GatewayResponse,
@@ -312,7 +313,7 @@ def handle_webhook_retry(
     log_extra_details = {
         "webhook": {
             "id": webhook.id,
-            "target_url": webhook.target_url,
+            "target_url": sanitize_url_for_logging(webhook.target_url),
             "event": delivery.event_type,
             "execution_mode": "async",
             "duration": response.duration,
@@ -323,7 +324,7 @@ def handle_webhook_retry(
         "[Webhook ID: %r] Failed request to %r: %r for event: %r."
         " Delivery attempt id: %r",
         webhook.id,
-        webhook.target_url,
+        sanitize_url_for_logging(webhook.target_url),
         response.content,
         delivery.event_type,
         delivery_attempt.id,
@@ -334,7 +335,7 @@ def handle_webhook_retry(
         task_logger.info(
             "[Webhook ID: %r] Failed request to %r: received HTTP %d. Delivery ID: %r",
             webhook.id,
-            webhook.target_url,
+            sanitize_url_for_logging(webhook.target_url),
             response.response_status_code,
             delivery.id,
             extra=log_extra_details,
@@ -352,7 +353,7 @@ def handle_webhook_retry(
         task_logger.info(
             "[Webhook ID: %r] Failed request to %r: exceeded retry limit. Delivery ID: %r",
             webhook.id,
-            webhook.target_url,
+            sanitize_url_for_logging(webhook.target_url),
             delivery.id,
             extra=log_extra_details,
         )


### PR DESCRIPTION
This adds an explicit credential anonymization step to logging of webhook URLs in case any of them contain usernames or passwords.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
