### PR TITLE
Fix gross prices as default values when prices entered with taxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed playground not displaying docs if api is hidden behind reverse proxy - #16810 by @jqob
 - Drop tax data line number validation for Avatax plugin - #16917 by @zedzior
 - Fix decreasing voucher code usage after changing `includeDraftOrderInVoucherUsage` to false - #17028 by @zedzior
+- Fix undiscounted price taxation when prices are entered with taxes - #16992 by @zedzior

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -305,7 +305,7 @@ def assign_order_line_prices(line: "OrderLine", total_price: Money):
         line.unit_price_net = unit_price
         line.unit_price_gross = unit_price
 
-        undiscounted_unit_price = line.undiscounted_total_price_net_amount / quantity
+        undiscounted_unit_price = line.undiscounted_base_unit_price_amount
         line.undiscounted_unit_price_net_amount = undiscounted_unit_price
         line.undiscounted_unit_price_gross_amount = undiscounted_unit_price
 

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -427,12 +427,12 @@ def _apply_tax_data(
 
 def remove_tax(order, lines, prices_entered_with_taxes):
     if prices_entered_with_taxes:
-        _remove_tax_gross(order, lines)
-    else:
         _remove_tax_net(order, lines)
+    else:
+        _remove_tax_gross(order, lines)
 
 
-def _remove_tax_net(order, lines):
+def _remove_tax_gross(order, lines):
     """Set gross values equal to net values."""
     order.total_gross_amount = order.total_net_amount
     order.undiscounted_total_gross_amount = order.undiscounted_total_net_amount
@@ -452,7 +452,7 @@ def _remove_tax_net(order, lines):
         line.tax_rate = Decimal("0.00")
 
 
-def _remove_tax_gross(order, lines):
+def _remove_tax_net(order, lines):
     """Set net values equal to gross values."""
     order.total_net_amount = order.total_gross_amount
     order.undiscounted_total_net_amount = order.undiscounted_total_gross_amount

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -174,7 +174,7 @@ def _recalculate_prices(
         if not should_charge_tax:
             # If charge_taxes is disabled or order is exempt from taxes, remove the
             # tax from the original gross prices.
-            _remove_tax(order, lines, prices_entered_with_tax)
+            remove_tax(order, lines, prices_entered_with_tax)
 
     else:
         # Prices are entered without taxes.
@@ -196,7 +196,7 @@ def _recalculate_prices(
                     logger.warning(str(e), extra=order_info_for_logs(order, lines))
                 order.tax_error = str(e)
         else:
-            _remove_tax(order, lines, prices_entered_with_tax)
+            remove_tax(order, lines, prices_entered_with_tax)
 
 
 def _calculate_and_add_tax(
@@ -425,7 +425,7 @@ def _apply_tax_data(
     order.undiscounted_total = undiscounted_shipping_price + undiscounted_subtotal
 
 
-def _remove_tax(order, lines, prices_entered_with_taxes):
+def remove_tax(order, lines, prices_entered_with_taxes):
     if prices_entered_with_taxes:
         _remove_tax_gross(order, lines)
     else:

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -174,7 +174,7 @@ def _recalculate_prices(
         if not should_charge_tax:
             # If charge_taxes is disabled or order is exempt from taxes, remove the
             # tax from the original gross prices.
-            _remove_tax(order, lines)
+            _remove_tax(order, lines, prices_entered_with_tax)
 
     else:
         # Prices are entered without taxes.
@@ -196,7 +196,7 @@ def _recalculate_prices(
                     logger.warning(str(e), extra=order_info_for_logs(order, lines))
                 order.tax_error = str(e)
         else:
-            _remove_tax(order, lines)
+            _remove_tax(order, lines, prices_entered_with_tax)
 
 
 def _calculate_and_add_tax(
@@ -425,7 +425,15 @@ def _apply_tax_data(
     order.undiscounted_total = undiscounted_shipping_price + undiscounted_subtotal
 
 
-def _remove_tax(order, lines):
+def _remove_tax(order, lines, prices_entered_with_taxes):
+    if prices_entered_with_taxes:
+        _remove_tax_gross(order, lines)
+    else:
+        _remove_tax_net(order, lines)
+
+
+def _remove_tax_net(order, lines):
+    """Set gross values equal to net values."""
     order.total_gross_amount = order.total_net_amount
     order.undiscounted_total_gross_amount = order.undiscounted_total_net_amount
     order.subtotal_gross_amount = order.subtotal_net_amount
@@ -441,6 +449,28 @@ def _remove_tax(order, lines):
         line.undiscounted_unit_price_gross_amount = undiscounted_unit_price_net_amount
         line.total_price_gross_amount = total_price_net_amount
         line.undiscounted_total_price_gross_amount = undiscounted_total_price_net_amount
+        line.tax_rate = Decimal("0.00")
+
+
+def _remove_tax_gross(order, lines):
+    """Set net values equal to gross values."""
+    order.total_net_amount = order.total_gross_amount
+    order.undiscounted_total_net_amount = order.undiscounted_total_gross_amount
+    order.subtotal_net_amount = order.subtotal_gross_amount
+    order.shipping_price_net_amount = order.shipping_price_gross_amount
+    order.shipping_tax_rate = Decimal("0.00")
+
+    for line in lines:
+        total_price_gross_amount = line.total_price_gross_amount
+        unit_price_gross_amount = line.unit_price_gross_amount
+        undiscounted_unit_price_gross_amount = line.undiscounted_unit_price_gross_amount
+        undiscounted_total_price_gross_amount = (
+            line.undiscounted_total_price_gross_amount
+        )
+        line.unit_price_net_amount = unit_price_gross_amount
+        line.undiscounted_unit_price_net_amount = undiscounted_unit_price_gross_amount
+        line.total_price_net_amount = total_price_gross_amount
+        line.undiscounted_total_price_net_amount = undiscounted_total_price_gross_amount
         line.tax_rate = Decimal("0.00")
 
 

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -628,13 +628,20 @@ def get_taxed_money(
     attr: Literal["unit", "total", "subtotal", "shipping_price"],
     currency: str,
     exempt_taxes: bool = False,
+    prices_entered_with_taxes: bool = False,
 ) -> TaxedMoney:
-    net_value = Money(getattr(obj, f"{attr}_net_amount"), currency)
-
-    if exempt_taxes:
-        gross_value = net_value
-    else:
+    if prices_entered_with_taxes:
         gross_value = Money(getattr(obj, f"{attr}_gross_amount"), currency)
+        if exempt_taxes:
+            net_value = gross_value
+        else:
+            net_value = Money(getattr(obj, f"{attr}_net_amount"), currency)
+    else:
+        net_value = Money(getattr(obj, f"{attr}_net_amount"), currency)
+        if exempt_taxes:
+            gross_value = net_value
+        else:
+            gross_value = Money(getattr(obj, f"{attr}_gross_amount"), currency)
 
     return TaxedMoney(net_value, gross_value)
 
@@ -849,13 +856,23 @@ def test_fetch_order_prices_when_tax_exemption(
     # then
     order_with_lines.refresh_from_db()
     shipping_price = get_taxed_money(
-        tax_data, "shipping_price", currency, exempt_taxes=True
+        tax_data,
+        "shipping_price",
+        currency,
+        exempt_taxes=True,
+        prices_entered_with_taxes=prices_entered_with_tax,
     )
     assert order_with_lines.shipping_price == shipping_price
     assert order_with_lines.shipping_tax_rate == Decimal("0.00")
     subtotal = zero_taxed_money(currency)
     for order_line, tax_line in zip(order_with_lines.lines.all(), tax_data.lines):
-        line_total = get_taxed_money(tax_line, "total", currency, exempt_taxes=True)
+        line_total = get_taxed_money(
+            tax_line,
+            "total",
+            currency,
+            exempt_taxes=True,
+            prices_entered_with_taxes=prices_entered_with_tax,
+        )
         subtotal += line_total
         assert order_line.total_price == line_total
         assert order_line.unit_price == quantize_price(

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -3099,3 +3099,126 @@ def test_fetch_order_prices_voucher_shipping_and_manual_discount_fixed_exceed_to
     # assert order.undiscounted_total_gross_amount == round(
     #     (undiscounted_subtotal + undiscounted_shipping_price) * tax_rate, 2
     # )
+
+
+def test_fetch_order_prices_catalogue_discount_prices_entered_with_tax_tax_exemption(
+    order_with_lines_and_catalogue_promotion,
+    plugins_manager,
+    tax_configuration_flat_rates,
+):
+    # given
+    order = order_with_lines_and_catalogue_promotion
+    order.status = OrderStatus.UNCONFIRMED
+    channel = order.channel
+    rule = PromotionRule.objects.get()
+    promotion_id = graphene.Node.to_global_id("Promotion", rule.promotion_id)
+    reward_value = rule.reward_value
+
+    tax_configuration = tax_configuration_flat_rates
+    tax_configuration.prices_entered_with_tax = True
+    tax_configuration.charge_taxes = False
+    tax_configuration.save(update_fields=["prices_entered_with_tax", "charge_taxes"])
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(
+        order, plugins_manager, None, True
+    )
+
+    # then
+    assert OrderLineDiscount.objects.count() == 1
+    assert not OrderDiscount.objects.exists()
+    line_1 = [line for line in lines if line.quantity == 3][0]
+    line_2 = [line for line in lines if line.quantity == 2][0]
+
+    discount = line_1.discounts.get()
+    reward_amount = reward_value * line_1.quantity
+    assert discount.amount_value == reward_amount
+    assert discount.value == reward_value
+    assert discount.value_type == DiscountValueType.FIXED
+    assert discount.type == DiscountType.PROMOTION
+    assert discount.reason == f"Promotion: {promotion_id}"
+
+    variant_1 = line_1.variant
+    variant_1_listing = variant_1.channel_listings.get(channel=channel)
+    variant_1_unit_price = variant_1_listing.discounted_price_amount
+    variant_1_undiscounted_unit_price = variant_1_listing.price_amount
+    assert variant_1_undiscounted_unit_price - variant_1_unit_price == reward_value
+
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == variant_1_undiscounted_unit_price * line_1.quantity
+    )
+    assert (
+        line_1.undiscounted_total_price_gross_amount
+        == line_1.undiscounted_total_price_net_amount
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount == variant_1_undiscounted_unit_price
+    )
+    assert (
+        line_1.undiscounted_unit_price_gross_amount
+        == line_1.undiscounted_unit_price_net_amount
+    )
+    assert (
+        line_1.base_unit_price_amount
+        == variant_1_undiscounted_unit_price - reward_value
+    )
+    assert (
+        line_1.unit_price_gross_amount
+        == variant_1_undiscounted_unit_price - reward_value
+    )
+    assert line_1.unit_price_gross_amount == line_1.unit_price_net_amount
+    assert (
+        line_1.total_price_gross_amount
+        == line_1.unit_price_gross_amount * line_1.quantity
+    )
+    assert line_1.total_price_gross_amount == line_1.total_price_net_amount
+
+    variant_2 = line_2.variant
+    variant_2_listing = variant_2.channel_listings.get(channel=channel)
+    variant_2_undiscounted_unit_price = variant_2_listing.price_amount
+    assert (
+        line_2.undiscounted_total_price_gross_amount
+        == variant_2_undiscounted_unit_price * line_2.quantity
+    )
+    assert (
+        line_2.undiscounted_total_price_gross_amount
+        == line_2.undiscounted_total_price_net_amount
+    )
+    assert (
+        line_2.undiscounted_unit_price_gross_amount == variant_2_undiscounted_unit_price
+    )
+    assert (
+        line_2.undiscounted_unit_price_gross_amount
+        == line_2.undiscounted_unit_price_net_amount
+    )
+    assert line_2.base_unit_price_amount == variant_2_undiscounted_unit_price
+    assert line_2.unit_price_gross_amount == variant_2_undiscounted_unit_price
+    assert line_2.unit_price_gross_amount == line_2.unit_price_net_amount
+    assert line_2.total_price_net_amount == line_2.undiscounted_total_price_net_amount
+    assert (
+        line_2.total_price_gross_amount == line_2.undiscounted_total_price_gross_amount
+    )
+
+    shipping_gross_price = order.shipping_price_gross_amount
+    assert (
+        order.undiscounted_total_gross_amount
+        == line_1.undiscounted_total_price_gross_amount
+        + line_2.undiscounted_total_price_gross_amount
+        + shipping_gross_price
+    )
+    assert order.undiscounted_total_gross_amount == order.undiscounted_total_net_amount
+    assert (
+        order.total_gross_amount
+        == order.undiscounted_total_gross_amount - reward_amount
+    )
+    assert order.total_gross_amount == order.total_net_amount
+    assert (
+        order.subtotal_gross_amount == order.total_gross_amount - shipping_gross_price
+    )
+    assert order.subtotal_gross_amount == order.subtotal_net_amount
+
+    assert line_1.unit_discount_amount == reward_value
+    assert line_1.unit_discount_reason == f"Promotion: {promotion_id}"
+    assert line_1.unit_discount_type == DiscountValueType.FIXED
+    assert line_1.unit_discount_value == reward_value

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -158,7 +158,9 @@ def update_taxes_for_order_lines(
             tax_rate = default_tax_rate
 
         undiscounted_subtotal += line.undiscounted_base_unit_price * line.quantity
-        price_with_discounts = line.unit_price.net
+        price_with_discounts = (
+            line.unit_price.gross if prices_entered_with_tax else line.unit_price.net
+        )
         unit_price = calculate_flat_rate_tax(
             price_with_discounts, tax_rate, prices_entered_with_tax
         )

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -116,7 +116,11 @@ def _set_order_totals(
 def _calculate_order_shipping(
     order: "Order", tax_rate: Decimal, prices_entered_with_tax: bool
 ) -> TaxedMoney:
-    shipping_price = order.shipping_price.net
+    shipping_price = (
+        order.shipping_price_gross
+        if prices_entered_with_tax
+        else order.shipping_price_net
+    )
     taxed_shipping_price = calculate_flat_rate_tax(
         shipping_price, tax_rate, prices_entered_with_tax
     )

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -10,6 +10,7 @@ from ...discount import DiscountType, DiscountValueType
 from ...order import OrderStatus
 from ...order.base_calculations import apply_order_discounts
 from ...order.calculations import fetch_order_prices_if_expired
+from ...order.models import OrderLine
 from ...order.utils import get_order_country
 from ...payment.model_helpers import get_subtotal
 from ...plugins.manager import get_plugins_manager
@@ -28,9 +29,9 @@ def _enable_flat_rates(order, prices_entered_with_tax):
     tc.save()
 
 
-def test_calculations_calculate_order_total(order_with_lines):
+def test_calculations_calculate_order_total(order_with_lines_untaxed):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -45,10 +46,10 @@ def test_calculations_calculate_order_total(order_with_lines):
 
 
 def test_calculations_calculate_order_undiscounted_total(
-    order_with_lines, voucher_shipping_type
+    order_with_lines_untaxed, voucher_shipping_type
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -82,10 +83,10 @@ def test_calculations_calculate_order_undiscounted_total(
 
 
 def test_calculations_calculate_order_total_use_product_type_tax_class(
-    order_with_lines,
+    order_with_lines_untaxed,
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -105,9 +106,9 @@ def test_calculations_calculate_order_total_use_product_type_tax_class(
     )
 
 
-def test_calculations_calculate_order_total_no_rates(order_with_lines):
+def test_calculations_calculate_order_total_no_rates(order_with_lines_untaxed):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -123,9 +124,11 @@ def test_calculations_calculate_order_total_no_rates(order_with_lines):
     )
 
 
-def test_calculations_calculate_order_total_default_country_rate(order_with_lines):
+def test_calculations_calculate_order_total_default_country_rate(
+    order_with_lines_untaxed,
+):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     country = get_order_country(order)
     _enable_flat_rates(order, prices_entered_with_tax)
@@ -143,9 +146,9 @@ def test_calculations_calculate_order_total_default_country_rate(order_with_line
     )
 
 
-def test_calculations_calculate_order_total_voucher(order_with_lines, voucher):
+def test_calculations_calculate_order_total_voucher(order_with_lines_untaxed, voucher):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -161,7 +164,7 @@ def test_calculations_calculate_order_total_voucher(order_with_lines, voucher):
         amount_value=10,
         voucher=voucher,
     )
-    apply_order_discounts(order_with_lines, lines)
+    apply_order_discounts(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -172,9 +175,11 @@ def test_calculations_calculate_order_total_voucher(order_with_lines, voucher):
     )
 
 
-def test_calculations_calculate_order_total_with_manual_discount(order_with_lines):
+def test_calculations_calculate_order_total_with_manual_discount(
+    order_with_lines_untaxed,
+):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -188,7 +193,7 @@ def test_calculations_calculate_order_total_with_manual_discount(order_with_line
         currency=order.currency,
         amount_value=10,
     )
-    apply_order_discounts(order_with_lines, lines)
+    apply_order_discounts(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -200,10 +205,10 @@ def test_calculations_calculate_order_total_with_manual_discount(order_with_line
 
 
 def test_calculations_calculate_order_total_with_discount_for_order_total(
-    order_with_lines,
+    order_with_lines_untaxed,
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -226,10 +231,10 @@ def test_calculations_calculate_order_total_with_discount_for_order_total(
 
 
 def test_calculations_calculate_order_total_with_discount_for_subtotal_and_shipping(
-    order_with_lines,
+    order_with_lines_untaxed,
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -243,7 +248,7 @@ def test_calculations_calculate_order_total_with_discount_for_subtotal_and_shipp
         currency=order.currency,
         amount_value=75,
     )
-    apply_order_discounts(order_with_lines, lines)
+    apply_order_discounts(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -255,10 +260,10 @@ def test_calculations_calculate_order_total_with_discount_for_subtotal_and_shipp
 
 
 def test_calculations_calculate_order_total_with_discount_for_more_than_order_total(
-    order_with_lines,
+    order_with_lines_untaxed,
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -281,10 +286,10 @@ def test_calculations_calculate_order_total_with_discount_for_more_than_order_to
 
 
 def test_calculations_calculate_order_total_with_manual_discount_and_voucher(
-    order_with_lines, voucher
+    order_with_lines_untaxed, voucher
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
@@ -308,7 +313,7 @@ def test_calculations_calculate_order_total_with_manual_discount_and_voucher(
         amount_value=10,
         voucher=voucher,
     )
-    apply_order_discounts(order_with_lines, lines)
+    apply_order_discounts(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -453,9 +458,9 @@ def test_calculate_order_shipping_free_shipping_voucher(
     assert price == zero_taxed_money(currency)
 
 
-def test_update_taxes_for_order_lines(order_with_lines):
+def test_update_taxes_for_order_lines(order_with_lines_untaxed):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     currency = order.currency
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
@@ -485,10 +490,10 @@ def test_update_taxes_for_order_lines(order_with_lines):
 
 
 def test_update_taxes_for_order_lines_voucher_on_entire_order(
-    order_with_lines, voucher
+    order_with_lines_untaxed, voucher
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     currency = order.currency
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
@@ -549,10 +554,10 @@ def test_update_taxes_for_order_lines_voucher_on_entire_order(
 
 
 def test_update_taxes_for_order_lines_voucher_on_shipping(
-    order_with_lines, voucher_shipping_type
+    order_with_lines_untaxed, voucher_shipping_type
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     currency = order.currency
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
@@ -560,17 +565,7 @@ def test_update_taxes_for_order_lines_voucher_on_shipping(
     country_code = get_order_country(order)
 
     order.voucher = voucher_shipping_type
-    lines = list(order.lines.all())
-    total_amount = sum([line.base_unit_price.amount * line.quantity for line in lines])
-    order.undiscounted_total_gross_amount = total_amount
-    order.undiscounted_total_net_amount = total_amount
-    order.save(
-        update_fields=[
-            "voucher",
-            "undiscounted_total_gross_amount",
-            "undiscounted_total_net_amount",
-        ]
-    )
+    order.save(update_fields=["voucher"])
 
     order_discount_amount = Decimal("5.0")
     order.discounts.create(
@@ -606,16 +601,15 @@ def test_update_taxes_for_order_lines_voucher_on_shipping(
 
 
 def test_update_taxes_for_order_line_on_promotion(
-    order_with_lines, order_line_on_promotion
+    order_with_lines_untaxed, order_line_on_promotion
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     currency = order.currency
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     country_code = get_order_country(order)
 
-    line = order_with_lines.lines.first()
     order_line_on_promotion.order = order
     order_line_on_promotion.save(update_fields=["order"])
 
@@ -656,15 +650,19 @@ def test_update_taxes_for_order_line_on_promotion(
 
 
 def test_use_original_tax_rate_when_tax_class_is_removed_from_order_line(
-    order_with_lines,
+    order_with_lines_untaxed,
 ):
     # given
-    order = order_with_lines
+    order = order_with_lines_untaxed
     prices_entered_with_tax = True
     _enable_flat_rates(order, prices_entered_with_tax)
     lines = order.lines.all()
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
-    apply_order_discounts(order_with_lines, lines)
+    OrderLine.objects.bulk_update(lines, ["tax_rate"])
+
+    assert order.total == TaxedMoney(
+        net=Money("65.04", "USD"), gross=Money("80.00", "USD")
+    )
 
     # when
     for line in lines:
@@ -690,11 +688,11 @@ def test_use_original_tax_rate_when_tax_class_is_removed_from_order_line(
 
 
 def test_use_default_country_rate_when_no_tax_class_was_set_before(
-    order_with_lines,
+    order_with_lines_untaxed,
 ):
     # given
     manager = get_plugins_manager(allow_replica=False)
-    order = order_with_lines
+    order = order_with_lines_untaxed
     country = get_order_country(order)
     TaxClassCountryRate.objects.create(country=country, rate=20)
 


### PR DESCRIPTION
I want to merge this change because we didn't take into account `prices_enetred_with_taxes` setting for undiscounted prices.

Issue: https://linear.app/saleor/issue/SHOPX-1669

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
