### PR TITLE
Fix rounding issue when propagating order/checkout level discount on lines

### DIFF
--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -262,9 +262,7 @@ def get_line_total_price_with_propagated_checkout_discount(
 
 
 def _propagate_checkout_discount_on_checkout_lines_prices(
-    # checkout_line_info: "CheckoutLineInfo",
     lines: Iterable["CheckoutLineInfo"],
-    # line_total_price: Money,
     total_discount: Money,
     currency: str,
 ):

--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -307,7 +307,9 @@ def _propagate_checkout_discount_on_checkout_lines_prices(
             elif idx < lines_count - 1:
                 line_total_price = lines_total_prices[idx]
                 share = line_total_price / total_price
-                discount = min(share * total_discount, line_total_price)
+                discount = quantize_price(
+                    min(share * total_discount, line_total_price), currency
+                )
                 yield (
                     line,
                     max(

--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -298,10 +298,12 @@ def _get_discounted_checkout_line_price(
     last_element = lines[-1].line.id == checkout_line_info.line.id
     if last_element:
         discount_amount = _calculate_discount_for_last_element(
-            lines_total_prices, total_price, total_discount_amount
+            lines_total_prices, total_price, total_discount_amount, currency
         )
     else:
-        discount_amount = line_total_price.amount / total_price * total_discount_amount
+        discount_amount = quantize_price(
+            line_total_price.amount / total_price * total_discount_amount, currency
+        )
     return max(
         (line_total_price - Money(discount_amount, currency)),
         zero_money(currency),
@@ -309,7 +311,7 @@ def _get_discounted_checkout_line_price(
 
 
 def _calculate_discount_for_last_element(
-    lines_total_prices, total_price, total_discount_amount
+    lines_total_prices, total_price, total_discount_amount, currency
 ):
     """Calculate the discount for last element.
 
@@ -319,7 +321,9 @@ def _calculate_discount_for_last_element(
     """
     sum_of_discounts_other_elements = sum(
         [
-            line_total_price / total_price * total_discount_amount
+            quantize_price(
+                line_total_price / total_price * total_discount_amount, currency
+            )
             for line_total_price in lines_total_prices
         ]
     )

--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -16,8 +16,6 @@ from ..core.taxes import zero_money
 from ..discount import VoucherType
 
 if TYPE_CHECKING:
-    from decimal import Decimal
-
     from ..channel.models import Channel
     from .fetch import CheckoutInfo, CheckoutLineInfo, ShippingMethodInfo
 
@@ -226,12 +224,11 @@ def checkout_total(
     return subtotal + shipping_price
 
 
-def apply_checkout_discount_on_checkout_line(
+def get_line_total_price_with_propagated_checkout_discount(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     checkout_line_info: "CheckoutLineInfo",
-    line_total_price: Money,
-):
+) -> Money:
     """Calculate the checkout line price with discounts.
 
     Include the entire order voucher discount or discount from order
@@ -240,91 +237,91 @@ def apply_checkout_discount_on_checkout_line(
     the rate of total line price to checkout total price.
     """
     voucher = checkout_info.voucher
+    base_total_price = calculate_base_line_total_price(
+        checkout_line_info,
+    )
     if voucher and (
         voucher.apply_once_per_order
         or voucher.type in [VoucherType.SHIPPING, VoucherType.SPECIFIC_PRODUCT]
     ):
-        return line_total_price
+        return base_total_price
 
     if not voucher and not checkout_info.discounts:
-        return line_total_price
+        return base_total_price
 
-    total_discount_amount = checkout_info.checkout.discount_amount
-    return _get_discounted_checkout_line_price(
-        checkout_line_info,
-        lines,
-        line_total_price,
-        total_discount_amount,
-        checkout_info.channel,
-    )
+    total_discount = checkout_info.checkout.discount
+    for (
+        checkout_line,
+        total_price,
+    ) in _propagate_checkout_discount_on_checkout_lines_prices(
+        lines, total_discount, checkout_info.channel.currency_code
+    ):
+        if checkout_line_info.line.id == checkout_line.id:
+            return total_price
+    return base_total_price
 
 
-def _get_discounted_checkout_line_price(
-    checkout_line_info: "CheckoutLineInfo",
+def _propagate_checkout_discount_on_checkout_lines_prices(
+    # checkout_line_info: "CheckoutLineInfo",
     lines: Iterable["CheckoutLineInfo"],
-    line_total_price: Money,
-    total_discount_amount: "Decimal",
-    channel: "Channel",
+    # line_total_price: Money,
+    total_discount: Money,
+    currency: str,
 ):
     """Apply checkout discount on checkout line price.
 
     Propagate the discount amount proportionally to total prices of items.
     Ensure that the sum of discounts is equal to the discount amount.
     """
-    currency = channel.currency_code
-
     lines = list(lines)
+    lines_count = len(lines)
 
     # if the checkout has a single line, the whole discount amount will be applied
     # to this line
-    if len(lines) == 1:
-        return max(
-            (line_total_price - Money(total_discount_amount, currency)),
-            zero_money(currency),
+    if lines_count == 1:
+        line_info = lines[0]
+        line_total_price = calculate_base_line_total_price(line_info)
+        yield (
+            line_info.line,
+            max(
+                (line_total_price - total_discount),
+                zero_money(currency),
+            ),
         )
-
-    # if the checkout has more lines we need to propagate the discount amount
-    # proportionally to total prices of items
-    lines_total_prices = [
-        calculate_base_line_total_price(
-            line_info,
-        ).amount
-        for line_info in lines
-        if line_info.line.id != checkout_line_info.line.id
-    ]
-
-    total_price = sum(lines_total_prices) + line_total_price.amount
-
-    last_element = lines[-1].line.id == checkout_line_info.line.id
-    if last_element:
-        discount_amount = _calculate_discount_for_last_element(
-            lines_total_prices, total_price, total_discount_amount, currency
-        )
-    else:
-        discount_amount = quantize_price(
-            line_total_price.amount / total_price * total_discount_amount, currency
-        )
-    return max(
-        (line_total_price - Money(discount_amount, currency)),
-        zero_money(currency),
-    )
-
-
-def _calculate_discount_for_last_element(
-    lines_total_prices, total_price, total_discount_amount, currency
-):
-    """Calculate the discount for last element.
-
-    If the given line is last on the list we should calculate the discount by difference
-    between total discount amount and sum of discounts applied to rest of the lines,
-    otherwise the sum of discounts won't be equal to the discount amount.
-    """
-    sum_of_discounts_other_elements = sum(
-        [
-            quantize_price(
-                line_total_price / total_price * total_discount_amount, currency
+    elif lines_count > 1:
+        # if the checkout has more lines we need to propagate the discount amount
+        # proportionally to total prices of items
+        lines_total_prices = [
+            calculate_base_line_total_price(
+                line_info,
             )
-            for line_total_price in lines_total_prices
+            for line_info in lines
         ]
-    )
-    return total_discount_amount - sum_of_discounts_other_elements
+
+        total_price = sum(lines_total_prices, start=Money(0, currency))
+        remaining_discount = total_discount
+        for idx, line_info in enumerate(lines):
+            line = line_info.line
+            if not total_price:
+                yield line, zero_money(currency)
+            elif idx < lines_count - 1:
+                line_total_price = lines_total_prices[idx]
+                share = line_total_price / total_price
+                discount = min(share * total_discount, line_total_price)
+                yield (
+                    line,
+                    max(
+                        (line_total_price - discount),
+                        zero_money(currency),
+                    ),
+                )
+                remaining_discount -= discount
+            else:
+                line_total_price = lines_total_prices[idx]
+                yield (
+                    line,
+                    max(
+                        (line_total_price - remaining_discount),
+                        zero_money(currency),
+                    ),
+                )

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -635,11 +635,10 @@ def _set_checkout_base_prices(
 
     for line_info in lines:
         line = line_info.line
-        quantity = line.quantity
-
-        unit_price = base_calculations.calculate_base_line_unit_price(line_info)
-        total_price = base_calculations.apply_checkout_discount_on_checkout_line(
-            checkout_info, lines, line_info, unit_price * quantity
+        total_price = (
+            base_calculations.get_line_total_price_with_propagated_checkout_discount(
+                checkout_info, lines, line_info
+            )
         )
         line_total_price = quantize_price(total_price, currency)
         subtotal += line_total_price

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -110,7 +110,6 @@ def test_checkout_add_voucher_for_entire_order(api_client, checkout_with_item, v
         total_price_gross_amount
         == taxed_total.gross.amount - checkout_with_item.discount_amount
     )
-    # TODO: check line prices
 
 
 def test_checkout_add_voucher_code_by_token(api_client, checkout_with_item, voucher):

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -110,6 +110,7 @@ def test_checkout_add_voucher_for_entire_order(api_client, checkout_with_item, v
         total_price_gross_amount
         == taxed_total.gross.amount - checkout_with_item.discount_amount
     )
+    # TODO: check line prices
 
 
 def test_checkout_add_voucher_code_by_token(api_client, checkout_with_item, voucher):

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -245,7 +245,10 @@ def propagate_order_discount_on_order_lines_prices(
                 share = (
                     line.base_unit_price_amount * line.quantity / base_subtotal.amount
                 )
-                discount = min(share * subtotal_discount, base_subtotal)
+                discount = quantize_price(
+                    min(share * subtotal_discount, base_subtotal),
+                    base_subtotal.currency,
+                )
                 yield (
                     line,
                     _get_total_price_with_subtotal_discount_for_order_line(
@@ -290,8 +293,7 @@ def apply_subtotal_discount_to_order_lines(
 
 
 def assign_order_line_prices(line: "OrderLine", total_price: Money):
-    currency = total_price.currency
-    line.total_price_net = quantize_price(total_price, currency)
+    line.total_price_net = total_price
     line.total_price_gross = line.total_price_net
     line.undiscounted_total_price_gross_amount = (
         line.undiscounted_total_price_net_amount

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -452,15 +452,13 @@ class PluginsManager(PaymentInterface):
         address: Optional["Address"],
         plugin_ids: Optional[list[str]] = None,
     ) -> TaxedMoney:
-        default_value = base_calculations.calculate_base_line_total_price(
-            checkout_line_info,
-        )
         # apply entire order discount or discount from order promotion
-        default_value = base_calculations.apply_checkout_discount_on_checkout_line(
-            checkout_info,
-            lines,
-            checkout_line_info,
-            default_value,
+        default_value = (
+            base_calculations.get_line_total_price_with_propagated_checkout_discount(
+                checkout_info,
+                lines,
+                checkout_line_info,
+            )
         )
         default_value = quantize_price(default_value, checkout_info.checkout.currency)
         default_taxed_value = TaxedMoney(net=default_value, gross=default_value)
@@ -529,15 +527,13 @@ class PluginsManager(PaymentInterface):
         plugin_ids: Optional[list[str]] = None,
     ) -> TaxedMoney:
         quantity = checkout_line_info.line.quantity
-        default_value = base_calculations.calculate_base_line_unit_price(
-            checkout_line_info
-        )
         # apply entire order discount
-        total_value = base_calculations.apply_checkout_discount_on_checkout_line(
-            checkout_info,
-            lines,
-            checkout_line_info,
-            default_value * quantity,
+        total_value = (
+            base_calculations.get_line_total_price_with_propagated_checkout_discount(
+                checkout_info,
+                lines,
+                checkout_line_info,
+            )
         )
         default_taxed_value = TaxedMoney(
             net=total_value / quantity, gross=total_value / quantity

--- a/saleor/tax/calculations/checkout.py
+++ b/saleor/tax/calculations/checkout.py
@@ -103,14 +103,12 @@ def calculate_checkout_line_total(
     tax_rate: Decimal,
     prices_entered_with_tax: bool,
 ) -> TaxedMoney:
-    base_total_price = base_calculations.calculate_base_line_total_price(
-        checkout_line_info,
-    )
-    total_price = base_calculations.apply_checkout_discount_on_checkout_line(
-        checkout_info,
-        lines,
-        checkout_line_info,
-        base_total_price,
+    total_price = (
+        base_calculations.get_line_total_price_with_propagated_checkout_discount(
+            checkout_info,
+            lines,
+            checkout_line_info,
+        )
     )
     total_price = calculate_flat_rate_tax(
         total_price, tax_rate, prices_entered_with_tax

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -250,7 +250,7 @@ def test_calculations_calculate_order_total_with_discount_for_subtotal_and_shipp
 
     # then
     assert order.total == TaxedMoney(
-        net=Money("4.06", "USD"), gross=Money("5.01", "USD")
+        net=Money("4.07", "USD"), gross=Money("5.01", "USD")
     )
 
 
@@ -315,7 +315,7 @@ def test_calculations_calculate_order_total_with_manual_discount_and_voucher(
 
     # then
     assert order.total == TaxedMoney(
-        net=Money("48.78", "USD"), gross=Money("60.00", "USD")
+        net=Money("48.77", "USD"), gross=Money("60.00", "USD")
     )
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5091,9 +5091,7 @@ def order_with_lines(
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
-    Stock.objects.create(
-        warehouse=warehouse, product_variant=variant_1, quantity=5
-    )
+    Stock.objects.create(warehouse=warehouse, product_variant=variant_1, quantity=5)
 
     product = Product.objects.create(
         name="Test product 2",
@@ -5119,11 +5117,14 @@ def order_with_lines(
         cost_price_amount=Decimal(2),
         currency=channel_USD.currency_code,
     )
-    Stock.objects.create(
-        warehouse=warehouse, product_variant=variant_2, quantity=2
-    )
+    Stock.objects.create(warehouse=warehouse, product_variant=variant_2, quantity=2)
 
-    order_lines_generator(order, [variant_1, variant_2], [10, 20], [variant_1_quantity, variant_2_quantity])
+    order_lines_generator(
+        order,
+        [variant_1, variant_2],
+        [10, 20],
+        [variant_1_quantity, variant_2_quantity],
+    )
 
     order.shipping_address = order.billing_address.get_copy()
     order.channel = channel_USD

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4990,6 +4990,73 @@ def get_products_voucher_discount_for_order(order: Order, voucher: Voucher) -> M
 
 
 @pytest.fixture
+def order_lines_generator():
+    def create_order_line(
+        order, variants, unit_prices, quantities, create_allocations=True
+    ):
+        channel = order.channel
+        order_lines = []
+        allocations = []
+        stocks_to_update = []
+        variant_channel_listings_map = {
+            cl.variant_id: cl
+            for cl in ProductVariantChannelListing.objects.filter(
+                variant__in=variants, channel=channel
+            )
+        }
+        for variant, price, quantity in zip(variants, unit_prices, quantities):
+            product = variant.product
+            variant_channel_listing = variant_channel_listings_map[variant.id]
+            currency = channel.currency_code
+            base_price = Money(price, currency)
+            net = Money(price, channel.currency_code)
+            gross = Money(amount=net.amount * Decimal(1.23), currency=currency)
+            unit_price = TaxedMoney(net=net, gross=gross)
+            order_line = OrderLine(
+                order=order,
+                product_name=str(product),
+                variant_name=str(variant),
+                product_sku=variant.sku,
+                product_variant_id=variant.get_global_id(),
+                is_shipping_required=variant.is_shipping_required(),
+                is_gift_card=variant.is_gift_card(),
+                quantity=quantity,
+                variant=variant,
+                unit_price=unit_price,
+                total_price=unit_price * quantity,
+                undiscounted_unit_price=unit_price,
+                undiscounted_total_price=unit_price * quantity,
+                base_unit_price=base_price,
+                undiscounted_base_unit_price=base_price,
+                tax_rate=Decimal("0.23"),
+                **get_tax_class_kwargs_for_order_line(product.product_type.tax_class),
+            )
+            order_lines.append(order_line)
+            variant_channel_listing.price_amount = price
+            variant_channel_listing.discounted_price_amount = price
+            if create_allocations:
+                stock = variant.stocks.first()
+                allocation = Allocation(
+                    order_line=order_line, stock=stock, quantity_allocated=quantity
+                )
+                allocations.append(allocation)
+                stock.quantity_allocated += quantity
+                stocks_to_update.append(stock)
+
+        OrderLine.objects.bulk_create(order_lines)
+        if allocations:
+            Allocation.objects.bulk_create(allocations)
+            Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
+        ProductVariantChannelListing.objects.bulk_update(
+            variant_channel_listings_map.values(),
+            ["price_amount", "discounted_price_amount"],
+        )
+        return order_lines
+
+    return create_order_line
+
+
+@pytest.fixture
 def order_with_lines(
     order,
     product_type,
@@ -4998,6 +5065,7 @@ def order_with_lines(
     warehouse,
     channel_USD,
     default_tax_class,
+    order_lines_generator,
 ):
     product = Product.objects.create(
         name="Test product",
@@ -5013,46 +5081,18 @@ def order_with_lines(
         visible_in_listings=True,
         available_for_purchase_at=datetime.datetime.now(pytz.UTC),
     )
-    variant = ProductVariant.objects.create(product=product, sku="SKU_AA")
-    channel_listing = ProductVariantChannelListing.objects.create(
-        variant=variant,
+    variant_1_quantity = 3
+    variant_1 = ProductVariant.objects.create(product=product, sku="SKU_AA")
+    ProductVariantChannelListing.objects.create(
+        variant=variant_1,
         channel=channel_USD,
         price_amount=Decimal(10),
         discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
-    quantity = 3
-    stock = Stock.objects.create(
-        warehouse=warehouse,
-        product_variant=variant,
-        quantity=5,
-        quantity_allocated=quantity,
-    )
-    base_price = variant.get_price(channel_listing)
-    currency = base_price.currency
-    gross = Money(amount=base_price.amount * Decimal(1.23), currency=currency)
-    unit_price = TaxedMoney(net=base_price, gross=gross)
-    line = order.lines.create(
-        product_name=str(variant.product),
-        variant_name=str(variant),
-        product_sku=variant.sku,
-        product_variant_id=variant.get_global_id(),
-        is_shipping_required=variant.is_shipping_required(),
-        is_gift_card=variant.is_gift_card(),
-        quantity=quantity,
-        variant=variant,
-        unit_price=unit_price,
-        total_price=unit_price * quantity,
-        undiscounted_unit_price=unit_price,
-        undiscounted_total_price=unit_price * quantity,
-        base_unit_price=base_price,
-        undiscounted_base_unit_price=base_price,
-        tax_rate=Decimal("0.23"),
-        **get_tax_class_kwargs_for_order_line(product_type.tax_class),
-    )
-    Allocation.objects.create(
-        order_line=line, stock=stock, quantity_allocated=line.quantity
+    Stock.objects.create(
+        warehouse=warehouse, product_variant=variant_1, quantity=5
     )
 
     product = Product.objects.create(
@@ -5069,48 +5109,21 @@ def order_with_lines(
         visible_in_listings=True,
         available_for_purchase_at=timezone.now(),
     )
-    variant = ProductVariant.objects.create(product=product, sku="SKU_B")
-    channel_listing = ProductVariantChannelListing.objects.create(
-        variant=variant,
+    variant_2 = ProductVariant.objects.create(product=product, sku="SKU_B")
+    variant_2_quantity = 2
+    ProductVariantChannelListing.objects.create(
+        variant=variant_2,
         channel=channel_USD,
         price_amount=Decimal(20),
         discounted_price_amount=Decimal(20),
         cost_price_amount=Decimal(2),
         currency=channel_USD.currency_code,
     )
-    quantity = 2
-    stock = Stock.objects.create(
-        product_variant=variant,
-        warehouse=warehouse,
-        quantity=2,
-        quantity_allocated=quantity,
+    Stock.objects.create(
+        warehouse=warehouse, product_variant=variant_2, quantity=2
     )
 
-    base_price = variant.get_price(channel_listing)
-    currency = base_price.currency
-    gross = Money(amount=base_price.amount * Decimal(1.23), currency=currency)
-    unit_price = TaxedMoney(net=base_price, gross=gross)
-    line = order.lines.create(
-        product_name=str(variant.product),
-        variant_name=str(variant),
-        product_sku=variant.sku,
-        product_variant_id=variant.get_global_id(),
-        is_shipping_required=variant.is_shipping_required(),
-        is_gift_card=variant.is_gift_card(),
-        quantity=quantity,
-        variant=variant,
-        unit_price=unit_price,
-        total_price=unit_price * quantity,
-        undiscounted_unit_price=unit_price,
-        undiscounted_total_price=unit_price * quantity,
-        base_unit_price=base_price,
-        undiscounted_base_unit_price=base_price,
-        tax_rate=Decimal("0.23"),
-        **get_tax_class_kwargs_for_order_line(product_type.tax_class),
-    )
-    Allocation.objects.create(
-        order_line=line, stock=stock, quantity_allocated=line.quantity
-    )
+    order_lines_generator(order, [variant_1, variant_2], [10, 20], [variant_1_quantity, variant_2_quantity])
 
     order.shipping_address = order.billing_address.get_copy()
     order.channel = channel_USD


### PR DESCRIPTION
Previously, there were cases where a 0.01 discrepancy in price could occur due to rounding issues. I added rounding to the line portion calculation, which resolves this problem.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
