### PR TITLE
split payment module fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -44,6 +44,7 @@ pytest_plugins = [
     "saleor.discount.tests.fixtures",
     "saleor.checkout.tests.fixtures",
     "saleor.attribute.tests.fixtures",
+    "saleor.payment.tests.fixtures",
 ]
 
 

--- a/saleor/payment/tests/fixtures/__init__.py
+++ b/saleor/payment/tests/fixtures/__init__.py
@@ -1,0 +1,6 @@
+from .gateway_config import *  # noqa: F403
+from .gateway_response import *  # noqa: F403
+from .payment import *  # noqa: F403
+from .payment_data import *  # noqa: F403
+from .transaction_event import *  # noqa: F403
+from .transaction_item import *  # noqa: F403

--- a/saleor/payment/tests/fixtures/gateway_config.py
+++ b/saleor/payment/tests/fixtures/gateway_config.py
@@ -1,0 +1,13 @@
+import pytest
+
+from ....payment.interface import GatewayConfig
+
+
+@pytest.fixture
+def dummy_gateway_config():
+    return GatewayConfig(
+        gateway_name="Dummy",
+        auto_capture=True,
+        supported_currencies="USD",
+        connection_params={"secret-key": "nobodylikesspanishinqusition"},
+    )

--- a/saleor/payment/tests/fixtures/gateway_response.py
+++ b/saleor/payment/tests/fixtures/gateway_response.py
@@ -1,0 +1,45 @@
+from decimal import Decimal
+
+import pytest
+
+from ....payment import TransactionKind
+from ....payment.interface import GatewayResponse
+
+
+@pytest.fixture
+def action_required_gateway_response():
+    return GatewayResponse(
+        is_success=True,
+        action_required=True,
+        action_required_data={
+            "paymentData": "test",
+            "paymentMethodType": "scheme",
+            "url": "https://test.adyen.com/hpp/3d/validate.shtml",
+            "data": {
+                "MD": "md-test-data",
+                "PaReq": "PaReq-test-data",
+                "TermUrl": "http://127.0.0.1:3000/",
+            },
+            "method": "POST",
+            "type": "redirect",
+        },
+        kind=TransactionKind.CAPTURE,
+        amount=Decimal(3.0),
+        currency="usd",
+        transaction_id="1234",
+        error=None,
+    )
+
+
+@pytest.fixture
+def success_gateway_response():
+    return GatewayResponse(
+        is_success=True,
+        action_required=False,
+        action_required_data={},
+        kind=TransactionKind.CAPTURE,
+        amount=Decimal("10.0"),
+        currency="usd",
+        transaction_id="1234",
+        error=None,
+    )

