### PR TITLE
Skip request event in calculation, when the `pspReference` is missing in the response from payment app

### DIFF
--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -481,6 +481,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_psp_ref
     # then
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
     assert TransactionEvent.objects.count() == 1
 
 
@@ -528,6 +529,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_no_psp_
     request_event.refresh_from_db()
     transaction.refresh_from_db()
     assert request_event.psp_reference is None
+    assert request_event.include_in_calculations is False
     assert transaction.events.count() == event_count + 1
     assert event.psp_reference is None
     assert event.type == result_event_type
@@ -586,6 +588,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_no_psp_
     request_event.refresh_from_db()
     transaction.refresh_from_db()
     assert request_event.psp_reference is None
+    assert request_event.include_in_calculations is False
     assert transaction.events.count() == event_count + 1
     assert event.psp_reference is None
     assert event.transaction_id == transaction.id
@@ -625,6 +628,7 @@ def test_create_transaction_event_from_request_and_webhook_response_part_event(
     assert TransactionEvent.objects.count() == 2
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
     assert event
     assert event.psp_reference == expected_psp_reference
     assert event.amount_value == amount
@@ -983,6 +987,7 @@ def test_create_transaction_event_from_request_and_webhook_response_full_event(
     assert transaction.events.count() == 2
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
     assert event
     assert event.psp_reference == expected_psp_reference
     assert event.amount_value == event_amount
@@ -1263,6 +1268,7 @@ def test_create_transaction_event_from_request_and_webhook_response_twice_auth(
     assert TransactionEvent.objects.count() == 3
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
     assert failed_event
     assert failed_event.psp_reference == expected_psp_reference
     assert failed_event.type == TransactionEventType.AUTHORIZATION_FAILURE
@@ -1318,6 +1324,7 @@ def test_create_transaction_event_from_request_and_webhook_response_same_event(
     assert TransactionEvent.objects.count() == 2
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
     assert event
     assert event.pk == existing_authorize_success.pk
 
@@ -1367,6 +1374,7 @@ def test_create_transaction_event_from_request_handle_incorrect_values(
     assert TransactionEvent.objects.count() == 2
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is False
 
 
 @freeze_time("2018-05-31 12:00:01")
@@ -1414,6 +1422,7 @@ def test_create_transaction_event_from_request_and_webhook_response_different_am
     assert TransactionEvent.objects.count() == 3
     request_event.refresh_from_db()
     assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
     assert failed_event
     assert failed_event.psp_reference == expected_psp_reference
     assert failed_event.type == TransactionEventType.AUTHORIZATION_FAILURE

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1319,9 +1319,10 @@ def create_transaction_event_from_request_and_webhook_response(
         return failure_event
 
     psp_reference = transaction_request_response.psp_reference
-    request_event.psp_reference = psp_reference
-    request_event.include_in_calculations = True
-    request_event.save(update_fields=["psp_reference", "include_in_calculations"])
+    if psp_reference is not None:
+        request_event.psp_reference = psp_reference
+        request_event.include_in_calculations = True
+        request_event.save(update_fields=["psp_reference", "include_in_calculations"])
     event = None
     if response_event := transaction_request_response.event:
         event, error_msg = _create_event_from_response(


### PR DESCRIPTION
We should mark as `include_in_calculations` only when the response event contains the `pspReference`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
