### PR TITLE
Handle case when task is None in Celery Task formatter

### DIFF
--- a/saleor/core/logging.py
+++ b/saleor/core/logging.py
@@ -36,10 +36,14 @@ class JsonCeleryFormatter(JsonFormatter):
 class JsonCeleryTaskFormatter(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         task = get_current_celery_task()
+        # Similarly to the Celery task formatter, we need to handle the case when `task` is None.
+        # https://github.com/celery/celery/blob/main/celery/app/log.py#L31
+        task_id = task.request.id if task and task.request else "???"
+        task_name = task.name if task else "???"
         message_dict.update(
             {
-                "celeryTaskId": task.request.id,
-                "celeryTaskName": task.name,
+                "celeryTaskId": task_id,
+                "celeryTaskName": task_name,
             }
         )
         super().add_fields(log_record, record, message_dict)


### PR DESCRIPTION
I want to merge this change because...I want to merge this change because of handling cases when the task is None in the Celery Task formatter.

[Example Celery task formatter inside Celery repo. ](https://github.com/celery/celery/blob/main/celery/app/log.py#L31)

Port #17108

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