--- a/saleor/payment/tests/fixtures/payment.py
+++ b/saleor/payment/tests/fixtures/payment.py
@@ -1,0 +1,217 @@
+import pytest
+
+from ....payment import ChargeStatus, TransactionKind
+from ....payment.models import Payment
+from ....webhook.transport.utils import to_payment_app_id
+
+
+@pytest.fixture
+def payment_dummy(db, order_with_lines):
+    return Payment.objects.create(
+        gateway="mirumee.payments.dummy",
+        order=order_with_lines,
+        is_active=True,
+        cc_first_digits="4111",
+        cc_last_digits="1111",
+        cc_brand="visa",
+        cc_exp_month=12,
+        cc_exp_year=2027,
+        total=order_with_lines.total.gross.amount,
+        currency=order_with_lines.currency,
+        billing_first_name=order_with_lines.billing_address.first_name,
+        billing_last_name=order_with_lines.billing_address.last_name,
+        billing_company_name=order_with_lines.billing_address.company_name,
+        billing_address_1=order_with_lines.billing_address.street_address_1,
+        billing_address_2=order_with_lines.billing_address.street_address_2,
+        billing_city=order_with_lines.billing_address.city,
+        billing_postal_code=order_with_lines.billing_address.postal_code,
+        billing_country_code=order_with_lines.billing_address.country.code,
+        billing_country_area=order_with_lines.billing_address.country_area,
+        billing_email=order_with_lines.user_email,
+    )
+
+
+@pytest.fixture
+def payment_not_authorized(payment_dummy):
+    payment_dummy.is_active = False
+    payment_dummy.save()
+    return payment_dummy
+
+
+@pytest.fixture
+def payments_dummy(order_with_lines):
+    return Payment.objects.bulk_create(
+        [
+            Payment(
+                gateway="mirumee.payments.dummy",
+                order=order_with_lines,
+                is_active=True,
+                cc_first_digits="4111",
+                cc_last_digits="1111",
+                cc_brand="visa",
+                cc_exp_month=12,
+                cc_exp_year=2027,
+                total=order_with_lines.total.gross.amount,
+                currency=order_with_lines.currency,
+                billing_first_name=order_with_lines.billing_address.first_name,
+                billing_last_name=order_with_lines.billing_address.last_name,
+                billing_company_name=order_with_lines.billing_address.company_name,
+                billing_address_1=order_with_lines.billing_address.street_address_1,
+                billing_address_2=order_with_lines.billing_address.street_address_2,
+                billing_city=order_with_lines.billing_address.city,
+                billing_postal_code=order_with_lines.billing_address.postal_code,
+                billing_country_code=order_with_lines.billing_address.country.code,
+                billing_country_area=order_with_lines.billing_address.country_area,
+                billing_email=order_with_lines.user_email,
+            )
+            for _ in range(3)
+        ]
+    )
+
+
+@pytest.fixture
+def payment(payment_dummy, payment_app):
+    gateway_id = "credit-card"
+    gateway = to_payment_app_id(payment_app, gateway_id)
+    payment_dummy.gateway = gateway
+    payment_dummy.save()
+    return payment_dummy
+
+
+@pytest.fixture
+def payment_cancelled(payment_dummy):
+    payment_dummy.charge_status = ChargeStatus.CANCELLED
+    payment_dummy.save()
+    return payment_dummy
+
+
+@pytest.fixture
+def payment_dummy_fully_charged(payment_dummy):
+    payment_dummy.captured_amount = payment_dummy.total
+    payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_dummy.save()
+    return payment_dummy
+
+
+@pytest.fixture
+def payment_dummy_credit_card(db, order_with_lines):
+    return Payment.objects.create(
+        gateway="mirumee.payments.dummy_credit_card",
+        order=order_with_lines,
+        is_active=True,
+        cc_first_digits="4111",
+        cc_last_digits="1111",
+        cc_brand="visa",
+        cc_exp_month=12,
+        cc_exp_year=2027,
+        total=order_with_lines.total.gross.amount,
+        currency=order_with_lines.total.gross.currency,
+        billing_first_name=order_with_lines.billing_address.first_name,
+        billing_last_name=order_with_lines.billing_address.last_name,
+        billing_company_name=order_with_lines.billing_address.company_name,
+        billing_address_1=order_with_lines.billing_address.street_address_1,
+        billing_address_2=order_with_lines.billing_address.street_address_2,
+        billing_city=order_with_lines.billing_address.city,
+        billing_postal_code=order_with_lines.billing_address.postal_code,
+        billing_country_code=order_with_lines.billing_address.country.code,
+        billing_country_area=order_with_lines.billing_address.country_area,
+        billing_email=order_with_lines.user_email,
+    )
+
+
+@pytest.fixture
+def payment_txn_preauth(order_with_lines, payment_dummy):
+    order = order_with_lines
+    payment = payment_dummy
+    payment.order = order
+    payment.save()
+
+    payment.transactions.create(
+        amount=payment.total,
+        currency=payment.currency,
+        kind=TransactionKind.AUTH,
+        gateway_response={},
+        is_success=True,
+    )
+    return payment
+
+
+@pytest.fixture
+def payment_txn_captured(order_with_lines, payment_dummy):
+    order = order_with_lines
+    payment = payment_dummy
+    payment.order = order
+    payment.charge_status = ChargeStatus.FULLY_CHARGED
+    payment.captured_amount = payment.total
+    payment.save()
+
+    payment.transactions.create(
+        amount=payment.total,
+        currency=payment.currency,
+        kind=TransactionKind.CAPTURE,
+        gateway_response={},
+        is_success=True,
+    )
+    return payment
+
+
+@pytest.fixture
+def payment_txn_capture_failed(order_with_lines, payment_dummy):
+    order = order_with_lines
+    payment = payment_dummy
+    payment.order = order
+    payment.charge_status = ChargeStatus.REFUSED
+    payment.save()
+
+    payment.transactions.create(
+        amount=payment.total,
+        currency=payment.currency,
+        kind=TransactionKind.CAPTURE_FAILED,
+        gateway_response={
+            "status": 403,
+            "errorCode": "901",
+            "message": "Invalid Merchant Account",
+            "errorType": "security",
+        },
+        error="invalid",
+        is_success=False,
+    )
+    return payment
+
+
+@pytest.fixture
+def payment_txn_to_confirm(order_with_lines, payment_dummy):
+    order = order_with_lines
+    payment = payment_dummy
+    payment.order = order
+    payment.to_confirm = True
+    payment.save()
+
+    payment.transactions.create(
+        amount=payment.total,
+        currency=payment.currency,
+        kind=TransactionKind.ACTION_TO_CONFIRM,
+        gateway_response={},
+        is_success=True,
+        action_required=True,
+    )
+    return payment
+
+
+@pytest.fixture
+def payment_txn_refunded(order_with_lines, payment_dummy):
+    order = order_with_lines
+    payment = payment_dummy
+    payment.order = order
+    payment.charge_status = ChargeStatus.FULLY_REFUNDED
+    payment.is_active = False
+    payment.save()
+
+    payment.transactions.create(
+        amount=payment.total,
+        currency=payment.currency,
+        kind=TransactionKind.REFUND,
+        gateway_response={},
+        is_success=True,
+    )
+    return payment

