### PR TITLE
Handle long message when reporting transaction event

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -21,7 +21,7 @@ from .....payment import TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionCreateErrorCode
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
-from .....payment.utils import create_manual_adjustment_events
+from .....payment.utils import create_manual_adjustment_events, truncate_message
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
@@ -290,7 +290,7 @@ class TransactionCreate(BaseMutation):
             app_identifier = app.identifier
         return transaction.events.create(
             psp_reference=transaction_event_input.get("psp_reference"),
-            message=transaction_event_input.get("message", ""),
+            message=truncate_message(transaction_event_input.get("message", "")),
             transaction=transaction,
             user=user if user and user.is_authenticated else None,
             app_identifier=app_identifier,

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -26,6 +26,7 @@ from .....payment.utils import (
     create_failed_transaction_event,
     get_already_existing_event,
     get_transaction_event_amount,
+    truncate_message,
 )
 from .....permission.auth_filters import AuthorizationFilters
 from .....permission.enums import PaymentPermissions
@@ -116,7 +117,12 @@ class TransactionEventReport(ModelMutation):
                 "payment provider page with event details."
             )
         )
-        message = graphene.String(description="The message related to the event.")
+        message = graphene.String(
+            description=(
+                "The message related to the event. The maximum length is 512 "
+                "characters; any text exceeding this limit will be truncated."
+            )
+        )
         available_actions = graphene.List(
             graphene.NonNull(TransactionActionEnum),
             description="List of all possible actions for the transaction",
@@ -326,6 +332,7 @@ class TransactionEventReport(ModelMutation):
                 psp_reference, transaction
             )
 
