### PR TITLE
Add error handling when removing orders with protected related object

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -966,7 +966,7 @@ class BaseBulkMutation(BaseMutation):
         return cls._meta.object_type
 
     @classmethod
-    def clean_instance(cls, _info: ResolveInfo, _instance, /, _related_objects=None):
+    def clean_instance(cls, _info: ResolveInfo, _instance, /):
         """Perform additional logic.
 
         Override this method to raise custom validation error and prevent
@@ -974,25 +974,40 @@ class BaseBulkMutation(BaseMutation):
         """
 
     @classmethod
+    def clean_input(cls, info: ResolveInfo, instances, ids):
+        clean_instance_ids = []
+        errors_dict: dict[str, list[ValidationError]] = {}
+        for instance, node_id in zip(instances, ids):
+            instance_errors = []
+
+            # catch individual validation errors to raise them later as
+            # a single error
+            try:
+                cls.clean_instance(info, instance)
+            except ValidationError as e:
+                msg = ". ".join(e.messages)
+                instance_errors.append(msg)
+
+            if not instance_errors:
+                clean_instance_ids.append(instance.pk)
+            else:
+                instance_errors_msg = ". ".join(instance_errors)
+                # FIXME we are not propagating code error from the raised ValidationError
+                ValidationError({node_id: instance_errors_msg}).update_error_dict(
+                    errors_dict
+                )
+        return clean_instance_ids, errors_dict
+
+    @classmethod
     def bulk_action(cls, _info: ResolveInfo, _queryset: QuerySet, /):
         """Implement action performed on queryset."""
         raise NotImplementedError
-
-    @classmethod
-    def get_ids_with_related_objects(cls, _ids, /):
-        """Perform additional queries on db.
-
-        Ovveride this method if you need to additional data for validation.
-        """
-        return None
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, ids, **data
     ) -> tuple[int, Optional[ValidationError]]:
         """Perform a mutation that deletes a list of model instances."""
-        clean_instance_ids = []
-        errors_dict: dict[str, list[ValidationError]] = {}
         # Allow to pass empty list for dummy mutation
         if not ids:
             return 0, None
@@ -1011,29 +1026,7 @@ class BaseBulkMutation(BaseMutation):
         except ValidationError as error:
             return 0, error
 
-        instances_ids = [instance.id for instance in instances]
-        related_objects = cls.get_ids_with_related_objects(instances_ids)
-
-        for instance, node_id in zip(instances, ids):
-            instance_errors = []
-
-            # catch individual validation errors to raise them later as
-            # a single error
-            try:
-                cls.clean_instance(info, instance, related_objects)
-            except ValidationError as e:
-                msg = ". ".join(e.messages)
-                instance_errors.append(msg)
-
-            if not instance_errors:
-                clean_instance_ids.append(instance.pk)
-            else:
-                instance_errors_msg = ". ".join(instance_errors)
-                # FIXME we are not propagating code error from the raised ValidationError
-                ValidationError({node_id: instance_errors_msg}).update_error_dict(
-                    errors_dict
-                )
-
+        clean_instance_ids, errors_dict = cls.clean_input(info, instances, ids)
         if errors_dict:
             errors = ValidationError(errors_dict)
         else:
@@ -1078,8 +1071,6 @@ class BaseBulkWithRestrictedChannelAccessMutation(BaseBulkMutation):
         cls, _root, info: ResolveInfo, /, *, ids, **data
     ) -> tuple[int, Optional[ValidationError]]:
         """Perform a mutation that deletes a list of model instances."""
-        clean_instance_ids = []
-        errors_dict: dict[str, list[ValidationError]] = {}
         # Allow to pass empty list for dummy mutation
         if not ids:
             return 0, None
@@ -1098,32 +1089,10 @@ class BaseBulkWithRestrictedChannelAccessMutation(BaseBulkMutation):
         except ValidationError as error:
             return 0, error
 
-        instances_ids = [instance.id for instance in instances]
-        related_objects = cls.get_ids_with_related_objects(instances_ids)
-
         channel_ids = cls.get_channel_ids(instances)
         cls.check_channel_permissions(info, channel_ids)
 
-        for instance, node_id in zip(instances, ids):
-            instance_errors = []
-
-            # catch individual validation errors to raise them later as
-            # a single error
-            try:
-                cls.clean_instance(info, instance, related_objects)
-            except ValidationError as e:
-                msg = ". ".join(e.messages)
-                instance_errors.append(msg)
-
-            if not instance_errors:
-                clean_instance_ids.append(instance.pk)
-            else:
-                instance_errors_msg = ". ".join(instance_errors)
-                # FIXME we are not propagating code error from the raised ValidationError
-                ValidationError({node_id: instance_errors_msg}).update_error_dict(
-                    errors_dict
-                )
-
+        clean_instance_ids, errors_dict = cls.clean_input(info, instances, ids)
         if errors_dict:
             errors = ValidationError(errors_dict)
         else:

--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -1,5 +1,6 @@
 import graphene
 from django.core.exceptions import ValidationError
+from django.db.models import ProtectedError
 
 from ....core.tracing import traced_atomic_transaction
 from ....discount.models import VoucherCode