--- a/saleor/payment/tests/fixtures/payment_data.py
+++ b/saleor/payment/tests/fixtures/payment_data.py
@@ -1,0 +1,22 @@
+from decimal import Decimal
+
+import graphene
+import pytest
+
+from ....payment.interface import PaymentData
+
+
+@pytest.fixture
+def dummy_payment_data(payment_dummy):
+    return PaymentData(
+        gateway=payment_dummy.gateway,
+        amount=Decimal(10),
+        currency="USD",
+        graphql_payment_id=graphene.Node.to_global_id("Payment", payment_dummy.pk),
+        payment_id=payment_dummy.pk,
+        billing=None,
+        shipping=None,
+        order_id=None,
+        customer_ip_address=None,
+        customer_email="example@test.com",
+    )

--- a/saleor/payment/tests/fixtures/transaction_event.py
+++ b/saleor/payment/tests/fixtures/transaction_event.py
@@ -1,0 +1,33 @@
+from decimal import Decimal
+from typing import Callable
+
+import pytest
+
+from ....payment.models import TransactionEvent, TransactionItem
+
+
+@pytest.fixture
+def transaction_events_generator() -> (
+    Callable[
+        [list[str], list[str], list[Decimal], TransactionItem], list[TransactionEvent]
+    ]
+):
+    def factory(
+        psp_references: list[str],
+        types: list[str],
+        amounts: list[Decimal],
+        transaction: TransactionItem,
+    ):
+        return TransactionEvent.objects.bulk_create(
+            TransactionEvent(
+                transaction=transaction,
+                psp_reference=reference,
+                type=event_type,
+                amount_value=amount,
+                include_in_calculations=True,
+                currency=transaction.currency,
+            )
+            for reference, event_type, amount in zip(psp_references, types, amounts)
+        )
+
+    return factory

