### PR TITLE
Optimize ProductVariantUpdate mutation

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -750,6 +750,14 @@ class ModelMutation(BaseMutation):
         instance.save()
 
     @classmethod
+    def diff_instance_data_fields(cls, fields, old_instance_data, new_instance_data):
+        diff_fields = []
+        for field in fields:
+            if old_instance_data.get(field) != new_instance_data.get(field):
+                diff_fields.append(field)
+        return diff_fields
+
+    @classmethod
     def get_type_for_model(cls):
         if not cls._meta.object_type:
             raise ImproperlyConfigured(

--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -181,14 +181,6 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         return instance
 
     @classmethod
-    def diff_instance_data_fields(cls, fields, old_instance_data, new_instance_data):
-        diff_fields = []
-        for field in fields:
-            if old_instance_data.get(field) != new_instance_data.get(field):
-                diff_fields.append(field)
-        return diff_fields
-
-    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls,
         root,

--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -214,7 +214,7 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         new_instance_data = instance.serialize_for_comparison()
 
         changed_fields = cls.diff_instance_data_fields(
-            instance._comparison_fields,
+            instance.comparison_fields,
             old_instance_data,
             new_instance_data,
         )

--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -212,21 +212,21 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
             info, id=id, sku=sku, external_reference=external_reference, input=input
         )
         old_instance_data = instance.serialize_for_comparison()
-
         cleaned_input = cls.clean_input(info, instance, input)
         metadata_list = cleaned_input.pop("metadata", None)
         private_metadata_list = cleaned_input.pop("private_metadata", None)
-        instance = cls.construct_instance(instance, cleaned_input)
-        new_instance_data = instance.serialize_for_comparison()
 
+        instance = cls.construct_instance(instance, cleaned_input)
         cls.validate_and_update_metadata(instance, metadata_list, private_metadata_list)
         cls.clean_instance(info, instance)
+        new_instance_data = instance.serialize_for_comparison()
 
         changed_fields = cls.diff_instance_data_fields(
             instance._comparison_fields,
             old_instance_data,
             new_instance_data,
         )
+
         variant_modified = cls._save(info, instance, cleaned_input, changed_fields)
         cls._save_m2m(info, instance, cleaned_input)
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -247,6 +247,7 @@ def test_update_product_variant_update_fields_when_necessary(
     fields,
     changed_fields,
 ):
+    # given
     variant = product.variants.first()
     quantity_limit = 9
     external_reference = "test-ext-ref"
