### PR TITLE
Change error to warning when logging invalid data provided by customer in the payment integration 

### DIFF
--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -575,6 +575,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_no_psp_
     result_event_type,
     transaction_item_generator,
     app,
+    caplog,
 ):
     # given
     transaction = transaction_item_generator()
@@ -603,9 +604,10 @@ def test_create_transaction_event_from_request_and_webhook_response_with_no_psp_
     assert transaction.events.count() == event_count + 1
     assert event.psp_reference is None
     assert event.transaction_id == transaction.id
-    assert event.message == (
-        f"Providing `pspReference` is required for {result_event_type.upper()}."
-    )
+    error_msg = f"Providing `pspReference` is required for {result_event_type.upper()}."
+    assert event.message == error_msg
+    assert caplog.records[0].levelno == logging.WARNING
+    assert caplog.records[0].message == error_msg
 
 
 @freeze_time("2018-05-31 12:00:01")

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -23,6 +24,7 @@ from ..utils import (
     create_payment_lines_information,
     create_transaction_event_for_transaction_session,
     create_transaction_event_from_request_and_webhook_response,
+    deduplicate_event,
     get_channel_slug_from_payment,
     get_correct_event_types_based_on_request_type,
     get_transaction_event_amount,
@@ -3055,3 +3057,85 @@ def test_get_transaction_event_amount_for_info_event_type(
 
     # then
     assert amount == 0
+
+
+def test_deduplicate_event(transaction_events_generator, transaction_item, app):
+    # given
+    event = TransactionEvent(
+        psp_reference="psp:123",
+        type=TransactionEventType.CHARGE_SUCCESS,
+        amount_value=Decimal("10"),
+        transaction=transaction_item,
+        currency=transaction_item.currency,
+    )
+
+    # when
+    result_event, err_msg = deduplicate_event(event, app)
+
+    # then
+    assert err_msg is None
+    assert result_event
+
+
+def test_deduplicate_event_different_amount(
+    transaction_events_generator, transaction_item, app, caplog
+):
+    # given
+    events = transaction_events_generator(
+        psp_references=["psp:123"],
+        types=[TransactionEventType.CHARGE_SUCCESS],
+        amounts=[Decimal("10")],
+        transaction=transaction_item,
+    )
+    event = TransactionEvent(
+        psp_reference="psp:123",
+        type=TransactionEventType.CHARGE_SUCCESS,
+        amount_value=Decimal("12"),
+        transaction=transaction_item,
+        currency=transaction_item.currency,
+    )
+
+    # when
+    result_event, err_msg = deduplicate_event(event, app)
+
+    # then
+    assert result_event.id == events[0].id
+    assert err_msg == (
+        "The transaction with provided `pspReference` and "
+        "`type` already exists with different amount."
+    )
+    assert caplog.records[0].levelno == logging.WARNING
+    assert caplog.records[0].message == err_msg
+
+
+def test_deduplicate_event_authorization_already_exists(
+    transaction_events_generator, transaction_item, app, caplog
+):
+    # given
+    transaction_events_generator(
+        psp_references=["psp:123"],
+        types=[TransactionEventType.AUTHORIZATION_SUCCESS],
+        amounts=[Decimal("10")],
+        transaction=transaction_item,
+    )
+    event = TransactionEvent(
+        psp_reference="psp:111",
+        type=TransactionEventType.AUTHORIZATION_SUCCESS,
+        amount_value=Decimal("10"),
+        transaction=transaction_item,
+        currency=transaction_item.currency,
+    )
+
+    # when
+    result_event, err_msg = deduplicate_event(event, app)
+
+    # then
+    assert result_event
+    assert err_msg == (
+        "Event with `AUTHORIZATION_SUCCESS` already "
+        "reported for the transaction. Use "
+        "`AUTHORIZATION_ADJUSTMENT` to change the "
+        "authorization amount."
+    )
+    assert caplog.records[0].levelno == logging.WARNING
+    assert caplog.records[0].message == err_msg

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -956,7 +956,7 @@ def parse_transaction_action_data(
     request_event_type = parsed_event_data.get("type", request_type)
     if not psp_reference and request_event_type not in OPTIONAL_PSP_REFERENCE_EVENTS:
         msg = f"Providing `pspReference` is required for {request_event_type.upper()}."
-        logger.error(msg)
+        logger.warning(msg)
         return None, msg
 
     return (

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1091,7 +1091,7 @@ def deduplicate_event(
                 "authorization amount."
             )
     if error_message:
-        logger.error(
+        logger.warning(
             msg=error_message,
             extra={
                 "transaction_id": event.transaction_id,


### PR DESCRIPTION
In case of errors caused by invalid data provided by customer in their payment integration, we should use logger.warning instead of logger.errors, as it's not something to be fixed.

Port of https://github.com/saleor/saleor/pull/16971

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
