### PR TITLE
Add payload size to the webhook spans

### DIFF
--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -175,6 +175,7 @@ class EventPayload(models.Model):
 
     objects = EventPayloadManager()
 
+    # TODO (PE-568): change typing of return payload to `bytes` to avoid unnecessary decoding.
     def get_payload(self):
         if self.payload_file:
             with self.payload_file.open("rb") as f:

--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -23,7 +23,17 @@ def opentracing_trace(span_name, component_name, service_name):
 
 
 @contextmanager
-def webhooks_opentracing_trace(span_name, domain, sync=False, app=None):
+def webhooks_opentracing_trace(
+    span_name,
+    domain,
+    payload_size: int,
+    sync=False,
+    app=None,
+):
+    """Context manager for tracing webhooks.
+
+    :param payload_size: size of the payload in bytes
+    """
     with opentracing.global_tracer().start_active_span(
         f"webhooks.{span_name}"
     ) as scope:
@@ -35,4 +45,5 @@ def webhooks_opentracing_trace(span_name, domain, sync=False, app=None):
         span.set_tag("service.name", "webhooks")
         span.set_tag("webhooks.domain", domain)
         span.set_tag("webhooks.execution_mode", "sync" if sync else "async")
+        span.set_tag("webhooks.payload_size", payload_size)
         yield

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1944,7 +1944,7 @@ def test_send_webhook_request_async(
         "mirumee.com",
         event_delivery.webhook.secret_key,
         event_delivery.event_type,
-        event_delivery.payload.get_payload(),
+        event_delivery.payload.get_payload().encode("utf-8"),
         event_delivery.webhook.custom_headers,
     )
     mocked_clear_delivery.assert_called_once_with(event_delivery)

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -575,7 +575,13 @@ def send_webhook_request_async(self, event_delivery_id) -> None:
                 f"Event delivery id: %{event_delivery_id}r has no payload."
             )
         data = delivery.payload.get_payload()
-        with webhooks_opentracing_trace(delivery.event_type, domain, app=webhook.app):
+        # Covert payload to bytes if it's not already.
+        data = data if isinstance(data, bytes) else data.encode("utf-8")
+        # Count payload size in bytes.
+        payload_size = len(data)
+        with webhooks_opentracing_trace(
+            delivery.event_type, domain, payload_size, app=webhook.app
+        ):
             response = send_webhook_using_scheme_method(
                 webhook.target_url,
                 domain,

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -97,6 +97,7 @@ def _send_webhook_request_sync(
     parts = urlparse(webhook.target_url)
     domain = get_domain()
     message = data.encode("utf-8")
+    payload_size = len(message)
     signature = signature_for_payload(message, webhook.secret_key)
 
     if parts.scheme.lower() not in [WebhookSchemes.HTTP, WebhookSchemes.HTTPS]:
@@ -115,7 +116,7 @@ def _send_webhook_request_sync(
 
     try:
         with webhooks_opentracing_trace(
-            delivery.event_type, domain, sync=True, app=webhook.app
+            delivery.event_type, domain, payload_size, sync=True, app=webhook.app
         ):
             response = send_webhook_using_http(
                 webhook.target_url,

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -141,6 +141,7 @@ def generate_cache_key_for_webhook(
     )
 
 
+# TODO (PE-568): change typing of data to `bytes` to avoid unnecessary encoding.
 def send_webhook_using_http(
     target_url,
     message,
@@ -303,6 +304,7 @@ def send_webhook_using_google_cloud_pubsub(
         return WebhookResponse(content=response, duration=response_duration)
 
 
+# TODO (PE-568): change typing of data to `bytes` to avoid unnecessary encoding.
 def send_webhook_using_scheme_method(
     target_url,
     domain,


### PR DESCRIPTION
I want to merge this change because adding payload size to the webhook spans.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