@@ -276,15 +277,16 @@ def test_update_product_variant_update_fields_when_necessary(
     for field, value in fields.items():
         variables[field] = value
 
+    # when
     response = staff_api_client.post_graphql(
         QUERY_UPDATE_VARIANT_CHANGING_FIELDS,
         variables,
         permissions=[permission_manage_products],
     )
+
+    # then
     variant.refresh_from_db()
     get_graphql_content(response)
-    flush_post_commit_hooks()
-
     save_variant_mock.assert_called_once_with(variant, changed_fields)
     call_event_mock.assert_has_calls(
         [
@@ -318,6 +320,7 @@ def test_update_product_variant_skip_updating_fields_when_unchanged(
     permission_manage_products,
     field_values,
 ):
+    # given
     variant = product.variants.first()
     quantity_limit = 9
     external_reference = "test-ext-ref"
@@ -347,15 +350,16 @@ def test_update_product_variant_skip_updating_fields_when_unchanged(
     field, value = field_values
     variables[field] = value
 
+    # when
     response = staff_api_client.post_graphql(
         QUERY_UPDATE_VARIANT_CHANGING_FIELDS,
         variables,
         permissions=[permission_manage_products],
     )
+
+    # then
     variant.refresh_from_db()
     get_graphql_content(response)
-    flush_post_commit_hooks()
-
     save_variant_mock.assert_not_called()
     call_event_mock.assert_not_called()
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -247,6 +247,116 @@ def test_update_product_variant_skips_save_when_nothing_changes(
     product_variant_updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
+def test_update_product_variant_update_metadata_when_base_fields_unchanged(
+    product_variant_updated_webhook_mock,
+    staff_api_client,
+    product,
+    permission_manage_products,
+):
+    query = """
+        mutation updateVariant (
+            $id: ID!
+            $sku: String!
+            $quantityLimitPerCustomer: Int!
+            $trackInventory: Boolean!
+            $externalReference: String
+            $metadata: [MetadataInput!]
+            $privateMetadata: [MetadataInput!]
+            $attributes: [AttributeValueInput!]) {
+                productVariantUpdate(
+                    id: $id,
+                    input: {
+                        sku: $sku,
+                        trackInventory: $trackInventory,
+                        attributes: $attributes,
+                        externalReference: $externalReference
+                        quantityLimitPerCustomer: $quantityLimitPerCustomer,
+                        metadata: $metadata,
+                        privateMetadata: $privateMetadata
+                    }) {
+                    productVariant {
+                        name
+                        sku
+                        quantityLimitPerCustomer
+                        externalReference
+                        channelListings {
+                            channel {
+                                slug
+                            }
+                        }
+                        metadata {
+                            key
+                            value
+                        }
+                        privateMetadata {
+                            key
+                            value
+                        }
+                    }
+                    errors {
+                      field
+                      message
+                      attributes
+                      code}
+                }
+            }
+    """
+    variant = product.variants.first()
+    quantity_limit = 9
+    external_reference = "test-ext-ref"
+    variant_name = variant.attributes.first().values.first().name
+    variant_sku = "123"
+    new_metadata_value = "test_value2"
+    new_private_metadata_value = "private_value_2"
+    product.default_variant = variant
+    product.save(update_fields=["default_variant"])
+    variant.name = variant_name
+    variant.metadata = {"test_key1": "test_value1"}
+    variant.private_metadata = {"private_key1": "private_value_1"}
+    variant.external_reference = external_reference
+    variant.quantity_limit_per_customer = quantity_limit
+    variant.track_inventory = True
+    variant.save()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variables = {
+        "id": variant_id,
+        "sku": variant_sku,
+        "trackInventory": True,
+        "quantityLimitPerCustomer": quantity_limit,
+        "externalReference": external_reference,
+        "metadata": [{"key": "test_key1", "value": new_metadata_value}],
+        "privateMetadata": [
+            {"key": "private_key1", "value": new_private_metadata_value}
+        ],
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    variant.refresh_from_db()
+    content = get_graphql_content(response)
+    flush_post_commit_hooks()
+    data = content["data"]["productVariantUpdate"]["productVariant"]
+
+    assert data["name"] == variant_name
+    assert data["sku"] == variant_sku
+
+    assert data["metadata"] == [{"key": "test_key1", "value": new_metadata_value}]
+    assert variant.metadata == {"test_key1": new_metadata_value}
+    assert data["privateMetadata"] == [
+        {"key": "private_key1", "value": new_private_metadata_value}
+    ]
+    assert variant.private_metadata == {"private_key1": new_private_metadata_value}
+
+    assert data["externalReference"] == external_reference == variant.external_reference
+    assert data["quantityLimitPerCustomer"] == quantity_limit
+    product_variant_updated_webhook_mock.assert_called_once_with(
+        product.variants.last()
+    )
+
+
 def test_update_product_variant_marks_prices_as_dirty(
     staff_api_client,
     product,

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, call, patch
 from uuid import uuid4
 
 import graphene
@@ -12,6 +12,7 @@ from django.utils.text import slugify
 from .....attribute import AttributeInputType
 from .....attribute.models import AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
+from .....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
 from .....product.error_codes import ProductErrorCode
 from .....tests.utils import flush_post_commit_hooks
 from ....tests.utils import get_graphql_content
@@ -167,94 +168,7 @@ def test_update_product_variant_by_id(
     product_variant_created_webhook_mock.assert_not_called()
 
 
-@patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
-def test_update_product_variant_skips_save_when_nothing_changes(
-    product_variant_updated_webhook_mock,
-    staff_api_client,
-    product,
-    permission_manage_products,
-):
-    query = """
-        mutation updateVariant (
-            $id: ID!
-            $sku: String!
-            $quantityLimitPerCustomer: Int!
-            $trackInventory: Boolean!
-            $externalReference: String
-            $attributes: [AttributeValueInput!]) {
-                productVariantUpdate(
-                    id: $id,
-                    input: {
-                        sku: $sku,
-                        trackInventory: $trackInventory,
-                        attributes: $attributes,
-                        externalReference: $externalReference
-                        quantityLimitPerCustomer: $quantityLimitPerCustomer,
-                    }) {
-                    productVariant {
-                        name
-                        sku
-                        quantityLimitPerCustomer
-                        externalReference
-                        channelListings {
-                            channel {
-                                slug
-                            }
-                        }
-                    }
-                    errors {
-                      field
-                      message
-                      attributes
-                      code}
-                }
-            }
-    """
-    variant = product.variants.first()
-    quantity_limit = 9
-    external_reference = "test-ext-ref"
-    variant_name = variant.attributes.first().values.first().name
-    variant_sku = "123"
-    product.default_variant = variant
-    product.save(update_fields=["default_variant"])
-    variant.name = variant_name
-    variant.external_reference = external_reference
-    variant.quantity_limit_per_customer = quantity_limit
-    variant.track_inventory = True
-    variant.save()
-    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
-
-    variables = {
-        "id": variant_id,
-        "sku": variant_sku,
-        "trackInventory": True,
-        "quantityLimitPerCustomer": quantity_limit,
-        "externalReference": external_reference,
-    }
-
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
-    )
-    variant.refresh_from_db()
-    content = get_graphql_content(response)
-    flush_post_commit_hooks()
-    data = content["data"]["productVariantUpdate"]["productVariant"]
-
-    assert data["name"] == variant_name
-    assert data["sku"] == variant_sku
-    assert data["externalReference"] == external_reference == variant.external_reference
-    assert data["quantityLimitPerCustomer"] == quantity_limit
-    product_variant_updated_webhook_mock.assert_not_called()
-
-
-@patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
-def test_update_product_variant_update_metadata_when_base_fields_unchanged(
-    product_variant_updated_webhook_mock,
-    staff_api_client,
-    product,
-    permission_manage_products,
-):
-    query = """
+QUERY_UPDATE_VARIANT_CHANGING_FIELDS = """
         mutation updateVariant (
             $id: ID!
             $sku: String!
@@ -302,13 +216,47 @@ def test_update_product_variant_update_metadata_when_base_fields_unchanged(
                 }
             }
     """
+
+
+@pytest.mark.parametrize(
+    ("fields", "changed_fields"),
+    [
+        ({"sku": 123}, []),
+        ({"sku": 1234}, ["sku"]),
+        ({"metadata": [{"key": "test_key1", "value": "test_value1"}]}, []),
+        ({"metadata": [{"key": "test_key1", "value": "test_value2"}]}, ["metadata"]),
+        ({"trackInventory": True}, []),
+        ({"trackInventory": False}, ["track_inventory"]),
+        ({"quantityLimitPerCustomer": 9}, []),
+        ({"quantityLimitPerCustomer": 5}, ["quantity_limit_per_customer"]),
+        ({"externalReference": "test-ext-ref"}, []),
+        ({"externalReference": "test-ext-ref2"}, ["external_reference"]),
+        (
+            {"sku": 1234, "trackInventory": False, "externalReference": "test-ext-ref"},
+            ["sku", "track_inventory"],
+        ),
+    ],
+)
+@patch(
+    "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate.call_event"
+)
+@patch(
+    "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate._save_variant_instance"
+)
+def test_update_product_variant_update_fields_when_necessary(
+    save_variant_mock,
+    call_event_mock,
+    staff_api_client,
+    product,
+    permission_manage_products,
+    fields,
+    changed_fields,
+):
     variant = product.variants.first()
     quantity_limit = 9
     external_reference = "test-ext-ref"
     variant_name = variant.attributes.first().values.first().name
     variant_sku = "123"
-    new_metadata_value = "test_value2"
-    new_private_metadata_value = "private_value_2"
     product.default_variant = variant
     product.save(update_fields=["default_variant"])
     variant.name = variant_name
@@ -326,35 +274,33 @@ def test_update_product_variant_update_metadata_when_base_fields_unchanged(
         "trackInventory": True,
         "quantityLimitPerCustomer": quantity_limit,
         "externalReference": external_reference,
-        "metadata": [{"key": "test_key1", "value": new_metadata_value}],
-        "privateMetadata": [
-            {"key": "private_key1", "value": new_private_metadata_value}
-        ],
+        "metadata": [{"key": "test_key1", "value": "test_value1"}],
+        "privateMetadata": [{"key": "private_key1", "value": "private_value_1"}],
     }
 
+    for field, value in fields.items():
+        variables[field] = value
+
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        QUERY_UPDATE_VARIANT_CHANGING_FIELDS,
+        variables,
+        permissions=[permission_manage_products],
     )
     variant.refresh_from_db()
-    content = get_graphql_content(response)
+    get_graphql_content(response)
     flush_post_commit_hooks()
-    data = content["data"]["productVariantUpdate"]["productVariant"]
 
-    assert data["name"] == variant_name
-    assert data["sku"] == variant_sku
-
-    assert data["metadata"] == [{"key": "test_key1", "value": new_metadata_value}]
-    assert variant.metadata == {"test_key1": new_metadata_value}
-    assert data["privateMetadata"] == [
-        {"key": "private_key1", "value": new_private_metadata_value}
-    ]
-    assert variant.private_metadata == {"private_key1": new_private_metadata_value}
-
-    assert data["externalReference"] == external_reference == variant.external_reference
-    assert data["quantityLimitPerCustomer"] == quantity_limit
-    product_variant_updated_webhook_mock.assert_called_once_with(
-        product.variants.last()
-    )
+    if changed_fields:
+        save_variant_mock.assert_called_once_with(variant, changed_fields)
+        call_event_mock.assert_has_calls(
+            [
+                call(ANY, variant),
+                call(mark_active_catalogue_promotion_rules_as_dirty, ANY),
+            ]
+        )
+    else:
+        save_variant_mock.assert_not_called()
+        call_event_mock.assert_not_called()
 
 
 def test_update_product_variant_marks_prices_as_dirty(

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -441,7 +441,7 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
         )
 
     @property
-    def _comparison_fields(self):
+    def comparison_fields(self):
         return [
             "sku",
             "name",
@@ -455,7 +455,7 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
         ]
 
     def serialize_for_comparison(self):
-        return copy.deepcopy(model_to_dict(self, fields=self._comparison_fields))
+        return copy.deepcopy(model_to_dict(self, fields=self.comparison_fields))
 
 
 class ProductVariantTranslation(Translation):

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
@@ -12,6 +13,7 @@ from django.contrib.postgres.search import SearchVectorField
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
 from django.db.models import JSONField, TextField
+from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
 from django_measurement.models import MeasurementField
@@ -437,6 +439,23 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
         return self.is_preorder and (
             self.preorder_end_date is None or timezone.now() <= self.preorder_end_date
         )
+
+    @property
+    def _comparison_fields(self):
+        return [
+            "sku",
+            "name",
+            "track_inventory",
+            "is_preorder",
+            "quantity_limit_per_customer",
+            "weight",
+            "external_reference",
+            "metadata",
+            "private_metadata",
+        ]
+
+    def serialize_for_comparison(self):
+        return copy.deepcopy(model_to_dict(self, fields=self._comparison_fields))
 
 
 class ProductVariantTranslation(Translation):


### PR DESCRIPTION
I want to merge this change because it optimizes `ProductVariantUpdate` mutation.
- now utilizes `update_fields` when saving variant
- marks product search index as dirty only if needed
- mark promotion rules as dirty only if actual update was done
- found and fix bug that caused marking promotion rules as dirty twice (duplicated `post_save_action` regarding superclass)
- trigger `product_variant_updated` only if actual update was done

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
