### PR TITLE
Reduce time of execution when requesting `totalCount` with `stockAvailability` filter

### DIFF
--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -2,25 +2,11 @@ import itertools
 import uuid
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import (
-    TYPE_CHECKING,
-    Optional,
-    TypedDict,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Optional, TypedDict, TypeVar, Union, cast
 
 from django.contrib.postgres.indexes import BTreeIndex
 from django.db import models
-from django.db.models import (
-    Exists,
-    F,
-    OuterRef,
-    Prefetch,
-    Q,
-    Sum,
-)
+from django.db.models import Exists, F, OuterRef, Prefetch, Q, Sum
 from django.db.models.expressions import Subquery
 from django.db.models.functions import Coalesce
 from django.db.models.query import QuerySet
@@ -64,6 +50,39 @@ class WarehouseQueryset(models.QuerySet["Warehouse"]):
                 )
             )
         ).order_by("pk")
+
+    def for_channel_with_active_shipping_zone_or_cc(self, channel_slug: str):
+        WarehouseChannel = Channel.warehouses.through
+        ShippingZoneChannel = Channel.shipping_zones.through
+        WarehouseShippingZone = ShippingZone.warehouses.through
+
+        channel = Channel.objects.filter(slug=channel_slug).values("pk")
+        warehouse_channels = WarehouseChannel.objects.filter(
+            Exists(channel.filter(pk=OuterRef("channel_id")))
+        ).values("warehouse_id")
+
+        shipping_zone_channels = ShippingZoneChannel.objects.filter(
+            Exists(channel.filter(pk=OuterRef("channel_id")))
+        ).values("shippingzone_id")
+
+        warehouse_shipping_zones = WarehouseShippingZone.objects.filter(
+            Exists(warehouse_channels.filter(warehouse_id=OuterRef("warehouse_id"))),
+            Exists(
+                shipping_zone_channels.filter(
+                    shippingzone_id=OuterRef("shippingzone_id")
+                )
+            ),
+        ).values("warehouse_id")
+        return self.filter(
+            Q(
+                Exists(warehouse_channels.filter(warehouse_id=OuterRef("id"))),
+                click_and_collect_option__in=[
+                    WarehouseClickAndCollectOption.LOCAL_STOCK,
+                    WarehouseClickAndCollectOption.ALL_WAREHOUSES,
+                ],
+            )
+            | Q(Exists(warehouse_shipping_zones.filter(warehouse_id=OuterRef("id"))))
+        )
 
     def for_country_and_channel(self, country: str, channel_id: int):
         ShippingZoneChannel = Channel.shipping_zones.through

--- a/saleor/warehouse/tests/test_warehouse.py
+++ b/saleor/warehouse/tests/test_warehouse.py
@@ -807,3 +807,19 @@ def test_applicable_for_click_and_collect_no_quantity_check_additional_stock(
     # then
     assert len(result) == 1
     assert result.first().id == all_warehouse.id
+
+
+def test_for_channel_with_active_shipping_zone_or_cc(
+    warehouses_for_cc, warehouse, warehouse_JPY, warehouse_no_shipping_zone, channel_USD
+):
+    # given
+    expected_warehouse_pks = [wh.pk for wh in warehouses_for_cc]
+    expected_warehouse_pks.append(warehouse.pk)
+
+    # when
+    warehouses = Warehouse.objects.for_channel_with_active_shipping_zone_or_cc(
+        channel_USD.slug
+    )
+
+    # then
+    assert set(warehouses.values_list("pk", flat=True)) == set(expected_warehouse_pks)


### PR DESCRIPTION
I want to merge this change because it reduces the execution time of the query, when requesting `totalCount` with `stockAvailability` availability.

Setup used during tests:
- 400 Warehouses
- 557k Stocks
- 25k ProductVariants

Query used for testing:
```graphql
query products($channel: String!, $filter: ProductFilterInput, $first: Int, $after: String, $before: String, $last: Int, $sortBy: ProductOrder, $search: String) {
  products(
    channel: $channel
    filter: $filter
    first: $first
    after: $after
    before: $before
    last: $last
    sortBy: $sortBy
    search: $search
  ) {
    __typename
    edges {
      node{
        id
      }
      
    }
    pageInfo {
      __typename
      hasNextPage
      hasPreviousPage
      startCursor
      endCursor
    }
    totalCount
  }
}

```
Variables:
```json
{
  "channel": "default-channel",
  "first": 20,
  "filter": {
    "stockAvailability": "IN_STOCK"
  }
}
```
Results:
- 3.20:
  -  IN_STOCK:
      -  With `totalCount` in query:  `5.993674s`
      -  Without `totalCount` in query:   `0.322461s`
  -  OUT_OF_STOCK:
      -  With `totalCount` in query:  `6.600026s`
      -  Without `totalCount` in query:   `1.139934s`
- With the improvements:
  -  IN_STOCK:
      -  With `totalCount` in query:  `3.837313s`
      -  Without `totalCount` in query:   `0.307673s`
  -  OUT_OF_STOCK:
      -  With `totalCount` in query:  `3.966663s`
      -  Without `totalCount` in query:   `0.915774s`






<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
