### PR TITLE
Prevent raising an error for `AUTHORIZATION_SUCESS` in case parallel actions on transaction are performed

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -356,6 +356,12 @@ class TransactionEventReport(ModelMutation):
             # The mutation can be called multiple times by the app. That can cause a
             # thread race. We need to be sure, that we will always create a single event
             # on our side for specific action.
+            _transaction = (
+                payment_models.TransactionItem.objects.filter(pk=transaction.pk)
+                .select_for_update(of=("self",))
+                .first()
+            )
+
             existing_event = get_already_existing_event(transaction_event)
             if existing_event and existing_event.amount != transaction_event.amount:
                 error_code = TransactionEventReportErrorCode.INCORRECT_DETAILS.value

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1140,6 +1140,11 @@ def _create_event_from_response(
         related_granted_refund_id=related_granted_refund_id,
     )
     with transaction.atomic():
+        _transaction = (
+            TransactionItem.objects.filter(pk=transaction_id)
+            .select_for_update(of=("self",))
+            .first()
+        )
         event, error_msg = deduplicate_event(event, app)
         if error_msg:
             return None, error_msg


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/17056

Add a lock on `TransactionItem` that prevent raising en error when the `TransactionEventReport` is called twice for `AUTHORIZATION_SUCESS` event.

Add a lock in `_create_event_from_response` for `TransactionItem` to prevent creating `FAILURE` event in case `TransacionProcess` or `TransactionInitialize` are called twice (or more) at the same time.

⚠️ 
Tested locally.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