+        message = truncate_message(message) if message is not None else ""
         transaction_event_data = {
             "psp_reference": psp_reference,
             "type": type,
@@ -333,7 +340,7 @@ class TransactionEventReport(ModelMutation):
             "currency": transaction.currency,
             "created_at": time or timezone.now(),
             "external_url": external_url or "",
-            "message": message or "",
+            "message": message,
             "transaction": transaction,
             "app_identifier": app_identifier,
             "app": app,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2364,3 +2364,54 @@ def test_transaction_create_amount_with_lot_of_decimal_places(
     assert transaction.app == app_api_client.app
     assert transaction.user is None
     assert transaction.external_url == external_url
+
+
+def test_transaction_create_create_event_message_limit_exceeded(
+    order_with_lines, permission_manage_payments, app_api_client
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+    ]
+    authorized_value = Decimal("10")
+    transaction_reference = "transaction reference"
+    transaction_msg = "m" * 513
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+        },
+        "transaction_event": {
+            "pspReference": transaction_reference,
+            "message": transaction_msg,
+        },
+    }
+
+    # when
+    app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    assert order_with_lines.events.count() == 1
+    event = order_with_lines.events.first()
+
+    assert event.type == OrderEvents.TRANSACTION_EVENT
+    assert event.parameters == {
+        "message": transaction_msg,
+        "reference": transaction_reference,
+    }
+
+    transaction = order_with_lines.payment_transactions.first()
+    event = transaction.events.last()
+    assert event.message == transaction_msg[:509] + "..."
+    assert event.psp_reference == transaction_reference

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -3149,3 +3149,83 @@ def test_transaction_event_report_update_transaction_private_metadata(
     assert event.app == app_api_client.app
     assert event.user is None
     transaction_item_metadata_updated_mock.assert_not_called()
+
+
+def test_transaction_event_report_message_limit_exceeded(
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    event_time = timezone.now()
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+    message = "m" * 550
+    psp_reference = "111-abc"
+    amount = Decimal("11.00")
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+        "time": event_time.isoformat(),
+        "externalUrl": external_url,
+        "message": message,
+        "availableActions": [TransactionActionEnum.REFUND.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $time: DateTime
+        $externalUrl: String
+        $message: String
+        $availableActions: [TransactionActionEnum!]!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            time: $time
+            externalUrl: $externalUrl
+            message: $message
+            availableActions: $availableActions
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    event = TransactionEvent.objects.filter(
+        type=TransactionEventType.CHARGE_SUCCESS
+    ).first()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == TransactionEventTypeEnum.CHARGE_SUCCESS.value
+    assert event.amount_value == amount
+    assert event.currency == transaction.currency
+    assert event.created_at == event_time
+    assert event.external_url == external_url
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+    assert event.message == message[:509] + "..."

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -107,7 +107,7 @@ def _assert_fields(
     charge_pending_value=Decimal(0),
     authorize_pending_value=Decimal(0),
     returned_data=None,
-    expected_message="",
+    expected_message=None,
 ):
     assert not content["data"]["transactionInitialize"]["errors"]
     response_data = content["data"]["transactionInitialize"]
@@ -171,7 +171,8 @@ def _assert_fields(
     assert response_event.amount_value == expected_amount
     assert response_event.include_in_calculations
     assert response_event.psp_reference == expected_psp_reference
-    assert response_event.message == expected_message
+    if expected_message is not None:
+        assert response_event.message == expected_message
 
     mocked_initialize.assert_called_with(
         TransactionSessionData(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -158,6 +158,7 @@ def _assert_fields(
     charge_pending_value=Decimal(0),
     authorize_pending_value=Decimal(0),
     returned_data=None,
+    expected_message=None,
 ):
     assert not content["data"]["transactionProcess"]["errors"]
     response_data = content["data"]["transactionProcess"]
@@ -224,6 +225,8 @@ def _assert_fields(
     )
     assert response_event.include_in_calculations is include_in_calculations
     assert response_event.psp_reference == expected_psp_reference
+    if expected_message is not None:
+        assert response_event.message == expected_message
 
     mocked_process.assert_called_with(
         TransactionSessionData(
@@ -2238,3 +2241,68 @@ def test_for_checkout_with_payments_transaction_process_failure(
         payment.refresh_from_db()
     assert payments[0].is_active is True
     assert payments[1].is_active is False
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_for_order_too_long_message_in_response(
+    mocked_process,
+    user_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+    transaction_item_generator,
+    caplog,
+):
+    # given
+    expected_amount = Decimal("10.00")
+
+    order = order_with_lines
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    transaction_item = transaction_item_generator(order_id=order.pk, app=webhook_app)
+    TransactionEvent.objects.create(
+        transaction=transaction_item,
+        amount_value=expected_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = expected_amount
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    expected_response["message"] = "m" * 513
+    del expected_response["data"]
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "data": None,
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    _assert_fields(
+        content=content,
+        source_object=order,
+        expected_amount=expected_amount,
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_process=mocked_process,
+        charged_value=expected_amount,
+        returned_data=None,
+        expected_message=expected_response["message"][:509] + "...",
+    )
+    assert (
+        "Value for field: message in response of transaction action webhook "
+        "exceeds the character field limit. Message has been truncated."
+    ) in [record.message for record in caplog.records]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16973,7 +16973,9 @@ type Mutation {
     """The ID of the transaction. One of field id or token is required."""
     id: ID
 
-    """The message related to the event."""
+    """
+    The message related to the event. The maximum length is 512 characters; any text exceeding this limit will be truncated.
+    """
     message: String
 
     """PSP Reference of the event to report."""

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -1737,6 +1737,64 @@ def test_create_event_from_request_and_webhook_pending_event_calculate_refundabl
     assert checkout.automatically_refundable is True
 
 
+def test_create_transaction_event_from_request_and_webhook_response_message_loo_long(
+    transaction_item_generator, app, caplog
+):
+    # given
+    transaction = transaction_item_generator()
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=Decimal(11.00),
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_FAILURE
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+    event_message = "m" * 550
+
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_message,
+        "actions": ["CHARGE", "CHARGE", "CANCEL"],
+    }
+
+    # when
+    event = create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    transaction.refresh_from_db()
+    assert len(transaction.available_actions) == 2
+    assert set(transaction.available_actions) == set(["charge", "cancel"])
+    assert transaction.events.count() == 2
+    request_event.refresh_from_db()
+    assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
+    assert event
+    assert event.psp_reference == expected_psp_reference
+    assert event.amount_value == event_amount
+    assert event.created_at == datetime.fromisoformat(event_time)
+    assert event.external_url == event_url
+    assert event.message == event_message[:509] + "..."
+    assert event.type == event_type
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == (
+        "Value for field: message in response of transaction action webhook "
+        "exceeds the character field limit. Message has been truncated."
+    )
+    assert caplog.records[0].levelno == logging.WARNING
+
+
 @pytest.mark.parametrize(
     ("db_field_name", "value", "event_type"),
     [
@@ -2486,6 +2544,47 @@ def test_create_transaction_event_updates_transaction_modified_at_for_failure(
     checkout.refresh_from_db()
     assert transaction.modified_at == calculation_time
     assert checkout.last_transaction_modified_at == calculation_time
+
+
+def test_create_transaction_event_message_limit_exceeded(
+    transaction_item_generator,
+    transaction_session_response,
+    webhook_app,
+    plugins_manager,
+    checkout,
+    caplog,
+):
+    # given
+    expected_amount = Decimal("15")
+    message = "m" * 1000
+    response = transaction_session_response.copy()
+    response["amount"] = expected_amount
+    response["message"] = message
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    request_event = TransactionEvent.objects.create(
+        transaction=transaction, include_in_calculations=False
+    )
+
+    # when
+    create_transaction_event_for_transaction_session(
+        request_event,
+        webhook_app,
+        manager=plugins_manager,
+        transaction_webhook_response=response,
+    )
+
+    # then
+    transaction.refresh_from_db()
+    assert transaction.events.count() == 2
+    event = transaction.events.last()
+    assert event.message == message[:509] + "..."
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == (
+        "Value for field: message in response of transaction action webhook "
+        "exceeds the character field limit. Message has been truncated."
+    )
+    assert caplog.records[0].levelno == logging.WARNING
 
 
 def test_recalculate_refundable_for_checkout_with_request_refund(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -880,6 +880,16 @@ def parse_transaction_event_data(
         logger.warning(missing_msg, "result")
         error_field_msg.append(missing_msg % "result")
 
+    message = event_data.get("message", "")
+    if len(message) > 512:
+        message = truncate_message(message)
+        field_limit_exceeded_msg = (
+            "Value for field: %s in response of transaction action webhook "
+            "exceeds the character field limit. Message has been truncated."
+        )
+        logger.warning(field_limit_exceeded_msg, "message")
+    parsed_event_data["message"] = message
+
     amount_data = event_data.get("amount")
     parse_transaction_event_amount(
         amount_data,
@@ -910,7 +920,6 @@ def parse_transaction_event_data(
         parsed_event_data["time"] = timezone.now()
 
     parsed_event_data["external_url"] = event_data.get("externalUrl", "")
-    parsed_event_data["message"] = event_data.get("message", "")
 
 
 error_msg = str
@@ -955,8 +964,7 @@ def parse_transaction_action_data(
         # error field msg can contain details of the value returned by payment app
         # which means that we need to confirm that we don't exceed the field limit.
         msg = "\n".join(error_field_msg)
-        if len(msg) >= 512:
-            msg = msg[:509] + "..."
+        msg = truncate_message(msg)
         return None, msg
 
     request_event_type = parsed_event_data.get("type", request_type)
@@ -975,6 +983,10 @@ def parse_transaction_action_data(
         ),
         None,
     )
+
+
+def truncate_message(message: str):
+    return message[:509] + "..." if len(message) >= 512 else message
 
 
 def get_failed_transaction_event_type_for_request_event(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -986,7 +986,7 @@ def parse_transaction_action_data(
 
 
 def truncate_message(message: str):
-    return message[:509] + "..." if len(message) >= 512 else message
+    return message[:509] + "..." if len(message) > 512 else message
 
 
 def get_failed_transaction_event_type_for_request_event(


### PR DESCRIPTION
Previously, when the transaction event with the long massage (above 512 characters) was reported, the error was raised.
After the changes, the massage is truncated, and the warning is logged.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1396#pullrequestreview-2447716806

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
