### PR TITLE
Add paginated `productVariants` to `Product` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `CheckoutCustomerNoteUpdate` mutation - #16315 by @pitkes22
 - Add `customerNote` field to `Checkout` type to make it consistent with `Order` model - #16561 by @Air-t
 - Add `type` field to `TaxableObjectDiscount` type - #16630 by @zedzior
-- Add `productVariants` field to `Product` instead of `variants`. Mark `Product.variants` as depracated - #16998 by @kadewu
+- Add `productVariants` field to `Product` instead of `variants`. Mark `Product.variants` as deprecated - #16998 by @kadewu
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `CheckoutCustomerNoteUpdate` mutation - #16315 by @pitkes22
 - Add `customerNote` field to `Checkout` type to make it consistent with `Order` model - #16561 by @Air-t
 - Add `type` field to `TaxableObjectDiscount` type - #16630 by @zedzior
+- Add `productVariants` field to `Product` instead of `variants`. Mark `Product.variants` as depracated - #16998 by @kadewu
 
 ### Webhooks
 

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -191,6 +191,7 @@ def resolve_product_variants(
     requestor,
     ids=None,
     channel: Optional[Channel] = None,
+    product_id: Optional[int] = None,
     limited_channel_access: bool = False,
 ) -> ChannelQsContext:
     connection_name = get_database_connection_name(info.context)
@@ -204,6 +205,9 @@ def resolve_product_variants(
             from_global_id_or_error(node_id, "ProductVariant")[1] for node_id in ids
         ]
         qs = qs.filter(pk__in=db_ids)
