### PR TITLE
Improve the performance of StockBulkUpdate mutation

### DIFF
--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -160,7 +160,8 @@ class EventPayloadManager(models.Manager["EventPayload"]):
     ) -> list["EventPayload"]:
         created_objs = self.bulk_create(objs)
         for obj, payload_data in zip(created_objs, payloads):
-            obj.save_payload_file(payload_data)
+            obj.save_payload_file(payload_data, save_instance=False)
+        self.bulk_update(created_objs, ["payload_file"])
         return created_objs
 
 
@@ -182,12 +183,14 @@ class EventPayload(models.Model):
                 return payload_data.decode("utf-8")
         return self.payload
 
-    def save_payload_file(self, payload_data: str):
+    def save_payload_file(self, payload_data: str, save_instance=True):
         payload_bytes = payload_data.encode("utf-8")
         prefix = get_random_string(length=12)
         file_name = f"{self.pk}.json"
         file_path = safe_join(prefix, file_name)
-        self.payload_file.save(file_path, ContentFile(payload_bytes))
+        self.payload_file.save(
+            file_path, ContentFile(payload_bytes), save=save_instance
+        )
 
     def save_as_file(self):
         payload_data = self.payload

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
@@ -123,10 +123,10 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
 
             stock.quantity = stock_data["quantity"]
             stocks.append(stock)
-            cls.call_event(
-                manager.product_variant_stock_updated,
-                stock,
-                webhooks=webhooks_stock_update,
-            )
+        cls.call_event(
+            manager.product_variant_stocks_updated,
+            stocks,
+            webhooks=webhooks_stock_update,
+        )
 
         warehouse_models.Stock.objects.bulk_update(stocks, ["quantity"])

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -252,11 +252,11 @@ def test_update_or_create_variant_stocks(variant, warehouses):
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
     back_in_stock_webhook_trigger,
-    stock_updated_webhook_trigger,
+    stocks_updated_webhook_trigger,
     mocked_get_webhooks_for_event,
     variant,
     warehouses,
@@ -284,7 +284,9 @@ def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
         data["quantity"] for data in stocks_data
     }
     back_in_stock_webhook_trigger.assert_called_once_with(stock, webhooks=[any_webhook])
-    stock_updated_webhook_trigger.assert_called_once_with(stock, webhooks=[any_webhook])
+    stocks_updated_webhook_trigger.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
+    )
     assert variant.stocks.all()[0].quantity == 10
 
 
@@ -310,13 +312,13 @@ def test_update_or_create_variant_stocks_empty_stocks_data(variant, warehouses):
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_updated_webhook,
+    product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -344,11 +346,12 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 10
 
     flush_post_commit_hooks()
+    stock = Stock.objects.all()[1]
     product_variant_back_in_stock_webhook.assert_called_once_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+        stock, webhooks=[any_webhook]
     )
-    product_variant_stock_updated_webhook.assert_called_once_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+    product_variant_stocks_updated_webhook.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
     )
     product_variant_stock_out_of_stock_webhook.assert_not_called()
 
@@ -357,13 +360,13 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_update_webhook,
+    product_variant_stocks_update_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -392,13 +395,14 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 0
 
     flush_post_commit_hooks()
+    stock = Stock.objects.all()[1]
     product_variant_back_in_stock_webhook.assert_not_called()
     product_variant_stock_out_of_stock_webhook.assert_called_once_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+        stock, webhooks=[any_webhook]
     )
