### PR TITLE
Do not update EventAttempt for success event delivery

### DIFF
--- a/saleor/plugins/webhook/tests/test_deprecated_webhook_tasks.py
+++ b/saleor/plugins/webhook/tests/test_deprecated_webhook_tasks.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 from ....core.models import EventDeliveryAttempt
@@ -40,14 +41,24 @@ def test_send_webhook_request_async(
         event_delivery.webhook.custom_headers,
     )
     mocked_clear_delivery.assert_called_once_with(event_delivery)
-    attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
+    attempt = EventDeliveryAttempt.objects.get(delivery=event_delivery)
+    mocked_clear_delivery.assert_called_once_with(event_delivery)
 
-    assert attempt
     mocked_attempt_update.assert_called_once_with(
         attempt, webhook_response, with_save=False
     )
-    # Update attempt with the webhook response to make sure that overvability was called
-    # with up-to-date event
-    attempt_update(attempt, webhook_response, with_save=False)
-    mocked_observability.assert_called_once_with(attempt)
-    mocked_clear_delivery.assert_called_once_with(event_delivery)
+
+    mocked_observability.assert_called_once()
+    reported_attempt = mocked_observability.call_args.args[0]
+    assert reported_attempt.duration == webhook_response.duration
+    assert reported_attempt.response == webhook_response.content
+    assert reported_attempt.response_headers == json.dumps(
+        webhook_response.response_headers
+    )
+    assert (
+        reported_attempt.response_status_code == webhook_response.response_status_code
+    )
+    assert reported_attempt.request_headers == json.dumps(
+        webhook_response.request_headers
+    )
+    assert reported_attempt.status == webhook_response.status

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1992,15 +1992,25 @@ def test_send_webhook_request_async_with_success_response(
         event_delivery.webhook.custom_headers,
     )
     mocked_clear_delivery.assert_called_once_with(event_delivery)
-    attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
-    assert attempt
+    attempt = EventDeliveryAttempt.objects.get(delivery=event_delivery)
+
     mocked_attempt_update.assert_called_once_with(
         attempt, webhook_response, with_save=False
     )
-    # Update attempt with the webhook response to make sure that overvability was called
-    # with up-to-date event
-    attempt_update(attempt, webhook_response, with_save=False)
-    mocked_observability.assert_called_once_with(attempt)
+    mocked_observability.assert_called_once()
+    reported_attempt = mocked_observability.call_args.args[0]
+    assert reported_attempt.duration == webhook_response.duration
+    assert reported_attempt.response == webhook_response.content
+    assert reported_attempt.response_headers == json.dumps(
+        webhook_response.response_headers
+    )
+    assert (
+        reported_attempt.response_status_code == webhook_response.response_status_code
+    )
+    assert reported_attempt.request_headers == json.dumps(
+        webhook_response.request_headers
+    )
+    assert reported_attempt.status == webhook_response.status
 
 
 @mock.patch(

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -249,7 +249,7 @@ def send_webhook_request_async(self, event_delivery_id):
     webhook = delivery.webhook
     domain = get_domain()
     attempt = create_attempt(delivery, self.request.id)
-    delivery_status = EventDeliveryStatus.SUCCESS
+
     try:
         if not delivery.payload:
             raise ValueError(
@@ -266,10 +266,11 @@ def send_webhook_request_async(self, event_delivery_id):
                 webhook.custom_headers,
             )
 
-        attempt_update(attempt, response)
         if response.status == EventDeliveryStatus.FAILED:
+            attempt_update(attempt, response)
             handle_webhook_retry(self, webhook, response, delivery, attempt)
             delivery_status = EventDeliveryStatus.FAILED
+            delivery_update(delivery, delivery_status)
         elif response.status == EventDeliveryStatus.SUCCESS:
             task_logger.info(
                 "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",
@@ -278,7 +279,9 @@ def send_webhook_request_async(self, event_delivery_id):
                 delivery.event_type,
                 delivery.id,
             )
-        delivery_update(delivery, delivery_status)
+            delivery.status = EventDeliveryStatus.SUCCESS
+            # update attempt without save to provide proper data in observability
+            attempt_update(attempt, response, with_save=False)
     except ValueError as e:
         response = WebhookResponse(content=str(e), status=EventDeliveryStatus.FAILED)
         attempt_update(attempt, response)

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -269,8 +269,7 @@ def send_webhook_request_async(self, event_delivery_id):
         if response.status == EventDeliveryStatus.FAILED:
             attempt_update(attempt, response)
             handle_webhook_retry(self, webhook, response, delivery, attempt)
-            delivery_status = EventDeliveryStatus.FAILED
-            delivery_update(delivery, delivery_status)
+            delivery_update(delivery, EventDeliveryStatus.FAILED)
         elif response.status == EventDeliveryStatus.SUCCESS:
             task_logger.info(
                 "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -397,6 +397,7 @@ def create_attempt(
 def attempt_update(
     attempt: "EventDeliveryAttempt",
     webhook_response: "WebhookResponse",
+    with_save: bool = True,
 ):
     attempt.duration = webhook_response.duration
     attempt.response = webhook_response.content
@@ -404,16 +405,17 @@ def attempt_update(
     attempt.response_status_code = webhook_response.response_status_code
     attempt.request_headers = json.dumps(webhook_response.request_headers)
     attempt.status = webhook_response.status
-    attempt.save(
-        update_fields=[
-            "duration",
-            "response",
-            "response_headers",
-            "response_status_code",
-            "request_headers",
-            "status",
-        ]
-    )
+    if with_save:
+        attempt.save(
+            update_fields=[
+                "duration",
+                "response",
+                "response_headers",
+                "response_status_code",
+                "request_headers",
+                "status",
+            ]
+        )
 
 
 def clear_successful_delivery(delivery: "EventDelivery"):


### PR DESCRIPTION
I want to merge this change because right now when we have a successful webhook delivery, we delete the `EventDelivery` object at the end of the task. But in the meantime, we also always update `DeliveryAttempt` and `EventDelivery` with new status. It means two additional write db  queries, for the object that will be deleted a few lines later. 

With this PR, we skip updating EventAttempt for successful deliveries and update the status for EventDelivery.  As both of them will be deleted.

Port of changes from: #17038


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
