### PR TITLE
Truncate lenghty responses in `EventDeliveryAttempt` objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Webhooks
 
 - Fixed webhookTrigger payload type for events related to ProductVariant - #16956 by @delemeator
+- Truncate lenghty responses in `EventDeliveryAttempt` objects - #17044 by @wcislo-saleor
 
 ### Other changes
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -672,6 +672,9 @@ EVENT_PAYLOAD_DELETE_PERIOD = datetime.timedelta(
 EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT = datetime.timedelta(
     seconds=parse(os.environ.get("EVENT_PAYLOAD_DELETE_TASK_TIME_LIMIT", "1 hour"))
 )
+EVENT_DELIVERY_ATTEMPT_RESPONSE_SIZE_LIMIT = int(
+    os.environ.get("EVENT_DELIVERY_ATTEMPT_RESPONSE_SIZE_LIMIT", 1024)
+)
 # Time between marking app "to remove" and removing the app from the database.
 # App is not visible for the user after removing, but it still exists in the database.
 # Saleor needs time to process sending `APP_DELETED` webhook and possible retrying,

--- a/saleor/webhook/transport/tests/test_utils.py
+++ b/saleor/webhook/transport/tests/test_utils.py
@@ -12,6 +12,8 @@ from ....core.models import EventDelivery, EventDeliveryAttempt
 from ...event_types import WebhookEventAsyncType
 from ..utils import (
     WebhookResponse,
+    attempt_update,
+    create_attempt,
     get_delivery_for_webhook,
     get_multiple_deliveries_for_webhooks,
     handle_webhook_retry,
@@ -265,3 +267,33 @@ def test_get_multiple_deliveries_for_webhooks_with_inactive(
 
     inactive_delivery.refresh_from_db()
     assert inactive_delivery.status == EventDeliveryStatus.FAILED
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_attempt_response"),
+    [
+        ("", ""),
+        ("error", "error"),
+        ("errorerrorerrore", "errorerrorerrore"),
+        (100 * "error", "errorerrorerrore..."),
+    ],
+)
+def test_truncate_attempt_response(
+    content, expected_attempt_response, event_delivery, settings
+):
+    settings.EVENT_DELIVERY_ATTEMPT_RESPONSE_SIZE_LIMIT = 16
+
+    # given
+    attempt = create_attempt(event_delivery)
+    response = WebhookResponse(
+        content=content,
+        response_status_code=500,
+        status=EventDeliveryStatus.FAILED,
+    )
+
+    # when
+    attempt_update(attempt, response)
+
+    # then
+    attempt.refresh_from_db(fields=["response"])
+    assert attempt.response == expected_attempt_response

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -467,7 +467,11 @@ def attempt_update(
     webhook_response: "WebhookResponse",
 ):
     attempt.duration = webhook_response.duration
-    attempt.response = webhook_response.content
+    attempt.response = webhook_response.content[
+        : settings.EVENT_DELIVERY_ATTEMPT_RESPONSE_SIZE_LIMIT
+    ]
+    if attempt.response != webhook_response.content:
+        attempt.response += "..."
     attempt.response_headers = json.dumps(webhook_response.response_headers)
     attempt.response_status_code = webhook_response.response_status_code
     attempt.request_headers = json.dumps(webhook_response.request_headers)


### PR DESCRIPTION
I want to merge this change because it introduces upper bound for length of `response` in `EventDeliveryAttempt` objects.

Once merged this will be backported to relevant versions.