-    assert product_variant_stock_update_webhook.call_count == 1
-    product_variant_stock_update_webhook.assert_called_with(
-        Stock.objects.all()[1], webhooks=[any_webhook]
+    assert product_variant_stocks_update_webhook.call_count == 1
+    product_variant_stocks_update_webhook.assert_called_with(
+        [stock], webhooks=[any_webhook]
     )
 
 
@@ -406,13 +410,13 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_updated_webhook,
+    product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -443,8 +447,8 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     product_variant_back_in_stock_webhook.assert_called_once_with(
         stock, webhooks=[any_webhook]
     )
-    product_variant_stock_updated_webhook.assert_called_once_with(
-        stock, webhooks=[any_webhook]
+    product_variant_stocks_updated_webhook.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
     )
     product_variant_stock_out_of_stock_webhook.assert_not_called()
 
@@ -453,13 +457,13 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_updated_webhook,
+    product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -490,8 +494,8 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     product_variant_stock_out_of_stock_webhook.assert_called_once_with(
         stock, webhooks=[any_webhook]
     )
-    product_variant_stock_updated_webhook.assert_called_once_with(
-        stock, webhooks=[any_webhook]
+    product_variant_stocks_updated_webhook.assert_called_once_with(
+        [stock], webhooks=[any_webhook]
     )
     product_variant_back_in_stock_webhook.assert_not_called()
 
@@ -500,13 +504,13 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     "saleor.graphql.product.bulk_mutations."
     "product_variant_stocks_update.get_webhooks_for_event"
 )
-@patch("saleor.plugins.manager.PluginsManager.product_variant_stock_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_stocks_updated")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
 def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
     product_variant_stock_out_of_stock_webhook,
     product_variant_back_in_stock_webhook,
-    product_variant_stock_update_webhook,
+    product_variant_stocks_update_webhook,
     mocked_get_webhooks_for_event,
     settings,
     variant,
@@ -538,7 +542,12 @@ def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 2
     assert product_variant_stock_out_of_stock_webhook.call_count == 1
-    assert product_variant_stock_update_webhook.call_count == 2
+
+    assert product_variant_stocks_update_webhook.call_count == 1
+    product_variant_stocks_update_webhook.assert_called_once_with(
+        list(variant.stocks.all()), webhooks=[any_webhook]
+    )
+
     product_variant_back_in_stock_webhook.assert_not_called()
 
 

--- a/saleor/graphql/warehouse/tests/benchmark/test_stock_bulk_update.py
+++ b/saleor/graphql/warehouse/tests/benchmark/test_stock_bulk_update.py
@@ -115,6 +115,7 @@ def test_stocks_bulk_update_queries_count(
 
         content = get_graphql_content(response)
         data = content["data"]["stockBulkUpdate"]
+
         assert data["count"] == 4
         webhook_queries_count = sum(
             [

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -1358,7 +1358,7 @@ class BasePlugin:
     #
     # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from the plugin to core modules.
-    product_variant_stock_updated: Callable[["Stock", None, None], Any]
+    product_variant_stocks_updated: Callable[[list["Stock"], None, None], Any]
 
     # Trigger when a product export is completed.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -912,12 +912,12 @@ class PluginsManager(PaymentInterface):
 
     # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from plugin to core modules.
-    def product_variant_stock_updated(self, stock: "Stock", webhooks=None):
+    def product_variant_stocks_updated(self, stocks: list["Stock"], webhooks=None):
         default_value = None
         self.__run_method_on_plugins(
-            "product_variant_stock_updated",
+            "product_variant_stocks_updated",
             default_value,
-            stock,
+            stocks,
             webhooks=webhooks,
             channel_slug=None,
         )

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -255,6 +255,9 @@ class PluginSample(BasePlugin):
     def promotion_ended(self, promotion: "Promotion", previous_value: Any):
         return None
 
+    def product_variant_stock_updated(self, stock, previous_value: Any):
+        return None
+
     def get_checkout_line_tax_rate(
         self,
         checkout_info: "CheckoutInfo",

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -48,6 +48,7 @@ from ..tests.sample_plugins import (
     PluginSample,
     sample_tax_data,
 )
+from ..webhook.plugin import WebhookPlugin
 
 
 def test_get_plugins_manager(settings):
@@ -644,6 +645,28 @@ def test_manager_sale_toggle(promotion_converted_from_sale):
 
     assert promotion == promotion_returned
     assert current_catalogue == current_catalogue_returned
+
+
+@patch.object(PluginSample, "product_variant_stock_updated")
+@patch.object(WebhookPlugin, "product_variant_stocks_updated")
+def test_manager_with_fallback_to_previous_method_name(
+    mocked_stocks_updated, mocked_stock_updated, stock
+):
+    # given
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.webhook.plugin.WebhookPlugin",
+    ]
+
+    # when
+    PluginsManager(plugins=plugins).product_variant_stocks_updated([stock])
+    # then
+    mocked_stocks_updated.assert_called_once_with(
+        [stock], previous_value=None, webhooks=None
+    )
+    mocked_stock_updated.assert_called_once_with(
+        stock, previous_value=None, webhooks=None
+    )
 
 
 def test_manager_get_plugin_configuration(plugin_configuration):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -82,8 +82,10 @@ from ...webhook.payloads import (
     generate_translation_payload,
 )
 from ...webhook.transport.asynchronous.transport import (
+    WebhookPayloadData,
     send_webhook_request_async,
     trigger_webhooks_async,
+    trigger_webhooks_async_for_multiple_objects,
 )
 from ...webhook.transport.list_stored_payment_methods import (
     get_list_stored_payment_methods_data_dict,
@@ -1872,23 +1874,30 @@ class WebhookPlugin(BasePlugin):
                 legacy_data_generator=product_variant_data_generator,
             )
 
-    def product_variant_stock_updated(
-        self, stock: "Stock", previous_value: Any, webhooks=None
+    def product_variant_stocks_updated(
+        self, stocks: list["Stock"], previous_value: Any, webhooks=None
     ) -> Any:
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data_generator = partial(
-                generate_product_variant_with_stock_payload, [stock], self.requestor
-            )
-            self.trigger_webhooks_async(
-                None,
+            webhook_payload_details = []
+            for stock in stocks:
+                product_variant_data_generator = partial(
+                    generate_product_variant_with_stock_payload, [stock], self.requestor
+                )
+                webhook_payload_details.append(
+                    WebhookPayloadData(
+                        subscribable_object=stock,
+                        legacy_data_generator=product_variant_data_generator,
+                        data=None,
+                    )
+                )
+            trigger_webhooks_async_for_multiple_objects(
                 event_type,
                 webhooks,
-                stock,
-                self.requestor,
-                legacy_data_generator=product_variant_data_generator,
+                webhook_payloads_data=webhook_payload_details,
+                requestor=self.requestor,
             )
 
     def checkout_created(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -13,7 +13,11 @@ from .....graphql.product.tests.mutations.test_product_create import (
 )
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.models import Webhook
-from .....webhook.transport.asynchronous.transport import trigger_webhooks_async
+from .....webhook.transport.asynchronous.transport import (
+    WebhookPayloadData,
+    trigger_webhooks_async,
+    trigger_webhooks_async_for_multiple_objects,
+)
 from .....webhook.transport.synchronous.transport import trigger_webhook_sync
 from .payloads import generate_payment_payload
 
@@ -73,6 +77,68 @@ def test_trigger_webhooks_async_no_subscription_webhooks(
     data = '{"regular_webhook": "data"}'
     trigger_webhooks_async(data, webhook_type, webhooks, order, allow_replica=False)
     mocked_create_deliveries_for_subscriptions.assert_not_called()
+
+
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.MAX_WEBHOOK_EVENTS_IN_DB_BULK", 2
+)
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+def test_trigger_webhooks_async_for_multiple_objects(
+    mocked_send_webhook_request,
+    webhook,
+    subscription_order_created_webhook,
+    order_with_lines,
+    order_unconfirmed,
+):
+    # given
+    webhook_type = WebhookEventAsyncType.ORDER_CREATED
+    webhooks, payload = Webhook.objects.all(), '{"example": "payload"}'
+
+    # when
+    trigger_webhooks_async_for_multiple_objects(
+        webhook_type,
+        webhooks,
+        webhook_payloads_data=[
+            WebhookPayloadData(
+                data=payload,
+                subscribable_object=order_with_lines,
+            ),
+            WebhookPayloadData(
+                data=payload,
+                subscribable_object=order_unconfirmed,
+            ),
+        ],
+    )
+
+    # then
+    order_ids = [
+        graphene.Node.to_global_id("Order", order_unconfirmed.pk),
+        graphene.Node.to_global_id("Order", order_with_lines.pk),
+    ]
+    deliveries = EventDelivery.objects.all()
+    assert deliveries.count() == 4
+    simple_webhook_deliveries = deliveries.filter(webhook=webhook)
+    assert simple_webhook_deliveries.count() == 2
+    for delivery in simple_webhook_deliveries:
+        assert delivery.payload.get_payload() == payload
+    subscription_webhook = deliveries.filter(webhook=subscription_order_created_webhook)
+    for delivery in subscription_webhook:
+        generated_payload = delivery.payload.get_payload()
+        assert any(order_id in generated_payload for order_id in order_ids)
+
+    for delivery in deliveries:
+        assert (
+            mock.call(
+                kwargs={"event_delivery_id": delivery.id},
+                queue=None,
+                bind=True,
+                retry_backoff=10,
+                retry_kwargs={"max_retries": 5},
+            )
+            in mocked_send_webhook_request.mock_calls
+        )
 
 
 @mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -49,6 +49,7 @@ from ....webhook.payloads import (
 )
 from ....webhook.transport import signature_for_payload
 from ....webhook.transport.asynchronous.transport import (
+    WebhookPayloadData,
     send_webhook_request_async,
     trigger_webhooks_async,
 )
@@ -926,32 +927,41 @@ def test_product_variant_back_in_stock(
 
 @freeze_time("2014-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
-@mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_product_variant_stock_updated(
-    mocked_webhook_trigger,
+@mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async_for_multiple_objects")
+def test_product_variant_stocks_updated(
+    mocked_webhook_trigger_for_multiple_objects,
     mocked_get_webhooks_for_event,
     any_webhook,
     settings,
     variant_with_many_stocks,
 ):
-    variant = variant_with_many_stocks.stocks.first()
+    stock = variant_with_many_stocks.stocks.first()
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager(allow_replica=False)
-    manager.product_variant_stock_updated(variant)
+    manager.product_variant_stocks_updated([stock])
 
-    mocked_webhook_trigger.assert_called_once_with(
-        None,
+    mocked_webhook_trigger_for_multiple_objects.assert_called_once_with(
         WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED,
         [any_webhook],
-        variant,
-        None,
-        legacy_data_generator=ANY,
-        allow_replica=False,
+        webhook_payloads_data=[
+            WebhookPayloadData(
+                subscribable_object=stock, legacy_data_generator=ANY, data=None
+            )
+        ],
+        requestor=None,
     )
-    assert callable(mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"])
+
+    assert callable(
+        mocked_webhook_trigger_for_multiple_objects.call_args.kwargs[
+            "webhook_payloads_data"
+        ][0].legacy_data_generator
+    )
     assert isinstance(
-        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+        mocked_webhook_trigger_for_multiple_objects.call_args.kwargs[
+            "webhook_payloads_data"
+        ][0].legacy_data_generator,
+        partial,
     )
 
 

--- a/saleor/webhook/transport/asynchronous/tests/test_create_deliveries_for_subscriptions.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_create_deliveries_for_subscriptions.py
@@ -1,12 +1,17 @@
 import json
 from unittest import mock
 
+import graphene
 from django.test import override_settings
 
 from .....graphql.webhook.subscription_payload import generate_payload_from_subscription
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.models import Webhook
-from ..transport import create_deliveries_for_subscriptions, get_pre_save_payload_key
+from ..transport import (
+    create_deliveries_for_multiple_subscription_objects,
+    create_deliveries_for_subscriptions,
+    get_pre_save_payload_key,
+)
 
 SUBSCRIPTION_QUERY = """
     subscription {
@@ -154,3 +159,54 @@ def test_create_deliveries_reuse_request_for_webhooks(
     request_2 = mock_generate_payload_from_subscription.call_args_list[1][1]["request"]
     assert request_1 is request_2
     assert request_1.dataloaders is request_2.dataloaders
+
+
+def test_create_deliveries_for_multiple_subscription_objects(
+    subscription_product_updated_webhook, product_list
+):
+    # given
+    webhooks = [subscription_product_updated_webhook]
+    event_type = WebhookEventAsyncType.PRODUCT_UPDATED
+
+    # when
+    deliveries = create_deliveries_for_multiple_subscription_objects(
+        event_type, product_list, webhooks
+    )
+
+    # then
+    assert len(deliveries) == len(product_list)
+    for index, delivery in enumerate(deliveries):
+        assert delivery.webhook == subscription_product_updated_webhook
+        assert delivery.event_type == event_type
+        assert json.loads(delivery.payload.get_payload()) == {
+            "product": {
+                "id": graphene.Node.to_global_id("Product", product_list[index].pk)
+            }
+        }
+
+
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.MAX_WEBHOOK_EVENTS_IN_DB_BULK", 2
+)
+def test_create_deliveries_for_multiple_subscription_objects_when_more_objs_than_bulk(
+    subscription_product_updated_webhook, product_list
+):
+    # given
+    webhooks = [subscription_product_updated_webhook]
+    event_type = WebhookEventAsyncType.PRODUCT_UPDATED
+
+    # when
+    deliveries = create_deliveries_for_multiple_subscription_objects(
+        event_type, product_list, webhooks
+    )
+
+    # then
+    assert len(deliveries) == len(product_list)
+    for index, delivery in enumerate(deliveries):
+        assert delivery.webhook == subscription_product_updated_webhook
+        assert delivery.event_type == event_type
+        assert json.loads(delivery.payload.get_payload()) == {
+            "product": {
+                "id": graphene.Node.to_global_id("Product", product_list[index].pk)
+            }
+        }


### PR DESCRIPTION
I want to merge this change because it improves the time execution &db queries for `StockBulkMutation`

Port of changes from: #16952

## Changes:
- Do not send `product_variant_stock_updated` event for input stocks, when the `input_stock.quantity == db_stock.quantity`. We didn't change anything in the stock here, so no need to trigger the webhook event
- Add `select_for_update` when updating the stocks when processing bulk mutation.
- ❗❗ ❗   Change the definition of `PluginsManager.product_variant_stock_updated`, `WebhookPlugin. product_variant_stock_updated`, `BasePlugin.product_variant_stock_updated` to `product_variant_stocks_updated`. 
The method accepts a list of updated stocks instead of a single stock.  (In case of custom plugin, the fallback logic will call the previous method: `product_variant_stock_updated`).
- Provide a way to generate the subscription_payload for multiple subscribable objects. Use bulk_create with batch to reduce the number of DB queries, for my case reduction from 3810 DB queries to +/- 600
- When saving the payload data as a file, make bulk_update instead of `save()` for each object. DB queries reduction from +/- 600 to 156.

## Results (setup: updating 570 Stocks, active single webhook with `__typename` in subscription body):

### current main:
```
DB Queries: 3810 in 2.369000s
Response took 4.814884s 
```

### this PR - all stocks with new quantity value:
```
DB Queries: 156 in 0.417000s
Response took 1.884247s
```
### this PR - where 50% of stock inputs provide the same `quantity` as already present in DB:

```
DB Queries: 135 in 0.314000s
Response took 1.412252s
```

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