--- a/saleor/payment/tests/fixtures/transaction_item.py
+++ b/saleor/payment/tests/fixtures/transaction_item.py
@@ -1,0 +1,91 @@
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from ...models import TransactionItem
+from ...transaction_item_calculations import recalculate_transaction_amounts
+from ...utils import create_manual_adjustment_events
+
+
+@pytest.fixture
+def transaction_item_generator():
+    def create_transaction(
+        order_id=None,
+        checkout_id=None,
+        app=None,
+        user=None,
+        psp_reference="PSP ref1",
+        name="Credit card",
+        message="Transasction details",
+        available_actions=None,
+        authorized_value=Decimal(0),
+        charged_value=Decimal(0),
+        refunded_value=Decimal(0),
+        canceled_value=Decimal(0),
+        use_old_id=False,
+        last_refund_success=True,
+    ):
+        if available_actions is None:
+            available_actions = []
+        transaction = TransactionItem.objects.create(
+            token=uuid.uuid4(),
+            name=name,
+            message=message,
+            psp_reference=psp_reference,
+            available_actions=available_actions,
+            currency="USD",
+            order_id=order_id,
+            checkout_id=checkout_id,
+            app_identifier=app.identifier if app else None,
+            app=app,
+            user=user,
+            use_old_id=use_old_id,
+            last_refund_success=last_refund_success,
+        )
+        create_manual_adjustment_events(
+            transaction=transaction,
+            money_data={
+                "authorized_value": authorized_value,
+                "charged_value": charged_value,
+                "refunded_value": refunded_value,
+                "canceled_value": canceled_value,
+            },
+            user=user,
+            app=app,
+        )
+        recalculate_transaction_amounts(transaction)
+        return transaction
+
+    return create_transaction
+
+
+@pytest.fixture
+def transaction_item_created_by_app(order, app, transaction_item_generator):
+    charged_amount = Decimal("10.0")
+    return transaction_item_generator(
+        order_id=order.pk,
+        checkout_id=None,
+        app=app,
+        user=None,
+        charged_value=charged_amount,
+    )
+
+
+@pytest.fixture
+def transaction_item_created_by_user(order, staff_user, transaction_item_generator):
+    charged_amount = Decimal("10.0")
+    return transaction_item_generator(
+        order_id=order.pk,
+        checkout_id=None,
+        user=staff_user,
+        app=None,
+        charged_value=charged_amount,
+    )
+
+
+@pytest.fixture
+def transaction_item(order, transaction_item_generator):
+    return transaction_item_generator(
+        order_id=order.pk,
+    )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1,10 +1,8 @@
 import datetime
-import uuid
 from contextlib import contextmanager
-from decimal import Decimal
 from functools import partial
 from io import BytesIO
-from typing import Callable, Optional
+from typing import Optional
 from unittest.mock import MagicMock
 
 import graphene
@@ -22,20 +20,14 @@ from ..core.models import EventDelivery, EventDeliveryAttempt, EventPayload
 from ..core.payments import PaymentInterface
 from ..csv.events import ExportEvents
 from ..csv.models import ExportEvent, ExportFile
-from ..discount import (
-    PromotionEvents,
-)
+from ..discount import PromotionEvents
 from ..discount.models import (
     PromotionEvent,
     PromotionRuleTranslation,
     PromotionTranslation,
     VoucherTranslation,
 )
-from ..payment import ChargeStatus, TransactionKind
-from ..payment.interface import AddressData, GatewayConfig, GatewayResponse, PaymentData
-from ..payment.models import Payment, TransactionEvent, TransactionItem
-from ..payment.transaction_item_calculations import recalculate_transaction_amounts
-from ..payment.utils import create_manual_adjustment_events
+from ..payment.interface import AddressData
 from ..permission.enums import get_permissions
 from ..product.models import (
     CategoryTranslation,
@@ -338,137 +330,6 @@ def image_list():
         SimpleUploadedFile("image1.jpg", img_data_1.getvalue()),
         SimpleUploadedFile("image2.jpg", img_data_2.getvalue()),
     ]
