### PR TITLE
Do not call automatic checkout completion for checkout with unavailable lines

### DIFF
--- a/saleor/checkout/tasks.py
+++ b/saleor/checkout/tasks.py
@@ -144,8 +144,26 @@ def automatic_checkout_completion_task(
     app = App.objects.filter(pk=app_id).first()
 
     manager = get_plugins_manager(allow_replica=False)
-    lines, _ = fetch_checkout_lines(checkout)
+    lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    if unavailable_variant_pks:
+        checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+        not_available_variants_ids = {
+            graphene.Node.to_global_id("ProductVariant", pk)
+            for pk in unavailable_variant_pks
+        }
+        task_logger.info(
+            "The automatic checkout completion not triggered, as the checkout %s "
+            "contains unavailable variants: %s.",
+            checkout_id,
+            ", ".join(not_available_variants_ids),
+            extra={
+                "checkout_id": checkout_id,
+                "variant_ids": not_available_variants_ids,
+            },
+        )
+        return
 
     task_logger.info(
         "Automatic checkout completion triggered for checkout: %s.",


### PR DESCRIPTION
The automatic checkout completion is called when the checkout is fully paid. The behaviour should be compatible with the `CheckoutComplete` mutation. In the mutation, when the checkout contains some unavailable lines (the product is not published, the channel listing does not exist) the `ValidationError` is raised. 
After the changes, when the checkout contains unavailable lines, the automatic checkout completion is not called, the information will be logged, the problems with the checkout could be fetch with `checkout.problems`.

Port of https://github.com/saleor/saleor/pull/16941

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
