### PR TITLE
Improve the performance of StockBulkUpdate mutation

### DIFF
--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -159,7 +159,8 @@ class EventPayloadManager(models.Manager["EventPayload"]):
     ) -> list["EventPayload"]:
         created_objs = self.bulk_create(objs)
         for obj, payload_data in zip(created_objs, payloads):
-            obj.save_payload_file(payload_data)
+            obj.save_payload_file(payload_data, save_instance=False)
+        self.bulk_update(created_objs, ["payload_file"])
         return created_objs
 
 
@@ -181,12 +182,14 @@ class EventPayload(models.Model):
                 return payload_data.decode("utf-8")
         return self.payload
 
-    def save_payload_file(self, payload_data: str):
+    def save_payload_file(self, payload_data: str, save_instance=True):
         payload_bytes = payload_data.encode("utf-8")
         prefix = get_random_string(length=12)
         file_name = f"{self.pk}.json"
         file_path = safe_join(prefix, file_name)
-        self.payload_file.save(file_path, ContentFile(payload_bytes))
+        self.payload_file.save(
+            file_path, ContentFile(payload_bytes), save=save_instance
+        )
 
     def save_as_file(self):
         payload_data = self.payload

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
@@ -123,10 +123,10 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
 
             stock.quantity = stock_data["quantity"]
             stocks.append(stock)
-            cls.call_event(
-                manager.product_variant_stock_updated,
-                stock,
-                webhooks=webhooks_stock_update,
-            )
+        cls.call_event(
+            manager.product_variant_stocks_updated,
+            stocks,
+            webhooks=webhooks_stock_update,
+        )
 
         warehouse_models.Stock.objects.bulk_update(stocks, ["quantity"])

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -251,11 +251,11 @@ def test_update_or_create_variant_stocks(variant, warehouses):
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
     back_in_stock_webhook_trigger,
-    stock_updated_webhook_trigger,
+    stocks_updated_webhook_trigger,
     mocked_get_webhooks_for_event,
     variant,
     warehouses,
@@ -284,7 +284,9 @@ def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
         data["quantity"] for data in stocks_data
     }
     back_in_stock_webhook_trigger.assert_called_once_with(stock, webhooks=[any_webhook])
-    stock_updated_webhook_trigger.assert_called_once_with(stock, webhooks=[any_webhook])
+    stocks_updated_webhook_trigger.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
+    )
     assert variant.stocks.all()[0].quantity == 10
 
 
@@ -310,13 +312,13 @@ def test_update_or_create_variant_stocks_empty_stocks_data(variant, warehouses):
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_updated_webhook,
+    product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -345,11 +347,12 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 10
 
+    stock = Stock.objects.all()[1]
     product_variant_back_in_stock_webhook.assert_called_once_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+        stock, webhooks=[any_webhook]
     )
-    product_variant_stock_updated_webhook.assert_called_once_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+    product_variant_stocks_updated_webhook.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
     )
     product_variant_stock_out_of_stock_webhook.assert_not_called()
 
@@ -358,13 +361,13 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_update_webhook,
+    product_variant_stocks_update_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -394,13 +397,14 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 0
 
+    stock = Stock.objects.all()[1]
     product_variant_back_in_stock_webhook.assert_not_called()
     product_variant_stock_out_of_stock_webhook.assert_called_once_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+        stock, webhooks=[any_webhook]
     )
-    assert product_variant_stock_update_webhook.call_count == 1
-    product_variant_stock_update_webhook.assert_called_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+    assert product_variant_stocks_update_webhook.call_count == 1
+    product_variant_stocks_update_webhook.assert_called_with(
+        [stock], webhooks=[any_webhook]
     )
 
 
@@ -408,13 +412,13 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_updated_webhook,
+    product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -446,8 +450,8 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     product_variant_back_in_stock_webhook.assert_called_once_with(
         stock, webhooks=[any_webhook]
     )
-    product_variant_stock_updated_webhook.assert_called_once_with(
-        stock, webhooks=[any_webhook]
+    product_variant_stocks_updated_webhook.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
     )
     product_variant_stock_out_of_stock_webhook.assert_not_called()
 
@@ -456,13 +460,13 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_updated_webhook,
+    product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -494,8 +498,8 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     product_variant_stock_out_of_stock_webhook.assert_called_once_with(
         stock, webhooks=[any_webhook]
     )