-
-
-@pytest.fixture
-def payment_txn_preauth(order_with_lines, payment_dummy):
-    order = order_with_lines
-    payment = payment_dummy
-    payment.order = order
-    payment.save()
-
-    payment.transactions.create(
-        amount=payment.total,
-        currency=payment.currency,
-        kind=TransactionKind.AUTH,
-        gateway_response={},
-        is_success=True,
-    )
-    return payment
-
-
-@pytest.fixture
-def payment_txn_captured(order_with_lines, payment_dummy):
-    order = order_with_lines
-    payment = payment_dummy
-    payment.order = order
-    payment.charge_status = ChargeStatus.FULLY_CHARGED
-    payment.captured_amount = payment.total
-    payment.save()
-
-    payment.transactions.create(
-        amount=payment.total,
-        currency=payment.currency,
-        kind=TransactionKind.CAPTURE,
-        gateway_response={},
-        is_success=True,
-    )
-    return payment
-
-
-@pytest.fixture
-def payment_txn_capture_failed(order_with_lines, payment_dummy):
-    order = order_with_lines
-    payment = payment_dummy
-    payment.order = order
-    payment.charge_status = ChargeStatus.REFUSED
-    payment.save()
-
-    payment.transactions.create(
-        amount=payment.total,
-        currency=payment.currency,
-        kind=TransactionKind.CAPTURE_FAILED,
-        gateway_response={
-            "status": 403,
-            "errorCode": "901",
-            "message": "Invalid Merchant Account",
-            "errorType": "security",
-        },
-        error="invalid",
-        is_success=False,
-    )
-    return payment
-
-
-@pytest.fixture
-def payment_txn_to_confirm(order_with_lines, payment_dummy):
-    order = order_with_lines
-    payment = payment_dummy
-    payment.order = order
-    payment.to_confirm = True
-    payment.save()
-
-    payment.transactions.create(
-        amount=payment.total,
-        currency=payment.currency,
-        kind=TransactionKind.ACTION_TO_CONFIRM,
-        gateway_response={},
-        is_success=True,
-        action_required=True,
-    )
-    return payment
-
-
-@pytest.fixture
-def payment_txn_refunded(order_with_lines, payment_dummy):
-    order = order_with_lines
-    payment = payment_dummy
-    payment.order = order
-    payment.charge_status = ChargeStatus.FULLY_REFUNDED
-    payment.is_active = False
-    payment.save()
-
-    payment.transactions.create(
-        amount=payment.total,
-        currency=payment.currency,
-        kind=TransactionKind.REFUND,
-        gateway_response={},
-        is_success=True,
-    )
-    return payment
-
-
-@pytest.fixture
-def payment_not_authorized(payment_dummy):
-    payment_dummy.is_active = False
-    payment_dummy.save()
-    return payment_dummy
-
-
-@pytest.fixture
-def dummy_gateway_config():
-    return GatewayConfig(
-        gateway_name="Dummy",
-        auto_capture=True,
-        supported_currencies="USD",
-        connection_params={"secret-key": "nobodylikesspanishinqusition"},
-    )
-
-
-@pytest.fixture
-def dummy_payment_data(payment_dummy):
-    return PaymentData(
-        gateway=payment_dummy.gateway,
-        amount=Decimal(10),
-        currency="USD",
-        graphql_payment_id=graphene.Node.to_global_id("Payment", payment_dummy.pk),
-        payment_id=payment_dummy.pk,
-        billing=None,
-        shipping=None,
-        order_id=None,
-        customer_ip_address=None,
-        customer_email="example@test.com",
-    )
 
 
 @pytest.fixture
@@ -777,223 +638,6 @@ def promotion_rule_translation_fr(promotion_rule):
         promotion_rule=promotion_rule,
         name="French promotion rule name",
         description=dummy_editorjs("French promotion rule description."),
