### PR TITLE
Add deletion of granted refund to clearorders command

### DIFF
--- a/saleor/core/management/commands/clearorders.py
+++ b/saleor/core/management/commands/clearorders.py
@@ -12,7 +12,15 @@ from ....checkout.models import Checkout, CheckoutLine, CheckoutMetadata
 from ....discount.models import OrderDiscount, OrderLineDiscount
 from ....giftcard.models import GiftCard, GiftCardEvent, GiftCardTag
 from ....invoice.models import Invoice, InvoiceEvent
-from ....order.models import Fulfillment, FulfillmentLine, Order, OrderEvent, OrderLine
+from ....order.models import (
+    Fulfillment,
+    FulfillmentLine,
+    Order,
+    OrderEvent,
+    OrderGrantedRefund,
+    OrderGrantedRefundLine,
+    OrderLine,
+)
 from ....payment.models import Payment, Transaction, TransactionEvent, TransactionItem
 from ....warehouse.models import (
     Allocation,
@@ -76,8 +84,14 @@ class Command(BaseCommand):
         self.stdout.write("Removed checkouts")
 
     def delete_payments(self):
+        order_granted_refund_lines = OrderGrantedRefundLine.objects.all()
+        order_granted_refund_lines._raw_delete(order_granted_refund_lines.db)  # type: ignore[attr-defined] # raw access # noqa: E501
+
         transaction_events = TransactionEvent.objects.all()
         transaction_events._raw_delete(transaction_events.db)  # type: ignore[attr-defined] # raw access # noqa: E501
+
+        order_granted_refunds = OrderGrantedRefund.objects.all()
+        order_granted_refunds._raw_delete(order_granted_refunds.db)  # type: ignore[attr-defined] # raw access # noqa: E501
 
         transaction_items = TransactionItem.objects.all()
         transaction_items._raw_delete(transaction_items.db)  # type: ignore[attr-defined] # raw access # noqa: E501


### PR DESCRIPTION
I want to merge this change because because currently we are running into IntegrityError when users have granted refund objects and wants to use `clearorders` command

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
