### PR TITLE
Fix `EventPayload` and `EventDelivery` creation

### DIFF
--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -34,7 +34,7 @@ def delete_event_payloads_task(expiration_date=None):
     payloads_to_delete = EventPayload.objects.filter(
         ~Exists(valid_deliveries.filter(payload_id=OuterRef("id")))
     ).order_by("-pk")
-    ids = payloads_to_delete.values_list("pk", flat=True)[:BATCH_SIZE]
+    ids = list(payloads_to_delete.values_list("pk", flat=True)[:BATCH_SIZE])
     qs = EventPayload.objects.filter(pk__in=ids)
     if ids:
         if expiration_date > timezone.now():


### PR DESCRIPTION
Ensure atomic creation of `EventPayload` and related `EventDelivery`. This will prevent inconsistent DB state where payloads exist without deliveries what can lead to errors.

Port of https://github.com/saleor/saleor/pull/16721

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
