### PR TITLE
Fix for fetching all translations when using translate bulk mutation

### DIFF
--- a/saleor/attribute/tests/fixtures/attribute.py
+++ b/saleor/attribute/tests/fixtures/attribute.py
@@ -155,6 +155,26 @@ def color_attribute_with_translations(db):
 
 
 @pytest.fixture
+def second_color_attribute_with_translations(db):
+    attribute = Attribute.objects.create(
+        slug="second-color",
+        name="Second color",
+        type=AttributeType.PRODUCT_TYPE,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+    )
+    value1 = AttributeValue.objects.create(attribute=attribute, name="Red", slug="red")
+    AttributeValue.objects.create(attribute=attribute, name="Blue", slug="blue")
+    attribute.translations.create(language_code="pl", name="Czerwony")
+    attribute.translations.create(language_code="de", name="Rot")
+    value1.translations.create(language_code="pl", plain_text="Old Kolor")
+    value1.translations.create(language_code="de", name="Rot", plain_text="Old Kolor")
+
+    return attribute
+
+
+@pytest.fixture
 def attribute_without_values():
     return Attribute.objects.create(
         slug="dropdown",

--- a/saleor/graphql/translations/tests/mutations/test_attribute_value_bulk_transalte.py
+++ b/saleor/graphql/translations/tests/mutations/test_attribute_value_bulk_transalte.py
@@ -2,10 +2,12 @@ import json
 from unittest.mock import patch
 
 import graphene
+import pytest
 
 from .....tests.utils import dummy_editorjs
 from ....core.enums import LanguageCodeEnum, TranslationErrorCode
 from ....tests.utils import get_graphql_content
+from ...mutations import AttributeValueBulkTranslate
 
 ATTRIBUTE_VALUE_BULK_TRANSLATE_MUTATION = """
     mutation AttributeValueBulkTranslate(
@@ -32,6 +34,63 @@ ATTRIBUTE_VALUE_BULK_TRANSLATE_MUTATION = """
         }
     }
 """
+
+
+def test_attribute_value_bulk_translate_get_translations_returns_valid_translations(
+    color_attribute_with_translations, second_color_attribute_with_translations
+):
+    # given
+    attr_value = color_attribute_with_translations.values.first()
+
+    requested_language_code = LanguageCodeEnum.PL.value
+    translations = {
+        0: {
+            "id": attr_value.id,
+            "language_code": requested_language_code,
+            "translation_fields": {
+                "name": "Czerwony",
+            },
+        },
+    }
+
+    # when
+    translations = AttributeValueBulkTranslate.get_translations(
+        cleaned_inputs_map=translations, base_objects=[attr_value.id]
+    )
+
+    # then
+    for translation in translations:
+        assert translation.attribute_value_id == attr_value.id
+        assert translation.language_code == requested_language_code
+
+
+@pytest.mark.parametrize("identifier_field", ["external_reference", "id"])
+def test_attribute_value_bulk_translate_get_base_objects_returns_valid_objects(
+    identifier_field,
+    color_attribute_with_translations,
+    second_color_attribute_with_translations,
+):
+    # given
+    attr_value = color_attribute_with_translations.values.first()
+    attr_value.external_reference = "ext_ref"
+    attr_value.save()
+
+    requested_language_code = LanguageCodeEnum.PL.value
+    translations = {
+        0: {
+            identifier_field: getattr(attr_value, identifier_field),
+            "language_code": requested_language_code,
+            "translation_fields": {
+                "name": "Czerwony",
+            },
+        },
+    }
+
+    # when
+    base_objects = AttributeValueBulkTranslate.get_base_objects(translations)
+
+    # then
+    assert base_objects == [attr_value]
 
 
 @patch("saleor.plugins.manager.PluginsManager.translations_created")


### PR DESCRIPTION
I want to merge this change because it fixes the bug where calling bulk translate mutation would fetch all existing translations for defined `languageCode`. 
For example, updating the translation for product A and product B for language-code `DE`, would fetch all translations assigned to product A and product B, but also all translations existing in DB for `DE` language code. 
This PR fixes this by always returning only the requested translations. 

Additionally, I also cleaned up the `get_base_objects` method, to reduce the `OR` operations in generated DB query

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
