### PR TITLE
Update test_create_transaction_event_message_limit_exceeded

### DIFF
--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -2579,12 +2579,10 @@ def test_create_transaction_event_message_limit_exceeded(
     assert transaction.events.count() == 2
     event = transaction.events.last()
     assert event.message == message[:509] + "..."
-    assert len(caplog.records) == 1
-    assert caplog.records[0].message == (
+    assert (
         "Value for field: message in response of transaction action webhook "
         "exceeds the character field limit. Message has been truncated."
-    )
-    assert caplog.records[0].levelno == logging.WARNING
+    ) in [record.message for record in caplog.records]
 
 
 def test_recalculate_refundable_for_checkout_with_request_refund(


### PR DESCRIPTION
Update `test_create_transaction_event_message_limit_exceeded` to not check the len of caplog records

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
