### PR TITLE
Do not delete checkout lines when product-channel-listing is removed 

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -412,36 +412,22 @@ def fetch_checkout_lines(
             checkout, product, variant_channel_listing, product_channel_listing_mapping
         ):
             unavailable_variant_pks.append(variant.pk)
-            if (
-                not skip_lines_with_unavailable_variants
-                # variant price is denormalized on checkout line object. We have enough
-                # information to include the variant without listing in the
-                # calculations. This will allow to display a proper prices but we won't
-                # allow to finalize the checkout without removing `unavailable_variant`
-                # from the checkout.
-                or _only_variant_listing_is_missing(
-                    checkout,
-                    product,
-                    variant_channel_listing,
-                    product_channel_listing_mapping,
+            lines_info.append(
+                CheckoutLineInfo(
+                    line=line,
+                    variant=variant,
+                    channel_listing=variant_channel_listing,
+                    product=product,
+                    product_type=product_type,
+                    collections=collections,
+                    tax_class=product.tax_class or product_type.tax_class,
+                    discounts=discounts,
+                    rules_info=rules_info,
+                    channel=channel,
+                    voucher=None,
+                    voucher_code=None,
                 )
-            ):
-                lines_info.append(
-                    CheckoutLineInfo(
-                        line=line,
-                        variant=variant,
-                        channel_listing=variant_channel_listing,
-                        product=product,
-                        product_type=product_type,
-                        collections=collections,
-                        tax_class=product.tax_class or product_type.tax_class,
-                        discounts=discounts,
-                        rules_info=rules_info,
-                        channel=channel,
-                        voucher=None,
-                        voucher_code=None,
-                    )
-                )
+            )
             continue
 
         lines_info.append(
@@ -522,23 +508,6 @@ def _is_variant_valid(
     ):
         return False
     return True
-
-
-def _only_variant_listing_is_missing(
-    checkout: "Checkout",
-    product: "Product",
-    variant_channel_listing: Optional["ProductVariantChannelListing"],
-    product_channel_listing_mapping: dict,
-):
-    if not _product_channel_listing_is_valid(
-        checkout,
-        product,
-        product_channel_listing_mapping,
-    ):
-        return False
-    if not variant_channel_listing or variant_channel_listing.price is None:
-        return True
-    return False
 
 
 def _get_product_channel_listing(

--- a/saleor/checkout/tests/test_tasks.py
+++ b/saleor/checkout/tests/test_tasks.py
@@ -12,6 +12,7 @@ from ...core.taxes import zero_money
 from ...order import OrderChargeStatus, OrderEvents
 from ...order.models import Order
 from ...plugins.manager import get_plugins_manager
+from ...product.models import ProductChannelListing, ProductVariantChannelListing
 from .. import calculations
 from ..fetch import fetch_checkout_info, fetch_checkout_lines
 from ..models import Checkout, CheckoutLine
@@ -734,6 +735,60 @@ def test_automatic_checkout_completion_task_unavailable_variant(
     variant = line.variant
     product = line.variant.product
     product.channel_listings.update(is_published=False)
+
+    # allow catching the log in caplog
+    parent_logger = task_logger.parent
+    parent_logger.propagate = True
+
+    transaction_item_generator(
+        checkout_id=checkout.pk, charged_value=checkout.total.gross.amount
+    )
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        automatic_checkout_completion_task(checkout_pk, None, app.id)
+
+    # then
+    assert Checkout.objects.filter(pk=checkout_pk).exists()
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout_pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == (
+        "The automatic checkout completion not triggered, as the checkout "
+        f"{checkout_id} contains unavailable variants: {variant_id}."
+    )
+    assert caplog.records[0].checkout_id == checkout_id
+    assert caplog.records[0].levelno == logging.INFO
+
+
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_automatic_checkout_completion_task_line_without_listing(
+    channel_listing_model,
+    listing_filter_field,
+    checkout_with_prices,
+    transaction_item_generator,
+    app,
+    caplog,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    checkout = checkout_with_prices
+    checkout_pk = checkout.pk
+
+    # make the checkout line unavailable
+    line = checkout.lines.first()
+    variant = line.variant
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: variant.id},
+    ).delete()
 
     # allow catching the log in caplog
     parent_logger = task_logger.parent

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -30,6 +30,7 @@ from .....payment.gateways.dummy_credit_card import TOKEN_VALIDATION_MAPPING
 from .....payment.interface import GatewayResponse
 from .....payment.model_helpers import get_subtotal
 from .....plugins.manager import PluginsManager, get_plugins_manager
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.models import Reservation, Stock, WarehouseClickAndCollectOption
 from .....warehouse.tests.utils import get_available_quantity_for_stock
@@ -816,7 +817,16 @@ def test_checkout_complete_with_variant_without_price(
     assert not checkout.completing_started_at
 
 
-def test_checkout_complete_with_variant_without_channel_listing(
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_checkout_complete_with_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
     site_settings,
     user_api_client,
     checkout_with_item,
@@ -833,7 +843,11 @@ def test_checkout_complete_with_variant_without_channel_listing(
 
     checkout_line = checkout.lines.first()
     checkout_line_variant = checkout_line.variant
-    checkout_line_variant.channel_listings.filter(channel=checkout.channel).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: checkout_line.variant_id},
+    ).delete()
 
     variant_id = graphene.Node.to_global_id("ProductVariant", checkout_line_variant.pk)
     redirect_url = "https://www.example.com"

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -17,7 +17,7 @@ from .....checkout.fetch import fetch_checkout_lines
 from .....checkout.models import Checkout
 from .....checkout.utils import calculate_checkout_quantity
 from .....core.models import EventDelivery
-from .....product.models import ProductChannelListing
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....warehouse.models import Reservation, Stock
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -208,11 +208,36 @@ def test_checkout_create_with_unavailable_variant(
     assert error["variants"] == [variant_id]
 
 
-def test_checkout_create_with_variant_without_channel_listing(
-    api_client, stock, graphql_address_data, channel_USD
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field", "expected_error_code"),
+    [
+        (
+            ProductVariantChannelListing,
+            "variant_id",
+            CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name,
+        ),
+        (
+            ProductChannelListing,
+            "product__variants__id",
+            CheckoutErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE.name,
+        ),
+    ],
+)
+def test_checkout_create_with_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
+    expected_error_code,
+    api_client,
+    stock,
+    graphql_address_data,
+    channel_USD,
 ):
     variant = stock.product_variant
-    variant.channel_listings.filter(channel=channel_USD).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=channel_USD.id, **{listing_filter_field: variant.id}
+    ).delete()
+
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     test_email = "test@example.com"
     shipping_address = graphql_address_data
@@ -230,7 +255,7 @@ def test_checkout_create_with_variant_without_channel_listing(
     error = get_graphql_content(response)["data"]["checkoutCreate"]["errors"][0]
 
     assert error["field"] == "lines"
-    assert error["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
+    assert error["code"] == expected_error_code
     assert error["variants"] == [variant_id]
 
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create_from_order.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create_from_order.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timedelta
 
 import graphene
+import pytest
 import pytz
 
 from .....checkout.error_codes import CheckoutCreateFromOrderUnavailableVariantErrorCode
 from .....checkout.models import Checkout
-from .....product.models import ProductVariantChannelListing
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....warehouse.models import Stock
 from ....tests.utils import get_graphql_content
 from ...enums import CheckoutCreateFromOrderErrorCode
@@ -315,15 +316,38 @@ def test_checkout_create_from_order_variant_not_found(
     assert unavailable_variant["variantId"] == first_line.product_variant_id
 
 
-def test_checkout_create_from_order_variant_without_channel_listing(
-    user_api_client, order_with_lines
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field", "expected_error_code"),
+    [
+        (
+            ProductVariantChannelListing,
+            "variant_id",
+            CheckoutCreateFromOrderUnavailableVariantErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name,
+        ),
+        (
+            ProductChannelListing,
+            "product__variants__id",
+            CheckoutCreateFromOrderUnavailableVariantErrorCode.PRODUCT_NOT_PUBLISHED.name,
+        ),
+    ],
+)
+def test_checkout_create_from_order_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
+    expected_error_code,
+    user_api_client,
+    order_with_lines,
 ):
     # given
     order_with_lines.user = user_api_client.user
     order_with_lines.save()
     Stock.objects.update(quantity=10)
     first_line = order_with_lines.lines.first()
-    first_line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=order_with_lines.channel_id,
+        **{listing_filter_field: first_line.variant_id},
+    ).delete()
 
     variables = {"id": graphene.Node.to_global_id("Order", order_with_lines.pk)}
     # when
@@ -355,12 +379,9 @@ def test_checkout_create_from_order_variant_without_channel_listing(
         order_lines_map, checkout_lines, checkout_lines_from_response_map
     )
 
-    error_codes = CheckoutCreateFromOrderUnavailableVariantErrorCode
     assert len(data["unavailableVariants"]) == 1
     unavailable_variant = data["unavailableVariants"][0]
-    assert (
-        unavailable_variant["code"] == error_codes.UNAVAILABLE_VARIANT_IN_CHANNEL.name
-    )
+    assert unavailable_variant["code"] == expected_error_code
     assert unavailable_variant["lineId"] == graphene.Node.to_global_id(
         "OrderLine", first_line.pk
     )

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import pytest
 from django.test import override_settings
 
 from .....checkout.actions import call_checkout_event
 from .....checkout.error_codes import CheckoutErrorCode
 from .....core.models import EventDelivery
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
@@ -48,8 +50,15 @@ def test_checkout_email_update(user_api_client, checkout_with_item):
     assert checkout.last_change != previous_last_change
 
 
-def test_checkout_email_update_when_variant_without_channel_listing(
-    user_api_client, checkout_with_item
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_checkout_email_update_when_line_without_channel_listing(
+    channel_listing_model, listing_filter_field, user_api_client, checkout_with_item
 ):
     # given
     checkout = checkout_with_item
@@ -58,7 +67,10 @@ def test_checkout_email_update_when_variant_without_channel_listing(
     previous_last_change = checkout.last_change
 
     line = checkout.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id, **{listing_filter_field: line.variant_id}
+    ).delete()
 
     email = "test@example.com"
     variables = {"id": to_global_id_or_none(checkout), "email": email}

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -2,6 +2,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import graphene
+import pytest
 from django.test import override_settings
 
 from .....checkout import base_calculations
@@ -16,6 +17,7 @@ from .....checkout.utils import (
 )
 from .....core.models import EventDelivery
 from .....plugins.manager import get_plugins_manager
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....warehouse.models import Reservation
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
@@ -88,6 +90,13 @@ def test_checkout_line_delete(
     assert mocked_invalidate_checkout.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_line_delete."
     "update_checkout_shipping_method_if_invalid",
@@ -100,6 +109,8 @@ def test_checkout_line_delete(
 def test_checkout_line_delete_when_variant_without_channel_listing(
     mocked_invalidate_checkout,
     mocked_update_shipping_method,
+    channel_listing_model,
+    listing_filter_field,
     user_api_client,
     checkout_line_with_reservation_in_many_stocks,
 ):
@@ -111,7 +122,11 @@ def test_checkout_line_delete_when_variant_without_channel_listing(
     assert calculate_checkout_quantity(lines) == 3
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id, **{listing_filter_field: line.variant_id}
+    ).delete()
+
     assert line.quantity == 3
 
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
@@ -137,6 +152,13 @@ def test_checkout_line_delete_when_variant_without_channel_listing(
     assert mocked_invalidate_checkout.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_line_delete."
     "update_checkout_shipping_method_if_invalid",
@@ -146,9 +168,11 @@ def test_checkout_line_delete_when_variant_without_channel_listing(
     "saleor.graphql.checkout.mutations.checkout_line_delete.invalidate_checkout",
     wraps=invalidate_checkout,
 )
-def test_checkout_line_delete_when_checkout_has_variant_without_channel_listing(
+def test_checkout_line_delete_when_checkout_has_line_without_channel_listing(
     mocked_invalidate_checkout,
     mocked_update_shipping_method,
+    channel_listing_model,
+    listing_filter_field,
     user_api_client,
     checkout_with_items,
 ):
@@ -160,7 +184,11 @@ def test_checkout_line_delete_when_checkout_has_variant_without_channel_listing(
     assert calculate_checkout_quantity(lines) == 4
     assert checkout.lines.count() == 4
     line_without_listing = checkout.lines.last()
-    line_without_listing.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: line_without_listing.variant_id},
+    ).delete()
 
     line = checkout.lines.first()
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -135,6 +135,13 @@ def test_checkout_lines_add(
     assert mocked_invalidate_checkout.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_lines_add."
     "update_checkout_shipping_method_if_invalid",
@@ -144,19 +151,24 @@ def test_checkout_lines_add(
     "saleor.graphql.checkout.mutations.checkout_lines_add.invalidate_checkout",
     wraps=invalidate_checkout,
 )
-def test_checkout_lines_add_when_checkout_has_line_without_variant_listing(
+def test_checkout_lines_add_when_checkout_has_line_without_listing(
     mocked_invalidate_checkout,
     mocked_update_shipping_method,
+    channel_listing_model,
+    listing_filter_field,
     user_api_client,
     checkout_with_item,
-    stock,
+    variant_without_inventory_tracking,
 ):
     # given
-    variant = stock.product_variant
+    variant = variant_without_inventory_tracking
     checkout = checkout_with_item
 
     line = checkout.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id, **{listing_filter_field: line.variant_id}
+    ).delete()
 
     lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
@@ -1413,12 +1425,36 @@ def test_checkout_lines_add_with_unavailable_variant(
     assert errors[0]["variants"] == [variant_id]
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field", "expected_error_code"),
+    [
+        (
+            ProductVariantChannelListing,
+            "variant_id",
+            CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name,
+        ),
+        (
+            ProductChannelListing,
+            "product__variants__id",
+            CheckoutErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE.name,
+        ),
+    ],
+)
 def test_checkout_lines_add_variant_without_channel_listing(
-    user_api_client, checkout_with_item, stock
+    channel_listing_model,
+    listing_filter_field,
+    expected_error_code,
+    user_api_client,
+    checkout_with_item,
+    stock,
 ):
     # given
     variant = stock.product_variant
-    variant.channel_listings.filter(channel=checkout_with_item.channel).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout_with_item.channel_id, **{listing_filter_field: variant.id}
+    ).delete()
+
     checkout = checkout_with_item
     line = checkout.lines.first()
     assert line.quantity == 3
@@ -1436,7 +1472,7 @@ def test_checkout_lines_add_variant_without_channel_listing(
     # then
     content = get_graphql_content(response)
     errors = content["data"]["checkoutLinesAdd"]["errors"]
-    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
+    assert errors[0]["code"] == expected_error_code
     assert errors[0]["field"] == "lines"
     assert errors[0]["variants"] == [variant_id]
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -21,7 +21,7 @@ from .....checkout.utils import (
 from .....core.models import EventDelivery
 from .....discount import RewardValueType
 from .....plugins.manager import get_plugins_manager
-from .....product.models import ProductChannelListing
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....warehouse.models import Reservation, Stock
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.transport.asynchronous.transport import send_webhook_request_async
@@ -127,6 +127,13 @@ def test_checkout_lines_update(
     assert mocked_invalidate_checkout.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_lines_add."
     "update_checkout_shipping_method_if_invalid",
@@ -136,9 +143,11 @@ def test_checkout_lines_update(
     "saleor.graphql.checkout.mutations.checkout_lines_add.invalidate_checkout",
     wraps=invalidate_checkout,
 )
-def test_checkout_lines_update_when_checkout_has_variant_without_listing(
+def test_checkout_lines_update_when_checkout_has_line_without_listing(
     mocked_invalidate_checkout,
     mocked_update_shipping_method,
+    channel_listing_model,
+    listing_filter_field,
     user_api_client,
     checkout_with_items,
 ):
@@ -153,7 +162,11 @@ def test_checkout_lines_update_when_checkout_has_variant_without_listing(
     assert line.quantity == 1
 
     line_without_listing = checkout.lines.last()
-    line_without_listing.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: line_without_listing.variant_id},
+    ).delete()
 
     previous_last_change = checkout.last_change
 
@@ -1086,15 +1099,38 @@ def test_checkout_lines_update_with_unavailable_variant(
     assert checkout.last_change == previous_last_change
 
 
-def test_checkout_lines_update_with_variant_without_channel_listing(
-    user_api_client, checkout_with_item
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field", "expected_error_code"),
+    [
+        (
+            ProductVariantChannelListing,
+            "variant_id",
+            CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name,
+        ),
+        (
+            ProductChannelListing,
+            "product__variants__id",
+            CheckoutErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE.name,
+        ),
+    ],
+)
+def test_checkout_lines_update_with_line_without_channel_listing(
+    channel_listing_model,
+    listing_filter_field,
+    expected_error_code,
+    user_api_client,
+    checkout_with_item,
 ):
     checkout = checkout_with_item
     previous_last_change = checkout.last_change
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     variant = line.variant
-    variant.channel_listings.filter(channel=checkout_with_item.channel).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id, **{listing_filter_field: variant.id}
+    ).delete()
+
     assert line.quantity == 3
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
@@ -1107,7 +1143,7 @@ def test_checkout_lines_update_with_variant_without_channel_listing(
     content = get_graphql_content(response)
 
     errors = content["data"]["checkoutLinesUpdate"]["errors"]
-    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
+    assert errors[0]["code"] == expected_error_code
     assert errors[0]["field"] == "lines"
     assert errors[0]["variants"] == [variant_id]
     checkout.refresh_from_db()

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import graphene
+import pytest
 from django.test import override_settings
 from django.utils import timezone
 from prices import Money
@@ -15,6 +16,7 @@ from .....core.models import EventDelivery
 from .....discount import RewardValueType
 from .....discount.models import Voucher, VoucherChannelListing, VoucherCode
 from .....plugins.manager import get_plugins_manager
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.transport.asynchronous.transport import send_webhook_request_async
 from .....webhook.transport.utils import WebhookResponse
@@ -93,13 +95,28 @@ def test_checkout_remove_voucher_code(
     )
 
 
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
 @patch("saleor.plugins.manager.PluginsManager.checkout_updated")
-def test_checkout_remove_voucher_code_when_variant_without_listing(
-    checkout_updated_webhook_mock, api_client, checkout_with_voucher
+def test_checkout_remove_voucher_code_when_line_without_listing(
+    checkout_updated_webhook_mock,
+    channel_listing_model,
+    listing_filter_field,
+    api_client,
+    checkout_with_voucher,
 ):
     # given
     line = checkout_with_voucher.lines.first()
-    line.variant.channel_listings.all().delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout_with_voucher.channel_id,
+        **{listing_filter_field: line.variant_id},
+    ).delete()
 
     assert checkout_with_voucher.voucher_code is not None
     previous_checkout_last_change = checkout_with_voucher.last_change

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -22,7 +22,7 @@ from .....order import OrderOrigin, OrderStatus
 from .....order.models import Fulfillment, Order
 from .....payment.model_helpers import get_subtotal
 from .....plugins.manager import PluginsManager, get_plugins_manager
-from .....product.models import ProductVariantChannelListing
+from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.models import Reservation, Stock, WarehouseClickAndCollectOption
 from .....warehouse.tests.utils import get_available_quantity_for_stock
@@ -2146,7 +2146,16 @@ def test_order_from_draft_create_click_collect_preorder_fails_for_disabled_wareh
     assert Order.objects.count() == initial_order_count
 
 
-def test_order_from_draft_create_variant_channel_listing_does_not_exist(
+@pytest.mark.parametrize(
+    ("channel_listing_model", "listing_filter_field"),
+    [
+        (ProductVariantChannelListing, "variant_id"),
+        (ProductChannelListing, "product__variants__id"),
+    ],
+)
+def test_order_from_checkout_create_when_line_without_listing(
+    channel_listing_model,
+    listing_filter_field,
     checkout_with_items,
     address,
     shipping_method,
@@ -2167,7 +2176,11 @@ def test_order_from_draft_create_variant_channel_listing_does_not_exist(
 
     checkout_line = checkout.lines.first()
     checkout_line_variant = checkout_line.variant
-    checkout_line_variant.channel_listings.get(channel__id=checkout.channel_id).delete()
+
+    channel_listing_model.objects.filter(
+        channel_id=checkout.channel_id,
+        **{listing_filter_field: checkout_line_variant.id},
+    ).delete()
 
     lines, _ = fetch_checkout_lines(checkout)
 

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -7,7 +7,6 @@ import pytz
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 
-from ....checkout.models import CheckoutLine
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.date_time import convert_to_utc_date_time
 from ....permission.enums import ProductPermissions
@@ -327,17 +326,6 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
             product_channel_listing.delete()
 
     @classmethod
-    def perform_checkout_lines_delete(cls, variants, channel_id):
-        lines_id_and_checkout_id = list(
-            CheckoutLine.objects.filter(
-                variant__in=variants, checkout__channel__id__in=channel_id
-            ).values("id", "checkout__pk")
-        )
-        lines_ids = {line["id"] for line in lines_id_and_checkout_id}
-
-        CheckoutLine.objects.filter(id__in=lines_ids).delete()
-
-    @classmethod
     def remove_channels(cls, product: "ProductModel", remove_channels: list[dict]):
         ProductChannelListing.objects.filter(
             product=product, channel_id__in=remove_channels
@@ -345,8 +333,6 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
         ProductVariantChannelListing.objects.filter(
             variant__product_id=product.pk, channel_id__in=remove_channels
         ).delete()
-        variant_ids = product.variants.all().values_list("id", flat=True)
-        cls.perform_checkout_lines_delete(variant_ids, remove_channels)
 
     @classmethod
     def save(cls, info: ResolveInfo, product: "ProductModel", cleaned_input: dict):

--- a/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
@@ -944,7 +944,7 @@ def test_product_channel_listing_update_remove_channel(
     assert variant.channel_listings.get() == variant_channel_listing_pln
 
 
-def test_product_channel_listing_update_remove_channel_removes_checkout_lines(
+def test_product_channel_listing_update_remove_channel_dont_remove_checkout_lines(
     staff_api_client,
     product_available_in_many_channels,
     permission_manage_products,
@@ -979,7 +979,7 @@ def test_product_channel_listing_update_remove_channel_removes_checkout_lines(
     # then
     data = content["data"]["productChannelListingUpdate"]
     assert not data["errors"]
-    assert not checkout.lines.all().exists()
+    assert checkout.lines.all().exists()
 
 
 def test_product_channel_listing_update_remove_not_assigned_channel(


### PR DESCRIPTION
I want to merge this change because it fixes the problem of deleting the existing CheckoutLines in the background when removing `ProductChannelListing`. 
This could impact on existing checkouts, as we could change the checkout content without informing the user. 

----

With the fix, all "invalid" lines, are present in the API response, and they are included in all calculations. 
The lines without `ProductChannelListing` are visible in `Checkout.problems` and `checkout.lines[].problems`:

```json
	"problems": [
		{
			"__typename": "CheckoutLineProblemVariantNotAvailable",
			"line": {
				"id": "Q2hlY2tvdXRMaW5lOmQyM2I4ZTEyLTEzZGMtNDA1OC04Yzk4LTliNDQyM2EyNzYyMQ=="
			}
		}
	],
```
(This interface was already present, I didn't change anything related to this). 
`CheckoutComplete`, `OrderCreateFromCheckout`, and async `automatic_checkout_completion_task` will not allow closing the checkout when there are lines without listing (also already present in the code).

When using `Channel.checkoutSettings.useLegacyErrorFlow`, some checkout mutations can raise an exception about not-available variants - this is also something already present in the code.  

---

Just ☝️  pointing to these parts of the code to provide more context. 

---

Port of changes from: #17027

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
