### PR TITLE
Fix line unit discount amount and reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `CheckoutCustomerNoteUpdate` mutation - #16315 by @pitkes22
 - Add `customerNote` field to `Checkout` type to make it consistent with `Order` model - #16561 by @Air-t
 - Add `type` field to `TaxableObjectDiscount` type - #16630 by @zedzior
+- Deprecate order line's `unitDiscountType` and `unitDiscountValue` fields - #16973 by @zedzior
 
 ### Webhooks
 
@@ -40,3 +41,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed support for the django-debug-toolbar debugging tool and the `ENABLE_DEBUG_TOOLBAR` env variable - #16902 by @patrys
 - Fixed playground not displaying docs if api is hidden behind reverse proxy - #16810 by @jqob
 - Drop tax data line number validation for Avatax plugin - #16917 by @zedzior
+- Fix order line's `unitDiscount` and `unitDiscountReason` values - #16973 by @zedzior

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -271,13 +271,13 @@ def update_unit_discount_reason_with_order_level_discounts(
         order_discounts, DEFAULT_MANUAL_ORDER_DISCOUNT_REASON
     )
 
-    order_level_discounts_reason = ", ".join(
+    order_level_discounts_reason = "; ".join(
         discount.reason
         for discount in order_discounts
         if discount.reason and is_order_level_discount(discount)
     )
     for line in lines:
-        line.unit_discount_reason = ", ".join(
+        line.unit_discount_reason = "; ".join(
             reason
             for reason in [line.unit_discount_reason, order_level_discounts_reason]
             if reason

--- a/saleor/graphql/order/tests/deprecated/test_order.py
+++ b/saleor/graphql/order/tests/deprecated/test_order.py
@@ -654,7 +654,7 @@ def test_update_order_line_discount_old_id(
     )
 
     assert line_to_discount.unit_discount == unit_discount
-    assert line_to_discount.unit_discount_reason == f"{reason}, {order_discount.reason}"
+    assert line_to_discount.unit_discount_reason == f"{reason}; {order_discount.reason}"
 
     event = order.events.get()
     assert event.type == OrderEvents.ORDER_LINE_DISCOUNT_UPDATED

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1374,7 +1374,10 @@ def test_draft_order_complete_with_catalogue_and_order_discount(
         line_1_db.undiscounted_total_price_net_amount - line_1_order_discount_portion,
         currency,
     )
-    assert line_1["totalPrice"]["net"]["amount"] == float(line_1_total)
+    assert (
+        quantize_price(Decimal(line_1["totalPrice"]["net"]["amount"]), currency)
+        == line_1_total
+    )
 
     line_1_undiscounted_unit_price = line_1_db.undiscounted_base_unit_price_amount
     line_1_unit_discount = quantize_price(
@@ -1387,8 +1390,14 @@ def test_draft_order_complete_with_catalogue_and_order_discount(
         line_1["undiscountedUnitPrice"]["net"]["amount"]
         == line_1_undiscounted_unit_price
     )
-    assert line_1["unitPrice"]["net"]["amount"] == float(line_1_unit_price)
-    assert line_1["unitDiscount"]["amount"] == float(line_1_unit_discount)
+    assert (
+        quantize_price(Decimal(line_1["unitPrice"]["net"]["amount"]), currency)
+        == line_1_unit_price
+    )
+    assert (
+        quantize_price(Decimal(line_1["unitDiscount"]["amount"]), currency)
+        == line_1_unit_discount
+    )
     assert line_1["unitDiscountReason"] == f"Promotion: {order_promotion_id}"
     assert line_1["unitDiscountValue"] == 0.00
 
@@ -1398,7 +1407,10 @@ def test_draft_order_complete_with_catalogue_and_order_discount(
         - line_2_order_discount_portion,
         currency,
     )
-    assert line_2["totalPrice"]["net"]["amount"] == float(line_2_total)
+    assert (
+        quantize_price(Decimal(line_2["totalPrice"]["net"]["amount"]), currency)
+        == line_2_total
+    )
 
     line_2_undiscounted_unit_price = line_2_db.undiscounted_base_unit_price_amount
     line_2_unit_discount = quantize_price(
@@ -1412,8 +1424,14 @@ def test_draft_order_complete_with_catalogue_and_order_discount(
         line_2["undiscountedUnitPrice"]["net"]["amount"]
         == line_2_undiscounted_unit_price
     )
-    assert line_2["unitPrice"]["net"]["amount"] == float(line_2_unit_price)
-    assert line_2["unitDiscount"]["amount"] == float(line_2_unit_discount)
+    assert (
+        quantize_price(Decimal(line_2["unitPrice"]["net"]["amount"]), currency)
+        == line_2_unit_price
+    )
+    assert (
+        quantize_price(Decimal(line_2["unitDiscount"]["amount"]), currency)
+        == line_2_unit_discount
+    )
     assert (
         line_2["unitDiscountReason"]
         == f"Promotion: {catalogue_promotion_id}, Promotion: {order_promotion_id}"

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1482,7 +1482,7 @@ def test_draft_order_complete_with_catalogue_and_gift_discount(
     line_1_total = line_1_db.undiscounted_total_price_net_amount
     assert line_1["totalPrice"]["net"]["amount"] == line_1_total
     assert line_1["unitDiscount"]["amount"] == 0.00
-    assert line_1["unitDiscountReason"] is None
+    assert line_1["unitDiscountReason"] == ""
     assert line_1["unitDiscountValue"] == 0.00
 
     line_2_total = quantize_price(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1434,7 +1434,7 @@ def test_draft_order_complete_with_catalogue_and_order_discount(
     )
     assert (
         line_2["unitDiscountReason"]
-        == f"Promotion: {catalogue_promotion_id}, Promotion: {order_promotion_id}"
+        == f"Promotion: {catalogue_promotion_id}; Promotion: {order_promotion_id}"
     )
     assert line_2["unitDiscountType"] == DiscountValueType.FIXED.upper()
     assert line_2["unitDiscountValue"] == rule_catalogue_value

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -826,7 +826,7 @@ def test_draft_order_create_with_voucher_specific_product(
     assert line_1_data["totalPrice"]["gross"]["amount"] == variant_1_total
     assert line_1_data["unitDiscount"]["amount"] == 0
     assert line_1_data["unitDiscountType"] is None
-    assert line_1_data["unitDiscountReason"] is None
+    assert line_1_data["unitDiscountReason"] == ""
 
     assert order.discounts.count() == 0
 
@@ -968,7 +968,7 @@ def test_draft_order_create_with_voucher_apply_once_per_order(
     assert line_1_data["totalPrice"]["gross"]["amount"] == variant_1_total
     assert line_1_data["unitDiscount"]["amount"] == 0
     assert line_1_data["unitDiscountType"] is None
-    assert line_1_data["unitDiscountReason"] is None
+    assert line_1_data["unitDiscountReason"] == ""
 
     assert order.discounts.count() == 0
 

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -352,7 +352,7 @@ def test_draft_order_update_with_voucher_specific_product(
     assert line_1_data["totalPrice"]["net"]["amount"] == line_1_total
     assert line_1_data["unitDiscount"]["amount"] == 0
     assert line_1_data["unitDiscountType"] is None
-    assert line_1_data["unitDiscountReason"] is None
+    assert line_1_data["unitDiscountReason"] == ""
 
     order.refresh_from_db()
     assert order.voucher_code == voucher.code
@@ -444,7 +444,7 @@ def test_draft_order_update_with_voucher_apply_once_per_order(
     assert line_1_data["totalPrice"]["net"]["amount"] == line_1_total
     assert line_1_data["unitDiscount"]["amount"] == 0
     assert line_1_data["unitDiscountType"] is None
-    assert line_1_data["unitDiscountReason"] is None
+    assert line_1_data["unitDiscountReason"] == ""
 
     order.refresh_from_db()
     assert order.voucher_code == voucher.code

--- a/saleor/graphql/order/tests/mutations/test_order_discount.py
+++ b/saleor/graphql/order/tests/mutations/test_order_discount.py
@@ -1076,7 +1076,7 @@ def test_update_order_line_discount(
     )
 
     assert line_to_discount.unit_discount == unit_discount
-    assert line_to_discount.unit_discount_reason == f"{reason}, {order_discount.reason}"
+    assert line_to_discount.unit_discount_reason == f"{reason}; {order_discount.reason}"
 
     event = order.events.get()
     assert event.type == OrderEvents.ORDER_LINE_DISCOUNT_UPDATED

--- a/saleor/graphql/order/tests/mutations/test_order_discount.py
+++ b/saleor/graphql/order/tests/mutations/test_order_discount.py
@@ -1191,12 +1191,12 @@ def test_update_order_line_discount_by_app(
 @pytest.mark.parametrize("status", [OrderStatus.DRAFT, OrderStatus.UNCONFIRMED])
 def test_update_order_line_discount_line_with_discount(
     status,
-    draft_order_with_fixed_discount_order,
+    draft_order,
     staff_api_client,
     permission_group_manage_orders,
 ):
     # given
-    order = draft_order_with_fixed_discount_order
+    order = draft_order
     order.status = status
     order.save(update_fields=["status"])
     line_to_discount = order.lines.first()

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -68,6 +68,7 @@ ORDER_LINES_CREATE_MUTATION = """
                 unitDiscount {
                   amount
                 }
+                unitDiscountReason
                 isPriceOverridden
             }
             order {
@@ -714,7 +715,8 @@ def test_order_lines_create_order_promotion(
     line_data = data["orderLines"][0]
     assert line_data["productSku"] == variant.sku
     assert line_data["quantity"] == quantity
-    assert line_data["unitDiscount"]["amount"] == 0.00
+    assert line_data["unitDiscount"]["amount"] == expected_unit_discount
+    assert line_data["unitDiscountReason"] == f"Promotion: {promotion_id}"
     assert (
         line_data["unitPrice"]["gross"]["amount"]
         == variant_channel_listing.price_amount - expected_unit_discount
@@ -725,7 +727,8 @@ def test_order_lines_create_order_promotion(
     )
 
     line = order.lines.get(product_sku=variant.sku)
-    assert line.unit_discount_amount == 0
+    assert line.unit_discount_amount == expected_unit_discount
+    assert line.unit_discount_reason == f"Promotion: {promotion_id}"
     assert (
         line.unit_price_gross_amount
         == variant_channel_listing.discounted_price.amount - expected_unit_discount

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -818,8 +818,8 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         PositiveDecimal,
         description="Value of the discount. Can store fixed value or percent value",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X_FIELD} Since the order line can have multiple "
-            f"discounts applied, this field is not valid anymore."
+            f"{DEPRECATED_IN_3X_FIELD} Since the order line can be affected by multiple"
+            f" discounts, this field is only valid for single discount."
         ),
         required=True,
     )
@@ -872,8 +872,8 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         DiscountValueTypeEnum,
         description="Type of the discount: fixed or percent",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X_FIELD} Since the order line can have multiple "
-            f"discounts applied, this field is not valid anymore."
+            f"{DEPRECATED_IN_3X_FIELD} Since the order line can be affected by multiple"
+            f" discounts, this field is only valid for single discount."
         ),
     )
     tax_class = PermissionsField(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -817,6 +817,10 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     unit_discount_value = graphene.Field(
         PositiveDecimal,
         description="Value of the discount. Can store fixed value or percent value",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Since the order line can have multiple "
+            f"discounts applied, this field is not valid anymore."
+        ),
         required=True,
     )
     total_price = graphene.Field(
@@ -867,6 +871,10 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     unit_discount_type = graphene.Field(
         DiscountValueTypeEnum,
         description="Type of the discount: fixed or percent",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Since the order line can have multiple "
+            f"discounts applied, this field is not valid anymore."
+        ),
     )
     tax_class = PermissionsField(
         TaxClass,

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1027,6 +1027,22 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         return Promise.all([order, lines, manager]).then(_resolve_unit_discount_type)
 
     @staticmethod
+    @traced_resolver
+    @prevent_sync_event_circular_query
+    def resolve_unit_discount_reason(root: models.OrderLine, info):
+        @allow_writer_in_context(info.context)
+        def _resolve_unit_discount_reason(data):
+            order, lines, manager = data
+            return calculations.order_line_unit_discount_reason(
+                order, root, manager, lines
+            )
+
+        order = OrderByIdLoader(info.context).load(root.order_id)
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_discount_reason)
+
+    @staticmethod
     def resolve_unit_discount_value(root: models.OrderLine, info):
         def _resolve_unit_discount_value(data):
             order, lines, manager = data

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10998,7 +10998,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   unitDiscount: Money!
 
   """Value of the discount. Can store fixed value or percent value"""
-  unitDiscountValue: PositiveDecimal!
+  unitDiscountValue: PositiveDecimal! @deprecated(reason: "This field will be removed in Saleor 4.0. Since the order line can have multiple discounts applied, this field is not valid anymore.")
 
   """Price of the order line."""
   totalPrice: TaxedMoney!
@@ -11036,7 +11036,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   quantityToFulfill: Int!
 
   """Type of the discount: fixed or percent"""
-  unitDiscountType: DiscountValueTypeEnum
+  unitDiscountType: DiscountValueTypeEnum @deprecated(reason: "This field will be removed in Saleor 4.0. Since the order line can have multiple discounts applied, this field is not valid anymore.")
 
   """
   Denormalized tax class of the product in this order line.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10998,7 +10998,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   unitDiscount: Money!
 
   """Value of the discount. Can store fixed value or percent value"""
-  unitDiscountValue: PositiveDecimal! @deprecated(reason: "This field will be removed in Saleor 4.0. Since the order line can have multiple discounts applied, this field is not valid anymore.")
+  unitDiscountValue: PositiveDecimal! @deprecated(reason: "This field will be removed in Saleor 4.0. Since the order line can be affected by multiple discounts, this field is only valid for single discount.")
 
   """Price of the order line."""
   totalPrice: TaxedMoney!
@@ -11036,7 +11036,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   quantityToFulfill: Int!
 
   """Type of the discount: fixed or percent"""
-  unitDiscountType: DiscountValueTypeEnum @deprecated(reason: "This field will be removed in Saleor 4.0. Since the order line can have multiple discounts applied, this field is not valid anymore.")
+  unitDiscountType: DiscountValueTypeEnum @deprecated(reason: "This field will be removed in Saleor 4.0. Since the order line can be affected by multiple discounts, this field is only valid for single discount.")
 
   """
   Denormalized tax class of the product in this order line.

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -308,7 +308,7 @@ def assign_order_line_prices(line: "OrderLine", total_price: Money):
         line.unit_price_net_amount = unit_price
         line.unit_price_gross_amount = unit_price
 
-        undiscounted_unit_price = line.undiscounted_total_price_net_amount / quantity
+        undiscounted_unit_price = line.undiscounted_base_unit_price_amount
         line.undiscounted_unit_price_net_amount = undiscounted_unit_price
         line.undiscounted_unit_price_gross_amount = undiscounted_unit_price
 

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -174,6 +174,10 @@ def apply_order_discounts(
     assign_prices=True,
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ) -> tuple[Money, Money]:
+    from ..discount.utils.order import (
+        update_unit_discount_reason_with_order_level_discounts,
+    )
+
     """Calculate prices after applying order level discounts.
 
     Handles manual discounts, ENTIRE_ORDER vouchers and ORDER_PROMOTION.
@@ -313,20 +317,6 @@ def assign_order_line_prices(line: "OrderLine", total_price: Money):
                 undiscounted_unit_price - unit_price, currency
             )
             line.unit_discount_amount = unit_discount
-
-
-def update_unit_discount_reason_with_order_level_discounts(
-    lines: Iterable["OrderLine"], order: "Order"
-):
-    order_level_discounts_reason = ", ".join(
-        discount.reason for discount in order.discounts.all() if discount.reason
-    )
-    for line in lines:
-        line.unit_discount_reason = ", ".join(
-            reason
-            for reason in [line.unit_discount_reason, order_level_discounts_reason]
-            if reason
-        )
 
 
 def assign_order_prices(

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -621,6 +621,19 @@ def order_line_unit_discount_type(
     return order_line.unit_discount_type
 
 
+def order_line_unit_discount_reason(
+    order: Order,
+    order_line: OrderLine,
+    manager: PluginsManager,
+    lines: Optional[Iterable[OrderLine]] = None,
+    force_update: bool = False,
+) -> Optional[str]:
+    """Return the line unit discount reason."""
+    _, lines = fetch_order_prices_if_expired(order, manager, lines, force_update)
+    order_line = _find_order_line(lines, order_line)
+    return order_line.unit_discount_reason
+
+
 def order_undiscounted_shipping(
     order: Order,
     manager: PluginsManager,

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -432,9 +432,14 @@ def _apply_tax_data(
         undiscounted_subtotal += order_line.undiscounted_total_price
 
         if not order_line.is_gift:
+            unit_price_to_compare = (
+                order_line.unit_price.gross
+                if prices_entered_with_tax
+                else order_line.unit_price.net
+            )
             order_line.unit_discount_amount = quantize_price(
-                order_line.undiscounted_unit_price_net_amount
-                - order_line.unit_price_net_amount,
+                order_line.undiscounted_base_unit_price_amount
+                - unit_price_to_compare.amount,
                 currency,
             )
 

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -12,7 +12,7 @@ from ...discount.models import (
     OrderLineDiscount,
     PromotionRule,
 )
-from ...discount.utils.order import DEFAULT_MANUAL_DISCOUNT_REASON
+from ...discount.utils.order import DEFAULT_MANUAL_ORDER_DISCOUNT_REASON
 from ...tests.utils import round_down, round_up
 from .. import OrderStatus, calculations
 
@@ -1270,7 +1270,7 @@ def test_fetch_order_prices_manual_discount_and_catalogue_discount_flat_rates(
         line_1.unit_price_net_amount * tax_rate
     )
     assert line_1.unit_discount_reason == ", ".join(
-        [catalogue_discount.reason, DEFAULT_MANUAL_DISCOUNT_REASON]
+        [catalogue_discount.reason, DEFAULT_MANUAL_ORDER_DISCOUNT_REASON]
     )
     assert line_1.unit_discount_amount == quantize_price(
         line_1.undiscounted_unit_price_net_amount - line_1.unit_price_net_amount,
@@ -1312,7 +1312,7 @@ def test_fetch_order_prices_manual_discount_and_catalogue_discount_flat_rates(
     assert line_2.unit_price_gross_amount == quantize_price(
         line_2.unit_price_net_amount * tax_rate, currency
     )
-    assert line_2.unit_discount_reason == DEFAULT_MANUAL_DISCOUNT_REASON
+    assert line_2.unit_discount_reason == DEFAULT_MANUAL_ORDER_DISCOUNT_REASON
     assert line_2.unit_discount_amount == quantize_price(
         line_2.undiscounted_unit_price_net_amount - line_2.unit_price_net_amount,
         currency,

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -537,8 +537,9 @@ def test_fetch_order_prices_catalogue_and_order_discounts_flat_rates(
     assert line_2.unit_price_gross_amount == quantize_price(
         line_2.unit_price_net_amount * tax_rate, currency
     )
-    assert line_2.unit_discount_reason == ", ".join(
-        [catalogue_discount.reason, order_discount.reason]
+    assert (
+        line_2.unit_discount_reason
+        == f"{catalogue_discount.reason}; {order_discount.reason}"
     )
     assert line_2.unit_discount_amount == quantize_price(
         line_2.undiscounted_unit_price_net_amount - line_2.unit_price_net_amount,
@@ -848,8 +849,9 @@ def test_fetch_order_prices_catalogue_and_order_discounts_exceed_total_flat_rate
     assert line_2.total_price_gross_amount == Decimal(0)
     assert line_2.unit_price_net_amount == Decimal(0)
     assert line_2.unit_price_gross_amount == Decimal(0)
-    assert line_2.unit_discount_reason == ", ".join(
-        [catalogue_discount.reason, order_discount.reason]
+    assert (
+        line_2.unit_discount_reason
+        == f"{catalogue_discount.reason}; {order_discount.reason}"
     )
     assert line_2.unit_discount_amount == quantize_price(
         line_2.undiscounted_unit_price_net_amount - line_2.unit_price_net_amount,
@@ -1269,8 +1271,9 @@ def test_fetch_order_prices_manual_discount_and_catalogue_discount_flat_rates(
     assert line_1.unit_price_gross_amount == round_up(
         line_1.unit_price_net_amount * tax_rate
     )
-    assert line_1.unit_discount_reason == ", ".join(
-        [catalogue_discount.reason, DEFAULT_MANUAL_ORDER_DISCOUNT_REASON]
+    assert (
+        line_1.unit_discount_reason
+        == f"{catalogue_discount.reason}; {DEFAULT_MANUAL_ORDER_DISCOUNT_REASON}"
     )
     assert line_1.unit_discount_amount == quantize_price(
         line_1.undiscounted_unit_price_net_amount - line_1.unit_price_net_amount,
@@ -2002,7 +2005,7 @@ def test_fetch_order_prices_manual_order_discount_voucher_specific_product(
     assert discounted_line.unit_discount_type == DiscountValueType.FIXED
     assert (
         discounted_line.unit_discount_reason
-        == f"Voucher code: {order.voucher_code}, Manual order discount"
+        == f"Voucher code: {order.voucher_code}; Manual order discount"
     )
 
     assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount
@@ -2132,7 +2135,7 @@ def test_fetch_order_prices_manual_order_discount_and_voucher_apply_once_per_ord
     assert discounted_line.unit_discount_type == DiscountValueType.FIXED
     assert (
         discounted_line.unit_discount_reason
-        == f"Voucher code: {order.voucher_code}, {order_discount.reason}"
+        == f"Voucher code: {order.voucher_code}; {order_discount.reason}"
     )
 
     assert line_1.base_unit_price_amount == line_1.undiscounted_base_unit_price_amount

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -12,6 +12,7 @@ from ...discount.models import (
     OrderLineDiscount,
     PromotionRule,
 )
+from ...discount.utils.order import DEFAULT_MANUAL_DISCOUNT_REASON
 from ...tests.utils import round_down, round_up
 from .. import OrderStatus, calculations
 
@@ -1195,7 +1196,6 @@ def test_fetch_order_prices_manual_discount_and_catalogue_discount_flat_rates(
         value=manual_discount_value,
         name="Manual order discount",
         type=DiscountType.MANUAL,
-        reason="Manual 50% discount",
     )
 
     # when
@@ -1218,7 +1218,7 @@ def test_fetch_order_prices_manual_discount_and_catalogue_discount_flat_rates(
     assert manual_discount.value == manual_discount_value
     assert manual_discount.value_type == DiscountValueType.PERCENTAGE
     assert manual_discount.type == DiscountType.MANUAL
-    assert manual_discount.reason
+    assert not manual_discount.reason
 
     line_1 = [line for line in lines if line.quantity == 3][0]
     line_2 = [line for line in lines if line.quantity == 2][0]
@@ -1270,7 +1270,7 @@ def test_fetch_order_prices_manual_discount_and_catalogue_discount_flat_rates(
         line_1.unit_price_net_amount * tax_rate
     )
     assert line_1.unit_discount_reason == ", ".join(
-        [catalogue_discount.reason, manual_discount.reason]
+        [catalogue_discount.reason, DEFAULT_MANUAL_DISCOUNT_REASON]
     )
     assert line_1.unit_discount_amount == quantize_price(
         line_1.undiscounted_unit_price_net_amount - line_1.unit_price_net_amount,
@@ -1312,7 +1312,7 @@ def test_fetch_order_prices_manual_discount_and_catalogue_discount_flat_rates(
     assert line_2.unit_price_gross_amount == quantize_price(
         line_2.unit_price_net_amount * tax_rate, currency
     )
-    assert line_2.unit_discount_reason == manual_discount.reason
+    assert line_2.unit_discount_reason == DEFAULT_MANUAL_DISCOUNT_REASON
     assert line_2.unit_discount_amount == quantize_price(
         line_2.undiscounted_unit_price_net_amount - line_2.unit_price_net_amount,
         currency,

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -2579,7 +2579,8 @@ def test_fetch_order_prices_voucher_entire_order_percentage(
     # given
     assert voucher.type == VoucherType.ENTIRE_ORDER
     voucher.discount_value_type = DiscountValueType.PERCENTAGE
-    voucher.save(update_fields=["discount_value_type"])
+    voucher.name = "Voucher name"
+    voucher.save(update_fields=["discount_value_type", "name"])
 
     order = order_with_lines
     order.status = OrderStatus.UNCONFIRMED
@@ -2589,9 +2590,6 @@ def test_fetch_order_prices_voucher_entire_order_percentage(
     discount_value = Decimal("50")
     voucher_listing.discount_value = discount_value
     voucher_listing.save(update_fields=["discount_value"])
-
-    voucher.name = "Voucher name"
-    voucher.save(update_fields=["name"])
 
     order.voucher = voucher
     code = voucher.codes.first().code
@@ -2699,7 +2697,8 @@ def test_fetch_order_prices_voucher_shipping_fixed(
     # given
     voucher.type = VoucherType.SHIPPING
     voucher.discount_value_type = DiscountValueType.FIXED
-    voucher.save(update_fields=["type", "discount_value_type"])
+    voucher.name = "Voucher shipping"
+    voucher.save(update_fields=["type", "discount_value_type", "name"])
 
     order = order_with_lines
     order.status = OrderStatus.UNCONFIRMED
@@ -2709,9 +2708,6 @@ def test_fetch_order_prices_voucher_shipping_fixed(
     discount_value = Decimal("5")
     voucher_listing.discount_value = discount_value
     voucher_listing.save(update_fields=["discount_value"])
-
-    voucher.name = "Voucher shipping"
-    voucher.save(update_fields=["name"])
 
     order.voucher = voucher
     code = voucher.codes.first().code
@@ -2776,7 +2772,8 @@ def test_fetch_order_prices_voucher_shipping_percentage(
     # given
     voucher.type = VoucherType.SHIPPING
     voucher.discount_value_type = DiscountValueType.PERCENTAGE
-    voucher.save(update_fields=["type", "discount_value_type"])
+    voucher.name = "Voucher shipping"
+    voucher.save(update_fields=["type", "discount_value_type", "name"])
 
     order = order_with_lines
     order.status = OrderStatus.UNCONFIRMED
@@ -2786,9 +2783,6 @@ def test_fetch_order_prices_voucher_shipping_percentage(
     discount_value = Decimal("50")
     voucher_listing.discount_value = discount_value
     voucher_listing.save(update_fields=["discount_value"])
-
-    voucher.name = "Voucher shipping"
-    voucher.save(update_fields=["name"])
 
     order.voucher = voucher
     code = voucher.codes.first().code

--- a/saleor/order/tests/test_fetch_order_prices_tax_app.py
+++ b/saleor/order/tests/test_fetch_order_prices_tax_app.py
@@ -980,7 +980,7 @@ def test_fetch_order_prices_manual_order_discount_and_line_level_voucher_tax_app
     line_1, line_2 = order.lines.all()
 
     voucher_listing = voucher.channel_listings.get(channel=order.channel)
-    voucher_reward = Decimal("3")
+    voucher_reward = Decimal("4")
     voucher_listing.discount_value = voucher_reward
     voucher_listing.save(update_fields=["discount_value"])
 
@@ -993,7 +993,7 @@ def test_fetch_order_prices_manual_order_discount_and_line_level_voucher_tax_app
     order.save(update_fields=["voucher", "voucher_code"])
 
     # create manual order discount
-    manual_reward = Decimal("8")
+    manual_reward = Decimal("10")
     manual_discount_reason = "Manual discount reason"
     manual_discount = order.discounts.create(
         value_type=DiscountValueType.FIXED,
@@ -1043,19 +1043,23 @@ def test_fetch_order_prices_manual_order_discount_and_line_level_voucher_tax_app
         manual_reward * base_subtotal / base_total, currency
     )
     shipping_discount_portion = manual_reward - subtotal_discount_portion
-    line_1_manual_discount_portion = (
-        subtotal_discount_portion * line_1_base_total_price / base_subtotal
+    line_1_manual_discount_portion = quantize_price(
+        subtotal_discount_portion * line_1_base_total_price / base_subtotal, currency
     )
-    line_2_manual_discount_portion = (
-        subtotal_discount_portion - line_1_manual_discount_portion
+    line_2_manual_discount_portion = quantize_price(
+        subtotal_discount_portion - line_1_manual_discount_portion, currency
     )
     line_1_total_price_net = line_1_base_total_price - line_1_manual_discount_portion
     line_2_total_price_net = line_2_base_total_price - line_2_manual_discount_portion
     line_1_total_price_gross = line_1_total_price_net * tax_rate
     line_2_total_price_gross = line_2_total_price_net * tax_rate
 
-    line_1_unit_price_net = line_1_total_price_net / line_1.quantity
-    line_2_unit_price_net = line_2_total_price_net / line_2.quantity
+    line_1_unit_price_net = quantize_price(
+        line_1_total_price_net / line_1.quantity, currency
+    )
+    line_2_unit_price_net = quantize_price(
+        line_2_total_price_net / line_2.quantity, currency
+    )
     line_1_unit_price_gross = line_1_unit_price_net * tax_rate
     line_2_unit_price_gross = line_2_unit_price_net * tax_rate
 

--- a/saleor/order/tests/test_fetch_order_prices_tax_app.py
+++ b/saleor/order/tests/test_fetch_order_prices_tax_app.py
@@ -742,7 +742,7 @@ def test_fetch_order_prices_catalogue_and_order_discounts_tax_app(
     assert line_2.unit_price_gross_amount == quantize_price(
         line_2.unit_price_net_amount * tax_rate, currency
     )
-    assert line_2.unit_discount_reason == ", ".join(
+    assert line_2.unit_discount_reason == "; ".join(
         [catalogue_discount.reason, order_discount.reason]
     )
     assert line_2.unit_discount_amount == quantize_price(
@@ -949,7 +949,7 @@ def test_fetch_order_prices_manual_order_discount_and_line_level_voucher_tax_app
 
     assert (
         line_1.unit_discount_reason
-        == f"Voucher code: {order.voucher_code}, {manual_discount_reason}"
+        == f"Voucher code: {order.voucher_code}; {manual_discount_reason}"
     )
     assert line_1.unit_discount_amount == quantize_price(
         line_1_undiscounted_unit_price_net - line_1_unit_price_net, currency
@@ -1163,7 +1163,7 @@ def test_fetch_order_prices_manual_line_discount_and_entire_order_voucher_tax_ap
 
     assert (
         line_1.unit_discount_reason
-        == f"{manual_discount_reason}, Voucher code: {order.voucher_code}"
+        == f"{manual_discount_reason}; Voucher code: {order.voucher_code}"
     )
     assert line_1.unit_discount_amount == quantize_price(
         line_1_undiscounted_unit_price_net - line_1_unit_price_net, currency

--- a/saleor/order/tests/test_fetch_order_prices_tax_app.py
+++ b/saleor/order/tests/test_fetch_order_prices_tax_app.py
@@ -1,0 +1,1418 @@
+from decimal import Decimal
+from unittest.mock import Mock
+
+import graphene
+import pytest
+
+from ...core.prices import quantize_price
+from ...core.taxes import TaxData, TaxLineData
+from ...discount import DiscountType, DiscountValueType, VoucherType
+from ...discount.models import OrderDiscount, OrderLineDiscount, PromotionRule
+from ...plugins.avatax.tests.conftest import plugin_configuration  # noqa: F401
+from .. import OrderStatus
+from ..calculations import fetch_order_prices_if_expired
+
+
+@pytest.fixture
+def order_with_lines(order_with_lines):
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    return order_with_lines
+
+
+def test_fetch_order_prices_tax_app(order_with_lines, tax_configuration_tax_app):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_total_price_net = line_1.undiscounted_total_price_net_amount
+    line_1_total_price_gross = line_1_total_price_net * tax_rate
+    line_1_unit_price_net = quantize_price(
+        line_1_total_price_net / line_1.quantity, currency
+    )
+    line_1_unit_price_gross = quantize_price(
+        line_1_total_price_gross / line_1.quantity, currency
+    )
+
+    line_2_total_price_net = line_2.undiscounted_total_price_net_amount
+    line_2_total_price_gross = line_2_total_price_net * tax_rate
+    line_2_unit_price_net = quantize_price(
+        line_2_total_price_net / line_2.quantity, currency
+    )
+    line_2_unit_price_gross = quantize_price(
+        line_2_total_price_gross / line_2.quantity, currency
+    )
+
+    shipping_price_net = order.shipping_price_net_amount
+    shipping_price_gross = shipping_price_net * tax_rate
+
+    subtotal_net = line_1_total_price_net + line_2_total_price_net
+    subtotal_gross = line_1_total_price_gross + line_2_total_price_gross
+    total_net = subtotal_net + shipping_price_net
+    total_gross = subtotal_gross + shipping_price_gross
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    assert order.shipping_price_net_amount == shipping_price_net
+    assert order.shipping_price_gross_amount == shipping_price_gross
+    assert order.shipping_tax_rate == db_tax_rate
+    assert order.subtotal_net_amount == subtotal_net
+    assert order.subtotal_gross_amount == subtotal_gross
+    assert order.total_net_amount == total_net
+    assert order.total_gross_amount == total_gross
+
+    line_1, line_2 = lines
+
+    assert line_1.undiscounted_total_price_net_amount == line_1_total_price_net
+    assert line_1.undiscounted_total_price_gross_amount == line_1_total_price_gross
+    assert line_1.undiscounted_unit_price_net_amount == line_1_unit_price_net
+    assert line_1.undiscounted_unit_price_gross_amount == line_1_unit_price_gross
+
+    assert line_1.base_unit_price_amount == line_1_unit_price_net
+    assert line_1.total_price_net_amount == line_1_total_price_net
+    assert line_1.total_price_gross_amount == line_1_total_price_gross
+    assert line_1.unit_price_net_amount == line_1_unit_price_net
+    assert line_1.unit_price_gross_amount == line_1_unit_price_gross
+
+    assert line_1.unit_discount_reason == ""
+    assert line_1.unit_discount_amount == Decimal(0)
+
+    assert line_2.undiscounted_total_price_net_amount == line_2_total_price_net
+    assert line_2.undiscounted_total_price_gross_amount == line_2_total_price_gross
+    assert line_2.undiscounted_unit_price_net_amount == line_2_unit_price_net
+    assert line_2.undiscounted_unit_price_gross_amount == line_2_unit_price_gross
+
+    assert line_2.base_unit_price_amount == line_2_unit_price_net
+    assert line_2.total_price_net_amount == line_2_total_price_net
+    assert line_2.total_price_gross_amount == line_2_total_price_gross
+    assert line_2.unit_price_net_amount == line_2_unit_price_net
+    assert line_2.unit_price_gross_amount == line_2_unit_price_gross
+
+    assert line_2.unit_discount_reason == ""
+    assert line_2.unit_discount_amount == Decimal(0)
+
+
+def test_fetch_order_prices_catalogue_discount_tax_app(
+    order_with_lines_and_catalogue_promotion,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines_and_catalogue_promotion
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+
+    rule = PromotionRule.objects.get()
+    assert rule.reward_value_type == DiscountValueType.FIXED
+    promotion_id = graphene.Node.to_global_id("Promotion", rule.promotion_id)
+    reward_value = rule.reward_value
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_undiscounted_total_price_net = line_1.undiscounted_total_price_net_amount
+    line_1_undiscounted_total_price_gross = (
+        line_1_undiscounted_total_price_net * tax_rate
+    )
+    line_1_undiscounted_unit_price_net = quantize_price(
+        line_1_undiscounted_total_price_net / line_1.quantity, currency
+    )
+    line_1_undiscounted_unit_price_gross = quantize_price(
+        line_1_undiscounted_total_price_gross / line_1.quantity, currency
+    )
+
+    line_1_unit_price_net = quantize_price(
+        line_1_undiscounted_unit_price_net - reward_value, currency
+    )
+    line_1_unit_price_gross = line_1_unit_price_net * tax_rate
+    line_1_total_price_net = line_1_unit_price_net * line_1.quantity
+    line_1_total_price_gross = line_1_total_price_net * tax_rate
+
+    line_2_total_price_net = line_2.undiscounted_total_price_net_amount
+    line_2_total_price_gross = line_2_total_price_net * tax_rate
+    line_2_unit_price_net = quantize_price(
+        line_2_total_price_net / line_2.quantity, currency
+    )
+    line_2_unit_price_gross = quantize_price(
+        line_2_total_price_gross / line_2.quantity, currency
+    )
+
+    shipping_price_net = order.shipping_price_net_amount
+    shipping_price_gross = shipping_price_net * tax_rate
+
+    subtotal_net = line_1_total_price_net + line_2_total_price_net
+    subtotal_gross = line_1_total_price_gross + line_2_total_price_gross
+    total_net = subtotal_net + shipping_price_net
+    total_gross = subtotal_gross + shipping_price_gross
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    discount = line_1.discounts.get()
+    reward_amount = reward_value * line_1.quantity
+    assert discount.amount_value == reward_amount
+    assert discount.value == reward_value
+    assert discount.type == DiscountType.PROMOTION
+    assert discount.reason == f"Promotion: {promotion_id}"
+
+    assert order.shipping_price_net_amount == shipping_price_net
+    assert order.shipping_price_gross_amount == shipping_price_gross
+    assert order.shipping_tax_rate == db_tax_rate
+    assert order.subtotal_net_amount == subtotal_net
+    assert order.subtotal_gross_amount == subtotal_gross
+    assert order.total_net_amount == total_net
+    assert order.total_gross_amount == total_gross
+
+    line_1, line_2 = lines
+
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == line_1_undiscounted_total_price_net
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1_undiscounted_total_price_gross
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == line_1_undiscounted_unit_price_net
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount
+        == line_1_undiscounted_unit_price_gross
+    )
+
+    assert line_1.base_unit_price_amount == line_1_unit_price_net
+    assert line_1.total_price_net_amount == line_1_total_price_net
+    assert line_1.total_price_gross_amount == line_1_total_price_gross
+    assert line_1.unit_price_net_amount == line_1_unit_price_net
+    assert line_1.unit_price_gross_amount == line_1_unit_price_gross
+
+    assert line_1.unit_discount_reason == f"Promotion: {promotion_id}"
+    assert line_1.unit_discount_amount == reward_value
+
+    assert line_2.undiscounted_total_price_net_amount == line_2_total_price_net
+    assert line_2.undiscounted_total_price_gross_amount == line_2_total_price_gross
+    assert line_2.undiscounted_unit_price_net_amount == line_2_unit_price_net
+    assert line_2.undiscounted_unit_price_gross_amount == line_2_unit_price_gross
+
+    assert line_2.base_unit_price_amount == line_2_unit_price_net
+    assert line_2.total_price_net_amount == line_2_total_price_net
+    assert line_2.total_price_gross_amount == line_2_total_price_gross
+    assert line_2.unit_price_net_amount == line_2_unit_price_net
+    assert line_2.unit_price_gross_amount == line_2_unit_price_gross
+
+    assert line_2.unit_discount_reason == ""
+    assert line_2.unit_discount_amount == Decimal(0)
+
+
+def test_fetch_order_prices_order_discount_tax_app(
+    order_with_lines_and_order_promotion,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines_and_order_promotion
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+
+    rule = PromotionRule.objects.get()
+    assert rule.reward_value_type == DiscountValueType.FIXED
+    promotion_id = graphene.Node.to_global_id("Promotion", rule.promotion_id)
+    reward_value = rule.reward_value
+
+    line_1_base_total = line_1.quantity * line_1.base_unit_price_amount
+    line_2_base_total = line_2.quantity * line_2.base_unit_price_amount
+    base_total = line_1_base_total + line_2_base_total
+    line_1_order_discount_portion = reward_value * line_1_base_total / base_total
+    line_2_order_discount_portion = reward_value - line_1_order_discount_portion
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_undiscounted_total_price_net = line_1.undiscounted_total_price_net_amount
+    line_1_undiscounted_total_price_gross = (
+        line_1_undiscounted_total_price_net * tax_rate
+    )
+    line_1_undiscounted_unit_price_net = (
+        line_1_undiscounted_total_price_net / line_1.quantity
+    )
+    line_1_undiscounted_unit_price_gross = line_1_undiscounted_unit_price_net * tax_rate
+
+    line_1_total_price_net = (
+        line_1_undiscounted_total_price_net - line_1_order_discount_portion
+    )
+    line_1_total_price_gross = line_1_total_price_net * tax_rate
+    line_1_unit_price_net = line_1_total_price_net / line_1.quantity
+    line_1_unit_price_gross = line_1_unit_price_net * tax_rate
+
+    line_2_undiscounted_total_price_net = line_2.undiscounted_total_price_net_amount
+    line_2_undiscounted_total_price_gross = (
+        line_2_undiscounted_total_price_net * tax_rate
+    )
+    line_2_undiscounted_unit_price_net = quantize_price(
+        line_2_undiscounted_total_price_net / line_2.quantity, currency
+    )
+    line_2_undiscounted_unit_price_gross = quantize_price(
+        line_2_undiscounted_total_price_gross / line_2.quantity, currency
+    )
+
+    line_2_total_price_net = (
+        line_2_undiscounted_total_price_net - line_2_order_discount_portion
+    )
+    line_2_total_price_gross = line_2_total_price_net * tax_rate
+    line_2_unit_price_net = line_2_total_price_net / line_2.quantity
+    line_2_unit_price_gross = line_2_unit_price_net * tax_rate
+
+    shipping_price_net = order.shipping_price_net_amount
+    shipping_price_gross = shipping_price_net * tax_rate
+
+    undiscounted_subtotal_net = (
+        line_1_undiscounted_total_price_net + line_2_undiscounted_total_price_net
+    )
+    subtotal_net = line_1_total_price_net + line_2_total_price_net
+    subtotal_gross = line_1_total_price_gross + line_2_total_price_gross
+    total_net = subtotal_net + shipping_price_net
+    total_gross = subtotal_gross + shipping_price_gross
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    discount = order.discounts.get()
+    assert discount.amount_value == reward_value
+    assert discount.value == reward_value
+    assert discount.value_type == DiscountValueType.FIXED
+    assert discount.type == DiscountType.ORDER_PROMOTION
+    assert discount.reason == f"Promotion: {promotion_id}"
+
+    assert order.shipping_price_net_amount == shipping_price_net
+    assert order.shipping_price_gross_amount == shipping_price_gross
+    assert order.shipping_tax_rate == db_tax_rate
+    assert order.subtotal_net_amount == subtotal_net
+    assert order.subtotal_gross_amount == subtotal_gross
+    assert order.total_net_amount == total_net
+    assert order.total_gross_amount == total_gross
+    assert (
+        order.total_net_amount
+        == undiscounted_subtotal_net - reward_value + shipping_price_net
+    )
+    assert order.total_gross_amount == order.total_net_amount * tax_rate
+
+    line_1, line_2 = lines
+
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == line_1_undiscounted_total_price_net
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1_undiscounted_total_price_gross
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == line_1_undiscounted_unit_price_net
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount
+        == line_1_undiscounted_unit_price_gross
+    )
+
+    assert line_1.base_unit_price_amount == line_1_undiscounted_unit_price_net
+    assert line_1.total_price_net_amount == line_1_total_price_net
+    assert line_1.total_price_gross_amount == line_1_total_price_gross
+    assert line_1.unit_price_net_amount == quantize_price(
+        line_1_unit_price_net, currency
+    )
+    assert line_1.unit_price_gross_amount == quantize_price(
+        line_1_unit_price_gross, currency
+    )
+
+    assert line_1.unit_discount_reason == f"Promotion: {promotion_id}"
+    assert line_1.unit_discount_amount == quantize_price(
+        line_1_undiscounted_unit_price_net - line_1_unit_price_net, currency
+    )
+
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == line_2_undiscounted_total_price_net
+    )
+    assert (
+        line_2.undiscounted_total_price_gross_amount
+        == line_2_undiscounted_total_price_gross
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == line_2_undiscounted_unit_price_net
+    )
+    assert (
+        line_2.undiscounted_unit_price_gross_amount
+        == line_2_undiscounted_unit_price_gross
+    )
+
+    assert line_2.base_unit_price_amount == line_2_undiscounted_unit_price_net
+    assert line_2.total_price_net_amount == line_2_total_price_net
+    assert line_2.total_price_gross_amount == line_2_total_price_gross
+    assert line_2.unit_price_net_amount == quantize_price(
+        line_2_unit_price_net, currency
+    )
+    assert line_2.unit_price_gross_amount == quantize_price(
+        line_2_unit_price_gross, currency
+    )
+
+    assert line_2.unit_discount_reason == f"Promotion: {promotion_id}"
+    assert line_2.unit_discount_amount == quantize_price(
+        line_2_undiscounted_unit_price_net - line_2_unit_price_net, currency
+    )
+
+
+def test_fetch_order_prices_gift_discount_tax_app(
+    order_with_lines_and_gift_promotion,
+    tax_configuration_tax_app,
+    channel_USD,
+):
+    # given
+    order = order_with_lines_and_gift_promotion
+    currency = order.currency
+    line_1, line_2, gift_line = order.lines.all()
+
+    rule = PromotionRule.objects.get()
+    promotion_id = graphene.Node.to_global_id("Promotion", rule.promotion_id)
+    gift_variant = rule.gifts.get()
+    gift_price = gift_variant.channel_listings.get(channel=channel_USD).price_amount
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_total_price_net = line_1.undiscounted_total_price_net_amount
+    line_1_total_price_gross = line_1_total_price_net * tax_rate
+    line_1_unit_price_net = quantize_price(
+        line_1_total_price_net / line_1.quantity, currency
+    )
+    line_1_unit_price_gross = quantize_price(
+        line_1_total_price_gross / line_1.quantity, currency
+    )
+
+    line_2_total_price_net = line_2.undiscounted_total_price_net_amount
+    line_2_total_price_gross = line_2_total_price_net * tax_rate
+    line_2_unit_price_net = quantize_price(
+        line_2_total_price_net / line_2.quantity, currency
+    )
+    line_2_unit_price_gross = quantize_price(
+        line_2_total_price_gross / line_2.quantity, currency
+    )
+
+    shipping_price_net = order.shipping_price_net_amount
+    shipping_price_gross = shipping_price_net * tax_rate
+
+    subtotal_net = line_1_total_price_net + line_2_total_price_net
+    subtotal_gross = line_1_total_price_gross + line_2_total_price_gross
+    total_net = subtotal_net + shipping_price_net
+    total_gross = subtotal_gross + shipping_price_gross
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=Decimal(0),
+                total_gross_amount=Decimal(0),
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    assert order.shipping_price_net_amount == shipping_price_net
+    assert order.shipping_price_gross_amount == shipping_price_gross
+    assert order.shipping_tax_rate == db_tax_rate
+    assert order.subtotal_net_amount == subtotal_net
+    assert order.subtotal_gross_amount == subtotal_gross
+    assert order.total_net_amount == total_net
+    assert order.total_gross_amount == total_gross
+
+    line_1, line_2, gift_line = lines
+
+    assert line_1.undiscounted_total_price_net_amount == line_1_total_price_net
+    assert line_1.undiscounted_total_price_gross_amount == line_1_total_price_gross
+    assert line_1.undiscounted_unit_price_net_amount == line_1_unit_price_net
+    assert line_1.undiscounted_unit_price_gross_amount == line_1_unit_price_gross
+
+    assert line_1.base_unit_price_amount == line_1_unit_price_net
+    assert line_1.total_price_net_amount == line_1_total_price_net
+    assert line_1.total_price_gross_amount == line_1_total_price_gross
+    assert line_1.unit_price_net_amount == line_1_unit_price_net
+    assert line_1.unit_price_gross_amount == line_1_unit_price_gross
+
+    assert line_1.unit_discount_reason == ""
+    assert line_1.unit_discount_amount == Decimal(0)
+
+    assert line_2.undiscounted_total_price_net_amount == line_2_total_price_net
+    assert line_2.undiscounted_total_price_gross_amount == line_2_total_price_gross
+    assert line_2.undiscounted_unit_price_net_amount == line_2_unit_price_net
+    assert line_2.undiscounted_unit_price_gross_amount == line_2_unit_price_gross
+
+    assert line_2.base_unit_price_amount == line_2_unit_price_net
+    assert line_2.total_price_net_amount == line_2_total_price_net
+    assert line_2.total_price_gross_amount == line_2_total_price_gross
+    assert line_2.unit_price_net_amount == line_2_unit_price_net
+    assert line_2.unit_price_gross_amount == line_2_unit_price_gross
+
+    assert line_2.unit_discount_reason == ""
+    assert line_2.unit_discount_amount == Decimal(0)
+
+    assert gift_line.undiscounted_total_price_net_amount == Decimal(0)
+    assert gift_line.undiscounted_total_price_gross_amount == Decimal(0)
+    assert gift_line.undiscounted_unit_price_net_amount == Decimal(0)
+    assert gift_line.undiscounted_unit_price_gross_amount == Decimal(0)
+
+    assert gift_line.base_unit_price_amount == Decimal(0)
+    assert gift_line.total_price_net_amount == Decimal(0)
+    assert gift_line.total_price_gross_amount == Decimal(0)
+    assert gift_line.unit_price_net_amount == Decimal(0)
+    assert gift_line.unit_price_gross_amount == Decimal(0)
+
+    assert gift_line.unit_discount_reason == f"Promotion: {promotion_id}"
+    assert gift_line.unit_discount_amount == gift_price
+
+    gift_discount = gift_line.discounts.get()
+    assert gift_discount.amount.amount == gift_price
+
+
+def test_fetch_order_prices_catalogue_and_order_discounts_tax_app(
+    draft_order_and_promotions,
+    tax_configuration_tax_app,
+):
+    # given
+    order, rule_catalogue, rule_total, _ = draft_order_and_promotions
+    catalogue_promotion_id = graphene.Node.to_global_id(
+        "Promotion", rule_catalogue.promotion_id
+    )
+    order_promotion_id = graphene.Node.to_global_id(
+        "Promotion", rule_total.promotion_id
+    )
+    rule_catalogue_reward = rule_catalogue.reward_value
+    rule_total_reward = rule_total.reward_value
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_base_unit_price = line_1.undiscounted_unit_price_net_amount
+    line_2_base_unit_price = (
+        line_2.undiscounted_unit_price_net_amount - rule_catalogue_reward
+    )
+    line_1_base_total = line_1.quantity * line_1_base_unit_price
+    line_2_base_total = line_2.quantity * line_2_base_unit_price
+    base_total = line_1_base_total + line_2_base_total
+    line_1_order_discount_portion = rule_total_reward * line_1_base_total / base_total
+    line_2_order_discount_portion = rule_total_reward - line_1_order_discount_portion
+
+    line_1_total_price_net = quantize_price(
+        line_1_base_total - line_1_order_discount_portion, currency
+    )
+    line_1_total_price_gross = quantize_price(
+        line_1_total_price_net * tax_rate, currency
+    )
+    line_2_total_price_net = quantize_price(
+        line_2_base_total - line_2_order_discount_portion, currency
+    )
+    line_2_total_price_gross = quantize_price(
+        line_2_total_price_net * tax_rate, currency
+    )
+
+    shipping_price_net = order.shipping_price_net_amount
+    shipping_price_gross = shipping_price_net * tax_rate
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    line_1, line_2 = lines
+    catalogue_discount = OrderLineDiscount.objects.get()
+    order_discount = OrderDiscount.objects.get()
+
+    line_1_base_total = line_1.quantity * line_1.base_unit_price_amount
+    line_2_base_total = line_2.quantity * line_2.base_unit_price_amount
+    base_total = line_1_base_total + line_2_base_total
+    line_1_order_discount_portion = rule_total_reward * line_1_base_total / base_total
+    line_2_order_discount_portion = rule_total_reward - line_1_order_discount_portion
+
+    assert order_discount.order == order
+    assert order_discount.amount_value == rule_total_reward
+    assert order_discount.value == rule_total_reward
+    assert order_discount.value_type == DiscountValueType.FIXED
+    assert order_discount.type == DiscountType.ORDER_PROMOTION
+    assert order_discount.reason == f"Promotion: {order_promotion_id}"
+
+    variant_1 = line_1.variant
+    variant_1_listing = variant_1.channel_listings.get(channel=order.channel)
+    variant_1_undiscounted_unit_price = variant_1_listing.price_amount
+    line_1_total_net_amount = quantize_price(
+        line_1.undiscounted_total_price_net_amount - line_1_order_discount_portion,
+        currency,
+    )
+    assert not line_1.discounts.exists()
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == variant_1_undiscounted_unit_price * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_total_price_net_amount * tax_rate
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == variant_1_undiscounted_unit_price
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount
+        == variant_1_undiscounted_unit_price * tax_rate
+    )
+    assert line_1.base_unit_price_amount == variant_1_undiscounted_unit_price
+    assert line_1.total_price_net_amount == line_1_total_net_amount
+    assert line_1.total_price_gross_amount == quantize_price(
+        line_1_total_net_amount * tax_rate, currency
+    )
+    assert line_1.unit_price_net_amount == quantize_price(
+        line_1_total_net_amount / line_1.quantity, currency
+    )
+    assert line_1.unit_price_gross_amount == quantize_price(
+        line_1.unit_price_net_amount * tax_rate, currency
+    )
+
+    assert line_1.unit_discount_reason == order_discount.reason
+    assert line_1.unit_discount_amount == quantize_price(
+        line_1_order_discount_portion / line_1.quantity, currency
+    )
+    assert line_1.unit_discount_amount == quantize_price(
+        line_1.undiscounted_unit_price_net_amount - line_1.unit_price_net_amount,
+        currency,
+    )
+
+    assert catalogue_discount.line == line_2
+    assert catalogue_discount.amount_value == rule_catalogue_reward * line_2.quantity
+    assert catalogue_discount.value == rule_catalogue_reward
+    assert catalogue_discount.value_type == DiscountValueType.FIXED
+    assert catalogue_discount.type == DiscountType.PROMOTION
+    assert catalogue_discount.reason == f"Promotion: {catalogue_promotion_id}"
+
+    variant_2 = line_2.variant
+    variant_2_listing = variant_2.channel_listings.get(channel=order.channel)
+    variant_2_undiscounted_unit_price = variant_2_listing.price_amount
+    line_2_total_net_amount = quantize_price(
+        line_2.undiscounted_total_price_net_amount
+        - line_2_order_discount_portion
+        - catalogue_discount.amount_value,
+        currency,
+    )
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == variant_2_undiscounted_unit_price * line_2.quantity
+    )
+    assert (
+        line_2.undiscounted_total_price_gross_amount
+        == line_2.undiscounted_total_price_net_amount * tax_rate
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == variant_2_undiscounted_unit_price
+    )
+    assert (
+        line_2.undiscounted_unit_price_gross_amount
+        == variant_2_undiscounted_unit_price * tax_rate
+    )
+    assert (
+        line_2.base_unit_price_amount
+        == variant_2_undiscounted_unit_price - rule_catalogue_reward
+    )
+    assert line_2.total_price_net_amount == line_2_total_net_amount
+    assert line_2.total_price_gross_amount == quantize_price(
+        line_2_total_net_amount * tax_rate, currency
+    )
+    assert line_2.unit_price_net_amount == quantize_price(
+        line_2_total_net_amount / line_2.quantity, currency
+    )
+    assert line_2.unit_price_gross_amount == quantize_price(
+        line_2.unit_price_net_amount * tax_rate, currency
+    )
+    assert line_2.unit_discount_reason == ", ".join(
+        [catalogue_discount.reason, order_discount.reason]
+    )
+    assert line_2.unit_discount_amount == quantize_price(
+        line_2.undiscounted_unit_price_net_amount - line_2.unit_price_net_amount,
+        currency,
+    )
+
+    shipping_price = order.shipping_price_net_amount
+    total_net_amount = quantize_price(
+        order.undiscounted_total_net_amount
+        - order_discount.amount_value
+        - catalogue_discount.amount_value,
+        currency,
+    )
+    assert (
+        order.undiscounted_total_net_amount
+        == line_1.undiscounted_total_price_net_amount
+        + line_2.undiscounted_total_price_net_amount
+        + shipping_price
+    )
+    assert (
+        order.undiscounted_total_gross_amount
+        == order.undiscounted_total_net_amount * tax_rate
+    )
+    assert order.total_net_amount == total_net_amount
+    assert order.total_gross_amount == quantize_price(
+        total_net_amount * tax_rate, currency
+    )
+    assert (
+        order.subtotal_net_amount == line_1_total_net_amount + line_2_total_net_amount
+    )
+    assert order.subtotal_gross_amount == quantize_price(
+        order.subtotal_net_amount * tax_rate, currency
+    )
+
+
+def test_fetch_order_prices_manual_order_discount_and_line_level_voucher_tax_app(
+    order_with_lines,
+    voucher,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    voucher_reward = Decimal("3")
+    voucher_listing.discount_value = voucher_reward
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher.apply_once_per_order = True
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["discount_value_type", "apply_once_per_order"])
+
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    order.save(update_fields=["voucher", "voucher_code"])
+
+    # create manual order discount
+    manual_reward = Decimal("8")
+    manual_discount_reason = "Manual discount reason"
+    manual_discount = order.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=manual_reward,
+        name="Manual order discount",
+        type=DiscountType.MANUAL,
+        reason=manual_discount_reason,
+    )
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_undiscounted_unit_price_net = line_1.undiscounted_unit_price_net_amount
+    line_2_undiscounted_unit_price_net = line_2.undiscounted_unit_price_net_amount
+    line_1_undiscounted_unit_price_gross = line_1_undiscounted_unit_price_net * tax_rate
+    line_2_undiscounted_unit_price_gross = line_2_undiscounted_unit_price_net * tax_rate
+
+    line_1_undiscounted_total_price_net = (
+        line_1.undiscounted_unit_price_net_amount * line_1.quantity
+    )
+    line_2_undiscounted_total_price_net = (
+        line_2.undiscounted_unit_price_net_amount * line_2.quantity
+    )
+    line_1_undiscounted_total_price_gross = (
+        line_1_undiscounted_total_price_net * tax_rate
+    )
+    line_2_undiscounted_total_price_gross = (
+        line_2_undiscounted_total_price_net * tax_rate
+    )
+
+    undiscounted_subtotal_net = (
+        line_1_undiscounted_total_price_net + line_2_undiscounted_total_price_net
+    )
+    shipping_base_price = order.shipping_price_net_amount
+
+    line_1_base_unit_price = (
+        line_1.undiscounted_unit_price_net_amount - voucher_reward / line_1.quantity
+    )
+    line_2_base_unit_price = line_2.undiscounted_unit_price_net_amount
+    line_1_base_total_price = line_1_base_unit_price * line_1.quantity
+    line_2_base_total_price = line_2_base_unit_price * line_2.quantity
+    base_subtotal = line_1_base_total_price + line_2_base_total_price
+    base_total = base_subtotal + shipping_base_price
+
+    subtotal_discount_portion = quantize_price(
+        manual_reward * base_subtotal / base_total, currency
+    )
+    shipping_discount_portion = manual_reward - subtotal_discount_portion
+    line_1_manual_discount_portion = (
+        subtotal_discount_portion * line_1_base_total_price / base_subtotal
+    )
+    line_2_manual_discount_portion = (
+        subtotal_discount_portion - line_1_manual_discount_portion
+    )
+    line_1_total_price_net = line_1_base_total_price - line_1_manual_discount_portion
+    line_2_total_price_net = line_2_base_total_price - line_2_manual_discount_portion
+    line_1_total_price_gross = line_1_total_price_net * tax_rate
+    line_2_total_price_gross = line_2_total_price_net * tax_rate
+
+    line_1_unit_price_net = line_1_total_price_net / line_1.quantity
+    line_2_unit_price_net = line_2_total_price_net / line_2.quantity
+    line_1_unit_price_gross = line_1_unit_price_net * tax_rate
+    line_2_unit_price_gross = line_2_unit_price_net * tax_rate
+
+    shipping_price_net = shipping_base_price - shipping_discount_portion
+    shipping_price_gross = shipping_price_net * tax_rate
+    subtotal_net = line_1_total_price_net + line_2_total_price_net
+    subtotal_gross = subtotal_net * tax_rate
+    total_net = subtotal_net + shipping_price_net
+    total_gross = total_net * tax_rate
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    line_1, line_2 = lines
+    assert order.total_gross_amount == quantize_price(
+        (
+            undiscounted_subtotal_net
+            + shipping_base_price
+            - voucher_reward
+            - manual_reward
+        )
+        * tax_rate,
+        currency,
+    )
+
+    assert order.shipping_price_net_amount == shipping_price_net
+    assert order.shipping_price_gross_amount == shipping_price_gross
+    assert order.shipping_tax_rate == db_tax_rate
+    assert order.subtotal_net_amount == subtotal_net
+    assert order.subtotal_gross_amount == subtotal_gross
+    assert order.total_net_amount == total_net
+    assert order.total_gross_amount == total_gross
+
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == line_1_undiscounted_total_price_net
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1_undiscounted_total_price_gross
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == line_1_undiscounted_unit_price_net
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount
+        == line_1_undiscounted_unit_price_gross
+    )
+
+    assert line_1.base_unit_price_amount == line_1_base_unit_price
+    assert line_1.total_price_net_amount == line_1_total_price_net
+    assert line_1.total_price_gross_amount == line_1_total_price_gross
+    assert line_1.unit_price_net_amount == quantize_price(
+        line_1_unit_price_net, currency
+    )
+    assert line_1.unit_price_gross_amount == quantize_price(
+        line_1_unit_price_gross, currency
+    )
+
+    assert (
+        line_1.unit_discount_reason
+        == f"Voucher code: {order.voucher_code}, {manual_discount_reason}"
+    )
+    assert line_1.unit_discount_amount == quantize_price(
+        line_1_undiscounted_unit_price_net - line_1_unit_price_net, currency
+    )
+
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == line_2_undiscounted_total_price_net
+    )
+    assert (
+        line_2.undiscounted_total_price_gross_amount
+        == line_2_undiscounted_total_price_gross
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == line_2_undiscounted_unit_price_net
+    )
+    assert (
+        line_2.undiscounted_unit_price_gross_amount
+        == line_2_undiscounted_unit_price_gross
+    )
+
+    assert line_2.base_unit_price_amount == line_2_undiscounted_unit_price_net
+    assert line_2.total_price_net_amount == line_2_total_price_net
+    assert line_2.total_price_gross_amount == line_2_total_price_gross
+    assert line_2.unit_price_net_amount == quantize_price(
+        line_2_unit_price_net, currency
+    )
+    assert line_2.unit_price_gross_amount == quantize_price(
+        line_2_unit_price_gross, currency
+    )
+
+    assert line_2.unit_discount_reason == manual_discount_reason
+    assert line_2.unit_discount_amount == quantize_price(
+        line_2_undiscounted_unit_price_net - line_2_unit_price_net, currency
+    )
+
+    manual_discount.refresh_from_db()
+    assert manual_discount.amount.amount == manual_reward
+    voucher_discount = line_1.discounts.get()
+    assert voucher_discount.amount.amount == voucher_reward
+
+
+def test_fetch_order_prices_manual_line_discount_and_entire_order_voucher_tax_app(
+    order_with_lines,
+    voucher,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    voucher_reward_value = Decimal("20")
+    voucher_listing.discount_value = voucher_reward_value
+    voucher_listing.save(update_fields=["discount_value"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    manual_line_discount_value = Decimal("50")
+    manual_discount_reason = "Manual line discount"
+    manual_line_discount = line_1.discounts.create(
+        value_type=DiscountValueType.PERCENTAGE,
+        value=manual_line_discount_value,
+        name="Manual line discount",
+        type=DiscountType.MANUAL,
+        reason=manual_discount_reason,
+    )
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_undiscounted_unit_price_net = line_1.undiscounted_unit_price_net_amount
+    line_2_undiscounted_unit_price_net = line_2.undiscounted_unit_price_net_amount
+    line_1_undiscounted_unit_price_gross = line_1_undiscounted_unit_price_net * tax_rate
+    line_2_undiscounted_unit_price_gross = line_2_undiscounted_unit_price_net * tax_rate
+
+    line_1_undiscounted_total_price_net = (
+        line_1.undiscounted_unit_price_net_amount * line_1.quantity
+    )
+    line_2_undiscounted_total_price_net = (
+        line_2.undiscounted_unit_price_net_amount * line_2.quantity
+    )
+    line_1_undiscounted_total_price_gross = (
+        line_1_undiscounted_total_price_net * tax_rate
+    )
+    line_2_undiscounted_total_price_gross = (
+        line_2_undiscounted_total_price_net * tax_rate
+    )
+
+    undiscounted_subtotal_net = (
+        line_1_undiscounted_total_price_net + line_2_undiscounted_total_price_net
+    )
+    undiscounted_shipping_net = order.undiscounted_base_shipping_price_amount
+    undiscounted_total_net = undiscounted_subtotal_net + undiscounted_shipping_net
+    undiscounted_total_gross = undiscounted_total_net * tax_rate
+
+    line_1_base_unit_price = line_1.undiscounted_unit_price_net_amount * (
+        1 - manual_line_discount_value / 100
+    )
+    line_2_base_unit_price = line_2.undiscounted_unit_price_net_amount
+    line_1_base_total_price = line_1_base_unit_price * line_1.quantity
+    line_2_base_total_price = line_2_base_unit_price * line_2.quantity
+    manual_line_discount_amount = (
+        line_1_undiscounted_total_price_net - line_1_base_total_price
+    )
+
+    line_1_voucher_discount_portion = (
+        line_1_base_total_price * voucher_reward_value / 100
+    )
+    line_2_voucher_discount_portion = (
+        line_2_base_total_price * voucher_reward_value / 100
+    )
+    voucher_reward = line_1_voucher_discount_portion + line_2_voucher_discount_portion
+
+    line_1_total_price_net = line_1_base_total_price - line_1_voucher_discount_portion
+    line_2_total_price_net = line_2_base_total_price - line_2_voucher_discount_portion
+    line_1_total_price_gross = line_1_total_price_net * tax_rate
+    line_2_total_price_gross = line_2_total_price_net * tax_rate
+
+    line_1_unit_price_net = line_1_total_price_net / line_1.quantity
+    line_2_unit_price_net = line_2_total_price_net / line_2.quantity
+    line_1_unit_price_gross = line_1_unit_price_net * tax_rate
+    line_2_unit_price_gross = line_2_unit_price_net * tax_rate
+
+    shipping_price_net = undiscounted_shipping_net
+    shipping_price_gross = shipping_price_net * tax_rate
+    subtotal_net = line_1_total_price_net + line_2_total_price_net
+    subtotal_gross = subtotal_net * tax_rate
+    total_net = subtotal_net + shipping_price_net
+    total_gross = total_net * tax_rate
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    line_1, line_2 = lines
+    assert order.total_gross_amount == quantize_price(
+        (
+            undiscounted_subtotal_net
+            + shipping_price_net
+            - voucher_reward
+            - manual_line_discount_amount
+        )
+        * tax_rate,
+        currency,
+    )
+
+    assert order.shipping_price_net_amount == shipping_price_net
+    assert order.shipping_price_gross_amount == shipping_price_gross
+    assert order.shipping_tax_rate == db_tax_rate
+    assert order.subtotal_net_amount == subtotal_net
+    assert order.subtotal_gross_amount == subtotal_gross
+    assert order.total_net_amount == total_net
+    assert order.total_gross_amount == total_gross
+    assert order.undiscounted_total_net_amount == undiscounted_total_net
+    assert order.undiscounted_total_gross_amount == undiscounted_total_gross
+
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == line_1_undiscounted_total_price_net
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1_undiscounted_total_price_gross
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == line_1_undiscounted_unit_price_net
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount
+        == line_1_undiscounted_unit_price_gross
+    )
+
+    assert line_1.base_unit_price_amount == line_1_base_unit_price
+    assert line_1.total_price_net_amount == line_1_total_price_net
+    assert line_1.total_price_gross_amount == line_1_total_price_gross
+    assert line_1.unit_price_net_amount == quantize_price(
+        line_1_unit_price_net, currency
+    )
+    assert line_1.unit_price_gross_amount == quantize_price(
+        line_1_unit_price_gross, currency
+    )
+
+    assert (
+        line_1.unit_discount_reason
+        == f"{manual_discount_reason}, Voucher code: {order.voucher_code}"
+    )
+    assert line_1.unit_discount_amount == quantize_price(
+        line_1_undiscounted_unit_price_net - line_1_unit_price_net, currency
+    )
+
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == line_2_undiscounted_total_price_net
+    )
+    assert (
+        line_2.undiscounted_total_price_gross_amount
+        == line_2_undiscounted_total_price_gross
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == line_2_undiscounted_unit_price_net
+    )
+    assert (
+        line_2.undiscounted_unit_price_gross_amount
+        == line_2_undiscounted_unit_price_gross
+    )
+
+    assert line_2.base_unit_price_amount == line_2_undiscounted_unit_price_net
+    assert line_2.total_price_net_amount == line_2_total_price_net
+    assert line_2.total_price_gross_amount == line_2_total_price_gross
+    assert line_2.unit_price_net_amount == quantize_price(
+        line_2_unit_price_net, currency
+    )
+    assert line_2.unit_price_gross_amount == quantize_price(
+        line_2_unit_price_gross, currency
+    )
+
+    assert line_2.unit_discount_reason == f"Voucher code: {order.voucher_code}"
+    assert line_2.unit_discount_amount == quantize_price(
+        line_2_undiscounted_unit_price_net - line_2_unit_price_net, currency
+    )
+
+    manual_line_discount.refresh_from_db()
+    assert manual_line_discount.amount.amount == manual_line_discount_amount
+    voucher_discount = order.discounts.get()
+    assert voucher_discount.amount.amount == voucher_reward
+
+
+def test_fetch_order_prices_shipping_voucher_and_manual_discount_tax_app(
+    order_with_lines,
+    voucher,
+    tax_configuration_tax_app,
+):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+
+    voucher.type = VoucherType.SHIPPING
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.save(update_fields=["type", "discount_value_type"])
+    voucher_listing = voucher.channel_listings.get(channel=order.channel)
+    voucher_discount_amount = Decimal("4")
+    voucher_listing.discount_value = voucher_discount_amount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+
+    manual_discount_value = Decimal("10")
+    manual_discount_reason = "Manual discount reason"
+    order.discounts.create(
+        value_type=DiscountValueType.PERCENTAGE,
+        value=manual_discount_value,
+        name="Manual order discount",
+        type=DiscountType.MANUAL,
+        currency=currency,
+        reason=manual_discount_reason,
+    )
+
+    app_tax_rate = Decimal(10)
+    db_tax_rate = app_tax_rate / Decimal(100)
+    tax_rate = Decimal(1) + db_tax_rate
+
+    line_1_undiscounted_unit_price_net = line_1.undiscounted_unit_price_net_amount
+    line_2_undiscounted_unit_price_net = line_2.undiscounted_unit_price_net_amount
+    line_1_undiscounted_unit_price_gross = line_1_undiscounted_unit_price_net * tax_rate
+    line_2_undiscounted_unit_price_gross = line_2_undiscounted_unit_price_net * tax_rate
+
+    line_1_undiscounted_total_price_net = (
+        line_1.undiscounted_unit_price_net_amount * line_1.quantity
+    )
+    line_2_undiscounted_total_price_net = (
+        line_2.undiscounted_unit_price_net_amount * line_2.quantity
+    )
+    line_1_undiscounted_total_price_gross = (
+        line_1_undiscounted_total_price_net * tax_rate
+    )
+    line_2_undiscounted_total_price_gross = (
+        line_2_undiscounted_total_price_net * tax_rate
+    )
+
+    undiscounted_subtotal_net = (
+        line_1_undiscounted_total_price_net + line_2_undiscounted_total_price_net
+    )
+    undiscounted_shipping_price_net = order.undiscounted_base_shipping_price_amount
+    undiscounted_total_net = undiscounted_shipping_price_net + undiscounted_subtotal_net
+    undiscounted_total_gross = undiscounted_total_net * tax_rate
+
+    base_shipping_price = undiscounted_shipping_price_net - voucher_discount_amount
+    line_1_base_unit_price = line_1.undiscounted_unit_price_net_amount
+    line_2_base_unit_price = line_2.undiscounted_unit_price_net_amount
+    line_1_base_total_price = line_1_base_unit_price * line_1.quantity
+    line_2_base_total_price = line_2_base_unit_price * line_2.quantity
+
+    base_subtotal = line_1_base_total_price + line_2_base_total_price
+    subtotal_discount_portion = manual_discount_value / 100 * base_subtotal
+    shipping_discount_portion = manual_discount_value / 100 * base_shipping_price
+    manual_discount_amount = subtotal_discount_portion + shipping_discount_portion
+    line_1_manual_discount_portion = (
+        subtotal_discount_portion * line_1_base_total_price / base_subtotal
+    )
+    line_2_manual_discount_portion = (
+        subtotal_discount_portion - line_1_manual_discount_portion
+    )
+
+    line_1_total_price_net = line_1_base_total_price - line_1_manual_discount_portion
+    line_2_total_price_net = line_2_base_total_price - line_2_manual_discount_portion
+    line_1_total_price_gross = line_1_total_price_net * tax_rate
+    line_2_total_price_gross = line_2_total_price_net * tax_rate
+
+    line_1_unit_price_net = line_1_total_price_net / line_1.quantity
+    line_2_unit_price_net = line_2_total_price_net / line_2.quantity
+    line_1_unit_price_gross = line_1_unit_price_net * tax_rate
+    line_2_unit_price_gross = line_2_unit_price_net * tax_rate
+
+    shipping_price_net = base_shipping_price - shipping_discount_portion
+    shipping_price_gross = shipping_price_net * tax_rate
+    subtotal_net = line_1_total_price_net + line_2_total_price_net
+    subtotal_gross = subtotal_net * tax_rate
+    total_net = subtotal_net + shipping_price_net
+    total_gross = total_net * tax_rate
+
+    tax_data = TaxData(
+        shipping_price_net_amount=shipping_price_net,
+        shipping_price_gross_amount=shipping_price_gross,
+        shipping_tax_rate=app_tax_rate,
+        lines=[
+            TaxLineData(
+                total_net_amount=line_1_total_price_net,
+                total_gross_amount=line_1_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+            TaxLineData(
+                total_net_amount=line_2_total_price_net,
+                total_gross_amount=line_2_total_price_gross,
+                tax_rate=app_tax_rate,
+            ),
+        ],
+    )
+
+    manager_methods = {"get_taxes_for_order": Mock(return_value=tax_data)}
+    manager = Mock(**manager_methods)
+
+    # when
+    order, lines = fetch_order_prices_if_expired(order, manager, None, True)
+
+    # then
+    line_1, line_2 = lines
+    assert order.total_gross_amount == quantize_price(
+        (
+            undiscounted_subtotal_net
+            + undiscounted_shipping_price_net
+            - voucher_discount_amount
+            - manual_discount_amount
+        )
+        * tax_rate,
+        currency,
+    )
+
+    assert order.shipping_price_net_amount == shipping_price_net
+    assert order.shipping_price_gross_amount == shipping_price_gross
+    assert order.shipping_tax_rate == db_tax_rate
+    assert order.subtotal_net_amount == subtotal_net
+    assert order.subtotal_gross_amount == subtotal_gross
+    assert order.total_net_amount == total_net
+    assert order.total_gross_amount == total_gross
+    assert order.undiscounted_total_net_amount == undiscounted_total_net
+    assert order.undiscounted_total_gross_amount == undiscounted_total_gross
+
+    assert (
+        line_1.undiscounted_total_price_net_amount
+        == line_1_undiscounted_total_price_net
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1_undiscounted_total_price_gross
+    )
+    assert (
+        line_1.undiscounted_unit_price_net_amount == line_1_undiscounted_unit_price_net
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount
+        == line_1_undiscounted_unit_price_gross
+    )
+
+    assert line_1.base_unit_price_amount == line_1_base_unit_price
+    assert line_1.total_price_net_amount == line_1_total_price_net
+    assert line_1.total_price_gross_amount == line_1_total_price_gross
+    assert line_1.unit_price_net_amount == quantize_price(
+        line_1_unit_price_net, currency
+    )
+    assert line_1.unit_price_gross_amount == quantize_price(
+        line_1_unit_price_gross, currency
+    )
+
+    assert line_1.unit_discount_reason == manual_discount_reason
+    assert line_1.unit_discount_amount == quantize_price(
+        line_1_undiscounted_unit_price_net - line_1_unit_price_net, currency
+    )
+
+    assert (
+        line_2.undiscounted_total_price_net_amount
+        == line_2_undiscounted_total_price_net
+    )
+    assert (
+        line_2.undiscounted_total_price_gross_amount
+        == line_2_undiscounted_total_price_gross
+    )
+    assert (
+        line_2.undiscounted_unit_price_net_amount == line_2_undiscounted_unit_price_net
+    )
+    assert (
+        line_2.undiscounted_unit_price_gross_amount
+        == line_2_undiscounted_unit_price_gross
+    )
+
+    assert line_2.base_unit_price_amount == line_2_undiscounted_unit_price_net
+    assert line_2.total_price_net_amount == line_2_total_price_net
+    assert line_2.total_price_gross_amount == line_2_total_price_gross
+    assert line_2.unit_price_net_amount == quantize_price(
+        line_2_unit_price_net, currency
+    )
+    assert line_2.unit_price_gross_amount == quantize_price(
+        line_2_unit_price_gross, currency
+    )
+
+    assert line_2.unit_discount_reason == manual_discount_reason
+    assert line_2.unit_discount_amount == quantize_price(
+        line_2_undiscounted_unit_price_net - line_2_unit_price_net, currency
+    )
+
+    manual_discount = order.discounts.get(type=DiscountType.MANUAL)
+    assert manual_discount.amount.amount == manual_discount_amount
+
+    shipping_voucher_discount = order.discounts.get(type=DiscountType.VOUCHER)
+    assert shipping_voucher_discount.amount.amount == voucher_discount_amount

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_order_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_order_promotion.py
@@ -460,7 +460,7 @@ def test_draft_order_products_on_catalog_promotion_and_order_promotion_CORE_2132
     line1 = completed_order["lines"][0]
     assert (
         line1["unitDiscountReason"]
-        == f"Promotion: {catalog_promotion_id}, Promotion: {order_promotion_id}"
+        == f"Promotion: {catalog_promotion_id}; Promotion: {order_promotion_id}"
     )
     assert (
         line1["unitDiscount"]["amount"]
@@ -470,7 +470,7 @@ def test_draft_order_products_on_catalog_promotion_and_order_promotion_CORE_2132
     line2 = completed_order["lines"][1]
     assert (
         line2["unitDiscountReason"]
-        == f"Promotion: {catalog_promotion_id}, Promotion: {order_promotion_id}"
+        == f"Promotion: {catalog_promotion_id}; Promotion: {order_promotion_id}"
     )
     assert (
         line2["unitDiscount"]["amount"]

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_order_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_order_promotion.py
@@ -458,7 +458,23 @@ def test_draft_order_products_on_catalog_promotion_and_order_promotion_CORE_2132
         == expected_undiscounted_total_tax
     )
     line1 = completed_order["lines"][0]
-    assert line1["unitDiscountReason"] == f"Promotion: {catalog_promotion_id}"
+    assert (
+        line1["unitDiscountReason"]
+        == f"Promotion: {catalog_promotion_id}, Promotion: {order_promotion_id}"
+    )
+    assert (
+        line1["unitDiscount"]["amount"]
+        == line1["undiscountedUnitPrice"]["gross"]["amount"]
+        - line1["unitPrice"]["gross"]["amount"]
+    )
     line2 = completed_order["lines"][1]
-    assert line2["unitDiscountReason"] == f"Promotion: {catalog_promotion_id}"
+    assert (
+        line2["unitDiscountReason"]
+        == f"Promotion: {catalog_promotion_id}, Promotion: {order_promotion_id}"
+    )
+    assert (
+        line2["unitDiscount"]["amount"]
+        == line2["undiscountedUnitPrice"]["gross"]["amount"]
+        - line2["unitPrice"]["gross"]["amount"]
+    )
     assert completed_order["discounts"][0]["type"] == "ORDER_PROMOTION"

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_voucher_entire.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_voucher_entire.py
@@ -445,7 +445,7 @@ def test_order_products_on_catalog_promotion_and_voucher_entire_order_CORE_2131(
     line1 = completed_order["lines"][0]
     assert (
         line1["unitDiscountReason"]
-        == f"Promotion: {promotion_id}, Voucher code: {voucher_code}"
+        == f"Promotion: {promotion_id}; Voucher code: {voucher_code}"
     )
     assert (
         line1["unitDiscount"]["amount"]
@@ -455,7 +455,7 @@ def test_order_products_on_catalog_promotion_and_voucher_entire_order_CORE_2131(
     line2 = completed_order["lines"][1]
     assert (
         line2["unitDiscountReason"]
-        == f"Promotion: {promotion_id}, Voucher code: {voucher_code}"
+        == f"Promotion: {promotion_id}; Voucher code: {voucher_code}"
     )
     assert (
         line2["unitDiscount"]["amount"]

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_voucher_entire.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_catalog_promotion_and_voucher_entire.py
@@ -443,12 +443,22 @@ def test_order_products_on_catalog_promotion_and_voucher_entire_order_CORE_2131(
         == expected_undiscounted_total_tax
     )
     line1 = completed_order["lines"][0]
-    assert line1["unitDiscountReason"] == f"Promotion: {promotion_id}"
-    assert line1["unitDiscount"]["amount"] == round(
-        product1_variant_price * (catalog_promotion_value / 100), 2
+    assert (
+        line1["unitDiscountReason"]
+        == f"Promotion: {promotion_id}, Voucher code: {voucher_code}"
+    )
+    assert (
+        line1["unitDiscount"]["amount"]
+        == line1["undiscountedUnitPrice"]["gross"]["amount"]
+        - line1["unitPrice"]["gross"]["amount"]
     )
     line2 = completed_order["lines"][1]
-    assert line2["unitDiscountReason"] == f"Promotion: {promotion_id}"
-    assert line2["unitDiscount"]["amount"] == round(
-        product2_variant_price * (catalog_promotion_value / 100), 2
+    assert (
+        line2["unitDiscountReason"]
+        == f"Promotion: {promotion_id}, Voucher code: {voucher_code}"
+    )
+    assert (
+        line2["unitDiscount"]["amount"]
+        == line2["undiscountedUnitPrice"]["gross"]["amount"]
+        - line2["unitPrice"]["gross"]["amount"]
     )

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
@@ -120,9 +120,11 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
 
     # Step 3 - Add manual discount to the order
     manual_discount_value = 2
+    manual_discount_reason = "Manual discount reason"
     manual_discount_input = {
         "valueType": "FIXED",
         "value": manual_discount_value,
+        "reason": manual_discount_reason,
     }
     discount_data = order_discount_add(
         e2e_staff_api_client,
@@ -160,10 +162,17 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
         manual_discount_value - manual_discount_subtotal_share
     )
     assert product_price == product_variant_price
-    assert order_line["unitDiscount"]["amount"] == promotion_value
+    assert order_line["unitDiscount"]["amount"] == float(
+        quantize_price(
+            promotion_value + manual_discount_subtotal_share / quantity, currency
+        )
+    )
     assert order_line["unitDiscountType"] == "PERCENTAGE"
     assert order_line["unitDiscountValue"] == promotion_discount_value
-    assert order_line["unitDiscountReason"] == promotion_reason
+    assert (
+        order_line["unitDiscountReason"]
+        == f"{promotion_reason}, {manual_discount_reason}"
+    )
     product_discounted_price = product_price - promotion_value
     shipping_amount = quantize_price(
         Decimal(order["order"]["shippingPrice"]["gross"]["amount"]), currency

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
@@ -173,7 +173,7 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
     assert order_line["unitDiscountValue"] == promotion_discount_value
     assert (
         order_line["unitDiscountReason"]
-        == f"{promotion_reason}, {manual_discount_reason}"
+        == f"{promotion_reason}; {manual_discount_reason}"
     )
     product_discounted_price = product_price - promotion_value
     shipping_amount = quantize_price(

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
@@ -161,11 +161,13 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
     manual_discount_shipping_share = (
         manual_discount_value - manual_discount_subtotal_share
     )
+    unit_discount_amount = quantize_price(
+        promotion_value + manual_discount_subtotal_share / quantity, currency
+    )
     assert product_price == product_variant_price
-    assert order_line["unitDiscount"]["amount"] == float(
-        quantize_price(
-            promotion_value + manual_discount_subtotal_share / quantity, currency
-        )
+    assert (
+        quantize_price(Decimal(order_line["unitDiscount"]["amount"]), currency)
+        == unit_discount_amount
     )
     assert order_line["unitDiscountType"] == "PERCENTAGE"
     assert order_line["unitDiscountValue"] == promotion_discount_value

--- a/saleor/tests/e2e/orders/utils/order_discount_add.py
+++ b/saleor/tests/e2e/orders/utils/order_discount_add.py
@@ -30,6 +30,7 @@ mutation OrderDiscountAdd($input: OrderDiscountCommonInput!, $id: ID!) {
         amount {
           amount
         }
+        reason
       }
       shippingPrice {
         ...BaseTaxedMoney


### PR DESCRIPTION
I want to merge this change because it fixes OrderLine's `unit_discount` and `unit_discount_reason` values. I want to make sure all the discounts applied are visible in the fields.

This PR also deprecates the `unit_discount_type` and `unit_discount_value` fields. Since multiple discounts can affect a single line, the fields have no sense. 

Internal issue: https://linear.app/saleor/issue/SHOPX-1531

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [x] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
