### PR TITLE
Do not delete checkout lines when product-channel-listing is removed

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -379,36 +379,22 @@ def fetch_checkout_lines(
             checkout, product, variant_channel_listing, product_channel_listing_mapping
         ):
             unavailable_variant_pks.append(variant.pk)
-            if (
-                not skip_lines_with_unavailable_variants
-                # variant price is denormalized on checkout line object. We have enough
-                # information to include the variant without listing in the
-                # calculations. This will allow to display a proper prices but we won't
-                # allow to finalize the checkout without removing `unavailable_variant`
-                # from the checkout.
-                or _only_variant_listing_is_missing(
-                    checkout,
-                    product,
-                    variant_channel_listing,
-                    product_channel_listing_mapping,
+            lines_info.append(
+                CheckoutLineInfo(
+                    line=line,
+                    variant=variant,
+                    channel_listing=variant_channel_listing,
+                    product=product,
+                    product_type=product_type,
+                    collections=collections,
+                    tax_class=product.tax_class or product_type.tax_class,
+                    discounts=discounts,
+                    rules_info=rules_info,
+                    channel=channel,
+                    voucher=None,
+                    voucher_code=None,
                 )
-            ):
-                lines_info.append(
-                    CheckoutLineInfo(
-                        line=line,
-                        variant=variant,
-                        channel_listing=variant_channel_listing,
-                        product=product,
-                        product_type=product_type,
-                        collections=collections,
-                        tax_class=product.tax_class or product_type.tax_class,
-                        discounts=discounts,
-                        rules_info=rules_info,
-                        channel=channel,
-                        voucher=None,
-                        voucher_code=None,
-                    )
-                )
+            )
             continue
 
         lines_info.append(
@@ -489,23 +475,6 @@ def _is_variant_valid(
     ):
         return False
     return True
-
-
-def _only_variant_listing_is_missing(
-    checkout: "Checkout",
-    product: "Product",
-    variant_channel_listing: Optional["ProductVariantChannelListing"],
-    product_channel_listing_mapping: dict,
-):
-    if not _product_channel_listing_is_valid(
-        checkout,
-        product,
-        product_channel_listing_mapping,
-    ):
-        return False
-    if not variant_channel_listing or variant_channel_listing.price is None:
-        return True
-    return False
 
 
 def _get_product_channel_listing(

--- a/saleor/checkout/tests/test_fetch.py
+++ b/saleor/checkout/tests/test_fetch.py
@@ -1,3 +1,6 @@
+import pytest
+
+from ...product.models import ProductChannelListing, ProductVariantChannelListing
 from ..fetch import CheckoutLineInfo, fetch_checkout_lines
 
 
@@ -245,17 +248,31 @@ def test_fetch_checkout_lines_info_when_product_not_available(
     )
 
     # then
-    assert len(line_infos) == 0
+    assert len(line_infos) == 1
+    assert line_infos[0].line.pk == line.pk
     assert unavailable_variants == [line.variant_id]
 
 
-def test_fetch_checkout_lines_info_when_variant_without_channel_listing(
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_fetch_checkout_lines_info_when_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
     checkout_with_item_on_promotion,
 ):
     # given
     lines = list(checkout_with_item_on_promotion.lines.all())
     line = lines[0]
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout_with_item_on_promotion.channel_id,
+        **{listing_filter_field: line.variant_id},
+    ).delete()
 
     # when
     line_infos, unavailable_variants = fetch_checkout_lines(

--- a/saleor/checkout/tests/test_tasks.py
+++ b/saleor/checkout/tests/test_tasks.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from ...order import OrderEvents
 from ...order.models import Order
+from ...product.models import ProductChannelListing, ProductVariantChannelListing
 from ..models import Checkout, CheckoutLine
 from ..tasks import (
     automatic_checkout_completion_task,
@@ -713,6 +714,60 @@ def test_automatic_checkout_completion_task_unavailable_variant(
     variant = line.variant
     product = line.variant.product
     product.channel_listings.update(is_published=False)
+
+    # allow catching the log in caplog
+    parent_logger = task_logger.parent
+    parent_logger.propagate = True
+
+    transaction_item_generator(
+        checkout_id=checkout.pk, charged_value=checkout.total.gross.amount
+    )
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        automatic_checkout_completion_task(checkout_pk, None, app.id)
+
+    # then
+    assert Checkout.objects.filter(pk=checkout_pk).exists()
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout_pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == (
+        "The automatic checkout completion not triggered, as the checkout "
+        f"{checkout_id} contains unavailable variants: {variant_id}."
+    )
+    assert caplog.records[0].checkout_id == checkout_id
+    assert caplog.records[0].levelno == logging.INFO
+
+
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_automatic_checkout_completion_task_line_without_listing(
+    channel_listing_model,
+    listing_filter_field,
+    checkout_with_prices,
+    transaction_item_generator,
+    app,
+    caplog,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_pk = checkout.pk
+
+    # make the checkout line unavailable
+    line = checkout.lines.first()
+    variant = line.variant
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: variant.id},
+    ).delete()
 
     # allow catching the log in caplog
     parent_logger = task_logger.parent

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -29,6 +29,7 @@ from .....payment.gateways.dummy_credit_card import TOKEN_VALIDATION_MAPPING
 from .....payment.interface import GatewayResponse
 from .....payment.model_helpers import get_subtotal
 from .....plugins.manager import PluginsManager, get_plugins_manager
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....warehouse.models import Reservation, Stock, WarehouseClickAndCollectOption
 from .....warehouse.tests.utils import get_available_quantity_for_stock
 from ....core.utils import to_global_id_or_none
@@ -811,7 +812,16 @@ def test_checkout_complete_with_variant_without_price(
     assert not checkout.completing_started_at
 
 
-def test_checkout_complete_with_variant_without_channel_listing(
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_checkout_complete_with_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
     site_settings,
     user_api_client,
     checkout_with_item,
@@ -828,7 +838,11 @@ def test_checkout_complete_with_variant_without_channel_listing(
 
     checkout_line = checkout.lines.first()
     checkout_line_variant = checkout_line.variant
-    checkout_line_variant.channel_listings.filter(channel=checkout.channel).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: checkout_line.variant_id},
+    ).delete()
 
     variant_id = graphene.Node.to_global_id("ProductVariant", checkout_line_variant.pk)
     redirect_url = "https://www.example.com"

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -28,7 +28,11 @@ from .....payment import TransactionEventType
 from .....payment.model_helpers import get_subtotal
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....plugins.manager import PluginsManager, get_plugins_manager
-from .....product.models import VariantChannelListingPromotionRule
+from .....product.models import (
+    ProductChannelListing,
+    ProductVariantChannelListing,
+    VariantChannelListingPromotionRule,
+)
 from .....warehouse.models import Reservation, Stock, WarehouseClickAndCollectOption
 from .....warehouse.tests.utils import get_available_quantity_for_stock
 from ....core.utils import to_global_id_or_none
@@ -1145,7 +1149,16 @@ def test_checkout_with_variant_without_price(
     assert errors[0]["variants"] == [variant_id]
 
 
-def test_checkout_with_variant_without_channel_listing(
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_checkout_with_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
     site_settings,
     user_api_client,
     checkout_with_item,
@@ -1167,7 +1180,11 @@ def test_checkout_with_variant_without_channel_listing(
 
     checkout_line = checkout.lines.first()
     checkout_line_variant = checkout_line.variant
-    checkout_line_variant.channel_listings.filter(channel=checkout.channel).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: checkout_line.variant_id},
+    ).delete()
 
     variant_id = to_global_id_or_none(checkout_line_variant)
     redirect_url = "https://www.example.com"

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -12,6 +12,7 @@ from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.utils import PRIVATE_META_APP_SHIPPING_ID, invalidate_checkout
 from .....core.models import EventDelivery
 from .....plugins.manager import get_plugins_manager
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....shipping import models as shipping_models
 from .....shipping.utils import convert_to_shipping_method_data
 from .....warehouse import WarehouseClickAndCollectOption
@@ -137,6 +138,13 @@ def test_checkout_delivery_method_update(
 
 
 @pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+@pytest.mark.parametrize(
     ("delivery_method", "node_name", "attribute_name"),
     [
         ("warehouse", "Warehouse", "collection_point"),
@@ -144,16 +152,22 @@ def test_checkout_delivery_method_update(
     ],
     indirect=("delivery_method",),
 )
-def test_checkout_delivery_method_update_when_variant_without_channel_listing(
+def test_checkout_delivery_method_update_when_line_without_channel_listing(
     api_client,
     delivery_method,
     node_name,
     attribute_name,
+    channel_listing_model,
+    listing_filter_field,
     checkout_with_item_for_cc,
 ):
     # given
     line = checkout_with_item_for_cc.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout_with_item_for_cc.channel_id,
+        **{listing_filter_field: line.variant_id},
+    ).delete()
 
     checkout = checkout_with_item_for_cc
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import pytest
 from django.test import override_settings
 
 from .....checkout.actions import call_checkout_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....core.models import EventDelivery
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
@@ -48,8 +50,15 @@ def test_checkout_email_update(user_api_client, checkout_with_item):
     assert checkout.last_change != previous_last_change
 
 
-def test_checkout_email_update_when_variant_without_channel_listing(
-    user_api_client, checkout_with_item
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_checkout_email_update_when_line_without_channel_listing(
+    channel_listing_model, listing_filter_field, user_api_client, checkout_with_item
 ):
     # given
     checkout = checkout_with_item
@@ -58,7 +67,10 @@ def test_checkout_email_update_when_variant_without_channel_listing(
     previous_last_change = checkout.last_change
 
     line = checkout.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id, **{listing_filter_field: line.variant_id}
+    ).delete()
 
     email = "test@example.com"
     variables = {"id": to_global_id_or_none(checkout), "email": email}

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -2,6 +2,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import graphene
+import pytest
 from django.test import override_settings
 
 from .....checkout import base_calculations
@@ -16,6 +17,7 @@ from .....checkout.utils import (
 )
 from .....core.models import EventDelivery
 from .....plugins.manager import get_plugins_manager
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....warehouse.models import Reservation
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
@@ -88,6 +90,13 @@ def test_checkout_line_delete(
     assert mocked_invalidate_checkout.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_line_delete."
     "update_checkout_shipping_method_if_invalid",
@@ -100,6 +109,8 @@ def test_checkout_line_delete(
 def test_checkout_line_delete_when_variant_without_channel_listing(
     mocked_invalidate_checkout,
     mocked_update_shipping_method,
+    channel_listing_model,
+    listing_filter_field,
     user_api_client,
     checkout_line_with_reservation_in_many_stocks,
 ):
@@ -111,7 +122,11 @@ def test_checkout_line_delete_when_variant_without_channel_listing(
     assert calculate_checkout_quantity(lines) == 3
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id, **{listing_filter_field: line.variant_id}
+    ).delete()
+
     assert line.quantity == 3
 
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
@@ -137,6 +152,13 @@ def test_checkout_line_delete_when_variant_without_channel_listing(
     assert mocked_invalidate_checkout.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_line_delete."
     "update_checkout_shipping_method_if_invalid",
@@ -146,9 +168,11 @@ def test_checkout_line_delete_when_variant_without_channel_listing(
     "saleor.graphql.checkout.mutations.checkout_line_delete.invalidate_checkout",
     wraps=invalidate_checkout,
 )
-def test_checkout_line_delete_when_checkout_has_variant_without_channel_listing(
+def test_checkout_line_delete_when_checkout_has_line_without_channel_listing(
     mocked_invalidate_checkout,
     mocked_update_shipping_method,
+    channel_listing_model,
+    listing_filter_field,
     user_api_client,
     checkout_with_items,
 ):
@@ -160,7 +184,11 @@ def test_checkout_line_delete_when_checkout_has_variant_without_channel_listing(
     assert calculate_checkout_quantity(lines) == 4
     assert checkout.lines.count() == 4
     line_without_listing = checkout.lines.last()
-    line_without_listing.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: line_without_listing.variant_id},
+    ).delete()
 
     line = checkout.lines.first()
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -20,7 +20,7 @@ from .....checkout.utils import (
 from .....core.models import EventDelivery
 from .....discount import RewardValueType
 from .....plugins.manager import get_plugins_manager
-from .....product.models import ProductChannelListing
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....warehouse.models import Reservation, Stock
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
@@ -124,6 +124,13 @@ def test_checkout_lines_update(
     assert mocked_invalidate_checkout.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_lines_add."
     "update_checkout_shipping_method_if_invalid",
@@ -133,9 +140,11 @@ def test_checkout_lines_update(
     "saleor.graphql.checkout.mutations.checkout_lines_add.invalidate_checkout",
     wraps=invalidate_checkout,
 )
-def test_checkout_lines_update_when_checkout_has_variant_without_listing(
+def test_checkout_lines_update_when_checkout_has_line_without_listing(
     mocked_invalidate_checkout,
     mocked_update_shipping_method,
+    channel_listing_model,
+    listing_filter_field,
     user_api_client,
     checkout_with_items,
 ):
@@ -150,7 +159,11 @@ def test_checkout_lines_update_when_checkout_has_variant_without_listing(
     assert line.quantity == 1
 
     line_without_listing = checkout.lines.last()
-    line_without_listing.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: line_without_listing.variant_id},
+    ).delete()
 
     previous_last_change = checkout.last_change
 
@@ -1083,15 +1096,38 @@ def test_checkout_lines_update_with_unavailable_variant(
     assert checkout.last_change == previous_last_change
 
 
-def test_checkout_lines_update_with_variant_without_channel_listing(
-    user_api_client, checkout_with_item
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field", "expected_error_code"),
+    [
+        (
+            ProductVariantChannelListing,
+            "variant_id",
+            CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name,
+        ),
+        (
+            ProductChannelListing,
+            "product__variants__id",
+            CheckoutErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE.name,
+        ),
+    ],
+)
+def test_checkout_lines_update_with_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
+    expected_error_code,
+    user_api_client,
+    checkout_with_item,
 ):
     checkout = checkout_with_item
     previous_last_change = checkout.last_change
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     variant = line.variant
-    variant.channel_listings.filter(channel=checkout_with_item.channel).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id, **{listing_filter_field: variant.id}
+    ).delete()
+
     assert line.quantity == 3
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
@@ -1104,7 +1140,7 @@ def test_checkout_lines_update_with_variant_without_channel_listing(
     content = get_graphql_content(response)
 
     errors = content["data"]["checkoutLinesUpdate"]["errors"]
-    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
+    assert errors[0]["code"] == expected_error_code
     assert errors[0]["field"] == "lines"
     assert errors[0]["variants"] == [variant_id]
     checkout.refresh_from_db()

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import graphene
+import pytest
 from django.test import override_settings
 from django.utils import timezone
 from prices import Money
@@ -15,6 +16,7 @@ from .....core.models import EventDelivery
 from .....discount import RewardValueType
 from .....discount.models import Voucher, VoucherChannelListing, VoucherCode
 from .....plugins.manager import get_plugins_manager
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
@@ -91,13 +93,28 @@ def test_checkout_remove_voucher_code(
     )
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @patch("saleor.plugins.manager.PluginsManager.checkout_updated")
-def test_checkout_remove_voucher_code_when_variant_without_listing(
-    checkout_updated_webhook_mock, api_client, checkout_with_voucher
+def test_checkout_remove_voucher_code_when_line_without_listing(
+    checkout_updated_webhook_mock,
+    channel_listing_model,
+    listing_filter_field,
+    api_client,
+    checkout_with_voucher,
 ):
     # given
     line = checkout_with_voucher.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout_with_voucher.channel_id,
+        **{listing_filter_field: line.variant_id},
+    ).delete()
 
     assert checkout_with_voucher.voucher_code is not None
     previous_checkout_last_change = checkout_with_voucher.last_change

--- a/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
@@ -943,7 +943,7 @@ def test_product_channel_listing_update_remove_channel(
     assert variant.channel_listings.get() == variant_channel_listing_pln
 
 
-def test_product_channel_listing_update_remove_channel_removes_checkout_lines(
+def test_product_channel_listing_update_remove_channel_dont_remove_checkout_lines(
     staff_api_client,
     product_available_in_many_channels,
     permission_manage_products,
@@ -978,7 +978,7 @@ def test_product_channel_listing_update_remove_channel_removes_checkout_lines(
     # then
     data = content["data"]["productChannelListingUpdate"]
     assert not data["errors"]
-    assert not checkout.lines.all().exists()
+    assert checkout.lines.all().exists()
 
 
 def test_product_channel_listing_update_remove_not_assigned_channel(


### PR DESCRIPTION
I want to merge this change because it fixes the problem of deleting the existing CheckoutLines in the background when removing `ProductChannelListing`. 
This could impact on existing checkouts, as we could change the checkout content without informing the user. 

----

With the fix, all "invalid" lines, are present in the API response, and they are included in all calculations. 
The lines without `ProductChannelListing` are visible in `Checkout.problems` and `checkout.lines[].problems`:

```json
	"problems": [
		{
			"__typename": "CheckoutLineProblemVariantNotAvailable",
			"line": {
				"id": "Q2hlY2tvdXRMaW5lOmQyM2I4ZTEyLTEzZGMtNDA1OC04Yzk4LTliNDQyM2EyNzYyMQ=="
			}
		}
	],
```
(This interface was already present, I didn't change anything related to this). 
`CheckoutComplete`, `OrderCreateFromCheckout`, and async `automatic_checkout_completion_task` will not allow closing the checkout when there are lines without listing (also already present in the code).

When using `Channel.checkoutSettings.useLegacyErrorFlow`, some checkout mutations can raise an exception about not-available variants - this is also something already present in the code.  

---

Just ☝️  pointing to these parts of the code to provide more context. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
