### PR TITLE
Fix ProductVariantUpdate preorder fields

### DIFF
--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -174,6 +174,7 @@ QUERY_UPDATE_VARIANT_CHANGING_FIELDS = """
             $externalReference: String
             $metadata: [MetadataInput!]
             $privateMetadata: [MetadataInput!]
+            $preorder: PreorderSettingsInput
             $attributes: [AttributeValueInput!]) {
                 productVariantUpdate(
                     id: $id,
@@ -184,7 +185,8 @@ QUERY_UPDATE_VARIANT_CHANGING_FIELDS = """
                         externalReference: $externalReference
                         quantityLimitPerCustomer: $quantityLimitPerCustomer,
                         metadata: $metadata,
-                        privateMetadata: $privateMetadata
+                        preorder: $preorder,
+                        privateMetadata: $privateMetadata,
                     }) {
                     productVariant {
                         name
@@ -222,6 +224,18 @@ QUERY_UPDATE_VARIANT_CHANGING_FIELDS = """
         ({"metadata": [{"key": "test_key1", "value": "test_value2"}]}, ["metadata"]),
         ({"trackInventory": False}, ["track_inventory"]),
         ({"quantityLimitPerCustomer": 5}, ["quantity_limit_per_customer"]),
+        (
+            {"preorder": {"globalThreshold": 11, "endDate": "2024-12-03T00:00Z"}},
+            ["preorder_end_date", "preorder_global_threshold"],
+        ),
+        (
+            {"preorder": {"globalThreshold": 10, "endDate": "2024-12-03T00:00Z"}},
+            ["preorder_end_date"],
+        ),
+        (
+            {"preorder": {"globalThreshold": 11, "endDate": "2024-12-02T00:00Z"}},
+            ["preorder_global_threshold"],
+        ),
         ({"externalReference": "test-ext-ref2"}, ["external_reference"]),
         (
             {"sku": 1234, "trackInventory": False, "externalReference": "test-ext-ref"},
@@ -258,6 +272,9 @@ def test_update_product_variant_update_fields_when_necessary(
     variant.external_reference = external_reference
     variant.quantity_limit_per_customer = quantity_limit
     variant.track_inventory = True
+    variant.is_preorder = True
+    variant.preorder_global_threshold = 10
+    variant.preorder_end_date = "2024-12-02T00:00Z"
     variant.save()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -300,6 +317,7 @@ def test_update_product_variant_update_fields_when_necessary(
         ["metadata", [{"key": "test_key1", "value": "test_value1"}]],
         ["trackInventory", True],
         ["quantityLimitPerCustomer", 9],
+        ["preorder", {"globalThreshold": 10, "endDate": "2024-12-02T00:00Z"}],
         ["externalReference", "test-ext-ref"],
     ],
 )
@@ -326,6 +344,9 @@ def test_update_product_variant_skip_updating_fields_when_unchanged(
     product.default_variant = variant
     product.save(update_fields=["default_variant"])
     variant.name = variant_name
+    variant.is_preorder = True
+    variant.preorder_global_threshold = 10
+    variant.preorder_end_date = "2024-12-02T00:00Z"
     variant.metadata = {"test_key1": "test_value1"}
     variant.private_metadata = {"private_key1": "private_value_1"}
     variant.external_reference = external_reference

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -463,6 +463,8 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
             "external_reference",
             "metadata",
             "private_metadata",
+            "preorder_end_date",
+            "preorder_global_threshold",
         ]
 
     def serialize_for_comparison(self):


### PR DESCRIPTION
I want to merge this change because it fixes a bug with updating preorder related fields on ProductVariant in mutation ProductVariantUpdate.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