-    product_variant_stock_updated_webhook.assert_called_once_with(
-        stock, webhooks=[any_webhook]
+    product_variant_stocks_updated_webhook.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
     )
     product_variant_back_in_stock_webhook.assert_not_called()
 
@@ -504,13 +508,13 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_update_webhook,
+    product_variant_stocks_update_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -543,7 +547,12 @@ def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 2
     assert product_variant_stock_out_of_stock_webhook.call_count == 1
-    assert product_variant_stock_update_webhook.call_count == 2
+
+    assert product_variant_stocks_update_webhook.call_count == 1
+    product_variant_stocks_update_webhook.assert_called_once_with(
+        list(variant.stocks.all()), webhooks=[any_webhook]
+    )
+
     product_variant_back_in_stock_webhook.assert_not_called()
 
 

--- a/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
+++ b/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
@@ -309,9 +309,14 @@ class StockBulkUpdate(BaseMutation):
             filter_stock = selectors_stock_map.get(f"{variant_value}_{warehouse_value}")
 
             if filter_stock:
+                quantity_updated = filter_stock.quantity != cleaned_input["quantity"]
                 filter_stock.quantity = cleaned_input["quantity"]
                 instances_data_and_errors_list.append(
-                    {"instance": filter_stock, "errors": index_error_map[index]}
+                    {
+                        "instance": filter_stock,
+                        "errors": index_error_map[index],
+                        "quantity_updated": quantity_updated,
+                    }
                 )
             else:
                 index_error_map[index].append(
@@ -355,11 +360,13 @@ class StockBulkUpdate(BaseMutation):
         else:
             variant_lookup = Q(product_variant__external_reference__in=variants)
 
-        stocks = models.Stock.objects.filter(
-            warehouse_lookup & variant_lookup
-        ).annotate(
-            variant_external_reference=F("product_variant__external_reference"),
-            warehouse_external_reference=F("warehouse__external_reference"),
+        stocks = (
+            models.Stock.objects.select_for_update()
+            .filter(warehouse_lookup & variant_lookup)
+            .annotate(
+                variant_external_reference=F("product_variant__external_reference"),
+                warehouse_external_reference=F("warehouse__external_reference"),
+            )
         )
 
         selectors_stock_map = {
@@ -373,9 +380,8 @@ class StockBulkUpdate(BaseMutation):
         stocks_to_update = [
             stock_data["instance"]
             for stock_data in instances_data_with_errors_list
-            if stock_data["instance"]
+            if stock_data["instance"] and stock_data.get("quantity_updated")
         ]
-
         models.Stock.objects.bulk_update(stocks_to_update, fields=["quantity"])
 
         return stocks_to_update
@@ -383,12 +389,12 @@ class StockBulkUpdate(BaseMutation):
     @classmethod
     def post_save_actions(cls, info, instances):
         manager = get_plugin_manager_promise(info.context).get()
-        webhooks = get_webhooks_for_event(
-            WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
-        )
-        for instance in instances:
+        if instances:
+            webhooks = get_webhooks_for_event(
+                WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
+            )
             cls.call_event(
-                manager.product_variant_stock_updated, instance, webhooks=webhooks
+                manager.product_variant_stocks_updated, instances, webhooks=webhooks
             )
 
     @classmethod
@@ -399,14 +405,15 @@ class StockBulkUpdate(BaseMutation):
                 for data in instances_data_with_errors_list
             ]
         return [
-            StockBulkResult(stock=data.get("instance"), errors=data.get("errors"))
-            if data.get("instance")
-            else StockBulkResult(stock=None, errors=data.get("errors"))
+            (
+                StockBulkResult(stock=data.get("instance"), errors=data.get("errors"))
+                if data.get("instance")
+                else StockBulkResult(stock=None, errors=data.get("errors"))
+            )
             for data in instances_data_with_errors_list
         ]
 
     @classmethod
-    @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, **data):
         error_policy = data.get("error_policy", ErrorPolicyEnum.REJECT_EVERYTHING.value)
         index_error_map: dict = defaultdict(list)
@@ -414,25 +421,30 @@ class StockBulkUpdate(BaseMutation):
 
         warehouse_selector, variant_selector = cls.get_selectors(cleaned_inputs_map)
 
-        instances_data_with_errors_list = cls.update_stocks(
-            cleaned_inputs_map, warehouse_selector, variant_selector, index_error_map
-        )
+        with traced_atomic_transaction():
+            instances_data_with_errors_list = cls.update_stocks(
+                cleaned_inputs_map,
+                warehouse_selector,
+                variant_selector,
+                index_error_map,
+            )
 
-        if any(bool(error) for error in index_error_map.values()):
-            if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
-                results = cls.get_results(instances_data_with_errors_list, True)
-                return StockBulkUpdate(count=0, results=results)
+            if any(bool(error) for error in index_error_map.values()):
+                if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
+                    results = cls.get_results(instances_data_with_errors_list, True)
+                    return StockBulkUpdate(count=0, results=results)
 
-            if error_policy == ErrorPolicyEnum.REJECT_FAILED_ROWS.value:
-                for data in instances_data_with_errors_list:
-                    if data["errors"] and data["instance"]:
-                        data["instance"] = None
+                if error_policy == ErrorPolicyEnum.REJECT_FAILED_ROWS.value:
+                    for data in instances_data_with_errors_list:
+                        if data["errors"] and data["instance"]:
+                            data["instance"] = None
 
-        updated_stocks = cls.save_stocks(instances_data_with_errors_list)
+            updated_stocks = cls.save_stocks(instances_data_with_errors_list)
+            cls.post_save_actions(info, updated_stocks)
 
         # prepare and return data
         results = cls.get_results(instances_data_with_errors_list)
-
-        cls.post_save_actions(info, updated_stocks)
-
-        return StockBulkUpdate(count=len(updated_stocks), results=results)
+        count = len(
+            list(filter(lambda item: item["instance"], instances_data_with_errors_list))
+        )
+        return StockBulkUpdate(count=count, results=results)

--- a/saleor/graphql/warehouse/tests/benchmark/test_stock_bulk_update.py
+++ b/saleor/graphql/warehouse/tests/benchmark/test_stock_bulk_update.py
@@ -116,6 +116,7 @@ def test_stocks_bulk_update_queries_count(
 
         content = get_graphql_content(response)
         data = content["data"]["stockBulkUpdate"]
+
         assert data["count"] == 4
         webhook_queries_count = sum(
             [

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -1353,7 +1353,7 @@ class BasePlugin:
     #
     # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from the plugin to core modules.
-    product_variant_stock_updated: Callable[["Stock", None, None], Any]
+    product_variant_stocks_updated: Callable[[list["Stock"], None, None], Any]
 
     # Trigger when a product export is completed.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -908,12 +908,12 @@ class PluginsManager(PaymentInterface):
 
     # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from plugin to core modules.
-    def product_variant_stock_updated(self, stock: "Stock", webhooks=None):
+    def product_variant_stocks_updated(self, stocks: list["Stock"], webhooks=None):
         default_value = None
         self.__run_method_on_plugins(
-            "product_variant_stock_updated",
+            "product_variant_stocks_updated",
             default_value,
-            stock,
+            stocks,
             webhooks=webhooks,
             channel_slug=None,
         )

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -82,8 +82,10 @@ from ...webhook.payloads import (
     generate_translation_payload,
 )
 from ...webhook.transport.asynchronous.transport import (
+    WebhookPayloadData,
     send_webhook_request_async,
     trigger_webhooks_async,
+    trigger_webhooks_async_for_multiple_objects,
 )
 from ...webhook.transport.list_stored_payment_methods import (
     get_list_stored_payment_methods_data_dict,
@@ -1996,23 +1998,30 @@ class WebhookPlugin(BasePlugin):
             )
         return previous_value
 
-    def product_variant_stock_updated(
-        self, stock: "Stock", previous_value: None, webhooks=None
+    def product_variant_stocks_updated(
+        self, stocks: list["Stock"], previous_value: None, webhooks=None
     ) -> None:
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data_generator = partial(
-                generate_product_variant_with_stock_payload, [stock], self.requestor
-            )
-            self.trigger_webhooks_async(
-                None,
+            webhook_payload_details = []
+            for stock in stocks:
+                product_variant_data_generator = partial(
+                    generate_product_variant_with_stock_payload, [stock], self.requestor
+                )
+                webhook_payload_details.append(
+                    WebhookPayloadData(
+                        subscribable_object=stock,
+                        legacy_data_generator=product_variant_data_generator,
+                        data=None,
+                    )
+                )
+            trigger_webhooks_async_for_multiple_objects(
                 event_type,
                 webhooks,
-                stock,
-                self.requestor,
-                legacy_data_generator=product_variant_data_generator,
+                webhook_payloads_data=webhook_payload_details,
+                requestor=self.requestor,
             )
         return previous_value
 

--- a/saleor/webhook/transport/asynchronous/tests/test_create_deliveries_for_subscriptions.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_create_deliveries_for_subscriptions.py
@@ -1,12 +1,17 @@
 import json
 from unittest import mock
 
+import graphene
 from django.test import override_settings
 
 from .....graphql.webhook.subscription_payload import generate_payload_from_subscription
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.models import Webhook
-from ..transport import create_deliveries_for_subscriptions, get_pre_save_payload_key
+from ..transport import (
+    create_deliveries_for_multiple_subscription_objects,
+    create_deliveries_for_subscriptions,
+    get_pre_save_payload_key,
+)
 
 SUBSCRIPTION_QUERY = """
     subscription {
@@ -154,3 +159,54 @@ def test_create_deliveries_reuse_request_for_webhooks(
     request_2 = mock_generate_payload_from_subscription.call_args_list[1][1]["request"]
     assert request_1 is request_2
     assert request_1.dataloaders is request_2.dataloaders
+
+
+def test_create_deliveries_for_multiple_subscription_objects(
+    subscription_product_updated_webhook, product_list
+):
+    # given
+    webhooks = [subscription_product_updated_webhook]
+    event_type = WebhookEventAsyncType.PRODUCT_UPDATED
+
+    # when
+    deliveries = create_deliveries_for_multiple_subscription_objects(
+        event_type, product_list, webhooks
+    )
+
+    # then
+    assert len(deliveries) == len(product_list)
+    for index, delivery in enumerate(deliveries):
+        assert delivery.webhook == subscription_product_updated_webhook
+        assert delivery.event_type == event_type
+        assert json.loads(delivery.payload.get_payload()) == {
+            "product": {
+                "id": graphene.Node.to_global_id("Product", product_list[index].pk)
+            }
+        }
+
+
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.MAX_WEBHOOK_EVENTS_IN_DB_BULK", 2
+)
+def test_create_deliveries_for_multiple_subscription_objects_when_more_objs_than_bulk(
+    subscription_product_updated_webhook, product_list
+):
+    # given
+    webhooks = [subscription_product_updated_webhook]
+    event_type = WebhookEventAsyncType.PRODUCT_UPDATED
+
+    # when
+    deliveries = create_deliveries_for_multiple_subscription_objects(
+        event_type, product_list, webhooks
+    )
+
+    # then
+    assert len(deliveries) == len(product_list)
+    for index, delivery in enumerate(deliveries):
+        assert delivery.webhook == subscription_product_updated_webhook
+        assert delivery.event_type == event_type
+        assert json.loads(delivery.payload.get_payload()) == {
+            "product": {
+                "id": graphene.Node.to_global_id("Product", product_list[index].pk)
+            }
+        }


### PR DESCRIPTION
I want to merge this change because it improves the time execution &db queries for `StockBulkMutation`
## Changes:
- Do not send `product_variant_stock_updated` event for input stocks, when the `input_stock.quantity == db_stock.quantity`. We didn't change anything in the stock here, so no need to trigger the webhook event
- Add `select_for_update` when updating the stocks when processing bulk mutation.
- ❗❗ ❗   Change the definition of `PluginsManager.product_variant_stock_updated`, `WebhookPlugin. product_variant_stock_updated`, `BasePlugin.product_variant_stock_updated` to `product_variant_stocks_updated`. 
The method accepts a list of updated stocks instead of a single stock. 
- Provide a way to generate the subscription_payload for multiple subscribable objects. Use bulk_create with batch to reduce the number of DB queries, for my case reduction from 3810 DB queries to +/- 600
- When saving the payload data as a file, make bulk_update instead of `save()` for each object. DB queries reduction from +/- 600 to 156.

## Results (setup: updating 570 Stocks, active single webhook with `__typename` in subscription body):

### current main:
```
DB Queries: 3810 in 2.369000s
Response took 4.814884s 
```

### this PR - all stocks with new quantity value:
```
DB Queries: 156 in 0.417000s
Response took 1.884247s
```
### this PR - where 50% of stock inputs provide the same `quantity` as already present in DB:

```
DB Queries: 135 in 0.314000s
Response took 1.412252s
```

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
