### PR TITLE
Add tests fot completing checkout with voucher that 0 the total price

### DIFF
--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -20,7 +20,7 @@ from ...core.tests.utils import get_site_context_payload
 from ...discount.models import VoucherCustomer
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCard, GiftCardEvent
-from ...order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents
+from ...order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
 from ...order.models import OrderEvent
 from ...order.notifications import get_default_order_payload
 from ...payment import TransactionKind
@@ -41,7 +41,7 @@ from ..complete_checkout import (
 from ..fetch import fetch_checkout_info, fetch_checkout_lines
 from ..models import Checkout
 from ..payment_utils import update_checkout_payment_statuses
-from ..utils import add_variant_to_checkout
+from ..utils import add_variant_to_checkout, add_voucher_to_checkout
 
 
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
@@ -1261,6 +1261,7 @@ def test_complete_checkout_0_total_with_transaction_for_mark_as_paid(
     assert order
     assert order.authorize_status == OrderAuthorizeStatus.FULL
     assert order.charge_status == OrderChargeStatus.FULL
+    assert order.status == OrderStatus.UNFULFILLED
 
 
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
@@ -2692,3 +2693,77 @@ def test_complete_checkout_fail_handler_with_voucher_and_payment(
     assert not checkout.completing_started_at
     _payment_refund_or_void_mock.assert_called_once()
     _release_checkout_voucher_usage_mock.assert_called_once()
+
+
+def test_checkout_complete_with_voucher_0_total(
+    shipping_method,
+    checkout_with_item,
+    customer_user,
+    voucher_percentage,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.shipping_method = shipping_method
+    checkout.tracking_code = ""
+    checkout.redirect_url = "https://www.example.com"
+    checkout.save()
+
+    channel = checkout.channel
+
+    voucher_listing = voucher_percentage.channel_listings.get(channel=channel)
+    voucher_listing.discount_value = 100
+    voucher_listing.save(update_fields=["discount_value"])
+
+    shipping_listing = shipping_method.channel_listings.get(channel=channel)
+    shipping_listing.price_amount = 0
+    shipping_listing.save(update_fields=["price_amount"])
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    add_voucher_to_checkout(
+        manager,
+        checkout_info,
+        lines,
+        voucher_percentage,
+        voucher_percentage.codes.first(),
+    )
+    checkout_info, lines = calculations.fetch_checkout_data(
+        checkout_info, manager, lines, force_status_update=True
+    )
+
+    channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
+    channel.allow_unpaid_orders = True
+    channel.automatically_confirm_all_new_orders = True
+    channel.save(
+        update_fields=[
+            "order_mark_as_paid_strategy",
+            "allow_unpaid_orders",
+            "automatically_confirm_all_new_orders",
+        ]
+    )
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        order, _, _ = complete_checkout(
+            checkout_info=checkout_info,
+            manager=manager,
+            lines=lines,
+            payment_data={},
+            store_source=False,
+            user=customer_user,
+            app=None,
+        )
+
+    # then
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.lines.count() == 1
+    assert order.discounts.count() == 1
+    discount = order.discounts.first()
+    assert (
+        discount.amount_value == (order.undiscounted_total - order.total).gross.amount
+    )

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -6,18 +6,20 @@ import pytest
 from django.test import override_settings
 from prices import Money, TaxedMoney
 
+from ...channel import MarkAsPaidStrategy
 from ...checkout.models import Checkout, CheckoutLine
 from ...core.exceptions import InsufficientStock
 from ...core.prices import quantize_price
 from ...core.taxes import zero_money, zero_taxed_money
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCard, GiftCardEvent
+from ...order import OrderStatus
 from ...plugins.manager import get_plugins_manager
 from ...product.models import ProductTranslation, ProductVariantTranslation
 from .. import calculations
 from ..complete_checkout import create_order_from_checkout
 from ..fetch import fetch_checkout_info, fetch_checkout_lines
-from ..utils import add_variant_to_checkout
+from ..utils import add_variant_to_checkout, add_voucher_to_checkout
 
 
 def test_create_order_insufficient_stock(
@@ -956,6 +958,79 @@ def test_create_order_product_on_promotion(
     assert line.discounts.count() == 1
     discount = line.discounts.first()
     assert discount.promotion_rule
+    assert (
+        discount.amount_value == (order.undiscounted_total - order.total).gross.amount
+    )
+
+
+def test_create_order_with_voucher_0_total(
+    checkout_with_item,
+    customer_user,
+    shipping_method,
+    app,
+    voucher_percentage,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    voucher_code = voucher_percentage.codes.first()
+    checkout = checkout_with_item
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.shipping_method = shipping_method
+    checkout.tracking_code = "tracking_code"
+    checkout.redirect_url = "https://www.example.com"
+    checkout.save()
+
+    voucher_listing = voucher_percentage.channel_listings.get(channel=checkout.channel)
+    voucher_listing.discount_value = 100
+    voucher_listing.save(update_fields=["discount_value"])
+
+    shipping_listing = shipping_method.channel_listings.get(channel=checkout.channel)
+    shipping_listing.price_amount = 0
+    shipping_listing.save(update_fields=["price_amount"])
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    add_voucher_to_checkout(
+        manager, checkout_info, lines, voucher_percentage, voucher_code
+    )
+    checkout_info, lines = calculations.fetch_checkout_data(
+        checkout_info, manager, lines, force_status_update=True
+    )
+
+    assert checkout_info.checkout.total == zero_taxed_money(
+        checkout_info.checkout.currency
+    )
+
+    channel = checkout.channel
+    channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
+    channel.allow_unpaid_orders = True
+    channel.automatically_confirm_all_new_orders = True
+    channel.save(
+        update_fields=[
+            "order_mark_as_paid_strategy",
+            "allow_unpaid_orders",
+            "automatically_confirm_all_new_orders",
+        ]
+    )
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        order = create_order_from_checkout(
+            checkout_info=checkout_info,
+            manager=manager,
+            user=None,
+            app=app,
+        )
+
+    # then
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.lines.count() == 1
+    assert order.discounts.count() == 1
+    discount = order.discounts.first()
     assert (
         discount.amount_value == (order.undiscounted_total - order.total).gross.amount
     )


### PR DESCRIPTION
Add a test that checking the order status in case the order total is 0 after applying entire order voucher. 

Related issue https://github.com/saleor/saleor/issues/16238

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
