### PR TITLE
Fix failing import-path for promotion schedule for self-hosted instances

### DIFF
--- a/saleor/core/schedules.py
+++ b/saleor/core/schedules.py
@@ -37,7 +37,7 @@ class promotion_webhook_schedule(CustomSchedule):
             schedule=self,
             nowfun=nowfun,
             app=app,
-            import_path="saleor.core.schedules.promotion_webhook_schedule",
+            import_path="saleor.core.schedules.initiated_promotion_webhook_schedule",
         )
         # Seconds left to next batch processing
         self.NEXT_BATCH_RUN_TIME = 5

--- a/saleor/core/tests/test_schedules.py
+++ b/saleor/core/tests/test_schedules.py
@@ -1,6 +1,8 @@
 import datetime
 
+from celery.schedules import BaseSchedule
 from django.utils import timezone
+from django.utils.module_loading import import_string
 from freezegun import freeze_time
 
 from ...discount.models import Promotion
@@ -213,3 +215,14 @@ def test_is_due_no_promo_to_notify_about_upcoming_promo_exists_initial_time_retu
     # then
     assert is_due is False
     assert next_run == schedule.initial_timedelta.total_seconds()
+
+
+def test_promotion_webhook_schedule_import_path():
+    # given
+    schedule = promotion_webhook_schedule()
+
+    # when
+    scheduler_instance = import_string(schedule.import_path)
+
+    # then
+    assert isinstance(scheduler_instance, BaseSchedule)


### PR DESCRIPTION
I want to merge this change because when starting celery with `--scheduler saleor.schedulers.schedulers:DatabaseScheduler`, the `saleor.schedulers.models.CustomSchedule` raises an exception:

`django.core.exceptions.SuspiciousOperation: Expected type of 'saleor.core.schedules.promotion_webhook_schedule' to be inheriting from BaseScheduler but found: <class 'type'> ((<class 'object'>,))`.

The import path should be the path to the instance, not to the class. This caused, that we can't run our own `DatabaseScheduler`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
