### PR TITLE
Change error to warning when logging invalid data provided by customer in the payment integration

### DIFF
--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -560,6 +560,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_no_psp_
     result_event_type,
     transaction_item_generator,
     app,
+    caplog,
 ):
     # given
     transaction = transaction_item_generator()
@@ -588,9 +589,10 @@ def test_create_transaction_event_from_request_and_webhook_response_with_no_psp_
     assert transaction.events.count() == event_count + 1
     assert event.psp_reference is None
     assert event.transaction_id == transaction.id
-    assert event.message == (
-        f"Providing `pspReference` is required for {result_event_type.upper()}."
-    )
+    error_msg = f"Providing `pspReference` is required for {result_event_type.upper()}."
+    assert event.message == error_msg
+    assert caplog.records[0].levelno == logging.WARNING
+    assert caplog.records[0].message == error_msg
 
 
 @freeze_time("2018-05-31 12:00:01")

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -962,7 +962,7 @@ def parse_transaction_action_data(
     request_event_type = parsed_event_data.get("type", request_type)
     if not psp_reference and request_event_type not in OPTIONAL_PSP_REFERENCE_EVENTS:
         msg = f"Providing `pspReference` is required for {request_event_type.upper()}."
-        logger.error(msg)
+        logger.warning(msg)
         return None, msg
 
     return (

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1097,7 +1097,7 @@ def deduplicate_event(
                 "authorization amount."
             )
     if error_message:
-        logger.error(
+        logger.warning(
             msg=error_message,
             extra={
                 "transaction_id": event.transaction_id,


### PR DESCRIPTION
In case of errors caused by invalid data provided by customer in their payment integration, we should use logger.warning instead of logger.errors, as it's not something to be fixed.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
