### PR TITLE
Fix ProductVariantUpdate not to perform save when not necessary

### DIFF
--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -2,14 +2,17 @@ from collections import defaultdict
 
 import graphene
 from django.core.exceptions import ValidationError
+from django.forms.models import model_to_dict
 from django.utils.text import slugify
 
 from .....attribute import AttributeInputType
 from .....attribute import models as attribute_models
+from .....core.tracing import traced_atomic_transaction
 from .....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
 from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.models import ProductChannelListing
+from .....product.utils.variants import generate_and_set_variant_name
 from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_38, ADDED_IN_310
@@ -17,6 +20,7 @@ from ....core.mutations import ModelWithExtRefMutation
 from ....core.types import ProductError
 from ....core.utils import ext_ref_to_global_id_or_error
 from ....core.validators import validate_one_of_args_is_in_mutation
+from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import ProductVariant
 from ...utils import get_used_attribute_values_for_variant
 from .product_variant_create import ProductVariantCreate, ProductVariantInput
@@ -143,6 +147,40 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
 
     @classmethod
+    def _save(cls, info: ResolveInfo, instance, cleaned_input, base_fields_changed):
+        new_variant = instance.pk is None
+        cls.set_track_inventory(info, instance, cleaned_input)
+        variant_modified = False
+        with traced_atomic_transaction():
+            if base_fields_changed:
+                instance.save()
+                variant_modified = True
+            if not instance.product.default_variant:
+                instance.product.default_variant = instance
+                instance.product.save(update_fields=["default_variant", "updated_at"])
+            if stocks := cleaned_input.get("stocks"):
+                cls.create_variant_stocks(instance, stocks)
+                variant_modified = True
+            if attributes := cleaned_input.get("attributes"):
+                AttributeAssignmentMixin.save(instance, attributes)
+                variant_modified = True
+
+            if not instance.name:
+                generate_and_set_variant_name(instance, cleaned_input.get("sku"))
+                variant_modified = True
+
+            if variant_modified:
+                manager = get_plugin_manager_promise(info.context).get()
+                instance.product.search_index_dirty = True
+                instance.product.save(update_fields=["search_index_dirty"])
+                event_to_call = (
+                    manager.product_variant_created
+                    if new_variant
+                    else manager.product_variant_updated
+                )
+                cls.call_event(event_to_call, instance)
+
+    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls,
         root,
@@ -162,11 +200,28 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
             "external_reference",
             external_reference,
         )
-        return super().perform_mutation(
-            root,
-            info,
-            external_reference=external_reference,
-            id=id,
-            sku=sku,
-            input=input,
+        instance = cls.get_instance(
+            info, id=id, sku=sku, external_reference=external_reference, input=input
         )
+        old_instance_data = model_to_dict(instance).copy()
+
+        cleaned_input = cls.clean_input(info, instance, input)
+        metadata_list = cleaned_input.pop("metadata", None)
+        private_metadata_list = cleaned_input.pop("private_metadata", None)
+        instance = cls.construct_instance(instance, cleaned_input)
+
+        cls.validate_and_update_metadata(instance, metadata_list, private_metadata_list)
+        cls.clean_instance(info, instance)
+
+        base_fields_changed = old_instance_data != model_to_dict(instance)
+        cls._save(info, instance, cleaned_input, base_fields_changed)
+        cls._save_m2m(info, instance, cleaned_input)
+        # add to cleaned_input popped metadata to allow running post save events
+        # that depends on the metadata inputs
+        if metadata_list:
+            cleaned_input["metadata"] = metadata_list
+        if private_metadata_list:
+            cleaned_input["private_metadata"] = private_metadata_list
+
+        cls.post_save_action(info, instance, cleaned_input)
+        return cls.success_response(instance)


### PR DESCRIPTION
I want to merge this change because it skips saving of product variant on ProductVariantUpdate mutation when it's not necessary changes for now ignores case when there are attributes since it's bit more complicated, will be posted as separate pr along with update_fields.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
