### PR TITLE
Update unit discount fields description

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -831,7 +831,7 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         description=(
             "Value of the discount. Can store fixed value or percent value. "
             "This field shouldn't be used when multiple discounts affect the line. "
-            "There is known issue, that after running `checkoutComplete` mutation "
+            "There is a limitation, that after running `checkoutComplete` mutation "
             "the field always stores fixed value."
         ),
         required=True,
@@ -840,8 +840,8 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         DiscountValueTypeEnum,
         description=(
             "Type of the discount: `fixed` or `percent`. This field shouldn't be used "
-            "when multiple discounts affect the line. There is known issue, that after "
-            "running `checkoutComplete` mutation the field is always set to `fixed`."
+            "when multiple discounts affect the line. There is a limitation, that after"
+            " running `checkoutComplete` mutation the field is always set to `fixed`."
         ),
     )
     total_price = graphene.Field(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11032,9 +11032,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Number of variant items fulfilled."""
   quantityFulfilled: Int!
 
-  """Reason for any discounts applied on a product in the order."""
-  unitDiscountReason: String
-
   """Rate of tax applied on product variant."""
   taxRate: Float!
   digitalContentUrl: DigitalContentUrl
@@ -11050,19 +11047,35 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
     format: ThumbnailFormatEnum = ORIGINAL
   ): Image
 
-  """Price of the single item in the order line."""
+  """
+  Price of the single item in the order line with all the line-level discounts and order-level discount portions applied.
+  """
   unitPrice: TaxedMoney!
 
   """
-  Price of the single item in the order line without applied an order line discount.
+  Price of the single item in the order line without any discount applied.
   """
   undiscountedUnitPrice: TaxedMoney!
 
-  """The discount applied to the single order line."""
+  """
+  Sum of the line-level discounts applied to the order line. Order-level discounts which affect the line are not visible in this field. For order-level discount portion (if any), please query `order.discounts` field.
+  """
   unitDiscount: Money!
 
-  """Value of the discount. Can store fixed value or percent value"""
+  """
+  Reason for line-level discounts applied on the order line. Order-level discounts which affect the line are not visible in this field. For order-level discount reason (if any), please query `order.discounts` field.
+  """
+  unitDiscountReason: String
+
+  """
+  Value of the discount. Can store fixed value or percent value. This field shouldn't be used when multiple discounts affect the line. There is known issue, that after running `checkoutComplete` mutation the field always stores fixed value.
+  """
   unitDiscountValue: PositiveDecimal!
+
+  """
+  Type of the discount: `fixed` or `percent`. This field shouldn't be used when multiple discounts affect the line. There is known issue, that after running `checkoutComplete` mutation the field is always set to `fixed`.
+  """
+  unitDiscountType: DiscountValueTypeEnum
 
   """Price of the order line."""
   totalPrice: TaxedMoney!
@@ -11098,9 +11111,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """A quantity of items remaining to be fulfilled."""
   quantityToFulfill: Int!
-
-  """Type of the discount: fixed or percent"""
-  unitDiscountType: DiscountValueTypeEnum
 
   """
   Denormalized tax class of the product in this order line.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11068,12 +11068,12 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   unitDiscountReason: String
 
   """
-  Value of the discount. Can store fixed value or percent value. This field shouldn't be used when multiple discounts affect the line. There is known issue, that after running `checkoutComplete` mutation the field always stores fixed value.
+  Value of the discount. Can store fixed value or percent value. This field shouldn't be used when multiple discounts affect the line. There is a limitation, that after running `checkoutComplete` mutation the field always stores fixed value.
   """
   unitDiscountValue: PositiveDecimal!
 
   """
-  Type of the discount: `fixed` or `percent`. This field shouldn't be used when multiple discounts affect the line. There is known issue, that after running `checkoutComplete` mutation the field is always set to `fixed`.
+  Type of the discount: `fixed` or `percent`. This field shouldn't be used when multiple discounts affect the line. There is a limitation, that after running `checkoutComplete` mutation the field is always set to `fixed`.
   """
   unitDiscountType: DiscountValueTypeEnum
 


### PR DESCRIPTION
We should explicitly describe that `unitDiscount` and `unitDiscountReason` fields contain only line-level discounts

`unitDiscountType` and `unitDiscountValue` are legacy fields which only have sense when single discount affect the line. Furthermore, there is known issue that after running `checkoutComplete` mutation the fields always represent `fixed` values. We don't want to change this behaviour to not break potential integrations. In the future we will deprecate those fields and expose all the line-level discount details over `orderLine.discounts` field  

Internal issue: https://linear.app/saleor/issue/SHOPX-1612/update-unitdiscount-fields-description

<!-- Please me: ntion all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