+
+    if product_id:
+        qs = qs.filter(product_id=product_id)
 
     channel_slug = channel.slug if channel else None
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -281,26 +281,18 @@ def test_product_query_by_id_as_user(
     product_data = content["data"]["product"]
     assert product_data is not None
 
-    expected_variants = [
-        {
-            "node": {
-                "id": graphene.Node.to_global_id(
-                    "ProductVariant", product.variants.first().pk
-                )
-            }
-        }
-    ]
-    assert product_data["productVariants"]["edges"] == expected_variants
+    first_product_variant_id = graphene.Node.to_global_id(
+        "ProductVariant", product.variants.first().pk
+    )
+
+    assert len(product_data["productVariants"]["edges"]) == 1
+    assert (
+        product_data["productVariants"]["edges"][0]["node"]["id"]
+        == first_product_variant_id
+    )
 
     # deprecated field test
-    expected_variants = [
-        {
-            "id": graphene.Node.to_global_id(
-                "ProductVariant", product.variants.first().pk
-            )
-        }
-    ]
-    assert product_data["variants"] == expected_variants
+    assert product_data["variants"][0]["id"] == first_product_variant_id
 
 
 def test_product_query_invalid_id(user_api_client, product, channel_USD):

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -250,6 +250,9 @@ QUERY_PRODUCT_BY_ID = """
             variants {
                 id
             }
+            productVariants(first: 10){
+                edges{ node{ id }}
+            }
         }
     }
 """
@@ -258,12 +261,14 @@ QUERY_PRODUCT_BY_ID = """
 def test_product_query_by_id_as_user(
     user_api_client, permission_manage_products, product, channel_USD
 ):
+    # given
     query = QUERY_PRODUCT_BY_ID
     variables = {
         "id": graphene.Node.to_global_id("Product", product.pk),
         "channel": channel_USD.slug,
     }
 
+    # when
     response = user_api_client.post_graphql(
         query,
         variables=variables,
@@ -271,8 +276,23 @@ def test_product_query_by_id_as_user(
         check_no_permissions=False,
     )
     content = get_graphql_content(response)
+
+    # then
     product_data = content["data"]["product"]
     assert product_data is not None
+
+    expected_variants = [
+        {
+            "node": {
+                "id": graphene.Node.to_global_id(
+                    "ProductVariant", product.variants.first().pk
+                )
+            }
+        }
+    ]
+    assert product_data["productVariants"]["edges"] == expected_variants
+
+    # deprecated field test
     expected_variants = [
         {
             "id": graphene.Node.to_global_id(
@@ -389,6 +409,7 @@ def test_product_query_by_id_as_app_without_channel_slug(
 def test_product_variants_without_sku_query_by_staff(
     staff_api_client, product, channel_USD
 ):
+    # given
     product.variants.update(sku=None)
     product_id = graphene.Node.to_global_id("Product", product.pk)
 
@@ -397,10 +418,13 @@ def test_product_variants_without_sku_query_by_staff(
         "channel": channel_USD.slug,
     }
 
+    # when
     response = staff_api_client.post_graphql(
         QUERY_PRODUCT_BY_ID,
         variables=variables,
     )
+
+    # then
     content = get_graphql_content(response)
     product_data = content["data"]["product"]
 
@@ -409,12 +433,16 @@ def test_product_variants_without_sku_query_by_staff(
 
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    assert product_data["productVariants"]["edges"] == [{"node": {"id": variant_id}}]
+    # deprecated field test
     assert product_data["variants"] == [{"id": variant_id}]
 
 
 def test_product_only_with_variants_without_sku_query_by_customer(
     user_api_client, product, channel_USD
 ):
+    # given
     product.variants.update(sku=None)
     product_id = graphene.Node.to_global_id("Product", product.pk)
 
@@ -423,10 +451,13 @@ def test_product_only_with_variants_without_sku_query_by_customer(
         "channel": channel_USD.slug,
     }
 
+    # when
     response = user_api_client.post_graphql(
         QUERY_PRODUCT_BY_ID,
         variables=variables,
     )
+
+    # then
     content = get_graphql_content(response)
     product_data = content["data"]["product"]
 
@@ -435,12 +466,15 @@ def test_product_only_with_variants_without_sku_query_by_customer(
 
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    assert product_data["productVariants"]["edges"] == [{"node": {"id": variant_id}}]
+    # deprecated field test
     assert product_data["variants"] == [{"id": variant_id}]
 
 
 def test_product_only_with_variants_without_sku_query_by_anonymous(
     api_client, product, channel_USD
 ):
+    # given
     product.variants.update(sku=None)
     product_id = graphene.Node.to_global_id("Product", product.pk)
 
@@ -449,10 +483,13 @@ def test_product_only_with_variants_without_sku_query_by_anonymous(
         "channel": channel_USD.slug,
     }
 
+    # when
     response = api_client.post_graphql(
         QUERY_PRODUCT_BY_ID,
         variables=variables,
     )
+
+    # then
     content = get_graphql_content(response)
     product_data = content["data"]["product"]
 
@@ -461,6 +498,8 @@ def test_product_only_with_variants_without_sku_query_by_anonymous(
 
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    assert product_data["productVariants"]["edges"] == [{"node": {"id": variant_id}}]
+    # deprecated field test
     assert product_data["variants"] == [{"id": variant_id}]
 
 
@@ -473,13 +512,6 @@ QUERY_PRODUCT_BY_ID_WITH_MEDIA = """
             thumbnail(size: $size, format: $format) {
                 url
                 alt
-            }
-            variants {
-                id
-                name
-                media {
-                    id
-                }
             }
         }
     }
