### PR TITLE
Retry webhook request in case EventDelivery cannot be found

### DIFF
--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -9,8 +9,7 @@ from urllib.parse import urlencode
 import boto3
 import graphene
 import pytest
-from celery.exceptions import MaxRetriesExceededError
-from celery.exceptions import Retry
+from celery.exceptions import MaxRetriesExceededError, Retry
 from celery.exceptions import Retry as CeleryTaskRetryError
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
@@ -2071,14 +2070,16 @@ def test_send_webhook_request_async_when_webhook_is_disabled(
     event_delivery.refresh_from_db()
 
     # then
-    mocked_clear_delivery.not_called()
-    mocked_observability.not_called()
+    mocked_clear_delivery.assert_not_called()
+    mocked_observability.assert_not_called()
     assert event_delivery.status == EventDeliveryStatus.FAILED
 
 
-@mock.patch("saleor.plugins.webhook.tasks.observability.report_event_delivery_attempt")
-@mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
-@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_async.retry")
+@mock.patch("saleor.webhook.observability.utils.report_event_delivery_attempt")
+@mock.patch("saleor.webhook.transport.asynchronous.transport.clear_successful_delivery")
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.retry"
+)
 def test_send_webhook_request_async_when_event_delivery_is_missing(
     mocked_retry, mocked_clear_delivery, mocked_observability
 ):
@@ -2093,8 +2094,8 @@ def test_send_webhook_request_async_when_event_delivery_is_missing(
         pass
 
     # then
-    mocked_clear_delivery.not_called()
-    mocked_observability.not_called()
+    mocked_clear_delivery.assert_not_called()
+    mocked_observability.assert_not_called()
     mocked_retry.assert_called_once()
 
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 import boto3
 import graphene
 import pytest
-from celery.exceptions import MaxRetriesExceededError, Retry
+from celery.exceptions import MaxRetriesExceededError
 from celery.exceptions import Retry as CeleryTaskRetryError
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
@@ -2085,12 +2085,12 @@ def test_send_webhook_request_async_when_event_delivery_is_missing(
 ):
     # given
     event_delivery_id = 123
-    mocked_retry.side_effect = Retry()
+    mocked_retry.side_effect = CeleryTaskRetryError()
 
     # when
     try:
         send_webhook_request_async(event_delivery_id)
-    except Retry:
+    except CeleryTaskRetryError:
         pass
 
     # then

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -10,6 +10,7 @@ import boto3
 import graphene
 import pytest
 from celery.exceptions import MaxRetriesExceededError
+from celery.exceptions import Retry
 from celery.exceptions import Retry as CeleryTaskRetryError
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
@@ -2073,6 +2074,28 @@ def test_send_webhook_request_async_when_webhook_is_disabled(
     mocked_clear_delivery.not_called()
     mocked_observability.not_called()
     assert event_delivery.status == EventDeliveryStatus.FAILED
+
+
+@mock.patch("saleor.plugins.webhook.tasks.observability.report_event_delivery_attempt")
+@mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_async.retry")
+def test_send_webhook_request_async_when_event_delivery_is_missing(
+    mocked_retry, mocked_clear_delivery, mocked_observability
+):
+    # given
+    event_delivery_id = 123
+    mocked_retry.side_effect = Retry()
+
+    # when
+    try:
+        send_webhook_request_async(event_delivery_id)
+    except Retry:
+        pass
+
+    # then
+    mocked_clear_delivery.not_called()
+    mocked_observability.not_called()
+    mocked_retry.assert_called_once()
 
 
 @freeze_time("1914-06-28 10:50")

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -249,8 +249,10 @@ def trigger_webhooks_async(
     retry_kwargs={"max_retries": 5},
 )
 def send_webhook_request_async(self, event_delivery_id):
-    delivery = get_delivery_for_webhook(event_delivery_id)
+    delivery, not_found = get_delivery_for_webhook(event_delivery_id)
     if not delivery:
+        if not_found:
+            raise self.retry(countdown=1)
         return None
 
     webhook = delivery.webhook

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -64,7 +64,7 @@ def handle_transaction_request_task(self, delivery_id, request_event_id):
             f"for transaction-request webhook."
         )
         return None
-    delivery = get_delivery_for_webhook(delivery_id)
+    delivery, _ = get_delivery_for_webhook(delivery_id)
     if not delivery:
         recalculate_refundable_for_checkout(request_event.transaction, request_event)
         logger.error(

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -357,20 +357,24 @@ def handle_webhook_retry(
     return is_success
 
 
-def get_delivery_for_webhook(event_delivery_id) -> Optional["EventDelivery"]:
+def get_delivery_for_webhook(
+    event_delivery_id,
+) -> tuple[Optional["EventDelivery"], bool]:
+    not_found = False
     try:
         delivery = EventDelivery.objects.select_related("payload", "webhook__app").get(
             id=event_delivery_id
         )
     except EventDelivery.DoesNotExist:
+        not_found = True
         logger.error("Event delivery id: %r not found", event_delivery_id)
-        return None
+        return None, not_found
 
     if not delivery.webhook.is_active:
         delivery_update(delivery=delivery, status=EventDeliveryStatus.FAILED)
         logger.info("Event delivery id: %r webhook is disabled.", event_delivery_id)
-        return None
-    return delivery
+        return None, not_found
+    return delivery, not_found
 
 
 @contextmanager


### PR DESCRIPTION
Retry the celery task in case the `EventDelivery` object cannot be found.

Port of https://github.com/saleor/saleor/pull/17086

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
