### PR TITLE
Fix variant webhooks root object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed support for the django-debug-toolbar debugging tool and the `ENABLE_DEBUG_TOOLBAR` env variable - #16902 by @patrys
 - Fixed playground not displaying docs if api is hidden behind reverse proxy - #16810 by @jqob
 - Drop tax data line number validation for Avatax plugin - #16917 by @zedzior
+- Fix variant webhooks root object - #16964 by @zedzior

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -941,7 +941,7 @@ class ProductVariantBase(AbstractType):
 
 class ProductVariantCreated(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when new product variant is created."
@@ -949,7 +949,7 @@ class ProductVariantCreated(SubscriptionObjectType, ProductVariantBase):
 
 class ProductVariantUpdated(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when product variant is updated."
@@ -957,7 +957,7 @@ class ProductVariantUpdated(SubscriptionObjectType, ProductVariantBase):
 
 class ProductVariantDeleted(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when product variant is deleted."
@@ -965,7 +965,7 @@ class ProductVariantDeleted(SubscriptionObjectType, ProductVariantBase):
 
 class ProductVariantMetadataUpdated(SubscriptionObjectType, ProductVariantBase):
     class Meta:
-        root_type = "Product"
+        root_type = "ProductVariant"
         enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when product variant metadata is updated."

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1336,6 +1336,7 @@ def async_subscription_webhooks_with_root_objects(
     menu_item,
     shipping_method,
     product,
+    variant,
     fulfilled_order,
     fulfillment,
     stock,
@@ -1495,11 +1496,11 @@ def async_subscription_webhooks_with_root_objects(
         ],
         events.PRODUCT_VARIANT_CREATED: [
             subscription_product_variant_created_webhook,
-            product,
+            variant,
         ],
         events.PRODUCT_VARIANT_UPDATED: [
             subscription_product_variant_updated_webhook,
-            product,
+            variant,
         ],
         events.PRODUCT_VARIANT_OUT_OF_STOCK: [
             subscription_product_variant_out_of_stock_webhook,
@@ -1511,11 +1512,11 @@ def async_subscription_webhooks_with_root_objects(
         ],
         events.PRODUCT_VARIANT_DELETED: [
             subscription_product_variant_deleted_webhook,
-            product,
+            variant,
         ],
         events.PRODUCT_VARIANT_METADATA_UPDATED: [
             subscription_product_variant_metadata_updated_webhook,
-            product,
+            variant,
         ],
         events.SALE_CREATED: [
             subscription_sale_created_webhook,


### PR DESCRIPTION
I want to merge this change because it replaces the wrong `Product` with the proper `ProductVariant` root object for variant-related webhooks.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