@@ -1429,22 +1461,24 @@ def test_product_restricted_fields_permissions(
 QUERY_GET_PRODUCT_VARIANTS_PRICING = """
     query getProductVariants($id: ID!, $channel: String, $address: AddressInput) {
         product(id: $id, channel: $channel) {
-            variants {
-                id
-                pricingNoAddress: pricing {
-                    priceUndiscounted {
-                        gross {
-                            amount
+            productVariants(first:10) {
+                edges { node {
+                    id
+                    pricingNoAddress: pricing {
+                        priceUndiscounted {
+                            gross {
+                                amount
+                            }
                         }
                     }
-                }
-                pricing(address: $address) {
-                    priceUndiscounted {
-                        gross {
-                            amount
+                    pricing(address: $address) {
+                        priceUndiscounted {
+                            gross {
+                                amount
+                            }
                         }
                     }
-                }
+                } }
             }
         }
     }
@@ -1479,7 +1513,9 @@ def test_product_variant_price(
     )
     content = get_graphql_content(response)
     data = content["data"]["product"]
-    variant_price = data["variants"][0]["pricing"]["priceUndiscounted"]["gross"]
+    variant_price = data["productVariants"]["edges"][0]["node"]["pricing"][
+        "priceUndiscounted"
+    ]["gross"]
     assert variant_price["amount"] == api_variant_price
 
 
@@ -1503,8 +1539,8 @@ def test_product_variant_without_price_as_user(
     )
     content = get_graphql_content(response)
 
-    variants_data = content["data"]["product"]["variants"]
-    assert not variants_data[0]["id"] == variant_id
+    variants_data = content["data"]["product"]["productVariants"]["edges"]
+    assert not variants_data[0]["node"]["id"] == variant_id
     assert len(variants_data) == 1
 
 
@@ -1529,12 +1565,12 @@ def test_product_variant_without_price_as_staff_without_permission(
         QUERY_GET_PRODUCT_VARIANTS_PRICING, variables
     )
     content = get_graphql_content(response)
-    variants_data = content["data"]["product"]["variants"]
+    variants_data = content["data"]["product"]["productVariants"]["edges"]
 
     assert len(variants_data) == 1
 
-    assert variants_data[0]["pricing"] is not None
-    assert variants_data[0]["id"] != variant_id
+    assert variants_data[0]["node"]["pricing"] is not None
+    assert variants_data[0]["node"]["id"] != variant_id
 
 
 def test_product_variant_without_price_as_staff_with_permission(
@@ -1558,13 +1594,13 @@ def test_product_variant_without_price_as_staff_with_permission(
         check_no_permissions=False,
     )
     content = get_graphql_content(response)
-    variants_data = content["data"]["product"]["variants"]
+    variants_data = content["data"]["product"]["productVariants"]["edges"]
 
     assert len(variants_data) == 2
 
-    assert variants_data[0]["pricing"] is not None
-    assert variants_data[1]["id"] == variant_id
-    assert variants_data[1]["pricing"] is None
+    assert variants_data[0]["node"]["pricing"] is not None
+    assert variants_data[1]["node"]["id"] == variant_id
+    assert variants_data[1]["node"]["pricing"] is None
 
 
 def test_get_product_with_sorted_attribute_values(

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -948,7 +948,7 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
             "include the unpublished items: "
             f"{', '.join([p.name for p in ALL_PRODUCTS_PERMISSIONS])}."
         ),
-        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `productVariant` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `productVariants` field instead.",
     )
     product_variants = FilterConnectionField(
         ProductVariantCountableConnection,

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -256,6 +256,7 @@ COST_MAP = {
         "productType": {"complexity": 1},
         "thumbnail": {"complexity": 1},
         "variants": {"complexity": 1},
+        "productVariants": {"complexity": 100},
     },
     "ProductChannelListing": {
         "channel": {"complexity": 1},

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -256,7 +256,7 @@ COST_MAP = {
         "productType": {"complexity": 1},
         "thumbnail": {"complexity": 1},
         "variants": {"complexity": 1},
-        "productVariants": {"complexity": 100},
+        "productVariants": {"complexity": 1, "multipliers": ["first", "last"]},
     },
     "ProductChannelListing": {
         "channel": {"complexity": 1},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5520,7 +5520,7 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
   """
   List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
   """
-  variants: [ProductVariant!] @deprecated(reason: "This field will be removed in Saleor 4.0. Use `productVariant` field instead.")
+  variants: [ProductVariant!] @deprecated(reason: "This field will be removed in Saleor 4.0. Use `productVariants` field instead.")
 
   """
   List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5520,7 +5520,37 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
   """
   List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
   """
-  variants: [ProductVariant!]
+  variants: [ProductVariant!] @deprecated(reason: "This field will be removed in Saleor 4.0. Use `productVariant` field instead.")
+
+  """
+  List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
+  """
+  productVariants(
+    """Filtering options for product variant."""
+    filter: ProductVariantFilterInput
+
+    """Where filtering options."""
+    where: ProductVariantWhereInput
+
+    """Sort products variants."""
+    sortBy: ProductVariantSortingInput
+
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): ProductVariantCountableConnection
 
   """List of media for the product."""
   media(
@@ -7643,6 +7673,55 @@ type Margin @doc(category: "Products") {
   stop: Int
 }
 
+type ProductVariantCountableConnection @doc(category: "Products") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [ProductVariantCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
+}
+
+type ProductVariantCountableEdge @doc(category: "Products") {
+  """The item at the end of the edge."""
+  node: ProductVariant!
+
+  """A cursor for use in pagination."""
+  cursor: String!
+}
+
+input ProductVariantFilterInput @doc(category: "Products") {
+  search: String
+  sku: [String!]
+  metadata: [MetadataFilter!]
+  isPreorder: Boolean
+  updatedAt: DateTimeRangeInput
+}
+
+input ProductVariantWhereInput @doc(category: "Products") {
+  metadata: [MetadataFilter!]
+  ids: [ID!]
+
+  """List of conditions that must be met."""
+  AND: [ProductVariantWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [ProductVariantWhereInput!]
+}
+
+input ProductVariantSortingInput @doc(category: "Products") {
+  """Specifies the direction in which to sort productVariants."""
+  direction: OrderDirection!
+
+  """Sort productVariants by the selected field."""
+  field: ProductVariantSortField!
+}
+
+enum ProductVariantSortField @doc(category: "Products") {
+  """Sort products variants by last modified at."""
+  LAST_MODIFIED_AT
+}
+
 input MediaSortingInput @doc(category: "Products") {
   """Specifies the direction in which to sort media."""
   direction: OrderDirection!
@@ -8638,23 +8717,6 @@ type CollectionCountableConnection @doc(category: "Products") {
 type CollectionCountableEdge @doc(category: "Products") {
   """The item at the end of the edge."""
   node: Collection!
-
-  """A cursor for use in pagination."""
-  cursor: String!
-}
-
-type ProductVariantCountableConnection @doc(category: "Products") {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-  edges: [ProductVariantCountableEdge!]!
-
-  """A total count of items in the collection."""
-  totalCount: Int
-}
-
-type ProductVariantCountableEdge @doc(category: "Products") {
-  """The item at the end of the edge."""
-  node: ProductVariant!
 
   """A cursor for use in pagination."""
   cursor: String!
@@ -12379,38 +12441,6 @@ enum ProductTypeSortField @doc(category: "Products") {
 
   """Sort products by shipping."""
   SHIPPING_REQUIRED
-}
-
-input ProductVariantFilterInput @doc(category: "Products") {
-  search: String
-  sku: [String!]
-  metadata: [MetadataFilter!]
-  isPreorder: Boolean
-  updatedAt: DateTimeRangeInput
-}
-
-input ProductVariantWhereInput @doc(category: "Products") {
-  metadata: [MetadataFilter!]
-  ids: [ID!]
-
-  """List of conditions that must be met."""
-  AND: [ProductVariantWhereInput!]
-
-  """A list of conditions of which at least one must be met."""
-  OR: [ProductVariantWhereInput!]
-}
-
-input ProductVariantSortingInput @doc(category: "Products") {
-  """Specifies the direction in which to sort productVariants."""
-  direction: OrderDirection!
-
-  """Sort productVariants by the selected field."""
-  field: ProductVariantSortField!
-}
-
-enum ProductVariantSortField @doc(category: "Products") {
-  """Sort products variants by last modified at."""
-  LAST_MODIFIED_AT
 }
 
 type PaymentCountableConnection @doc(category: "Payments") {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5524,6 +5524,8 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
+  
+  Added in Saleor 3.21.
   """
   productVariants(
     """Filtering options for product variant."""


### PR DESCRIPTION
I want to merge this change because I want to add paginated variants to `Product` and deprecate the old field.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