@@ -53,12 +54,27 @@ class DraftOrderDelete(
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
         order = cls.get_instance(info, **data)
         manager = get_plugin_manager_promise(info.context).get()
-        with traced_atomic_transaction():
-            response = super().perform_mutation(_root, info, **data)
-            call_order_event(
-                manager,
-                WebhookEventAsyncType.DRAFT_ORDER_DELETED,
-                order,
+        try:
+            with traced_atomic_transaction():
+                response = super().perform_mutation(_root, info, **data)
+                call_order_event(
+                    manager,
+                    WebhookEventAsyncType.DRAFT_ORDER_DELETED,
+                    order,
+                )
+        except ProtectedError as e:
+            items = ", ".join(
+                [
+                    item._meta.object_name
+                    for item in e.protected_objects
+                    if item._meta.object_name
+                ]
+            )
+            raise ValidationError(
+                ValidationError(
+                    f"Draft order has attached items: {items}.",
+                    code=OrderErrorCode.CANNOT_DELETE.value,
+                )
             )
         return response
 

--- a/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
@@ -2,12 +2,18 @@ import graphene
 
 from .....order import OrderStatus
 from .....order import models as order_models
+from .....order.error_codes import OrderErrorCode
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 DRAFT_ORDER_BULK_DELETE = """
     mutation draftOrderBulkDelete($ids: [ID!]!) {
         draftOrderBulkDelete(ids: $ids) {
             count
+            errors {
+                field
+                code
+                message
+            }
         }
     }
 """
@@ -99,6 +105,44 @@ def test_delete_draft_orders_by_app(
     assert order_models.Order.objects.filter(
         id__in=[order.id for order in orders]
     ).count() == len(orders)
+
+
+def test_delete_draft_orders_orders_with_transaction_item(
+    staff_api_client,
+    order_list,
+    permission_group_manage_orders,
+    transaction_item_generator,
+):
+    # given
+    for order in order_list:
+        order.status = OrderStatus.DRAFT
+        order.save()
+        transaction_item_generator(order_id=order.pk)
+
+    query = DRAFT_ORDER_BULK_DELETE
+
+    ids = [graphene.Node.to_global_id("Order", order.id) for order in order_list]
+    variables = {"ids": ids}
+
+    # when
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert "errors" in content["data"]["draftOrderBulkDelete"]
+    errors = content["data"]["draftOrderBulkDelete"]["errors"]
+    assert len(errors) == 3
+    for i, order in enumerate(order_list):
+        assert errors[i]["code"] == OrderErrorCode.CANNOT_DELETE.name
+        assert errors[i]["field"] in ids
+        assert (
+            errors[i]["message"] == "Draft orders has attached items: TransactionItem."
+        )
+    assert content["data"]["draftOrderBulkDelete"]["count"] == 0
+    assert order_models.Order.objects.filter(
+        id__in=[order.id for order in order_list]
+    ).count() == len(order_list)
 
 
 MUTATION_DELETE_ORDER_LINES = """

--- a/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
@@ -134,10 +134,11 @@ def test_delete_draft_orders_orders_with_transaction_item(
     errors = content["data"]["draftOrderBulkDelete"]["errors"]
     assert len(errors) == 3
     for i, order in enumerate(order_list):
-        assert errors[i]["code"] == OrderErrorCode.CANNOT_DELETE.name
+        assert errors[i]["code"] == OrderErrorCode.INVALID.name
         assert errors[i]["field"] in ids
         assert (
-            errors[i]["message"] == "Draft orders has attached items: TransactionItem."
+            errors[i]["message"]
+            == "Cannot delete order with payments or transactions attached to it."
         )
     assert content["data"]["draftOrderBulkDelete"]["count"] == 0
     assert order_models.Order.objects.filter(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -21,6 +21,7 @@ DRAFT_ORDER_DELETE_MUTATION = """
             errors {
                 code
                 field
+                message
             }
         }
     }
@@ -69,6 +70,33 @@ def test_draft_order_delete_non_draft_order(
     assert len(account_errors) == 1
     assert account_errors[0]["field"] == "id"
     assert account_errors[0]["code"] == OrderErrorCode.INVALID.name
+
+
+def test_draft_order_delete_draft_with_transactions(
+    staff_api_client, permission_group_manage_orders, draft_order, transaction_item
+):
+    # given
+    order = draft_order
+    query = DRAFT_ORDER_DELETE_MUTATION
+    transaction_item.order_id = order.id
+    transaction_item.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+
+    # when
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    account_errors = content["data"]["draftOrderDelete"]["errors"]
+    assert len(account_errors) == 1
+    assert account_errors[0]["code"] == OrderErrorCode.CANNOT_DELETE.name
+    assert (
+        account_errors[0]["message"]
+        == "Draft order has attached items: TransactionItem."
+    )
 
 
 def test_draft_order_delete_by_user_no_channel_access(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -92,10 +92,10 @@ def test_draft_order_delete_draft_with_transactions(
     content = get_graphql_content(response)
     account_errors = content["data"]["draftOrderDelete"]["errors"]
     assert len(account_errors) == 1
-    assert account_errors[0]["code"] == OrderErrorCode.CANNOT_DELETE.name
+    assert account_errors[0]["code"] == OrderErrorCode.INVALID.name
     assert (
         account_errors[0]["message"]
-        == "Draft order has attached items: TransactionItem."
+        == "Cannot delete order with payments or transactions attached to it."
     )
 
 


### PR DESCRIPTION
Port of #16786

I want to merge this change because currently we return 500 error in case when DraftOrder has protected relation when trying to remove it from Saleor.
Changes contains only error handling and proper resposne in mutations.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
