### PR TITLE
Prevent attempts to truncate objects that are not strings

### DIFF
--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -242,11 +242,14 @@ def attempt_update(
 ):
     attempt.duration = webhook_response.duration
     attempt.response = webhook_response.content
-    attempt.response = webhook_response.content[
-        : settings.EVENT_DELIVERY_ATTEMPT_RESPONSE_SIZE_LIMIT
-    ]
-    if attempt.response != webhook_response.content:
-        attempt.response += "..."
+    if isinstance(webhook_response.content, str):
+        attempt.response = webhook_response.content[
+            : settings.EVENT_DELIVERY_ATTEMPT_RESPONSE_SIZE_LIMIT
+        ]
+        if attempt.response != webhook_response.content:
+            attempt.response += "..."
+    else:
+        attempt.response = webhook_response.content
     attempt.response_headers = json.dumps(webhook_response.response_headers)
     attempt.response_status_code = webhook_response.response_status_code
     attempt.request_headers = json.dumps(webhook_response.request_headers)


### PR DESCRIPTION
This code should have been cherry-picked here before the initial merge but I forgot to do so.