### PR TITLE
Fix `EventPayload` and `EventDelivery` creation

### DIFF
--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -41,7 +41,7 @@ def delete_event_payloads_task(expiration_date=None):
     payloads_to_delete = EventPayload.objects.filter(
         ~Exists(valid_deliveries.filter(payload_id=OuterRef("id")))
     ).order_by("-pk")
-    ids = payloads_to_delete.values_list("pk", flat=True)[:BATCH_SIZE]
+    ids = list(payloads_to_delete.values_list("pk", flat=True)[:BATCH_SIZE])
     qs = EventPayload.objects.filter(pk__in=ids)
     if ids:
         if expiration_date > timezone.now():

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -13,6 +13,7 @@ from celery import group
 from celery.exceptions import MaxRetriesExceededError, Retry
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.db import transaction
 from django.urls import reverse
 from google.cloud import pubsub_v1
 from requests.exceptions import RequestException
@@ -130,9 +131,11 @@ def create_deliveries_for_subscriptions(
                 webhook=webhook,
             )
         )
-
-    EventPayload.objects.bulk_create(event_payloads)
-    return EventDelivery.objects.bulk_create(event_deliveries)
+    # Use transaction to ensure EventPayload and EventDelivery are created together,
+    # preventing inconsistent DB state.
+    with transaction.atomic():
+        EventPayload.objects.bulk_create(event_payloads)
+        return EventDelivery.objects.bulk_create(event_deliveries)
 
 
 def create_delivery_for_subscription_sync_event(
@@ -184,13 +187,16 @@ def create_delivery_for_subscription_sync_event(
         # Return None so if subscription query returns no data Saleor will not crash but
         # log the issue and continue without creating a delivery.
         return None
-    event_payload = EventPayload.objects.create(payload=json.dumps({**data}))
-    event_delivery = EventDelivery.objects.create(
-        status=EventDeliveryStatus.PENDING,
-        event_type=event_type,
-        payload=event_payload,
-        webhook=webhook,
-    )
+    # Use transaction to ensure EventPayload and EventDelivery are created together,
+    # preventing inconsistent DB state.
+    with transaction.atomic():
+        event_payload = EventPayload.objects.create(payload=json.dumps({**data}))
+        event_delivery = EventDelivery.objects.create(
+            status=EventDeliveryStatus.PENDING,
+            event_type=event_type,
+            payload=event_payload,
+            webhook=webhook,
+        )
     return event_delivery
 
 
@@ -226,14 +232,17 @@ def trigger_webhooks_async(
         elif data is None:
             raise NotImplementedError("No payload was provided for regular webhooks.")
 
-        payload = EventPayload.objects.create(payload=data)
-        deliveries.extend(
-            create_event_delivery_list_for_webhooks(
-                webhooks=regular_webhooks,
-                event_payload=payload,
-                event_type=event_type,
+        # Use transaction to ensure EventPayload and EventDelivery are created together,
+        # preventing inconsistent DB state.
+        with transaction.atomic():
+            payload = EventPayload.objects.create(payload=data)
+            deliveries.extend(
+                create_event_delivery_list_for_webhooks(
+                    webhooks=regular_webhooks,
+                    event_payload=payload,
+                    event_type=event_type,
+                )
             )
-        )
     if subscription_webhooks:
         deliveries.extend(
             create_deliveries_for_subscriptions(
@@ -286,13 +295,16 @@ def trigger_webhook_sync(
         if not delivery:
             return None
     else:
-        event_payload = EventPayload.objects.create(payload=payload)
-        delivery = EventDelivery.objects.create(
-            status=EventDeliveryStatus.PENDING,
-            event_type=event_type,
-            payload=event_payload,
-            webhook=webhook,
-        )
+        # Use transaction to ensure EventPayload and EventDelivery are created together,
+        # preventing inconsistent DB state.
+        with transaction.atomic():
+            event_payload = EventPayload.objects.create(payload=payload)
+            delivery = EventDelivery.objects.create(
+                status=EventDeliveryStatus.PENDING,
+                event_type=event_type,
+                payload=event_payload,
+                webhook=webhook,
+            )
 
     kwargs = {}
     if timeout:
@@ -343,14 +355,23 @@ def trigger_all_webhooks_sync(
             if not delivery:
                 return None
         else:
-            if event_payload is None:
-                event_payload = EventPayload.objects.create(payload=generate_payload())
-            delivery = EventDelivery.objects.create(
+            delivery = EventDelivery(
                 status=EventDeliveryStatus.PENDING,
                 event_type=event_type,
                 payload=event_payload,
                 webhook=webhook,
             )
+            if event_payload is None:
+                # Use transaction to ensure EventPayload and EventDelivery are created
+                # together, preventing inconsistent DB state.
+                with transaction.atomic():
+                    event_payload = EventPayload.objects.create(
+                        payload=generate_payload()
+                    )
+                    delivery.payload = event_payload
+                    delivery.save()
+            else:
+                delivery.save()
 
         response_data = send_webhook_request_sync(delivery)
         if parsed_response := parse_response(response_data):
@@ -860,13 +881,16 @@ def trigger_transaction_request(
         payload = generate_transaction_action_request_payload(
             transaction_data, requestor
         )
-        event_payload = EventPayload.objects.create(payload=payload)
-        delivery = EventDelivery.objects.create(
-            status=EventDeliveryStatus.PENDING,
-            event_type=event_type,
-            payload=event_payload,
-            webhook=webhook,
-        )
+        # Use transaction to ensure EventPayload and EventDelivery are created together,
+        # preventing inconsistent DB state.
+        with transaction.atomic():
+            event_payload = EventPayload.objects.create(payload=payload)
+            delivery = EventDelivery.objects.create(
+                status=EventDeliveryStatus.PENDING,
+                event_type=event_type,
+                payload=event_payload,
+                webhook=webhook,
+            )
 
     call_event(
         handle_transaction_request_task.delay,


### PR DESCRIPTION
Ensure atomic creation of `EventPayload` and related `EventDelivery`. This will prevent inconsistent DB state where payloads exist without deliveries what can lead to errors.

Port of https://github.com/saleor/saleor/pull/16721

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
