### PR TITLE
Do not update EventAttempt for success event delivery

### DIFF
--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1958,15 +1958,25 @@ def test_send_webhook_request_async_with_success_response(
         event_delivery.webhook.custom_headers,
     )
     mocked_clear_delivery.assert_called_once_with(event_delivery)
-    attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
-    assert attempt
+    attempt = EventDeliveryAttempt.objects.get(delivery=event_delivery)
+
     mocked_attempt_update.assert_called_once_with(
         attempt, webhook_response, with_save=False
     )
-    # Update attempt with the webhook response to make sure that overvability was called
-    # with up-to-date event
-    attempt_update(attempt, webhook_response, with_save=False)
-    mocked_observability.assert_called_once_with(attempt)
+    mocked_observability.assert_called_once()
+    reported_attempt = mocked_observability.call_args.args[0]
+    assert reported_attempt.duration == webhook_response.duration
+    assert reported_attempt.response == webhook_response.content
+    assert reported_attempt.response_headers == json.dumps(
+        webhook_response.response_headers
+    )
+    assert (
+        reported_attempt.response_status_code == webhook_response.response_status_code
+    )
+    assert reported_attempt.request_headers == json.dumps(
+        webhook_response.request_headers
+    )
+    assert reported_attempt.status == webhook_response.status
 
 
 @mock.patch(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -57,6 +57,7 @@ from ....webhook.transport.asynchronous.transport import (
     send_webhook_request_async,
     trigger_webhooks_async,
 )
+from ....webhook.transport.utils import attempt_update
 from ....webhook.utils import get_webhooks_for_event
 from ...manager import get_plugins_manager
 from .utils import generate_request_headers
@@ -1923,22 +1924,31 @@ def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
 
 
 @mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.attempt_update",
+    wraps=attempt_update,
+)
+@mock.patch(
     "saleor.webhook.transport.asynchronous.transport.observability.report_event_delivery_attempt"
 )
 @mock.patch("saleor.webhook.transport.asynchronous.transport.clear_successful_delivery")
 @mock.patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
 )
-def test_send_webhook_request_async(
+def test_send_webhook_request_async_with_success_response(
     mocked_send_response,
     mocked_clear_delivery,
     mocked_observability,
+    mocked_attempt_update,
     event_delivery,
     webhook_response,
 ):
+    # given
     mocked_send_response.return_value = webhook_response
+
+    # when
     send_webhook_request_async(event_delivery.pk)
 
+    # then
     mocked_send_response.assert_called_once_with(
         event_delivery.webhook.target_url,
         "mirumee.com",
@@ -1949,18 +1959,35 @@ def test_send_webhook_request_async(
     )
     mocked_clear_delivery.assert_called_once_with(event_delivery)
     attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
-    delivery = EventDelivery.objects.get(id=event_delivery.pk)
-
     assert attempt
-    assert delivery
-    assert attempt.status == EventDeliveryStatus.SUCCESS
-    assert attempt.response == webhook_response.content
-    assert attempt.response_headers == json.dumps(webhook_response.response_headers)
-    assert attempt.response_status_code == webhook_response.response_status_code
-    assert attempt.request_headers == json.dumps(webhook_response.request_headers)
-    assert attempt.duration == webhook_response.duration
-    assert delivery.status == EventDeliveryStatus.SUCCESS
+    mocked_attempt_update.assert_called_once_with(
+        attempt, webhook_response, with_save=False
+    )
+    # Update attempt with the webhook response to make sure that overvability was called
+    # with up-to-date event
+    attempt_update(attempt, webhook_response, with_save=False)
     mocked_observability.assert_called_once_with(attempt)
+
+
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+def test_send_webhook_request_async_with_success_response_deletes_event_deliveries(
+    mocked_send_response,
+    event_delivery,
+    webhook_response,
+):
+    # given
+    mocked_send_response.return_value = webhook_response
+    assert webhook_response.status == EventDeliveryStatus.SUCCESS
+
+    # when
+    send_webhook_request_async(event_delivery.pk)
+
+    # then
+    assert mocked_send_response.called
+    assert not EventDelivery.objects.all().exists()
+    assert not EventDeliveryAttempt.objects.all().exists()
 
 
 @mock.patch(

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -567,7 +567,6 @@ def send_webhook_request_async(self, event_delivery_id) -> None:
     webhook = delivery.webhook
     domain = get_domain()
     attempt = create_attempt(delivery, self.request.id)
-    delivery_status = EventDeliveryStatus.SUCCESS
 
     try:
         if not delivery.payload:
@@ -591,10 +590,11 @@ def send_webhook_request_async(self, event_delivery_id) -> None:
                 webhook.custom_headers,
             )
 
-        attempt_update(attempt, response)
         if response.status == EventDeliveryStatus.FAILED:
+            attempt_update(attempt, response)
             handle_webhook_retry(self, webhook, response, delivery, attempt)
             delivery_status = EventDeliveryStatus.FAILED
+            delivery_update(delivery, delivery_status)
         elif response.status == EventDeliveryStatus.SUCCESS:
             task_logger.info(
                 "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",
@@ -603,7 +603,9 @@ def send_webhook_request_async(self, event_delivery_id) -> None:
                 delivery.event_type,
                 delivery.id,
             )
-        delivery_update(delivery, delivery_status)
+            delivery.status = EventDeliveryStatus.SUCCESS
+            # update attempt without save to provide proper data in observability
+            attempt_update(attempt, response, with_save=False)
     except ValueError as e:
         response = WebhookResponse(content=str(e), status=EventDeliveryStatus.FAILED)
         attempt_update(attempt, response)

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -593,8 +593,7 @@ def send_webhook_request_async(self, event_delivery_id) -> None:
         if response.status == EventDeliveryStatus.FAILED:
             attempt_update(attempt, response)
             handle_webhook_retry(self, webhook, response, delivery, attempt)
-            delivery_status = EventDeliveryStatus.FAILED
-            delivery_update(delivery, delivery_status)
+            delivery_update(delivery, EventDeliveryStatus.FAILED)
         elif response.status == EventDeliveryStatus.SUCCESS:
             task_logger.info(
                 "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -465,6 +465,7 @@ def create_attempt(
 def attempt_update(
     attempt: "EventDeliveryAttempt",
     webhook_response: "WebhookResponse",
+    with_save: bool = True,
 ):
     attempt.duration = webhook_response.duration
     attempt.response = webhook_response.content
@@ -473,7 +474,7 @@ def attempt_update(
     attempt.request_headers = json.dumps(webhook_response.request_headers)
     attempt.status = webhook_response.status
 
-    if attempt.id:
+    if attempt.id and with_save:
         attempt.save(
             update_fields=[
                 "duration",


### PR DESCRIPTION
I want to merge this change because right now when we have a successful webhook delivery, we delete the `EventDelivery` object at the end of the task. But in the meantime, we also always update `DeliveryAttempt` and `EventDelivery` with new status. It means two additional write db  queries, for the object that will be deleted a few lines later. 

With this PR, we skip updating EventAttempt for successful deliveries and update the status for EventDelivery.  As both of them will be deleted.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
