### PR TITLE
Fix failing save on checkout metadata storage

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -703,19 +703,21 @@ def _create_order(
 
     # assign checkout payments to the order
     checkout.payments.update(order=order)
-    checkout_metadata = get_checkout_metadata(checkout)
 
     # store current tax configuration
     update_order_display_gross_prices(order)
 
+    checkout_metadata = get_checkout_metadata(checkout)
     # copy metadata from the checkout into the new order
-    order.metadata = checkout_metadata.metadata
+    if checkout_metadata:
+        order.metadata = checkout_metadata.metadata
+        order.private_metadata = checkout_metadata.private_metadata
+
     if metadata_list:
         order.store_value_in_metadata({data.key: data.value for data in metadata_list})
 
     order.redirect_url = checkout.redirect_url
 
-    order.private_metadata = checkout_metadata.private_metadata
     if private_metadata_list:
         order.store_value_in_private_metadata(
             {data.key: data.value for data in private_metadata_list}

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -40,7 +40,7 @@ from ..fetch import (
     fetch_checkout_info,
     fetch_checkout_lines,
 )
-from ..models import Checkout, CheckoutLine
+from ..models import Checkout, CheckoutLine, CheckoutMetadata
 from ..utils import (
     PRIVATE_META_APP_SHIPPING_ID,
     add_voucher_to_checkout,
@@ -358,6 +358,52 @@ def test_clear_delivery_method(checkout, shipping_method):
     checkout.refresh_from_db()
     assert not checkout.shipping_method
     assert isinstance(checkout_info.delivery_method_info, DeliveryMethodBase)
+
+
+@patch.object(CheckoutMetadata, "save")
+def test_clear_delivery_method_do_not_update_metadata_when_no_external_shipping(
+    mocked_metadata_save, checkout, shipping_method
+):
+    # given
+    checkout.shipping_method = shipping_method
+    checkout.save()
+    manager = get_plugins_manager(allow_replica=False)
+    checkout_info = fetch_checkout_info(checkout, [], manager)
+
+    # when
+    clear_delivery_method(checkout_info)
+
+    # then
+    checkout.refresh_from_db()
+    assert not mocked_metadata_save.called
+    assert not checkout.shipping_method
+    assert isinstance(checkout_info.delivery_method_info, DeliveryMethodBase)
+
+
+@patch.object(CheckoutMetadata, "save")
+def test_clear_delivery_method_update_metadata_when_external_shipping(
+    mocked_metadata_save, checkout, shipping_method
+):
+    # given
+    checkout.shipping_method = shipping_method
+    checkout.metadata_storage.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: "ID"}
+    checkout.metadata_storage.save()
+    checkout.save()
+    manager = get_plugins_manager(allow_replica=False)
+    checkout_info = fetch_checkout_info(checkout, [], manager)
+
+    # when
+    clear_delivery_method(checkout_info)
+
+    # then
+    checkout.refresh_from_db()
+    checkout.metadata_storage.refresh_from_db()
+    assert mocked_metadata_save.called
+    assert not checkout.shipping_method
+    assert isinstance(checkout_info.delivery_method_info, DeliveryMethodBase)
+    assert (
+        PRIVATE_META_APP_SHIPPING_ID not in checkout.metadata_storage.private_metadata
+    )
 
 
 def test_last_change_update(checkout):
@@ -2228,19 +2274,62 @@ def test_checkout_without_delivery_method_creates_empty_delivery_method(
     assert not delivery_method_info.is_method_in_valid_methods(checkout_info)
 
 
-def test_manage_external_shipping_id(checkout):
+def test_set_external_shipping_id(checkout):
+    # given
     app_shipping_id = "abcd"
     initial_private_metadata = {"test": 123}
     checkout.metadata_storage.private_metadata = initial_private_metadata
     checkout.metadata_storage.save()
 
+    # when
     set_external_shipping_id(checkout, app_shipping_id)
+
+    # then
     assert PRIVATE_META_APP_SHIPPING_ID in checkout.metadata_storage.private_metadata
 
+
+def test_get_external_shipping_id(checkout):
+    # given
+    app_shipping_id = "abcd"
+    initial_private_metadata = {"test": 123}
+    checkout.metadata_storage.private_metadata = initial_private_metadata
+    checkout.metadata_storage.save()
+    set_external_shipping_id(checkout, app_shipping_id)
+
+    # when
     shipping_id = get_external_shipping_id(checkout)
+
+    # then
     assert shipping_id == app_shipping_id
 
-    delete_external_shipping_id(checkout)
+
+def test_delete_external_shipping_id(checkout):
+    # given
+    app_shipping_id = "abcd"
+    initial_private_metadata = {"test": 123}
+    checkout.metadata_storage.private_metadata = initial_private_metadata
+    checkout.metadata_storage.save()
+    set_external_shipping_id(checkout, app_shipping_id)
+
+    # when
+    deleted = delete_external_shipping_id(checkout)
+
+    # then
+    assert deleted
+    assert checkout.metadata_storage.private_metadata == initial_private_metadata
+
+
+def test_delete_external_shipping_id_when_external_shipping_missing(checkout):
+    # given
+    initial_private_metadata = {"test": 123}
+    checkout.metadata_storage.private_metadata = initial_private_metadata
+    checkout.metadata_storage.save()
+
+    # when
+    deleted = delete_external_shipping_id(checkout)
+
+    # then
+    assert not deleted
     assert checkout.metadata_storage.private_metadata == initial_private_metadata
 
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import graphene
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import prefetch_related_objects
 from django.utils import timezone
 from prices import Money
@@ -44,6 +44,7 @@ from ..giftcard.utils import (
     add_gift_card_code_to_checkout,
     remove_gift_card_code_from_checkout_or_error,
 )
+from ..order.models import Order, OrderLine
 from ..payment.models import Payment
 from ..plugins.manager import PluginsManager
 from ..product import models as product_models
@@ -62,7 +63,6 @@ if TYPE_CHECKING:
 
     from ..account.models import Address
     from ..core.pricing.interface import LineInfo
-    from ..order.models import Order, OrderLine
     from .fetch import CheckoutInfo, CheckoutLineInfo
 
 
@@ -1001,7 +1001,6 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
         shipping_channel_listings=checkout_info.shipping_channel_listings,
     )
 
-    delete_external_shipping_id(checkout=checkout)
     checkout.save(
         update_fields=[
             "shipping_method",
@@ -1009,7 +1008,8 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
             "last_change",
         ]
     )
-    get_checkout_metadata(checkout).save()
+    if delete_external_shipping_id(checkout=checkout):
+        checkout.metadata_storage.save()
 
 
 def is_fully_paid(
@@ -1088,18 +1088,38 @@ def set_external_shipping_id(checkout: Checkout, app_shipping_id: str):
 
 
 def get_external_shipping_id(container: Union["Checkout", "Order"]):
+    metadata_container: CheckoutMetadata | Order | None
+
     if type(container) == Checkout:
-        container = get_checkout_metadata(container)
-    return container.get_value_from_private_metadata(  # type:ignore
+        metadata_container = get_checkout_metadata(container)
+    else:
+        container = cast(Order, container)
+        metadata_container = container
+
+    if not metadata_container:
+        return None
+
+    return metadata_container.get_value_from_private_metadata(
         PRIVATE_META_APP_SHIPPING_ID
     )
 
 
-def delete_external_shipping_id(checkout: Checkout, save: bool = False):
+def delete_external_shipping_id(checkout: Checkout, save: bool = False) -> bool:
     metadata = get_or_create_checkout_metadata(checkout)
-    metadata.delete_value_from_private_metadata(PRIVATE_META_APP_SHIPPING_ID)
-    if save:
+    field_deleted = metadata.delete_value_from_private_metadata(
+        PRIVATE_META_APP_SHIPPING_ID
+    )
+    if save and field_deleted:
         metadata.save(update_fields=["private_metadata"])
+    return field_deleted
+
+
+@allow_writer()
+def create_checkout_metadata(checkout: "Checkout"):
+    try:
+        return CheckoutMetadata.objects.create(checkout=checkout)
+    except IntegrityError:
+        return checkout.metadata_storage
 
 
 @allow_writer()
@@ -1111,12 +1131,11 @@ def get_or_create_checkout_metadata(checkout: "Checkout") -> CheckoutMetadata:
 
 
 @allow_writer()
-def get_checkout_metadata(checkout: "Checkout"):
+def get_checkout_metadata(checkout: "Checkout") -> CheckoutMetadata | None:
     if hasattr(checkout, "metadata_storage"):
         # TODO: load metadata_storage with dataloader and pass as an argument
         return checkout.metadata_storage
-    else:
-        return CheckoutMetadata(checkout=checkout)
+    return None
 
 
 def calculate_checkout_weight(lines: Iterable["CheckoutLineInfo"]) -> "Weight":

--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -102,9 +102,11 @@ class ModelWithMetadata(models.Model):
     def clear_private_metadata(self):
         self.private_metadata = {}
 
-    def delete_value_from_private_metadata(self, key: str):
+    def delete_value_from_private_metadata(self, key: str) -> bool:
         if key in self.private_metadata:
             del self.private_metadata[key]
+            return True
+        return False
 
     def get_value_from_metadata(self, key: str, default: Any = None) -> Any:
         return self.metadata.get(key, default)

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from ....checkout import AddressType, models
 from ....checkout.actions import call_checkout_event
 from ....checkout.error_codes import CheckoutErrorCode
-from ....checkout.utils import add_variants_to_checkout
+from ....checkout.utils import add_variants_to_checkout, create_checkout_metadata
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.country import get_active_country
 from ....product import models as product_models
@@ -385,6 +385,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
                 instance.billing_address = billing_address.get_copy()
 
             instance.save()
+            create_checkout_metadata(instance)
 
     @classmethod
     def get_instance(cls, info: ResolveInfo, **data):

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -14,7 +14,6 @@ from ....checkout.fetch import (
 )
 from ....checkout.utils import (
     delete_external_shipping_id,
-    get_or_create_checkout_metadata,
     invalidate_checkout,
     is_shipping_required,
     set_external_shipping_id,
@@ -245,12 +244,17 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
     ) -> None:
         checkout_fields_to_update = ["shipping_method", "collection_point"]
         checkout = checkout_info.checkout
+        metadata_to_save = True
         if external_shipping_method:
             set_external_shipping_id(
                 checkout=checkout, app_shipping_id=external_shipping_method.id
             )
         else:
-            delete_external_shipping_id(checkout=checkout)
+            if not delete_external_shipping_id(checkout=checkout):
+                metadata_to_save = False
+
+        if metadata_to_save:
+            checkout.metadata_storage.save()
 
         # Clear checkout shipping address if it was switched from C&C.
         if checkout.collection_point_id and not collection_point:
@@ -269,7 +273,6 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
         checkout.save(
             update_fields=checkout_fields_to_update + invalidate_prices_updated_fields
         )
-        get_or_create_checkout_metadata(checkout).save()
         call_checkout_info_event(
             manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -8,7 +8,6 @@ from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import (
     delete_external_shipping_id,
-    get_checkout_metadata,
     invalidate_checkout,
     is_shipping_required,
     set_external_shipping_id,
@@ -211,7 +210,6 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             checkout_info, lines, delivery_method=delivery_method
         )
 
-        delete_external_shipping_id(checkout=checkout)
         checkout.shipping_method = shipping_method
         invalidate_prices_updated_fields = invalidate_checkout(
             checkout_info, lines, manager, save=False
@@ -222,7 +220,8 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        get_checkout_metadata(checkout).save()
+        if delete_external_shipping_id(checkout=checkout):
+            checkout.metadata_storage.save()
 
         call_checkout_info_event(
             manager,
@@ -263,7 +262,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        get_checkout_metadata(checkout).save()
+        checkout.metadata_storage.save()
         call_checkout_info_event(
             manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
@@ -276,7 +275,6 @@ class CheckoutShippingMethodUpdate(BaseMutation):
     @classmethod
     def remove_shipping_method(cls, checkout, checkout_info, lines, manager):
         checkout.shipping_method = None
-        delete_external_shipping_id(checkout=checkout)
         invalidate_prices_updated_fields = invalidate_checkout(
             checkout_info, lines, manager, save=False
         )
@@ -286,7 +284,8 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        get_checkout_metadata(checkout).save()
+        if delete_external_shipping_id(checkout=checkout):
+            checkout.metadata_storage.save()
 
         call_checkout_info_event(
             manager,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -417,7 +417,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(82):
+    with django_assert_num_queries(83):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -435,7 +435,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(82):
+    with django_assert_num_queries(83):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -566,7 +566,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(87):
+    with django_assert_num_queries(88):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -7,11 +7,6 @@ from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
 
 
-# `instance = get_checkout_metadata(instance)` is calling the
-# `get_checkout_metadata` function to retrieve the metadata associated with a
-# checkout instance. This function is defined in the `.../checkout/utils.py` file
-# and takes a `Checkout` instance as an argument. It returns a dictionary
-# containing the metadata associated with the checkout.
 def get_valid_metadata_instance(instance) -> ModelWithMetadata:
     if isinstance(instance, Checkout):
         instance = get_or_create_checkout_metadata(instance)

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -357,7 +357,12 @@ def request_data_for_gateway_config(
         country_code = country.code
     else:
         country_code = Country(settings.DEFAULT_COUNTRY).code
-    channel = get_checkout_metadata(checkout).get_value_from_metadata("channel", "web")
+    checkout_metadata = get_checkout_metadata(checkout)
+    if checkout_metadata:
+        channel = checkout_metadata.get_value_from_metadata("channel", "web")
+    else:
+        channel = "web"
+
     return {
         "merchantAccount": merchant_account,
         "countryCode": country_code,

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -4,12 +4,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import asdict
 from decimal import Decimal
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import graphene
 from django.db.models import F, QuerySet, Sum
@@ -336,11 +331,11 @@ def generate_order_payload(
         "original": graphene.Node.to_global_id("Order", order.original_id),
         "lines": json.loads(generate_order_lines_payload(lines)),
         "fulfillments": json.loads(fulfillments_data),
-        "collection_point": json.loads(
-            _generate_collection_point_payload(order.collection_point)
-        )[0]
-        if order.collection_point
-        else None,
+        "collection_point": (
+            json.loads(_generate_collection_point_payload(order.collection_point))[0]
+            if order.collection_point
+            else None
+        ),
         "payments": json.loads(_generate_order_payment_payload(payments)),
         "shipping_method": _generate_shipping_method_payload(
             order.shipping_method, order.channel
@@ -579,25 +574,31 @@ def generate_checkout_payload(
                 checkout.shipping_method, checkout.channel
             ),
             "lines": list(lines_dict_data),
-            "collection_point": json.loads(
-                _generate_collection_point_payload(checkout.collection_point)
-            )[0]
-            if checkout.collection_point
-            else None,
+            "collection_point": (
+                json.loads(
+                    _generate_collection_point_payload(checkout.collection_point)
+                )[0]
+                if checkout.collection_point
+                else None
+            ),
             "meta": generate_meta(requestor_data=generate_requestor(requestor)),
             "created": checkout.created_at,
             # We add token as a graphql ID as it worked in that way since we introduce
             # a checkout payload
             "token": graphene.Node.to_global_id("Checkout", checkout.token),
             "metadata": (
-                lambda c=checkout: get_checkout_metadata(c).metadata
-                if hasattr(c, "metadata_storage")
-                else {}
+                lambda c=checkout: (
+                    get_checkout_metadata(c).metadata  # type: ignore[union-attr]
+                    if hasattr(c, "metadata_storage")
+                    else {}
+                )
             ),
             "private_metadata": (
-                lambda c=checkout: get_checkout_metadata(c).private_metadata
-                if hasattr(c, "metadata_storage")
-                else {}
+                lambda c=checkout: (
+                    get_checkout_metadata(c).private_metadata  # type: ignore[union-attr]
+                    if hasattr(c, "metadata_storage")
+                    else {}
+                )
             ),
         },
     )
@@ -659,9 +660,11 @@ def generate_collection_payload(
             "metadata",
         ],
         extra_dict_data={
-            "background_image": build_absolute_uri(collection.background_image.url)
-            if collection.background_image
-            else None,
+            "background_image": (
+                build_absolute_uri(collection.background_image.url)
+                if collection.background_image
+                else None
+            ),
             "meta": generate_meta(requestor_data=generate_requestor(requestor)),
         },
     )
@@ -907,15 +910,19 @@ def generate_fulfillment_lines_payload(fulfillment: Fulfillment):
             "product_sku": lambda fl: fl.order_line.product_sku,
             "product_variant_id": lambda fl: fl.order_line.product_variant_id,
             "weight": (
-                lambda fl: fl.order_line.variant.get_weight().g
-                if fl.order_line.variant
-                else None
+                lambda fl: (
+                    fl.order_line.variant.get_weight().g
+                    if fl.order_line.variant
+                    else None
+                )
             ),
             "weight_unit": "gram",
             "product_type": (
-                lambda fl: fl.order_line.variant.product.product_type.name
-                if fl.order_line.variant
-                else None
+                lambda fl: (
+                    fl.order_line.variant.product.product_type.name
+                    if fl.order_line.variant
+                    else None
+                )
             ),
             "unit_price_net": lambda fl: quantize_price(
                 fl.order_line.unit_price_net_amount, fl.order_line.currency
@@ -950,11 +957,11 @@ def generate_fulfillment_lines_payload(fulfillment: Fulfillment):
                 * fl.quantity
             ),
             "currency": lambda fl: fl.order_line.currency,
-            "warehouse_id": lambda fl: graphene.Node.to_global_id(
-                "Warehouse", fl.stock.warehouse_id
-            )
-            if fl.stock
-            else None,
+            "warehouse_id": lambda fl: (
+                graphene.Node.to_global_id("Warehouse", fl.stock.warehouse_id)
+                if fl.stock
+                else None
+            ),
             "sale_id": lambda fl: fl.order_line.sale_id,
             "voucher_code": lambda fl: fl.order_line.voucher_code,
         },
@@ -1355,9 +1362,11 @@ def generate_checkout_payload_for_tax_calculation(
             "discounts": discounts,
             "lines": lines_dict_data,
             "metadata": (
-                lambda c=checkout: get_checkout_metadata(c).metadata
-                if hasattr(c, "metadata_storage")
-                else {}
+                lambda c=checkout: (
+                    get_checkout_metadata(c).metadata  # type: ignore[union-attr]
+                    if hasattr(c, "metadata_storage")
+                    else {}
+                )
             ),
         },
     )
@@ -1383,9 +1392,9 @@ def _generate_order_lines_payload_for_tax_calculation(lines: QuerySet[OrderLine]
                 lambda line: line.variant.product.metadata if line.variant else {}
             ),
             "product_type_metadata": (
-                lambda line: line.variant.product.product_type.metadata
-                if line.variant
-                else {}
+                lambda line: (
+                    line.variant.product.product_type.metadata if line.variant else {}
+                )
             ),
             "charge_taxes": (lambda _line: charge_taxes),
             "sku": (lambda line: line.product_sku),


### PR DESCRIPTION
I want to merge this change because it adds logic, to always create the checkout metadata, when creating the checkout. 
Additionally, I've drop some `UPDATE` queries, where there is no need to make an update on `CheckoutMetadata`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
