### PR TITLE
Release 3.20.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.40",
+  "version": "3.20.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.40",
+      "version": "3.20.41",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.40",
+  "version": "3.20.41",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.40"
+version = "3.20.41"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.40"
+__version__ = "3.20.41"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.20.41 (039faca660)
* Add error handling when removing orders with protected related object (#16786) (944efd0252)
* Add deletion of granted refund to clearorders command (#16901) (23a5c8802b)
* Fix failing import-path for promotion schedule (#16932) (5492cc201b)
* Improve performance  when requesting totalCount with in-stock filter (#16934) (4934ff49b6)
* populateDB - align stock.allocated_quantity with value from allocations (#16905) (8d80284572)
* Drop tax data line number validation for Avatax plugin (#16918) (cbba3fca95)
* Add workflow to publish to load test infra (#16920) (5df7da1918)
