### PR TITLE
Use denormalized quantity allocated in stock resolver

### DIFF
--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -240,11 +240,7 @@ class Stock(ModelObjectType[models.Stock]):
 
     @staticmethod
     def resolve_quantity_allocated(root, info: ResolveInfo):
-        return root.allocations.using(
-            get_database_connection_name(info.context)
-        ).aggregate(quantity_allocated=Coalesce(Sum("quantity_allocated"), 0))[
-            "quantity_allocated"
-        ]
+        return root.quantity_allocated
 
     @staticmethod
     @load_site_callback

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5022,13 +5022,16 @@ def order_with_lines(
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
+    quantity = 3
     stock = Stock.objects.create(
-        warehouse=warehouse, product_variant=variant, quantity=5
+        warehouse=warehouse,
+        product_variant=variant,
+        quantity=5,
+        quantity_allocated=quantity,
     )
     base_price = variant.get_price(channel_listing)
     currency = base_price.currency
     gross = Money(amount=base_price.amount * Decimal(1.23), currency=currency)
-    quantity = 3
     unit_price = TaxedMoney(net=base_price, gross=gross)
     line = order.lines.create(
         product_name=str(variant.product),
@@ -5075,16 +5078,18 @@ def order_with_lines(
         cost_price_amount=Decimal(2),
         currency=channel_USD.currency_code,
     )
+    quantity = 2
     stock = Stock.objects.create(
-        product_variant=variant, warehouse=warehouse, quantity=2
+        product_variant=variant,
+        warehouse=warehouse,
+        quantity=2,
+        quantity_allocated=quantity,
     )
-    stock.refresh_from_db()
 
     base_price = variant.get_price(channel_listing)
     currency = base_price.currency
     gross = Money(amount=base_price.amount * Decimal(1.23), currency=currency)
     unit_price = TaxedMoney(net=base_price, gross=gross)
-    quantity = 2
     line = order.lines.create(
         product_name=str(variant.product),
         variant_name=str(variant),


### PR DESCRIPTION
I want to merge this change because of using denormalized quantity allocated in the stock resolver. 


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
