### PR TITLE
Set the garbage collection baseline immediately after preloading the ASGI app

### DIFF
--- a/saleor/asgi/__init__.py
+++ b/saleor/asgi/__init__.py
@@ -6,6 +6,7 @@ For more information on this file, see
 https://docs.djangoproject.com/en/3.1/howto/deployment/asgi/
 """
 
+import gc
 import os
 
 from django.core.asgi import get_asgi_application
@@ -24,6 +25,8 @@ def preload_app() -> None:
     from django.urls import get_resolver
 
     getattr(get_resolver(settings.ROOT_URLCONF), "url_patterns")
+    gc.collect()
+    gc.freeze()  # mark anything that remains as uncollectable to speed up future collections
 
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")


### PR DESCRIPTION
This forces a garbage collection run after the app is loaded and tells the garbage collector never to attempt to free the objects it could not reach. This should speed up all subsequent collection cycles.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
