### PR TITLE
Reduce time of execution when requesting totalCount with stockAvailability filter

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -380,15 +380,17 @@ def filter_products_by_stock_availability(qs, stock_availability, channel_slug):
         .values_list(Sum("quantity_reserved"))
     )
     reservation_subquery = Subquery(queryset=reservations, output_field=IntegerField())
-
-    stocks = (
-        Stock.objects.for_channel_and_country(channel_slug)
-        .filter(
-            quantity__gt=Coalesce(allocated_subquery, 0)
-            + Coalesce(reservation_subquery, 0)
-        )
-        .values("product_variant_id")
+    warehouse_pks = list(
+        Warehouse.objects.for_channel_with_active_shipping_zone_or_cc(
+            channel_slug
+        ).values_list("pk", flat=True)
     )
+
+    stocks = Stock.objects.filter(
+        warehouse_id__in=warehouse_pks,
+        quantity__gt=Coalesce(allocated_subquery, 0)
+        + Coalesce(reservation_subquery, 0),
+    ).values("product_variant_id")
     variants = ProductVariant.objects.filter(
         Exists(stocks.filter(product_variant_id=OuterRef("pk")))
     ).values("product_id")
@@ -396,7 +398,7 @@ def filter_products_by_stock_availability(qs, stock_availability, channel_slug):
     if stock_availability == StockAvailability.IN_STOCK:
         qs = qs.filter(Exists(variants.filter(product_id=OuterRef("pk"))))
     if stock_availability == StockAvailability.OUT_OF_STOCK:
-        qs = qs.filter(~Exists(variants.filter(product_id=OuterRef("pk"))))
+        qs = qs.exclude(Exists(variants.filter(product_id=OuterRef("pk"))))
     return qs
 
 

--- a/saleor/warehouse/tests/test_warehouse.py
+++ b/saleor/warehouse/tests/test_warehouse.py
@@ -149,3 +149,19 @@ def test_applicable_for_click_and_collect_returns_empty_collection_if_different_
     result = Warehouse.objects.applicable_for_click_and_collect(lines, channel_PLN.id)
 
     assert not result
+
+
+def test_for_channel_with_active_shipping_zone_or_cc(
+    warehouses_for_cc, warehouse, warehouse_JPY, warehouse_no_shipping_zone, channel_USD
+):
+    # given
+    expected_warehouse_pks = [wh.pk for wh in warehouses_for_cc]
+    expected_warehouse_pks.append(warehouse.pk)
+
+    # when
+    warehouses = Warehouse.objects.for_channel_with_active_shipping_zone_or_cc(
+        channel_USD.slug
+    )
+
+    # then
+    assert set(warehouses.values_list("pk", flat=True)) == set(expected_warehouse_pks)


### PR DESCRIPTION
I want to merge this change because it reduces the execution time of the query, when requesting `totalCount` with `stockAvailability` availability.

Setup used during tests:
- 400 Warehouses
- 557k Stocks
- 25k ProductVariants

Query used for testing:
```graphql
query products($channel: String!, $filter: ProductFilterInput, $first: Int, $after: String, $before: String, $last: Int, $sortBy: ProductOrder, $search: String) {
  products(
    channel: $channel
    filter: $filter
    first: $first
    after: $after
    before: $before
    last: $last
    sortBy: $sortBy
    search: $search
  ) {
    __typename
    edges {
      node{
        id
      }
      
    }
    pageInfo {
      __typename
      hasNextPage
      hasPreviousPage
      startCursor
      endCursor
    }
    totalCount
  }
}

```
Variables:
```json
{
  "channel": "default-channel",
  "first": 20,
  "filter": {
    "stockAvailability": "IN_STOCK"
  }
}
```
Results:
- 3.20:
  -  IN_STOCK:
      -  With `totalCount` in query:  `5.993674s`
      -  Without `totalCount` in query:   `0.322461s`
  -  OUT_OF_STOCK:
      -  With `totalCount` in query:  `6.600026s`
      -  Without `totalCount` in query:   `1.139934s`
- With the improvements:
  -  IN_STOCK:
      -  With `totalCount` in query:  `3.837313s`
      -  Without `totalCount` in query:   `0.307673s`
  -  OUT_OF_STOCK:
      -  With `totalCount` in query:  `3.966663s`
      -  Without `totalCount` in query:   `0.915774s`


Port of changes from: #16904

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
