### PR TITLE
Fix root type for product variant webhook trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Webhooks
 
+- Fixed webhookTrigger payload type for events related to ProductVariant - #16956 by @delemeator
+
 ### Other changes
 
 - Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -941,7 +941,7 @@ class ProductVariantBase(AbstractType):
 
 class ProductVariantCreated(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when new product variant is created."
@@ -949,7 +949,7 @@ class ProductVariantCreated(SubscriptionObjectType, ProductVariantBase):
 
 class ProductVariantUpdated(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when product variant is updated."
@@ -957,7 +957,7 @@ class ProductVariantUpdated(SubscriptionObjectType, ProductVariantBase):
 
 class ProductVariantDeleted(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when product variant is deleted."
@@ -965,7 +965,7 @@ class ProductVariantDeleted(SubscriptionObjectType, ProductVariantBase):
 
 class ProductVariantMetadataUpdated(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when product variant metadata is updated."

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1363,6 +1363,7 @@ def async_subscription_webhooks_with_root_objects(
     page_type = page.page_type
     transaction_item_created_by_app.use_old_id = True
     transaction_item_created_by_app.save()
+    variant = product.variants.first()
     voucher_code = voucher.codes.first()
 
     return {
@@ -1495,11 +1496,11 @@ def async_subscription_webhooks_with_root_objects(
         ],
         events.PRODUCT_VARIANT_CREATED: [
             subscription_product_variant_created_webhook,
-            product,
+            variant,
         ],
         events.PRODUCT_VARIANT_UPDATED: [
             subscription_product_variant_updated_webhook,
-            product,
+            variant,
         ],
         events.PRODUCT_VARIANT_OUT_OF_STOCK: [
             subscription_product_variant_out_of_stock_webhook,
@@ -1511,11 +1512,11 @@ def async_subscription_webhooks_with_root_objects(
         ],
         events.PRODUCT_VARIANT_DELETED: [
             subscription_product_variant_deleted_webhook,
-            product,
+            variant,
         ],
         events.PRODUCT_VARIANT_METADATA_UPDATED: [
             subscription_product_variant_metadata_updated_webhook,
-            product,
+            variant,
         ],
         events.SALE_CREATED: [
             subscription_sale_created_webhook,


### PR DESCRIPTION
I want to merge this change because it fixes webhookTrigger mutation for events related to ProductVariant (https://github.com/saleor/saleor/discussions/16955)

All tests pass after the change and triggering ProductVariant webhooks works correctly on my instance
