### PR TITLE
Retry webhook request in case EventDelivery cannot be found

### DIFF
--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -2087,9 +2087,11 @@ def test_send_webhook_request_async_when_webhook_is_disabled(
     assert event_delivery.status == EventDeliveryStatus.FAILED
 
 
-@mock.patch("saleor.plugins.webhook.tasks.observability.report_event_delivery_attempt")
-@mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
-@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_async.retry")
+@mock.patch("saleor.webhook.observability.utils.report_event_delivery_attempt")
+@mock.patch("saleor.webhook.transport.asynchronous.transport.clear_successful_delivery")
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.retry"
+)
 def test_send_webhook_request_async_when_event_delivery_is_missing(
     mocked_retry, mocked_clear_delivery, mocked_observability
 ):
@@ -2104,8 +2106,8 @@ def test_send_webhook_request_async_when_event_delivery_is_missing(
         pass
 
     # then
-    mocked_clear_delivery.not_called()
-    mocked_observability.not_called()
+    mocked_clear_delivery.assert_not_called()
+    mocked_observability.assert_not_called()
     mocked_retry.assert_called_once()
 
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 import boto3
 import graphene
 import pytest
-from celery.exceptions import MaxRetriesExceededError
+from celery.exceptions import MaxRetriesExceededError, Retry
 from celery.exceptions import Retry as CeleryTaskRetryError
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
@@ -2085,6 +2085,28 @@ def test_send_webhook_request_async_when_webhook_is_disabled(
     assert not mocked_clear_delivery.called
     assert not mocked_observability.called
     assert event_delivery.status == EventDeliveryStatus.FAILED
+
+
+@mock.patch("saleor.plugins.webhook.tasks.observability.report_event_delivery_attempt")
+@mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_async.retry")
+def test_send_webhook_request_async_when_event_delivery_is_missing(
+    mocked_retry, mocked_clear_delivery, mocked_observability
+):
+    # given
+    event_delivery_id = 123
+    mocked_retry.side_effect = Retry()
+
+    # when
+    try:
+        send_webhook_request_async(event_delivery_id)
+    except Retry:
+        pass
+
+    # then
+    mocked_clear_delivery.not_called()
+    mocked_observability.not_called()
+    mocked_retry.assert_called_once()
 
 
 @freeze_time("1914-06-28 10:50")

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 import boto3
 import graphene
 import pytest
-from celery.exceptions import MaxRetriesExceededError, Retry
+from celery.exceptions import MaxRetriesExceededError
 from celery.exceptions import Retry as CeleryTaskRetryError
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
@@ -2097,12 +2097,12 @@ def test_send_webhook_request_async_when_event_delivery_is_missing(
 ):
     # given
     event_delivery_id = 123
-    mocked_retry.side_effect = Retry()
+    mocked_retry.side_effect = CeleryTaskRetryError()
 
     # when
     try:
         send_webhook_request_async(event_delivery_id)
-    except Retry:
+    except CeleryTaskRetryError:
         pass
 
     # then

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -66,7 +66,7 @@ def handle_transaction_request_task(self, delivery_id, request_event_id):
             f"for transaction-request webhook."
         )
         return None
-    delivery = get_delivery_for_webhook(delivery_id)
+    delivery, _ = get_delivery_for_webhook(delivery_id)
     if not delivery:
         recalculate_refundable_for_checkout(request_event.transaction, request_event)
         logger.error(

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -398,14 +398,22 @@ def handle_webhook_retry(
     return is_success
 
 
-def get_delivery_for_webhook(event_delivery_id) -> Optional["EventDelivery"]:
-    delivery = get_multiple_deliveries_for_webhooks([event_delivery_id])
-    return delivery.get(event_delivery_id)
+def get_delivery_for_webhook(
+    event_delivery_id,
+) -> tuple[Optional["EventDelivery"], bool]:
+    delivery, inactive_delivery_ids = get_multiple_deliveries_for_webhooks(
+        [event_delivery_id]
+    )
+    delivery = delivery.get(event_delivery_id)
+    not_found = False
+    if not delivery and event_delivery_id not in inactive_delivery_ids:
+        not_found = True
+    return delivery, not_found
 
 
 def get_multiple_deliveries_for_webhooks(
     event_delivery_ids,
-) -> dict[int, "EventDelivery"]:
+) -> tuple[dict[int, "EventDelivery"], set[int]]:
     deliveries = EventDelivery.objects.select_related("payload", "webhook__app").filter(
         id__in=event_delivery_ids
     )
@@ -431,7 +439,7 @@ def get_multiple_deliveries_for_webhooks(
             status=EventDeliveryStatus.FAILED
         )
 
-    return active_deliveries
+    return active_deliveries, inactive_delivery_ids
 
 
 @contextmanager


### PR DESCRIPTION
Retry the celery task in case the `EventDelivery` object cannot be found.

Port of https://github.com/saleor/saleor/pull/17086


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
