### PR TITLE
 Optimize database calls for webhooks in bulk mutations

### DIFF
--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -13,6 +13,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....core.utils import prepare_unique_slug
 from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
+from ....webhook.utils import get_webhooks_for_event
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
@@ -543,8 +544,9 @@ class AttributeBulkCreate(BaseMutation):
     @classmethod
     def post_save_actions(cls, info: ResolveInfo, attributes: list[models.Attribute]):
         manager = get_plugin_manager_promise(info.context).get()
+        webhooks = get_webhooks_for_event(WebhookEventAsyncType.ATTRIBUTE_CREATED)
         for attribute in attributes:
-            cls.call_event(manager.attribute_created, attribute)
+            cls.call_event(manager.attribute_created, attribute, webhooks=webhooks)
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -7,6 +7,8 @@ from ...attribute import models as attribute_models
 from ...core.tracing import traced_atomic_transaction
 from ...page import models
 from ...permission.enums import PagePermissions, PageTypePermissions
+from ...webhook.event_types import WebhookEventAsyncType
+from ...webhook.utils import get_webhooks_for_event
 from ..core import ResolveInfo
 from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
 from ..core.types import NonNullList, PageError
@@ -112,8 +114,9 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
         page_types = list(queryset)
         queryset.delete()
         manager = get_plugin_manager_promise(info.context).get()
+        webhooks = get_webhooks_for_event(WebhookEventAsyncType.PAGE_TYPE_DELETED)
         for pt in page_types:
-            cls.call_event(manager.page_type_deleted, pt)
+            cls.call_event(manager.page_type_deleted, pt, webhooks=webhooks)
 
     @staticmethod
     def delete_assigned_attribute_values(instance_pks):

