### PR TITLE
Release 3.20.56

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.55",
+  "version": "3.20.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.55",
+      "version": "3.20.56",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.55",
+  "version": "3.20.56",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.55"
+version = "3.20.56"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.55"
+__version__ = "3.20.56"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.20.56 (edfca5a123)
* Fix ProductVariantUpdate preorder fields (#17099) (0938a511bb)
* Fix for transaction message truncate  (#17061) (3812f708e4)
* Retry webhook request in case EventDelivery cannot be found (#17093) (bfd9db9ff2)
