### PR TITLE
Fix ProductVariantUpdate preorder fields

### DIFF
--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -452,6 +452,8 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
             "external_reference",
             "metadata",
             "private_metadata",
+            "preorder_end_date",
+            "preorder_global_threshold",
         ]
 
     def serialize_for_comparison(self):


### PR DESCRIPTION
I want to merge this change because it fixes a bug with updating preorder related fields on ProductVariant in mutation ProductVariantUpdate.
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