--- a/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
@@ -55,7 +55,7 @@ def test_page_type_bulk_delete_by_staff(
     assert not Page.objects.filter(pk__in=pages_pks)
 
 
-@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
+@mock.patch("saleor.graphql.page.bulk_mutations.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_type_bulk_delete_trigger_webhooks(
     mocked_webhook_trigger,

--- a/saleor/graphql/translations/mutations/utils.py
+++ b/saleor/graphql/translations/mutations/utils.py
@@ -434,24 +434,23 @@ class BaseBulkTranslateMutation(BaseMutation):
     def post_save_actions(cls, info, created_translations, updated_translations):
         manager = get_plugin_manager_promise(info.context).get()
 
-        translation_created_webhooks = get_webhooks_for_event(
-            WebhookEventAsyncType.TRANSLATION_CREATED
-        )
-        for translation in created_translations:
-            cls.call_event(
-                manager.translation_created,
-                translation,
-                webhooks=translation_created_webhooks,
-            )
-        translation_updated_webhooks = get_webhooks_for_event(
-            WebhookEventAsyncType.TRANSLATION_UPDATED
-        )
-        for translation in updated_translations:
-            cls.call_event(
-                manager.translation_updated,
-                translation,
-                webhooks=translation_updated_webhooks,
-            )
+        if created_translations:
+            webhooks = get_webhooks_for_event(WebhookEventAsyncType.TRANSLATION_CREATED)
+            for translation in created_translations:
+                cls.call_event(
+                    manager.translation_created,
+                    translation,
+                    webhooks=webhooks,
+                )
+
+        if updated_translations:
+            webhooks = get_webhooks_for_event(WebhookEventAsyncType.TRANSLATION_UPDATED)
+            for translation in updated_translations:
+                cls.call_event(
+                    manager.translation_updated,
+                    translation,
+                    webhooks=webhooks,
+                )
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/graphql/translations/mutations/utils.py
+++ b/saleor/graphql/translations/mutations/utils.py
@@ -14,6 +14,8 @@ from ....menu import models as menu_models
 from ....page import models as page_models
 from ....product import models as product_models
 from ....shipping import models as shipping_models
+from ....webhook.event_types import WebhookEventAsyncType
+from ....webhook.utils import get_webhooks_for_event
 from ...core import ResolveInfo
 from ...core.descriptions import RICH_CONTENT
 from ...core.doc_category import DOC_CATEGORY_MAP
@@ -432,10 +434,24 @@ class BaseBulkTranslateMutation(BaseMutation):
     def post_save_actions(cls, info, created_translations, updated_translations):
         manager = get_plugin_manager_promise(info.context).get()
 
+        translation_created_webhooks = get_webhooks_for_event(
+            WebhookEventAsyncType.TRANSLATION_CREATED
+        )
         for translation in created_translations:
-            cls.call_event(manager.translation_created, translation)
+            cls.call_event(
+                manager.translation_created,
+                translation,
+                webhooks=translation_created_webhooks,
+            )
+        translation_updated_webhooks = get_webhooks_for_event(
+            WebhookEventAsyncType.TRANSLATION_UPDATED
+        )
         for translation in updated_translations:
-            cls.call_event(manager.translation_updated, translation)
+            cls.call_event(
+                manager.translation_updated,
+                translation,
+                webhooks=translation_updated_webhooks,
+            )
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -291,7 +291,7 @@ class BasePlugin:
     #
     # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from the plugin to core modules.
-    attribute_created: Callable[["Attribute", None], None]
+    attribute_created: Callable[["Attribute", None, None], None]
 
     # Trigger when attribute is deleted.
     #
@@ -1136,7 +1136,7 @@ class BasePlugin:
     #
     # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from the plugin to core modules.
-    page_type_deleted: Callable[["PageType", Any], Any]
+    page_type_deleted: Callable[["PageType", Any, None], Any]
 
     # Trigger when page type is updated.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2486,16 +2486,24 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
-    def translation_created(self, translation: "Translation"):
+    def translation_created(self, translation: "Translation", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
-            "translation_created", default_value, translation, channel_slug=None
+            "translation_created",
+            default_value,
+            translation,
+            channel_slug=None,
+            webhooks=webhooks,
         )
 
-    def translation_updated(self, translation: "Translation"):
+    def translation_updated(self, translation: "Translation", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
-            "translation_updated", default_value, translation, channel_slug=None
+            "translation_updated",
+            default_value,
+            translation,
+            channel_slug=None,
+            webhooks=webhooks,
         )
 
     def get_all_plugins(self, active_only=False):

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1431,10 +1431,14 @@ class PluginsManager(PaymentInterface):
 
     # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from plugin to core modules.
-    def page_type_deleted(self, page_type: "PageType"):
+    def page_type_deleted(self, page_type: "PageType", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
-            "page_type_deleted", default_value, page_type, channel_slug=None
+            "page_type_deleted",
+            default_value,
+            page_type,
+            webhooks=webhooks,
+            channel_slug=None,
         )
 
     # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1719,10 +1719,14 @@ class PluginsManager(PaymentInterface):
 
     # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from plugin to core modules.
-    def attribute_created(self, attribute: "Attribute"):
+    def attribute_created(self, attribute: "Attribute", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
-            "attribute_created", default_value, attribute, channel_slug=None
+            "attribute_created",
+            default_value,
+            attribute,
+            webhooks=webhooks,
+            channel_slug=None,
         )
 
     # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2026,8 +2026,8 @@ class WebhookPlugin(BasePlugin):
                 legacy_data_generator=page_data_generator,
             )
 
-    def _trigger_page_type_event(self, event_type, page_type):
-        if webhooks := get_webhooks_for_event(event_type):
+    def _trigger_page_type_event(self, event_type, page_type, webhooks=None):
+        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
             payload = self._serialize_payload(
                 {
                     "id": graphene.Node.to_global_id("PageType", page_type.id),
@@ -2054,11 +2054,13 @@ class WebhookPlugin(BasePlugin):
             WebhookEventAsyncType.PAGE_TYPE_UPDATED, page_type
         )
 
-    def page_type_deleted(self, page_type: "PageType", previous_value: Any) -> Any:
+    def page_type_deleted(
+        self, page_type: "PageType", previous_value: Any, webhooks=None
+    ) -> Any:
         if not self.active:
             return previous_value
         self._trigger_page_type_event(
-            WebhookEventAsyncType.PAGE_TYPE_DELETED, page_type
+            WebhookEventAsyncType.PAGE_TYPE_DELETED, page_type, webhooks=webhooks
         )
 
     def _trigger_permission_group_event(self, event_type, group):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -439,11 +439,13 @@ class WebhookPlugin(BasePlugin):
                 self.requestor,
             )
 
-    def attribute_created(self, attribute: "Attribute", previous_value: None) -> None:
+    def attribute_created(
+        self, attribute: "Attribute", previous_value: None, webhooks=None
+    ) -> None:
         if not self.active:
             return previous_value
         self._trigger_attribute_event(
-            WebhookEventAsyncType.ATTRIBUTE_CREATED, attribute
+            WebhookEventAsyncType.ATTRIBUTE_CREATED, attribute, webhooks=webhooks
         )
 
     def attribute_updated(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2270,11 +2270,16 @@ class WebhookPlugin(BasePlugin):
                 legacy_data_generator=thumbnail_data_generator,
             )
 
-    def translation_created(self, translation: "Translation", previous_value: Any):
+    def translation_created(
+        self,
+        translation: "Translation",
+        previous_value: Any,
+        webhooks=None,
+    ):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_CREATED
-        if webhooks := get_webhooks_for_event(event_type):
+        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
             translation_data_generator = partial(
                 generate_translation_payload, translation, self.requestor
             )
@@ -2287,11 +2292,16 @@ class WebhookPlugin(BasePlugin):
                 legacy_data_generator=translation_data_generator,
             )
 
-    def translation_updated(self, translation: "Translation", previous_value: Any):
+    def translation_updated(
+        self,
+        translation: "Translation",
+        previous_value: Any,
+        webhooks=None,
+    ):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_UPDATED
-        if webhooks := get_webhooks_for_event(event_type):
+        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
             translation_data_generator = partial(
                 generate_translation_payload, translation, self.requestor
             )


### PR DESCRIPTION
Port of: https://github.com/saleor/saleor/pull/16947
I want to merge this change because it adds webhooks calls for call_event where it was still missing.


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