-    )
-
-
-@pytest.fixture
-def payment_dummy(db, order_with_lines):
-    return Payment.objects.create(
-        gateway="mirumee.payments.dummy",
-        order=order_with_lines,
-        is_active=True,
-        cc_first_digits="4111",
-        cc_last_digits="1111",
-        cc_brand="visa",
-        cc_exp_month=12,
-        cc_exp_year=2027,
-        total=order_with_lines.total.gross.amount,
-        currency=order_with_lines.currency,
-        billing_first_name=order_with_lines.billing_address.first_name,
-        billing_last_name=order_with_lines.billing_address.last_name,
-        billing_company_name=order_with_lines.billing_address.company_name,
-        billing_address_1=order_with_lines.billing_address.street_address_1,
-        billing_address_2=order_with_lines.billing_address.street_address_2,
-        billing_city=order_with_lines.billing_address.city,
-        billing_postal_code=order_with_lines.billing_address.postal_code,
-        billing_country_code=order_with_lines.billing_address.country.code,
-        billing_country_area=order_with_lines.billing_address.country_area,
-        billing_email=order_with_lines.user_email,
-    )
-
-
-@pytest.fixture
-def payments_dummy(order_with_lines):
-    return Payment.objects.bulk_create(
-        [
-            Payment(
-                gateway="mirumee.payments.dummy",
-                order=order_with_lines,
-                is_active=True,
-                cc_first_digits="4111",
-                cc_last_digits="1111",
-                cc_brand="visa",
-                cc_exp_month=12,
-                cc_exp_year=2027,
-                total=order_with_lines.total.gross.amount,
-                currency=order_with_lines.currency,
-                billing_first_name=order_with_lines.billing_address.first_name,
-                billing_last_name=order_with_lines.billing_address.last_name,
-                billing_company_name=order_with_lines.billing_address.company_name,
-                billing_address_1=order_with_lines.billing_address.street_address_1,
-                billing_address_2=order_with_lines.billing_address.street_address_2,
-                billing_city=order_with_lines.billing_address.city,
-                billing_postal_code=order_with_lines.billing_address.postal_code,
-                billing_country_code=order_with_lines.billing_address.country.code,
-                billing_country_area=order_with_lines.billing_address.country_area,
-                billing_email=order_with_lines.user_email,
-            )
-            for _ in range(3)
-        ]
-    )
-
-
-@pytest.fixture
-def payment(payment_dummy, payment_app):
-    gateway_id = "credit-card"
-    gateway = to_payment_app_id(payment_app, gateway_id)
-    payment_dummy.gateway = gateway
-    payment_dummy.save()
-    return payment_dummy
-
-
-@pytest.fixture
-def payment_cancelled(payment_dummy):
-    payment_dummy.charge_status = ChargeStatus.CANCELLED
-    payment_dummy.save()
-    return payment_dummy
-
-
-@pytest.fixture
-def payment_dummy_fully_charged(payment_dummy):
-    payment_dummy.captured_amount = payment_dummy.total
-    payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
-    payment_dummy.save()
-    return payment_dummy
-
-
-@pytest.fixture
-def payment_dummy_credit_card(db, order_with_lines):
-    return Payment.objects.create(
-        gateway="mirumee.payments.dummy_credit_card",
-        order=order_with_lines,
-        is_active=True,
-        cc_first_digits="4111",
-        cc_last_digits="1111",
-        cc_brand="visa",
-        cc_exp_month=12,
-        cc_exp_year=2027,
-        total=order_with_lines.total.gross.amount,
-        currency=order_with_lines.total.gross.currency,
-        billing_first_name=order_with_lines.billing_address.first_name,
-        billing_last_name=order_with_lines.billing_address.last_name,
-        billing_company_name=order_with_lines.billing_address.company_name,
-        billing_address_1=order_with_lines.billing_address.street_address_1,
-        billing_address_2=order_with_lines.billing_address.street_address_2,
-        billing_city=order_with_lines.billing_address.city,
-        billing_postal_code=order_with_lines.billing_address.postal_code,
-        billing_country_code=order_with_lines.billing_address.country.code,
-        billing_country_area=order_with_lines.billing_address.country_area,
-        billing_email=order_with_lines.user_email,
-    )
-
-
-@pytest.fixture
-def transaction_item_generator():
-    def create_transaction(
-        order_id=None,
-        checkout_id=None,
-        app=None,
-        user=None,
-        psp_reference="PSP ref1",
-        name="Credit card",
-        message="Transasction details",
-        available_actions=None,
-        authorized_value=Decimal(0),
-        charged_value=Decimal(0),
-        refunded_value=Decimal(0),
-        canceled_value=Decimal(0),
-        use_old_id=False,
-        last_refund_success=True,
-    ):
-        if available_actions is None:
-            available_actions = []
-        transaction = TransactionItem.objects.create(
-            token=uuid.uuid4(),
-            name=name,
-            message=message,
-            psp_reference=psp_reference,
-            available_actions=available_actions,
-            currency="USD",
-            order_id=order_id,
-            checkout_id=checkout_id,
-            app_identifier=app.identifier if app else None,
-            app=app,
-            user=user,
-            use_old_id=use_old_id,
-            last_refund_success=last_refund_success,
-        )
-        create_manual_adjustment_events(
-            transaction=transaction,
-            money_data={
-                "authorized_value": authorized_value,
-                "charged_value": charged_value,
-                "refunded_value": refunded_value,
-                "canceled_value": canceled_value,
-            },
-            user=user,
-            app=app,
-        )
-        recalculate_transaction_amounts(transaction)
-        return transaction
-
-    return create_transaction
-
-
-@pytest.fixture
-def transaction_events_generator() -> (
-    Callable[
-        [list[str], list[str], list[Decimal], TransactionItem], list[TransactionEvent]
-    ]
-):
-    def factory(
-        psp_references: list[str],
-        types: list[str],
-        amounts: list[Decimal],
-        transaction: TransactionItem,
-    ):
-        return TransactionEvent.objects.bulk_create(
-            TransactionEvent(
-                transaction=transaction,
-                psp_reference=reference,
-                type=event_type,
-                amount_value=amount,
-                include_in_calculations=True,
-                currency=transaction.currency,
-            )
-            for reference, event_type, amount in zip(psp_references, types, amounts)
-        )
-
-    return factory
-
-
-@pytest.fixture
-def transaction_item_created_by_app(order, app, transaction_item_generator):
-    charged_amount = Decimal("10.0")
-    return transaction_item_generator(
-        order_id=order.pk,
-        checkout_id=None,
-        app=app,
-        user=None,
-        charged_value=charged_amount,
-    )
-
-
-@pytest.fixture
-def transaction_item_created_by_user(order, staff_user, transaction_item_generator):
-    charged_amount = Decimal("10.0")
-    return transaction_item_generator(
-        order_id=order.pk,
-        checkout_id=None,
-        user=staff_user,
-        app=None,
-        charged_value=charged_amount,
-    )
-
-
-@pytest.fixture
-def transaction_item(order, transaction_item_generator):
-    return transaction_item_generator(
-        order_id=order.pk,
     )
 
 
