### PR TITLE
Fix decreasing voucher code usage after changing `includeDraftOrderInVoucherUsage` to false.

### DIFF
--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -234,7 +234,7 @@ def decrease_voucher_codes_usage_task(voucher_code_ids, codes=None):
             if voucher_code.voucher.usage_limit and voucher_code.used > 0:
                 # to ensure backward compatibility we must handle the case
                 # without `codes`
-                if not codes:
+                if codes is None:
                     used_in_draft_orders = 1
                 else:
                     used_in_draft_orders = len(

--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -217,11 +217,11 @@ def decrease_voucher_code_usage_of_draft_orders(channel_id: int):
     voucher_code_ids = VoucherCode.objects.filter(code__in=codes).values_list(
         "pk", flat=True
     )
-    decrease_voucher_codes_usage_task.delay(list(voucher_code_ids))
+    decrease_voucher_codes_usage_task.delay(list(voucher_code_ids), list(codes))
 
 
 @app.task
-def decrease_voucher_codes_usage_task(voucher_code_ids):
+def decrease_voucher_codes_usage_task(voucher_code_ids, codes):
     # Batch of size 1000 takes ~1sec and consumes ~20mb at peak
     BATCH_SIZE = 1000
     ids = voucher_code_ids[:BATCH_SIZE]
@@ -232,12 +232,16 @@ def decrease_voucher_codes_usage_task(voucher_code_ids):
     ):
         for voucher_code in voucher_codes:
             if voucher_code.voucher.usage_limit and voucher_code.used > 0:
-                voucher_code.used = F("used") - 1
+                used_in_draft_orders = len(
+                    list(filter(lambda x: voucher_code.code == x, codes))
+                )
+                total_used = voucher_code.used
+                voucher_code.used = max(total_used - used_in_draft_orders, 0)
             if voucher_code.voucher.single_use:
                 voucher_code.is_active = True
         VoucherCode.objects.bulk_update(voucher_codes, ["used", "is_active"])
         if remaining_ids := list(set(voucher_code_ids) - set(ids)):
-            decrease_voucher_codes_usage_task.delay(remaining_ids)
+            decrease_voucher_codes_usage_task.delay(remaining_ids, codes)
 
 
 def disconnect_voucher_codes_from_draft_orders(channel_id: int):

--- a/saleor/graphql/channel/tests/mutations/test_channel_update.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_update.py
@@ -10,6 +10,8 @@ from freezegun import freeze_time
 
 from .....channel.error_codes import ChannelErrorCode
 from .....core.utils.json_serializer import CustomJsonEncoder
+from .....discount.models import VoucherCode
+from .....order.models import Order
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -1105,15 +1107,37 @@ def test_channel_update_set_incorrect_delete_expired_orders_after(
     assert error["code"] == ChannelErrorCode.INVALID.name
 
 
-@patch("saleor.discount.tasks.decrease_voucher_codes_usage_task.delay")
 def test_channel_update_order_settings_voucher_usage_disable(
-    decrease_voucher_codes_usage_task_mock,
     permission_manage_orders,
     staff_api_client,
     channel_USD,
-    draft_order_list_with_multiple_use_voucher,
+    draft_order_list,
+    voucher_multiple_use,
 ):
     # given
+    voucher = voucher_multiple_use
+    code_1, code_2, _, _, _ = voucher.codes.all()
+
+    code_1_checkout_usage = 3
+    code_2_checkout_usage = 1
+    code_1.used = code_1_checkout_usage
+    code_2.used = code_2_checkout_usage
+
+    draft_order_list[0].voucher_code = code_1.code
+    draft_order_list[1].voucher_code = code_1.code
+    code_1_draft_order_usage = 2
+    code_1.used += code_1_draft_order_usage
+
+    draft_order_list[2].voucher_code = code_2.code
+    code_2_draft_order_usage = 1
+    code_2.used += code_2_draft_order_usage
+
+    Order.objects.bulk_update(draft_order_list, ["voucher_code"])
+    VoucherCode.objects.bulk_update([code_1, code_2], ["used"])
+
+    assert code_1.used == code_1_checkout_usage + code_1_draft_order_usage
+    assert code_2.used == code_2_checkout_usage + code_2_draft_order_usage
+
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     channel_USD.include_draft_order_in_voucher_usage = True
     channel_USD.save(update_fields=["include_draft_order_in_voucher_usage"])
@@ -1139,7 +1163,11 @@ def test_channel_update_order_settings_voucher_usage_disable(
     data = content["data"]["channelUpdate"]
     assert not data["errors"]
     assert data["channel"]["orderSettings"]["includeDraftOrderInVoucherUsage"] is False
-    decrease_voucher_codes_usage_task_mock.assert_called_once()
+
+    code_1.refresh_from_db()
+    assert code_1.used == code_1_checkout_usage
+    code_2.refresh_from_db()
+    assert code_2.used == code_2_checkout_usage
 
 
 @patch("saleor.discount.tasks.disconnect_voucher_codes_from_draft_orders_task.delay")


### PR DESCRIPTION
When the `includeDraftOrderInVoucherUsage` flag is changed from true to false, multiple-use voucher code usages are reduced by 1, but should be reduced by the number of draft orders that utilize the code.

internal issue: https://linear.app/saleor/issue/SHOPX-1090
port: https://github.com/saleor/saleor/pull/17028

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
