### PR TITLE
Optimize ProductVariantUpdate mutation

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -740,6 +740,14 @@ class ModelMutation(BaseMutation):
         instance.save()
 
     @classmethod
+    def diff_instance_data_fields(cls, fields, old_instance_data, new_instance_data):
+        diff_fields = []
+        for field in fields:
+            if old_instance_data.get(field) != new_instance_data.get(field):
+                diff_fields.append(field)
+        return diff_fields
+
+    @classmethod
     def get_type_for_model(cls):
         if not cls._meta.object_type:
             raise ImproperlyConfigured(

--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -6,16 +6,17 @@ from django.utils.text import slugify
 
 from .....attribute import AttributeInputType
 from .....attribute import models as attribute_models
-from .....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
+from .....core.tracing import traced_atomic_transaction
 from .....permission.enums import ProductPermissions
 from .....product import models
-from .....product.models import ProductChannelListing
+from .....product.utils.variants import generate_and_set_variant_name
 from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ....core import ResolveInfo
 from ....core.mutations import ModelWithExtRefMutation
 from ....core.types import ProductError
 from ....core.utils import ext_ref_to_global_id_or_error
 from ....core.validators import validate_one_of_args_is_in_mutation
+from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import ProductVariant
 from ...utils import get_used_attribute_values_for_variant
 from .product_variant_create import ProductVariantCreate, ProductVariantInput
@@ -135,12 +136,49 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
             instance.track_inventory = track_inventory
 
     @classmethod
-    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
-        super().post_save_action(info, instance, cleaned_input)
-        channel_ids = ProductChannelListing.objects.filter(
-            product_id=instance.product_id
-        ).values_list("channel_id", flat=True)
-        cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
+    def _save_variant_instance(cls, instance, changed_fields):
+        update_fields = ["updated_at"] + changed_fields
+        instance.save(update_fields=update_fields)
+
+    @classmethod
+    def _save(cls, info: ResolveInfo, instance, cleaned_input, changed_fields) -> bool:
+        refresh_product_search_index = False
+        with traced_atomic_transaction():
+            if changed_fields:
+                cls._save_variant_instance(instance, changed_fields)
+                if "sku" in changed_fields or "name" in changed_fields:
+                    refresh_product_search_index = True
+            if stocks := cleaned_input.get("stocks"):
+                cls.create_variant_stocks(instance, stocks)
+            if attributes := cleaned_input.get("attributes"):
+                AttributeAssignmentMixin.save(instance, attributes)
+                refresh_product_search_index = True
+
+            if refresh_product_search_index:
+                instance.product.search_index_dirty = True
+                product_update_fields = ["updated_at", "search_index_dirty"]
+            else:
+                product_update_fields = []
+            if not instance.product.default_variant:
+                instance.product.default_variant = instance
+                product_update_fields.append("default_variant")
+            if product_update_fields:
+                instance.product.save(update_fields=product_update_fields)
+
+            if changed_fields or stocks or attributes:
+                manager = get_plugin_manager_promise(info.context).get()
+                cls.call_event(manager.product_variant_updated, instance)
+                return True
+
+            return False
+
+    @classmethod
+    def construct_instance(cls, instance, cleaned_input) -> ProductVariant:
+        instance = super().construct_instance(instance, cleaned_input)
+        cls.set_track_inventory(None, instance, cleaned_input)
+        if not instance.name:
+            generate_and_set_variant_name(instance, cleaned_input.get("sku"))
+        return instance
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
@@ -162,11 +200,35 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
             "external_reference",
             external_reference,
         )
-        return super().perform_mutation(
-            root,
-            info,
-            external_reference=external_reference,
-            id=id,
-            sku=sku,
-            input=input,
+        instance = cls.get_instance(
+            info, id=id, sku=sku, external_reference=external_reference, input=input
         )
+        old_instance_data = instance.serialize_for_comparison()  # type: ignore[union-attr]
+        cleaned_input = cls.clean_input(info, instance, input)  # type: ignore[arg-type]
+        metadata_list = cleaned_input.pop("metadata", None)
+        private_metadata_list = cleaned_input.pop("private_metadata", None)
+
+        instance = cls.construct_instance(instance, cleaned_input)
+        cls.validate_and_update_metadata(instance, metadata_list, private_metadata_list)
+        cls.clean_instance(info, instance)
+        new_instance_data = instance.serialize_for_comparison()
+
+        changed_fields = cls.diff_instance_data_fields(
+            instance.comparison_fields,
+            old_instance_data,
+            new_instance_data,
+        )
+
+        variant_modified = cls._save(info, instance, cleaned_input, changed_fields)
+        cls._save_m2m(info, instance, cleaned_input)
+
+        if variant_modified:
+            # add to cleaned_input popped metadata to allow running post save events
+            # that depends on the metadata inputs
+            if metadata_list:
+                cleaned_input["metadata"] = metadata_list
+            if private_metadata_list:
+                cleaned_input["private_metadata"] = private_metadata_list
+            cls.post_save_action(info, instance, cleaned_input)
+
+        return cls.success_response(instance)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
@@ -11,6 +12,7 @@ from django.contrib.postgres.search import SearchVectorField
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
 from django.db.models import JSONField, TextField
+from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
 from django_measurement.models import MeasurementField
@@ -448,6 +450,23 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
         return self.is_preorder and (
             self.preorder_end_date is None or timezone.now() <= self.preorder_end_date
         )
+
+    @property
+    def comparison_fields(self):
+        return [
+            "sku",
+            "name",
+            "track_inventory",
+            "is_preorder",
+            "quantity_limit_per_customer",
+            "weight",
+            "external_reference",
+            "metadata",
+            "private_metadata",
+        ]
+
+    def serialize_for_comparison(self):
+        return copy.deepcopy(model_to_dict(self, fields=self.comparison_fields))
 
 
 class ProductVariantTranslation(Translation):


### PR DESCRIPTION
ℹ️ This is a main port of 3.20 change https://github.com/saleor/saleor/pull/16981

I want to merge this change because it optimizes ProductVariantUpdate mutation.

- now utilizes update_fields when saving variant
- marks product search index as dirty only if needed
- mark promotion rules as dirty only if actual update was done
- found and fix bug that caused marking promotion rules as dirty twice (duplicated post_save_action regarding superclass)
- trigger product_variant_updated only if actual update was done

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