@@ -1527,45 +1171,6 @@ def event_deliveries(event_payload, webhook, app):
         "delivery_2_id": delivery_2,
         "delivery_3_id": delivery_3,
     }
-
-
-@pytest.fixture
-def action_required_gateway_response():
-    return GatewayResponse(
-        is_success=True,
-        action_required=True,
-        action_required_data={
-            "paymentData": "test",
-            "paymentMethodType": "scheme",
-            "url": "https://test.adyen.com/hpp/3d/validate.shtml",
-            "data": {
-                "MD": "md-test-data",
-                "PaReq": "PaReq-test-data",
-                "TermUrl": "http://127.0.0.1:3000/",
-            },
-            "method": "POST",
-            "type": "redirect",
-        },
-        kind=TransactionKind.CAPTURE,
-        amount=Decimal(3.0),
-        currency="usd",
-        transaction_id="1234",
-        error=None,
-    )
-
-
-@pytest.fixture
-def success_gateway_response():
-    return GatewayResponse(
-        is_success=True,
-        action_required=False,
-        action_required_data={},
-        kind=TransactionKind.CAPTURE,
-        amount=Decimal("10.0"),
-        currency="usd",
-        transaction_id="1234",
-        error=None,
-    )
 
 
 @pytest.fixture


### PR DESCRIPTION
I want to merge this change because I want to split payment related fixtures.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
