### PR TITLE
Move import to local function

### DIFF
--- a/saleor/graphql/webhook/mutations/webhook_trigger.py
+++ b/saleor/graphql/webhook/mutations/webhook_trigger.py
@@ -15,7 +15,6 @@ from ....permission.auth_filters import AuthorizationFilters
 from ....webhook.error_codes import WebhookTriggerErrorCode
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.models import Webhook
-from ....webhook.transport.utils import prepare_deferred_payload_data
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_311, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_WEBHOOKS
@@ -157,6 +156,7 @@ class WebhookTrigger(BaseMutation):
             generate_deferred_payloads,
             send_webhook_request_async,
         )
+        from ....webhook.transport.utils import prepare_deferred_payload_data
 
         event_type, object, webhook = cls.validate_input(info, **data)
         delivery = None


### PR DESCRIPTION
Applying patches to Saleor causes a circular dependency. The root cause of the circular dependency is importing webhook utils in the `webhookTrigger` mutation. To unblock patches, the problematic import was moved to the local method (similar to other webhook imports in this mutation).

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
