### PR TITLE
Extend existing tests for sales 

### DIFF
--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
@@ -14,13 +14,16 @@ from ...utils import (
     checkout_create,
     checkout_delivery_method_update,
     checkout_dummy_payment_create,
+    checkout_lines_add,
+    checkout_lines_delete,
+    checkout_lines_update,
 )
 
 
-def prepare_sale_for_product(
+def prepare_sale_for_products(
     e2e_staff_api_client,
     channel_id,
-    product_id,
+    product_ids,
     sale_discount_type,
     sale_discount_value,
 ):
@@ -42,14 +45,42 @@ def prepare_sale_for_product(
         sale_id,
         add_channels=sale_listing_input,
     )
-    catalogue_input = {"products": [product_id]}
+    catalogue_input = {"products": product_ids}
     sale_catalogues_add(
         e2e_staff_api_client,
         sale_id,
         catalogue_input,
     )
 
-    return sale_id, sale_discount_value
+    return sale_id
+
+
+def prepare_products(
+    e2e_staff_api_client,
+    warehouse_id,
+    channel_id,
+    number_of_products,
+    prices,
+):
+    products_data = []
+
+    for i in range(number_of_products):
+        variant_price = prices[i]
+        product_id, variant_id, price = prepare_product(
+            e2e_staff_api_client,
+            warehouse_id,
+            channel_id,
+            variant_price,
+            product_type_slug=f"test-{i}",
+        )
+        product_data = {
+            "product_id": product_id,
+            "variant_id": variant_id,
+            "price": price,
+        }
+        products_data.append(product_data)
+
+    return products_data
 
 
 @pytest.mark.e2e
@@ -74,31 +105,58 @@ def test_checkout_products_on_fixed_sale_core_1002(
     warehouse_id = shop_data["warehouse"]["id"]
     shipping_method_id = shop_data["shipping_method"]["id"]
 
-    (
-        product_id,
-        product_variant_id,
-        product_variant_price,
-    ) = prepare_product(
+    products_data = prepare_products(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
-        variant_price="13.33",
+        4,
+        ["9.99", "12", "102.33", "20.5"],
     )
+    product1_id = products_data[0]["product_id"]
+    product1_variant_id = products_data[0]["variant_id"]
+    product1_variant_price = float(products_data[0]["price"])
 
-    sale_id, sale_discount_value = prepare_sale_for_product(
+    product2_id = products_data[1]["product_id"]
+    product2_variant_id = products_data[1]["variant_id"]
+    product2_variant_price = float(products_data[1]["price"])
+
+    product3_id = products_data[2]["product_id"]
+    product3_variant_id = products_data[2]["variant_id"]
+    product3_variant_price = float(products_data[2]["price"])
+
+    product4_variant_id = products_data[3]["variant_id"]
+    product4_variant_price = float(products_data[3]["price"])
+
+    product_ids = [product1_id, product2_id, product3_id]
+    fixed_sale_discount_value = 5
+    sale_id = prepare_sale_for_products(
         e2e_staff_api_client,
         channel_id,
-        product_id,
+        product_ids,
         sale_discount_type="FIXED",
-        sale_discount_value=3,
+        sale_discount_value=fixed_sale_discount_value,
     )
+
     # prices are updated in the background, we need to force it to retrieve the correct
     # ones
     recalculate_discounted_price_for_products_task()
 
+    product1_quantity = 3
+    product2_quantity = 1
+    product3_quantity = 2
+    product4_quantity = 2
+
     # Step 1 - checkoutCreate for product on sale
+
     lines = [
-        {"variantId": product_variant_id, "quantity": 2},
+        {
+            "variantId": product1_variant_id,
+            "quantity": product1_quantity,
+        },
+        {
+            "variantId": product2_variant_id,
+            "quantity": product2_quantity,
+        },
     ]
     checkout_data = checkout_create(
         e2e_not_logged_api_client,
@@ -109,46 +167,219 @@ def test_checkout_products_on_fixed_sale_core_1002(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    checkout_lines = checkout_data["lines"][0]
-    unit_price = float(product_variant_price) - sale_discount_value
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
 
-    assert checkout_data["isShippingRequired"] is True
-    assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price
-    assert checkout_lines["undiscountedUnitPrice"]["amount"] == float(
-        product_variant_price
+    assert checkout_line1["variant"]["id"] == product1_variant_id
+    assert checkout_line1["quantity"] == product1_quantity
+    line1_unit_price = product1_variant_price - fixed_sale_discount_value
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+
+    assert checkout_line2["variant"]["id"] == product2_variant_id
+    assert checkout_line2["quantity"] == product2_quantity
+    line2_unit_price = product2_variant_price - fixed_sale_discount_value
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 2 - Add Lines
+    lines = [
+        {
+            "variantId": product3_variant_id,
+            "quantity": product3_quantity,
+        },
+        {
+            "variantId": product4_variant_id,
+            "quantity": product4_quantity,
+        },
+    ]
+    checkout_data = checkout_lines_add(
+        e2e_not_logged_api_client,
+        checkout_id,
+        lines,
+    )
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["variant"]["id"] == product3_variant_id
+    assert checkout_line3["quantity"] == product3_quantity
+    line3_unit_price = product3_variant_price - fixed_sale_discount_value
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+
+    checkout_line4 = checkout_data["lines"][3]
+    assert checkout_line4["variant"]["id"] == product4_variant_id
+    assert checkout_line4["quantity"] == product4_quantity
+    line4_unit_price = product4_variant_price
+    assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price
+        + product2_quantity * line2_unit_price
+        + product3_quantity * line3_unit_price
+        + product4_quantity * line4_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 3 - Remove lines
+    checkout_data = checkout_lines_delete(
+        e2e_not_logged_api_client, checkout_id, linesIds=[checkout_line1["id"]]
+    )
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    new_checkout_line1 = checkout_data["lines"][0]
+    new_checkout_line2 = checkout_data["lines"][1]
+    new_checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert new_checkout_line1["variant"]["id"] == product2_variant_id
+    assert new_checkout_line1["quantity"] == product2_quantity
+    line1_unit_price = product2_variant_price - fixed_sale_discount_value
+    assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert (
+        new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
     )
 
-    # Step 2 - Set DeliveryMethod for checkout.
+    assert new_checkout_line2["variant"]["id"] == product3_variant_id
+    assert new_checkout_line2["quantity"] == product3_quantity
+    line2_unit_price = product3_variant_price - fixed_sale_discount_value
+    assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert (
+        new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    )
+
+    assert new_checkout_line3["variant"]["id"] == product4_variant_id
+    assert new_checkout_line3["quantity"] == product4_quantity
+    line3_unit_price = product4_variant_price
+    assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_subtotal = round(
+        product2_quantity * line1_unit_price
+        + product3_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 4 - Update lines
+    product2_new_quantity = 3
+    product3_new_quantity = 1
+
+    lines = [
+        {
+            "quantity": product2_new_quantity,
+            "lineId": new_checkout_line1["id"],
+        },
+        {
+            "quantity": product3_new_quantity,
+            "lineId": new_checkout_line2["id"],
+        },
+    ]
+    checkout_data = checkout_lines_update(e2e_not_logged_api_client, checkout_id, lines)
+    checkout_data = checkout_data["checkout"]
+    assert len(checkout_data["lines"]) == 3
+
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+    checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert checkout_line1["variant"]["id"] == product2_variant_id
+    assert checkout_line1["quantity"] == product2_new_quantity
+    line1_unit_price = product2_variant_price - fixed_sale_discount_value
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+
+    assert checkout_line2["variant"]["id"] == product3_variant_id
+    assert checkout_line2["quantity"] == product3_new_quantity
+    line2_unit_price = product3_variant_price - fixed_sale_discount_value
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+
+    assert checkout_line3["variant"]["id"] == product4_variant_id
+    assert checkout_line3["quantity"] == product4_quantity
+    line3_unit_price = product4_variant_price
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_subtotal = round(
+        product2_new_quantity * line1_unit_price
+        + product3_new_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 5 - Set DeliveryMethod for checkout.
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,
         checkout_id,
         shipping_method_id,
     )
     assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    calculated_total = calculated_subtotal + shipping_price
     total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
     subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+    assert total_gross_amount == calculated_total
+    assert subtotal_gross_amount == calculated_subtotal
 
-    # Step 3 - Create payment for checkout.
+    # Step 6 - Create payment for checkout.
     checkout_dummy_payment_create(
         e2e_not_logged_api_client,
         checkout_id,
         total_gross_amount,
     )
 
-    # Step 5 - Complete checkout.
+    # Step 7 - Complete checkout.
     order_data = checkout_complete(
         e2e_not_logged_api_client,
         checkout_id,
     )
     assert order_data["status"] == "UNFULFILLED"
-    assert order_data["total"]["gross"]["amount"] == total_gross_amount
-    assert order_data["subtotal"]["gross"]["amount"] == subtotal_gross_amount
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
 
-    order_line = order_data["lines"][0]
-    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
-        product_variant_price
+    order_line1 = order_data["lines"][0]
+    order_line2 = order_data["lines"][1]
+    order_line3 = order_data["lines"][2]
+
+    assert len(order_data["lines"]) == 3
+
+    assert order_line1["quantity"] == product2_new_quantity
+    assert order_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert order_line1["unitDiscount"]["amount"] == fixed_sale_discount_value
+    assert order_line1["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert (
+        order_line1["undiscountedUnitPrice"]["gross"]["amount"]
+        == product2_variant_price
     )
-    assert order_line["unitDiscountType"] == "FIXED"
-    assert order_line["unitPrice"]["gross"]["amount"] == unit_price
-    assert order_line["unitDiscount"]["amount"] == float(sale_discount_value)
-    assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"
+
+    assert order_line2["quantity"] == product3_new_quantity
+    assert order_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert order_line2["unitDiscount"]["amount"] == fixed_sale_discount_value
+    assert order_line2["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert (
+        order_line2["undiscountedUnitPrice"]["gross"]["amount"]
+        == product3_variant_price
+    )
+
+    assert order_line3["quantity"] == product4_quantity
+    assert order_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert order_line3["unitDiscount"]["amount"] == 0
+    assert order_line3["unitDiscountReason"] is None
+    assert (
+        order_line3["undiscountedUnitPrice"]["gross"]["amount"]
+        == product4_variant_price
+    )
+
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
+    assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
@@ -145,12 +145,18 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert checkout_line1["quantity"] == product1_quantity
     line1_unit_price = product1_variant_price - fixed_sale_discount_value
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product1_quantity, 2
+    )
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
 
     assert checkout_line2["variant"]["id"] == product2_variant_id
     assert checkout_line2["quantity"] == product2_quantity
     line2_unit_price = product2_variant_price - fixed_sale_discount_value
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product2_quantity, 2
+    )
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
     calculated_subtotal = round(
         product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
@@ -178,6 +184,9 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert checkout_line3["quantity"] == product3_quantity
     line3_unit_price = product3_variant_price - fixed_sale_discount_value
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product3_quantity, 2
+    )
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
 
     checkout_line4 = checkout_data["lines"][3]
@@ -185,6 +194,9 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert checkout_line4["quantity"] == product4_quantity
     line4_unit_price = product4_variant_price
     assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["totalPrice"]["gross"]["amount"] == round(
+        line4_unit_price * product4_quantity, 2
+    )
     assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
     calculated_subtotal = round(
         product1_quantity * line1_unit_price
@@ -212,6 +224,9 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert new_checkout_line1["quantity"] == product2_quantity
     line1_unit_price = product2_variant_price - fixed_sale_discount_value
     assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert new_checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_quantity, 2
+    )
     assert (
         new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
     )
@@ -220,6 +235,9 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert new_checkout_line2["quantity"] == product3_quantity
     line2_unit_price = product3_variant_price - fixed_sale_discount_value
     assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert new_checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_quantity, 2
+    )
     assert (
         new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
     )
@@ -228,6 +246,9 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert new_checkout_line3["quantity"] == product4_quantity
     line3_unit_price = product4_variant_price
     assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
     assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
     calculated_subtotal = round(
         product2_quantity * line1_unit_price
@@ -267,18 +288,27 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert checkout_line1["quantity"] == product2_new_quantity
     line1_unit_price = product2_variant_price - fixed_sale_discount_value
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_new_quantity, 2
+    )
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
 
     assert checkout_line2["variant"]["id"] == product3_variant_id
     assert checkout_line2["quantity"] == product3_new_quantity
     line2_unit_price = product3_variant_price - fixed_sale_discount_value
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_new_quantity, 2
+    )
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
 
     assert checkout_line3["variant"]["id"] == product4_variant_id
     assert checkout_line3["quantity"] == product4_quantity
     line3_unit_price = product4_variant_price
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
     calculated_subtotal = round(
         product2_new_quantity * line1_unit_price

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
@@ -145,6 +145,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     line1_discount = round(product1_variant_price * sale_discount_value / 100, 2)
     line1_unit_price = product1_variant_price - line1_discount
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product1_quantity, 2
+    )
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
 
     assert checkout_line2["variant"]["id"] == product2_variant_id
@@ -152,6 +155,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     line2_discount = round(product2_variant_price * sale_discount_value / 100, 2)
     line2_unit_price = product2_variant_price - line2_discount
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product2_quantity, 2
+    )
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
     calculated_subtotal = round(
         product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
@@ -180,6 +186,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     line3_discount = round(product3_variant_price * sale_discount_value / 100, 2)
     line3_unit_price = product3_variant_price - line3_discount
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product3_quantity, 2
+    )
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
 
     checkout_line4 = checkout_data["lines"][3]
@@ -187,6 +196,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     assert checkout_line4["quantity"] == 1
     line4_unit_price = product4_variant_price
     assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["totalPrice"]["gross"]["amount"] == round(
+        line4_unit_price * product4_quantity, 2
+    )
     assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
     calculated_subtotal = round(
         product1_quantity * line1_unit_price
@@ -215,6 +227,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
     line1_unit_price = product2_variant_price - line1_discount
     assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert new_checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_quantity, 2
+    )
     assert (
         new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
     )
@@ -224,6 +239,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
     line2_unit_price = product3_variant_price - line2_discount
     assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert new_checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_quantity, 2
+    )
     assert (
         new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
     )
@@ -232,6 +250,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     assert new_checkout_line3["quantity"] == 1
     line3_unit_price = product4_variant_price
     assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
     assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
     calculated_subtotal = round(
         +product2_quantity * line1_unit_price
@@ -271,6 +292,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
     line1_unit_price = product2_variant_price - line1_discount
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_new_quantity, 2
+    )
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
 
     assert checkout_line2["variant"]["id"] == product3_variant_id
@@ -278,12 +302,18 @@ def test_checkout_products_on_percentage_sale_core_1004(
     line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
     line2_unit_price = product3_variant_price - line2_discount
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_new_quantity, 2
+    )
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
 
     assert checkout_line3["variant"]["id"] == product4_variant_id
     assert checkout_line3["quantity"] == product4_quantity
     line3_unit_price = product4_variant_price
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
     calculated_subtotal = round(
         +product2_new_quantity * line1_unit_price
@@ -349,7 +379,7 @@ def test_checkout_products_on_percentage_sale_core_1004(
         order_line2["undiscountedUnitPrice"]["gross"]["amount"]
         == product3_variant_price
     )
-    assert order_line1["totalPrice"]["gross"]["amount"] == round(
+    assert order_line2["totalPrice"]["gross"]["amount"] == round(
         line2_unit_price * product3_new_quantity, 2
     )
 

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
@@ -14,13 +14,16 @@ from ...utils import (
     checkout_create,
     checkout_delivery_method_update,
     checkout_dummy_payment_create,
+    checkout_lines_add,
+    checkout_lines_delete,
+    checkout_lines_update,
 )
 
 
-def prepare_sale_for_product(
+def prepare_sale_for_products(
     e2e_staff_api_client,
     channel_id,
-    product_id,
+    product_ids,
     sale_discount_type,
     sale_discount_value,
 ):
@@ -42,7 +45,7 @@ def prepare_sale_for_product(
         sale_id,
         add_channels=sale_listing_input,
     )
-    catalogue_input = {"products": [product_id]}
+    catalogue_input = {"products": product_ids}
     sale_catalogues_add(
         e2e_staff_api_client,
         sale_id,
@@ -50,6 +53,37 @@ def prepare_sale_for_product(
     )
 
     return sale_id, sale_discount_value
+
+
+def prepare_products(
+    e2e_staff_api_client,
+    warehouse_id,
+    channel_id,
+    number_of_products,
+    prices,
+):
+    if len(prices) < number_of_products:
+        raise ValueError("Not enough prices provided for the number of products.")
+
+    products_data = []
+
+    for i in range(number_of_products):
+        variant_price = prices[i]
+        product_id, variant_id, price = prepare_product(
+            e2e_staff_api_client,
+            warehouse_id,
+            channel_id,
+            variant_price,
+            product_type_slug=f"test-{i}",
+        )
+        product_data = {
+            "product_id": product_id,
+            "variant_id": variant_id,
+            "price": price,
+        }
+        products_data.append(product_data)
+
+    return products_data
 
 
 @pytest.mark.e2e
@@ -74,21 +108,34 @@ def test_checkout_products_on_percentage_sale_core_1004(
     warehouse_id = shop_data["warehouse"]["id"]
     shipping_method_id = shop_data["shipping_method"]["id"]
 
-    (
-        product_id,
-        product_variant_id,
-        product_variant_price,
-    ) = prepare_product(
+    products_data = prepare_products(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
-        variant_price="13.33",
+        4,
+        ["13.33", "15", "9.99", "20.5"],
     )
+    product1_id = products_data[0]["product_id"]
+    product1_variant_id = products_data[0]["variant_id"]
+    product1_variant_price = float(products_data[0]["price"])
 
-    sale_id, sale_discount_value = prepare_sale_for_product(
+    product2_id = products_data[1]["product_id"]
+    product2_variant_id = products_data[1]["variant_id"]
+    product2_variant_price = float(products_data[1]["price"])
+
+    product3_id = products_data[2]["product_id"]
+    product3_variant_id = products_data[2]["variant_id"]
+    product3_variant_price = float(products_data[2]["price"])
+
+    product4_variant_id = products_data[3]["variant_id"]
+    product4_variant_price = float(products_data[3]["price"])
+
+    product_ids = [product1_id, product2_id, product3_id]
+
+    sale_id, sale_discount_value = prepare_sale_for_products(
         e2e_staff_api_client,
         channel_id,
-        product_id,
+        product_ids,
         sale_discount_type="PERCENTAGE",
         sale_discount_value=3,
     )
@@ -100,8 +147,12 @@ def test_checkout_products_on_percentage_sale_core_1004(
     # Step 1 - checkoutCreate for product on sale
     lines = [
         {
-            "variantId": product_variant_id,
+            "variantId": product1_variant_id,
             "quantity": 2,
+        },
+        {
+            "variantId": product2_variant_id,
+            "quantity": 4,
         },
     ]
     checkout_data = checkout_create(
@@ -113,47 +164,221 @@ def test_checkout_products_on_percentage_sale_core_1004(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    checkout_lines = checkout_data["lines"][0]
-    line_discount = round(float(product_variant_price) * sale_discount_value / 100, 2)
-    unit_price = float(product_variant_price) - line_discount
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
 
-    assert checkout_data["isShippingRequired"] is True
-    assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price
-    assert checkout_lines["undiscountedUnitPrice"]["amount"] == float(
-        product_variant_price
+    assert checkout_line1["variant"]["id"] == product1_variant_id
+    assert checkout_line1["quantity"] == 2
+    line1_discount = round(product1_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product1_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+
+    assert checkout_line2["variant"]["id"] == product2_variant_id
+    assert checkout_line2["quantity"] == 4
+    line2_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = product2_variant_price - line2_discount
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+
+    assert (
+        checkout_data["subtotalPrice"]["gross"]["amount"]
+        == 2 * line1_unit_price + 4 * line2_unit_price
     )
 
-    # Step 2 - Set DeliveryMethod for checkout.
+    # Step 2 - Add Lines
+    lines = [
+        {
+            "variantId": product3_variant_id,
+            "quantity": 1,
+        },
+        {
+            "variantId": product4_variant_id,
+            "quantity": 1,
+        },
+    ]
+    checkout_data = checkout_lines_add(
+        e2e_not_logged_api_client,
+        checkout_id,
+        lines,
+    )
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["variant"]["id"] == product3_variant_id
+    assert checkout_line3["quantity"] == 1
+    line3_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line3_unit_price = product3_variant_price - line3_discount
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+
+    checkout_line4 = checkout_data["lines"][3]
+    assert checkout_line4["variant"]["id"] == product4_variant_id
+    assert checkout_line4["quantity"] == 1
+    line4_unit_price = product4_variant_price
+    assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    assert (
+        checkout_data["subtotalPrice"]["gross"]["amount"]
+        == 2 * line1_unit_price
+        + 4 * line2_unit_price
+        + line3_unit_price
+        + line4_unit_price
+    )
+
+    # Step 3 - Remove lines
+    checkout_data = checkout_lines_delete(
+        e2e_not_logged_api_client, checkout_id, linesIds=[checkout_line1["id"]]
+    )
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    new_checkout_line1 = checkout_data["lines"][0]
+    new_checkout_line2 = checkout_data["lines"][1]
+    new_checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert new_checkout_line1["variant"]["id"] == product2_variant_id
+    assert new_checkout_line1["quantity"] == 4
+    line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product2_variant_price - line1_discount
+    assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert new_checkout_line1["undiscountedUnitPrice"]["amount"] == float(
+        product2_variant_price
+    )
+
+    assert new_checkout_line2["variant"]["id"] == product3_variant_id
+    assert new_checkout_line2["quantity"] == 1
+    line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = product3_variant_price - line2_discount
+    assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert new_checkout_line2["undiscountedUnitPrice"]["amount"] == float(
+        product3_variant_price
+    )
+
+    assert new_checkout_line3["variant"]["id"] == product4_variant_id
+    assert new_checkout_line3["quantity"] == 1
+    line3_unit_price = product4_variant_price
+    assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    assert (
+        checkout_data["subtotalPrice"]["gross"]["amount"]
+        == (4 * line1_unit_price) + line2_unit_price + line3_unit_price
+    )
+
+    # Step 4 - Update lines
+    lines = [
+        {
+            "quantity": 3,
+            "lineId": new_checkout_line1["id"],
+        },
+        {
+            "quantity": 2,
+            "lineId": new_checkout_line2["id"],
+        },
+    ]
+    checkout_data = checkout_lines_update(e2e_not_logged_api_client, checkout_id, lines)
+    checkout_data = checkout_data["checkout"]
+    assert len(checkout_data["lines"]) == 3
+
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+    checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert checkout_line1["variant"]["id"] == product2_variant_id
+    assert checkout_line1["quantity"] == 3
+    line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product2_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == float(
+        product2_variant_price
+    )
+
+    assert checkout_line2["variant"]["id"] == product3_variant_id
+    assert checkout_line2["quantity"] == 2
+    line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = product3_variant_price - line2_discount
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == float(
+        product3_variant_price
+    )
+
+    assert checkout_line3["variant"]["id"] == product4_variant_id
+    assert checkout_line3["quantity"] == 1
+    line3_unit_price = product4_variant_price
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_subtotal = (
+        (3 * line1_unit_price) + 2 * line2_unit_price + line3_unit_price
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 5 - Set DeliveryMethod for checkout.
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,
         checkout_id,
         shipping_method_id,
     )
     assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    calculated_total = calculated_subtotal + shipping_price
     total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
     subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+    assert total_gross_amount == calculated_total
+    assert subtotal_gross_amount == calculated_subtotal
 
-    # Step 3 - Create payment for checkout.
+    # Step 6 - Create payment for checkout.
     checkout_dummy_payment_create(
         e2e_not_logged_api_client,
         checkout_id,
         total_gross_amount,
     )
 
-    # Step 5 - Complete checkout.
+    # Step 7 - Complete checkout.
     order_data = checkout_complete(
         e2e_not_logged_api_client,
         checkout_id,
     )
     assert order_data["status"] == "UNFULFILLED"
-    assert order_data["total"]["gross"]["amount"] == total_gross_amount
-    assert order_data["subtotal"]["gross"]["amount"] == subtotal_gross_amount
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
 
-    order_line = order_data["lines"][0]
-    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
-        product_variant_price
+    order_line1 = order_data["lines"][0]
+    order_line2 = order_data["lines"][1]
+    order_line3 = order_data["lines"][2]
+
+    assert len(order_data["lines"]) == 3
+
+    assert order_line1["quantity"] == 3
+    assert order_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert order_line1["unitDiscount"]["amount"] == line1_discount
+    assert order_line1["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert (
+        order_line1["undiscountedUnitPrice"]["gross"]["amount"]
+        == product2_variant_price
     )
-    assert order_line["unitDiscountType"] == "FIXED"
-    assert order_line["unitPrice"]["gross"]["amount"] == unit_price
-    assert order_line["unitDiscount"]["amount"] == line_discount
-    assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"
+
+    assert order_line2["quantity"] == 2
+    assert order_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert order_line2["unitDiscount"]["amount"] == line2_discount
+    assert order_line2["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert (
+        order_line2["undiscountedUnitPrice"]["gross"]["amount"]
+        == product3_variant_price
+    )
+
+    assert order_line3["quantity"] == 1
+    assert order_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert order_line3["unitDiscount"]["amount"] == 0
+    assert order_line3["unitDiscountReason"] is None
+    assert (
+        order_line3["undiscountedUnitPrice"]["gross"]["amount"]
+        == product4_variant_price
+    )
+
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
+    assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ......product.tasks import recalculate_discounted_price_for_products_task
-from ....product.utils.preparing_product import prepare_product
+from ....product.utils.preparing_product import prepare_products
 from ....sales.utils import (
     create_sale,
     create_sale_channel_listing,
@@ -55,34 +55,6 @@ def prepare_sale_for_products(
     return sale_id, sale_discount_value
 
 
-def prepare_products(
-    e2e_staff_api_client,
-    warehouse_id,
-    channel_id,
-    number_of_products,
-    prices,
-):
-    products_data = []
-
-    for i in range(number_of_products):
-        variant_price = prices[i]
-        product_id, variant_id, price = prepare_product(
-            e2e_staff_api_client,
-            warehouse_id,
-            channel_id,
-            variant_price,
-            product_type_slug=f"test-{i}",
-        )
-        product_data = {
-            "product_id": product_id,
-            "variant_id": variant_id,
-            "price": price,
-        }
-        products_data.append(product_data)
-
-    return products_data
-
-
 @pytest.mark.e2e
 def test_checkout_products_on_percentage_sale_core_1004(
     e2e_not_logged_api_client,
@@ -109,7 +81,6 @@ def test_checkout_products_on_percentage_sale_core_1004(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
-        4,
         ["13.33", "15", "9.99", "20.5"],
     )
     product1_id = products_data[0]["product_id"]
@@ -366,6 +337,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
         order_line1["undiscountedUnitPrice"]["gross"]["amount"]
         == product2_variant_price
     )
+    assert order_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_new_quantity, 2
+    )
 
     assert order_line2["quantity"] == product3_new_quantity
     assert order_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
@@ -374,6 +348,9 @@ def test_checkout_products_on_percentage_sale_core_1004(
     assert (
         order_line2["undiscountedUnitPrice"]["gross"]["amount"]
         == product3_variant_price
+    )
+    assert order_line1["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_new_quantity, 2
     )
 
     assert order_line3["quantity"] == product4_quantity
@@ -384,7 +361,18 @@ def test_checkout_products_on_percentage_sale_core_1004(
         order_line3["undiscountedUnitPrice"]["gross"]["amount"]
         == product4_variant_price
     )
+    assert order_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
 
     assert order_data["total"]["gross"]["amount"] == calculated_total
     assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
+    received_subtotal_from_lines = round(
+        order_line1["totalPrice"]["gross"]["amount"]
+        + order_line2["totalPrice"]["gross"]["amount"]
+        + order_line3["totalPrice"]["gross"]["amount"],
+        2,
+    )
+
+    assert order_data["subtotal"]["gross"]["amount"] == received_subtotal_from_lines
     assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
@@ -2,8 +2,12 @@ import pytest
 
 from .....product.tasks import recalculate_discounted_price_for_products_task
 from ...product.utils.preparing_product import prepare_product
-from ...sales.utils import create_sale, create_sale_channel_listing, sale_catalogues_add
-from ...shop.utils.preparing_shop import prepare_default_shop
+from ...sales.utils import (
+    create_sale,
+    create_sale_channel_listing,
+    sale_catalogues_add,
+)
+from ...shop.utils import prepare_default_shop
 from ...utils import assign_permissions
 from ...vouchers.utils import create_voucher, create_voucher_channel_listing
 from ..utils import (
@@ -13,17 +17,48 @@ from ..utils import (
     checkout_delivery_method_update,
     checkout_dummy_payment_create,
     checkout_lines_add,
+    checkout_lines_delete,
+    checkout_lines_update,
 )
 
 
-def prepare_sale_for_variant(
+def prepare_products(
+    e2e_staff_api_client,
+    warehouse_id,
+    channel_id,
+    number_of_products,
+    prices,
+):
+    products_data = []
+
+    for i in range(number_of_products):
+        variant_price = prices[i]
+        product_id, variant_id, price = prepare_product(
+            e2e_staff_api_client,
+            warehouse_id,
+            channel_id,
+            variant_price,
+            product_type_slug=f"test-{i}",
+        )
+        product_data = {
+            "product_id": product_id,
+            "variant_id": variant_id,
+            "price": price,
+        }
+        products_data.append(product_data)
+
+    return products_data
+
+
+def prepare_sale_for_products(
     e2e_staff_api_client,
     channel_id,
-    product_variant_id,
+    product_ids,
     sale_discount_type,
     sale_discount_value,
+    sale_name,
 ):
-    sale_name = "Sale"
+    sale_name = sale_name
     sale = create_sale(
         e2e_staff_api_client,
         sale_name,
@@ -41,7 +76,7 @@ def prepare_sale_for_variant(
         sale_id,
         add_channels=sale_listing_input,
     )
-    catalogue_input = {"variants": [product_variant_id]}
+    catalogue_input = {"products": product_ids}
     sale_catalogues_add(
         e2e_staff_api_client,
         sale_id,
@@ -81,38 +116,12 @@ def prepare_voucher(
 
 
 @pytest.mark.e2e
-@pytest.mark.parametrize(
-    (
-        "variant_price",
-        "sale_discount_value",
-        "sale_discount_type",
-        "expected_sale_discount",
-        "voucher_discount_value",
-        "voucher_discount_type",
-        "expected_voucher_discount",
-        "expected_unit_price",
-    ),
-    [
-        ("19.99", 13, "PERCENTAGE", 2.60, 13, "PERCENTAGE", 2.26, 15.13),
-        ("30", 10, "FIXED", 10, 5, "FIXED", 5, 17.5),
-        ("56.50", 19.99, "FIXED", 19.99, 33, "PERCENTAGE", 12.05, 24.46),
-        ("77.77", 17.5, "PERCENTAGE", 13.61, 25, "FIXED", 25, 51.66),
-    ],
-)
-def test_checkout_calculate_discount_for_sale_and_voucher_1014(
+def test_checkout_calculate_discount_for_percentage_sale_and_percentage_voucher_CORE_0114(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
     shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    variant_price,
-    sale_discount_value,
-    sale_discount_type,
-    expected_sale_discount,
-    voucher_discount_value,
-    voucher_discount_type,
-    expected_voucher_discount,
-    expected_unit_price,
 ):
     # Before
     permissions = [
@@ -128,40 +137,67 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     warehouse_id = shop_data["warehouse"]["id"]
     shipping_method_id = shop_data["shipping_method"]["id"]
 
-    (
-        _product_id,
-        product_variant_id,
-        product_variant_price,
-    ) = prepare_product(
+    products_data = prepare_products(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
-        variant_price,
+        4,
+        ["13.33", "16", "9.99", "20.5"],
     )
+    product1_id = products_data[0]["product_id"]
+    product1_variant_id = products_data[0]["variant_id"]
+    product1_variant_price = float(products_data[0]["price"])
 
-    sale_id, sale_discount_value = prepare_sale_for_variant(
+    product2_id = products_data[1]["product_id"]
+    product2_variant_id = products_data[1]["variant_id"]
+    product2_variant_price = float(products_data[1]["price"])
+
+    product3_id = products_data[2]["product_id"]
+    product3_variant_id = products_data[2]["variant_id"]
+    product3_variant_price = float(products_data[2]["price"])
+
+    product4_variant_id = products_data[3]["variant_id"]
+    product4_variant_price = float(products_data[3]["price"])
+
+    product_ids = [product1_id, product2_id, product3_id]
+
+    sale_id, sale_discount_value = prepare_sale_for_products(
         e2e_staff_api_client,
         channel_id,
-        product_variant_id,
-        sale_discount_type,
-        sale_discount_value,
-    )
-
-    voucher_discount_value, voucher_code = prepare_voucher(
-        e2e_staff_api_client,
-        channel_id,
-        "VOUCHER001",
-        voucher_discount_type,
-        voucher_discount_value,
+        product_ids,
+        sale_discount_type="PERCENTAGE",
+        sale_discount_value=13,
+        sale_name="Sale_Percentage",
     )
 
     # prices are updated in the background, we need to force it to retrieve the correct
     # ones
     recalculate_discounted_price_for_products_task()
 
-    # Step 1 - Create checkout for product on sale
+    voucher_discount_value, voucher_code = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        "VOUCHER001",
+        voucher_discount_type="PERCENTAGE",
+        voucher_discount_value=13,
+    )
+    product1_quantity = 2
+    product2_quantity = 3
+    product3_quantity = 4
+    product4_quantity = 1
+    product2_new_quantity = 2
+    product3_new_quantity = 3
+
+    # Step 1 - checkoutCreate for product on sale
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {
+            "variantId": product1_variant_id,
+            "quantity": product1_quantity,
+        },
+        {
+            "variantId": product2_variant_id,
+            "quantity": product2_quantity,
+        },
     ]
     checkout_data = checkout_create(
         e2e_not_logged_api_client,
@@ -172,38 +208,218 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    checkout_lines = checkout_data["lines"][0]
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
 
-    assert checkout_data["isShippingRequired"] is True
-    unit_price_on_sale = round(float(product_variant_price - expected_sale_discount), 2)
-    assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price_on_sale
-    assert checkout_lines["undiscountedUnitPrice"]["amount"] == product_variant_price
+    assert checkout_line1["variant"]["id"] == product1_variant_id
+    assert checkout_line1["quantity"] == product1_quantity
+    line1_discount = round(product1_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product1_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
 
-    # Step 2 Add voucher code to checkout
+    assert checkout_line2["variant"]["id"] == product2_variant_id
+    assert checkout_line2["quantity"] == product2_quantity
+    line2_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = product2_variant_price - line2_discount
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 2 - Add Lines
+    lines = [
+        {
+            "variantId": product3_variant_id,
+            "quantity": product3_quantity,
+        },
+        {
+            "variantId": product4_variant_id,
+            "quantity": product4_quantity,
+        },
+    ]
+    checkout_data = checkout_lines_add(
+        e2e_not_logged_api_client,
+        checkout_id,
+        lines,
+    )
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["variant"]["id"] == product3_variant_id
+    assert checkout_line3["quantity"] == product3_quantity
+    line3_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line3_unit_price = product3_variant_price - line3_discount
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+
+    checkout_line4 = checkout_data["lines"][3]
+    assert checkout_line4["variant"]["id"] == product4_variant_id
+    assert checkout_line4["quantity"] == 1
+    line4_unit_price = product4_variant_price
+    assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price
+        + product2_quantity * line2_unit_price
+        + product3_quantity * line3_unit_price
+        + product4_quantity * line4_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 3 - Remove lines
+    checkout_data = checkout_lines_delete(
+        e2e_not_logged_api_client, checkout_id, linesIds=[checkout_line1["id"]]
+    )
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    new_checkout_line1 = checkout_data["lines"][0]
+    new_checkout_line2 = checkout_data["lines"][1]
+    new_checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert new_checkout_line1["variant"]["id"] == product2_variant_id
+    assert new_checkout_line1["quantity"] == product2_quantity
+    line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product2_variant_price - line1_discount
+    assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert (
+        new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    )
+
+    assert new_checkout_line2["variant"]["id"] == product3_variant_id
+    assert new_checkout_line2["quantity"] == product3_quantity
+    line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert (
+        new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    )
+
+    assert new_checkout_line3["variant"]["id"] == product4_variant_id
+    assert new_checkout_line3["quantity"] == 1
+    line3_unit_price = product4_variant_price
+    assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_subtotal = round(
+        +product2_quantity * line1_unit_price
+        + product3_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 4 - Update lines
+    lines = [
+        {
+            "quantity": product2_new_quantity,
+            "lineId": new_checkout_line1["id"],
+        },
+        {
+            "quantity": product3_new_quantity,
+            "lineId": new_checkout_line2["id"],
+        },
+    ]
+    checkout_data = checkout_lines_update(e2e_not_logged_api_client, checkout_id, lines)
+    checkout_data = checkout_data["checkout"]
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+    checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert checkout_line1["variant"]["id"] == product2_variant_id
+    assert checkout_line1["quantity"] == product2_new_quantity
+    line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product2_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_line1_total = round(product2_new_quantity * line1_unit_price, 2)
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    assert checkout_line2["variant"]["id"] == product3_variant_id
+    assert checkout_line2["quantity"] == product3_new_quantity
+    line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    calculated_line2_total = round(product3_new_quantity * line2_unit_price, 2)
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    assert checkout_line3["variant"]["id"] == product4_variant_id
+    assert checkout_line3["quantity"] == product4_quantity
+    line3_unit_price = product4_variant_price
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_line3_total = round(product4_quantity * line3_unit_price, 2)
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    calculated_subtotal = round(
+        +product2_new_quantity * line1_unit_price
+        + product3_new_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 5 - Add voucher code to checkout
     checkout_data = checkout_add_promo_code(
         e2e_not_logged_api_client, checkout_id, voucher_code
     )
-    assert checkout_data["discount"]["amount"] == expected_voucher_discount
-    assert checkout_data["lines"][0]["unitPrice"]["gross"]["amount"] == round(
-        float(unit_price_on_sale - expected_voucher_discount), 2
-    )
+    calculated_discount = round(calculated_subtotal * voucher_discount_value / 100, 2)
+    assert checkout_data["discount"]["amount"] == calculated_discount
+    assert checkout_data["voucherCode"] == voucher_code
 
-    # Step 3 Add variant to the checkout
-    lines_add = [
-        {"variantId": product_variant_id, "quantity": 1},
-    ]
-    checkout_data = checkout_lines_add(
-        e2e_staff_api_client,
-        checkout_id,
-        lines_add,
-    )
-    checkout_lines = checkout_data["lines"][0]
-    assert checkout_lines["quantity"] == 2
-    assert checkout_lines["unitPrice"]["gross"]["amount"] == expected_unit_price
-    subtotal_amount = expected_unit_price * 2
-    assert checkout_lines["totalPrice"]["gross"]["amount"] == subtotal_amount
+    # Assert lines after voucher code
+    assert len(checkout_data["lines"]) == 3
+    checkout_line1 = checkout_data["lines"][0]
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line1["quantity"] == product2_new_quantity
 
-    # Step 4 - Set DeliveryMethod for checkout.
+    calculated_line1_discount = round(
+        calculated_line1_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line1_total = round(
+        calculated_line1_total - calculated_line1_discount, 2
+    )
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    checkout_line2 = checkout_data["lines"][1]
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line2["quantity"] == product3_new_quantity
+
+    calculated_line2_discount = round(
+        calculated_line2_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line2_total = round(
+        calculated_line2_total - calculated_line2_discount, 2
+    )
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product4_variant_price
+    assert checkout_line3["quantity"] == product4_quantity
+
+    calculated_line3_discount = round(
+        calculated_discount - calculated_line1_discount - calculated_line2_discount, 2
+    )
+    calculated_line3_total = round(
+        calculated_line3_total - calculated_line3_discount, 2
+    )
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+
+    # Assert total and subtotal after voucher code
+    calculated_subtotal = round(calculated_subtotal - calculated_discount, 2)
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+    calculated_total = calculated_subtotal
+    assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_total
+
+    # Step 6 - Set DeliveryMethod for checkout.
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,
         checkout_id,
@@ -211,31 +427,1214 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     )
     assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
     shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
-    total_gross_amount = round(subtotal_amount + shipping_price, 2)
-    assert checkout_data["totalPrice"]["gross"]["amount"] == total_gross_amount
+    calculated_total = calculated_subtotal + shipping_price
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+    assert total_gross_amount == calculated_total
+    assert subtotal_gross_amount == calculated_subtotal
 
-    # Step 5 - Create payment for checkout.
+    # Step 7 - Create payment for checkout.
     checkout_dummy_payment_create(
-        e2e_not_logged_api_client, checkout_id, total_gross_amount
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
     )
 
-    # Step 6 - Complete checkout.
+    # Step 8 - Complete checkout.
     order_data = checkout_complete(
         e2e_not_logged_api_client,
         checkout_id,
     )
     assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
+    assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price
+
     assert order_data["discounts"][0]["type"] == "VOUCHER"
     assert order_data["voucher"]["code"] == voucher_code
+    assert order_data["discounts"][0]["value"] == calculated_discount
 
-    order_line = order_data["lines"][0]
-    assert order_line["unitDiscountType"] == "FIXED"
-    assert order_line["unitPrice"]["gross"]["amount"] == expected_unit_price
-    assert order_line["unitDiscountReason"] == (
+    assert len(order_data["lines"]) == 3
+    order_line1 = order_data["lines"][0]
+    order_line2 = order_data["lines"][1]
+    order_line3 = order_data["lines"][2]
+
+    assert order_line1["quantity"] == product2_new_quantity
+    assert order_line1["unitDiscountReason"] == (
         f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
     )
-    assert order_data["total"]["gross"]["amount"] == total_gross_amount
-    assert order_data["subtotal"]["gross"]["amount"] == subtotal_amount
-    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
-        product_variant_price
+    assert (
+        order_line1["undiscountedUnitPrice"]["gross"]["amount"]
+        == product2_variant_price
     )
+    assert order_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+    assert order_line1["unitDiscount"]["amount"] == round(
+        line1_discount + (calculated_line1_discount / product2_new_quantity), 2
+    )
+    assert order_line2["quantity"] == product3_new_quantity
+    assert order_line2["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
+    assert (
+        order_line2["undiscountedUnitPrice"]["gross"]["amount"]
+        == product3_variant_price
+    )
+    assert order_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+    assert order_line2["unitDiscount"]["amount"] == round(
+        line2_discount + (calculated_line2_discount / product3_new_quantity), 2
+    )
+
+    assert order_line3["quantity"] == product4_quantity
+    assert order_line3["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code}"
+    )
+    assert (
+        order_line3["undiscountedUnitPrice"]["gross"]["amount"]
+        == product4_variant_price
+    )
+    assert order_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    assert order_line3["unitDiscount"]["amount"] == calculated_line3_discount
+
+
+@pytest.mark.e2e
+def test_checkout_calculate_discount_for_fixed_sale_and_fixed_voucher_CORE_0114(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    products_data = prepare_products(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        4,
+        ["13.33", "16", "19.99", "20.5"],
+    )
+    product1_id = products_data[0]["product_id"]
+    product1_variant_id = products_data[0]["variant_id"]
+    product1_variant_price = float(products_data[0]["price"])
+
+    product2_id = products_data[1]["product_id"]
+    product2_variant_id = products_data[1]["variant_id"]
+    product2_variant_price = float(products_data[1]["price"])
+
+    product3_id = products_data[2]["product_id"]
+    product3_variant_id = products_data[2]["variant_id"]
+    product3_variant_price = float(products_data[2]["price"])
+
+    product4_variant_id = products_data[3]["variant_id"]
+    product4_variant_price = float(products_data[3]["price"])
+
+    product_ids = [product1_id, product2_id, product3_id]
+
+    sale_id, sale_discount_value = prepare_sale_for_products(
+        e2e_staff_api_client,
+        channel_id,
+        product_ids,
+        sale_discount_type="FIXED",
+        sale_discount_value=10,
+        sale_name="Sale_FIXED",
+    )
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    voucher_discount_value, voucher_code = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        "VOUCHER002",
+        voucher_discount_type="FIXED",
+        voucher_discount_value=5,
+    )
+    product1_quantity = 2
+    product2_quantity = 3
+    product3_quantity = 4
+    product4_quantity = 1
+    product2_new_quantity = 2
+    product3_new_quantity = 3
+
+    # Step 1 - checkoutCreate for product on sale
+    lines = [
+        {
+            "variantId": product1_variant_id,
+            "quantity": product1_quantity,
+        },
+        {
+            "variantId": product2_variant_id,
+            "quantity": product2_quantity,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+
+    assert checkout_line1["variant"]["id"] == product1_variant_id
+    assert checkout_line1["quantity"] == product1_quantity
+    line1_discount = sale_discount_value
+    line1_unit_price = product1_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+
+    assert checkout_line2["variant"]["id"] == product2_variant_id
+    assert checkout_line2["quantity"] == product2_quantity
+    line2_discount = sale_discount_value
+    line2_unit_price = round(product2_variant_price - line2_discount, 2)
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 2 - Add Lines
+    lines = [
+        {
+            "variantId": product3_variant_id,
+            "quantity": product3_quantity,
+        },
+        {
+            "variantId": product4_variant_id,
+            "quantity": product4_quantity,
+        },
+    ]
+    checkout_data = checkout_lines_add(
+        e2e_not_logged_api_client,
+        checkout_id,
+        lines,
+    )
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["variant"]["id"] == product3_variant_id
+    assert checkout_line3["quantity"] == product3_quantity
+    line3_discount = sale_discount_value
+    line3_unit_price = round(product3_variant_price - line3_discount, 2)
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+
+    checkout_line4 = checkout_data["lines"][3]
+    assert checkout_line4["variant"]["id"] == product4_variant_id
+    assert checkout_line4["quantity"] == 1
+    line4_unit_price = product4_variant_price
+    assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price
+        + product2_quantity * line2_unit_price
+        + product3_quantity * line3_unit_price
+        + product4_quantity * line4_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 3 - Remove lines
+    checkout_data = checkout_lines_delete(
+        e2e_not_logged_api_client, checkout_id, linesIds=[checkout_line1["id"]]
+    )
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    new_checkout_line1 = checkout_data["lines"][0]
+    new_checkout_line2 = checkout_data["lines"][1]
+    new_checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert new_checkout_line1["variant"]["id"] == product2_variant_id
+    assert new_checkout_line1["quantity"] == product2_quantity
+    line1_discount = sale_discount_value
+    line1_unit_price = product2_variant_price - line1_discount
+    assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert (
+        new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    )
+
+    assert new_checkout_line2["variant"]["id"] == product3_variant_id
+    assert new_checkout_line2["quantity"] == product3_quantity
+    line2_discount = sale_discount_value
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert (
+        new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    )
+
+    assert new_checkout_line3["variant"]["id"] == product4_variant_id
+    assert new_checkout_line3["quantity"] == 1
+    line3_unit_price = product4_variant_price
+    assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_subtotal = round(
+        +product2_quantity * line1_unit_price
+        + product3_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 4 - Update lines
+    lines = [
+        {
+            "quantity": product2_new_quantity,
+            "lineId": new_checkout_line1["id"],
+        },
+        {
+            "quantity": product3_new_quantity,
+            "lineId": new_checkout_line2["id"],
+        },
+    ]
+    checkout_data = checkout_lines_update(e2e_not_logged_api_client, checkout_id, lines)
+    checkout_data = checkout_data["checkout"]
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+    checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert checkout_line1["variant"]["id"] == product2_variant_id
+    assert checkout_line1["quantity"] == product2_new_quantity
+    line1_discount = sale_discount_value
+    line1_unit_price = product2_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_line1_total = round(product2_new_quantity * line1_unit_price, 2)
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    assert checkout_line2["variant"]["id"] == product3_variant_id
+    assert checkout_line2["quantity"] == product3_new_quantity
+    line2_discount = sale_discount_value
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    calculated_line2_total = round(product3_new_quantity * line2_unit_price, 2)
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    assert checkout_line3["variant"]["id"] == product4_variant_id
+    assert checkout_line3["quantity"] == product4_quantity
+    line3_unit_price = product4_variant_price
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_line3_total = round(product4_quantity * line3_unit_price, 2)
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    calculated_subtotal = round(
+        +product2_new_quantity * line1_unit_price
+        + product3_new_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 5 - Add voucher code to checkout
+    checkout_data = checkout_add_promo_code(
+        e2e_not_logged_api_client, checkout_id, voucher_code
+    )
+    calculated_discount = voucher_discount_value
+    assert checkout_data["discount"]["amount"] == calculated_discount
+    assert checkout_data["voucherCode"] == voucher_code
+
+    # Assert lines after voucher code
+    assert len(checkout_data["lines"]) == 3
+    checkout_line1 = checkout_data["lines"][0]
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line1["quantity"] == product2_new_quantity
+
+    # jak dzielic discount na linie przy fixed voucher
+    calculated_line1_discount = round(
+        calculated_line1_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line1_total = round(
+        calculated_line1_total - calculated_line1_discount, 2
+    )
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    checkout_line2 = checkout_data["lines"][1]
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line2["quantity"] == product3_new_quantity
+
+    calculated_line2_discount = round(
+        calculated_line2_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line2_total = round(
+        calculated_line2_total - calculated_line2_discount, 2
+    )
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product4_variant_price
+    assert checkout_line3["quantity"] == product4_quantity
+
+    calculated_line3_discount = round(
+        calculated_discount - calculated_line1_discount - calculated_line2_discount, 2
+    )
+    calculated_line3_total = round(
+        calculated_line3_total - calculated_line3_discount, 2
+    )
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+
+    # Assert total and subtotal after voucher code
+    calculated_subtotal = round(calculated_subtotal - calculated_discount, 2)
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+    calculated_total = calculated_subtotal
+    assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_total
+
+    # Step 6 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    calculated_total = calculated_subtotal + shipping_price
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+    assert total_gross_amount == calculated_total
+    assert subtotal_gross_amount == calculated_subtotal
+
+    # Step 7 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 8 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
+    assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price
+
+    assert order_data["discounts"][0]["type"] == "VOUCHER"
+    assert order_data["voucher"]["code"] == voucher_code
+    assert order_data["discounts"][0]["value"] == calculated_discount
+
+    assert len(order_data["lines"]) == 3
+    order_line1 = order_data["lines"][0]
+    order_line2 = order_data["lines"][1]
+    order_line3 = order_data["lines"][2]
+
+    assert order_line1["quantity"] == product2_new_quantity
+    assert order_line1["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
+    assert (
+        order_line1["undiscountedUnitPrice"]["gross"]["amount"]
+        == product2_variant_price
+    )
+    assert order_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+    assert order_line1["unitDiscount"]["amount"] == round(
+        line1_discount + (calculated_line1_discount / product2_new_quantity), 2
+    )
+    assert order_line2["quantity"] == product3_new_quantity
+    assert order_line2["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
+    assert (
+        order_line2["undiscountedUnitPrice"]["gross"]["amount"]
+        == product3_variant_price
+    )
+    assert order_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+    assert order_line2["unitDiscount"]["amount"] == round(
+        line2_discount + (calculated_line2_discount / product3_new_quantity), 2
+    )
+
+    assert order_line3["quantity"] == product4_quantity
+    assert order_line3["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code}"
+    )
+    assert (
+        order_line3["undiscountedUnitPrice"]["gross"]["amount"]
+        == product4_variant_price
+    )
+    assert order_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    assert order_line3["unitDiscount"]["amount"] == calculated_line3_discount
+
+
+@pytest.mark.e2e
+def test_checkout_calculate_discount_for_fixed_sale_and_percentage_voucher_CORE_0114(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    products_data = prepare_products(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        4,
+        ["13.33", "16", "9.99", "20.5"],
+    )
+    product1_id = products_data[0]["product_id"]
+    product1_variant_id = products_data[0]["variant_id"]
+    product1_variant_price = float(products_data[0]["price"])
+
+    product2_id = products_data[1]["product_id"]
+    product2_variant_id = products_data[1]["variant_id"]
+    product2_variant_price = float(products_data[1]["price"])
+
+    product3_id = products_data[2]["product_id"]
+    product3_variant_id = products_data[2]["variant_id"]
+    product3_variant_price = float(products_data[2]["price"])
+
+    product4_variant_id = products_data[3]["variant_id"]
+    product4_variant_price = float(products_data[3]["price"])
+
+    product_ids = [product1_id, product2_id, product3_id]
+
+    sale_id, sale_discount_value = prepare_sale_for_products(
+        e2e_staff_api_client,
+        channel_id,
+        product_ids,
+        sale_discount_type="FIXED",
+        sale_discount_value=5,
+        sale_name="Sale_fixed",
+    )
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    voucher_discount_value, voucher_code = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        "VOUCHER003",
+        voucher_discount_type="PERCENTAGE",
+        voucher_discount_value=15,
+    )
+    product1_quantity = 2
+    product2_quantity = 3
+    product3_quantity = 4
+    product4_quantity = 1
+    product2_new_quantity = 2
+    product3_new_quantity = 3
+
+    # Step 1 - checkoutCreate for product on sale
+    lines = [
+        {
+            "variantId": product1_variant_id,
+            "quantity": product1_quantity,
+        },
+        {
+            "variantId": product2_variant_id,
+            "quantity": product2_quantity,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+
+    assert checkout_line1["variant"]["id"] == product1_variant_id
+    assert checkout_line1["quantity"] == product1_quantity
+    line1_discount = sale_discount_value
+    line1_unit_price = product1_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+
+    assert checkout_line2["variant"]["id"] == product2_variant_id
+    assert checkout_line2["quantity"] == product2_quantity
+    line2_discount = sale_discount_value
+    line2_unit_price = product2_variant_price - line2_discount
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 2 - Add Lines
+    lines = [
+        {
+            "variantId": product3_variant_id,
+            "quantity": product3_quantity,
+        },
+        {
+            "variantId": product4_variant_id,
+            "quantity": product4_quantity,
+        },
+    ]
+    checkout_data = checkout_lines_add(
+        e2e_not_logged_api_client,
+        checkout_id,
+        lines,
+    )
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["variant"]["id"] == product3_variant_id
+    assert checkout_line3["quantity"] == product3_quantity
+    line3_discount = sale_discount_value
+    line3_unit_price = product3_variant_price - line3_discount
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+
+    checkout_line4 = checkout_data["lines"][3]
+    assert checkout_line4["variant"]["id"] == product4_variant_id
+    assert checkout_line4["quantity"] == 1
+    line4_unit_price = product4_variant_price
+    assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price
+        + product2_quantity * line2_unit_price
+        + product3_quantity * line3_unit_price
+        + product4_quantity * line4_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 3 - Remove lines
+    checkout_data = checkout_lines_delete(
+        e2e_not_logged_api_client, checkout_id, linesIds=[checkout_line1["id"]]
+    )
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    new_checkout_line1 = checkout_data["lines"][0]
+    new_checkout_line2 = checkout_data["lines"][1]
+    new_checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert new_checkout_line1["variant"]["id"] == product2_variant_id
+    assert new_checkout_line1["quantity"] == product2_quantity
+    line1_discount = sale_discount_value
+    line1_unit_price = product2_variant_price - line1_discount
+    assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert (
+        new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    )
+
+    assert new_checkout_line2["variant"]["id"] == product3_variant_id
+    assert new_checkout_line2["quantity"] == product3_quantity
+    line2_discount = sale_discount_value
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert (
+        new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    )
+
+    assert new_checkout_line3["variant"]["id"] == product4_variant_id
+    assert new_checkout_line3["quantity"] == 1
+    line3_unit_price = product4_variant_price
+    assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_subtotal = round(
+        +product2_quantity * line1_unit_price
+        + product3_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 4 - Update lines
+    lines = [
+        {
+            "quantity": product2_new_quantity,
+            "lineId": new_checkout_line1["id"],
+        },
+        {
+            "quantity": product3_new_quantity,
+            "lineId": new_checkout_line2["id"],
+        },
+    ]
+    checkout_data = checkout_lines_update(e2e_not_logged_api_client, checkout_id, lines)
+    checkout_data = checkout_data["checkout"]
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+    checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert checkout_line1["variant"]["id"] == product2_variant_id
+    assert checkout_line1["quantity"] == product2_new_quantity
+    line1_discount = sale_discount_value
+    line1_unit_price = product2_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_line1_total = round(product2_new_quantity * line1_unit_price, 2)
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    assert checkout_line2["variant"]["id"] == product3_variant_id
+    assert checkout_line2["quantity"] == product3_new_quantity
+    line2_discount = sale_discount_value
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    calculated_line2_total = round(product3_new_quantity * line2_unit_price, 2)
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    assert checkout_line3["variant"]["id"] == product4_variant_id
+    assert checkout_line3["quantity"] == product4_quantity
+    line3_unit_price = product4_variant_price
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_line3_total = round(product4_quantity * line3_unit_price, 2)
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    calculated_subtotal = round(
+        +product2_new_quantity * line1_unit_price
+        + product3_new_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 5 - Add voucher code to checkout
+    checkout_data = checkout_add_promo_code(
+        e2e_not_logged_api_client, checkout_id, voucher_code
+    )
+    calculated_discount = round(calculated_subtotal * voucher_discount_value / 100, 2)
+    assert checkout_data["discount"]["amount"] == calculated_discount
+    assert checkout_data["voucherCode"] == voucher_code
+
+    # Assert lines after voucher code
+    assert len(checkout_data["lines"]) == 3
+    checkout_line1 = checkout_data["lines"][0]
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line1["quantity"] == product2_new_quantity
+
+    calculated_line1_discount = round(
+        calculated_line1_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line1_total = round(
+        calculated_line1_total - calculated_line1_discount, 2
+    )
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    checkout_line2 = checkout_data["lines"][1]
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line2["quantity"] == product3_new_quantity
+
+    calculated_line2_discount = round(
+        calculated_line2_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line2_total = round(
+        calculated_line2_total - calculated_line2_discount, 2
+    )
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product4_variant_price
+    assert checkout_line3["quantity"] == product4_quantity
+
+    calculated_line3_discount = round(
+        calculated_discount - calculated_line1_discount - calculated_line2_discount, 2
+    )
+    calculated_line3_total = round(
+        calculated_line3_total - calculated_line3_discount, 2
+    )
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+
+    # Assert total and subtotal after voucher code
+    calculated_subtotal = round(calculated_subtotal - calculated_discount, 2)
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+    calculated_total = calculated_subtotal
+    assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_total
+
+    # Step 6 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    calculated_total = calculated_subtotal + shipping_price
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+    assert total_gross_amount == calculated_total
+    assert subtotal_gross_amount == calculated_subtotal
+
+    # Step 7 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 8 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
+    assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price
+
+    assert order_data["discounts"][0]["type"] == "VOUCHER"
+    assert order_data["voucher"]["code"] == voucher_code
+    assert order_data["discounts"][0]["value"] == calculated_discount
+
+    assert len(order_data["lines"]) == 3
+    order_line1 = order_data["lines"][0]
+    order_line2 = order_data["lines"][1]
+    order_line3 = order_data["lines"][2]
+
+    assert order_line1["quantity"] == product2_new_quantity
+    assert order_line1["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
+    assert (
+        order_line1["undiscountedUnitPrice"]["gross"]["amount"]
+        == product2_variant_price
+    )
+    assert order_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+    assert order_line1["unitDiscount"]["amount"] == round(
+        line1_discount + (calculated_line1_discount / product2_new_quantity), 2
+    )
+    assert order_line2["quantity"] == product3_new_quantity
+    assert order_line2["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
+    assert (
+        order_line2["undiscountedUnitPrice"]["gross"]["amount"]
+        == product3_variant_price
+    )
+    assert order_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+    assert order_line2["unitDiscount"]["amount"] == round(
+        line2_discount + (calculated_line2_discount / product3_new_quantity), 2
+    )
+
+    assert order_line3["quantity"] == product4_quantity
+    assert order_line3["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code}"
+    )
+    assert (
+        order_line3["undiscountedUnitPrice"]["gross"]["amount"]
+        == product4_variant_price
+    )
+    assert order_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    assert order_line3["unitDiscount"]["amount"] == calculated_line3_discount
+
+
+@pytest.mark.e2e
+def test_checkout_calculate_discount_for_percentage_sale_and_fixed_voucher_CORE_0114(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    products_data = prepare_products(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        4,
+        ["13.33", "16", "9.99", "20.5"],
+    )
+    product1_id = products_data[0]["product_id"]
+    product1_variant_id = products_data[0]["variant_id"]
+    product1_variant_price = float(products_data[0]["price"])
+
+    product2_id = products_data[1]["product_id"]
+    product2_variant_id = products_data[1]["variant_id"]
+    product2_variant_price = float(products_data[1]["price"])
+
+    product3_id = products_data[2]["product_id"]
+    product3_variant_id = products_data[2]["variant_id"]
+    product3_variant_price = float(products_data[2]["price"])
+
+    product4_variant_id = products_data[3]["variant_id"]
+    product4_variant_price = float(products_data[3]["price"])
+
+    product_ids = [product1_id, product2_id, product3_id]
+
+    sale_id, sale_discount_value = prepare_sale_for_products(
+        e2e_staff_api_client,
+        channel_id,
+        product_ids,
+        sale_discount_type="PERCENTAGE",
+        sale_discount_value=20,
+        sale_name="Sale_Percentage",
+    )
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    voucher_discount_value, voucher_code = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        "VOUCHER004",
+        voucher_discount_type="FIXED",
+        voucher_discount_value=3,
+    )
+    product1_quantity = 2
+    product2_quantity = 3
+    product3_quantity = 4
+    product4_quantity = 1
+    product2_new_quantity = 2
+    product3_new_quantity = 3
+
+    # Step 1 - checkoutCreate for product on sale
+    lines = [
+        {
+            "variantId": product1_variant_id,
+            "quantity": product1_quantity,
+        },
+        {
+            "variantId": product2_variant_id,
+            "quantity": product2_quantity,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+
+    assert checkout_line1["variant"]["id"] == product1_variant_id
+    assert checkout_line1["quantity"] == product1_quantity
+    line1_discount = round(product1_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product1_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+
+    assert checkout_line2["variant"]["id"] == product2_variant_id
+    assert checkout_line2["quantity"] == product2_quantity
+    line2_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = product2_variant_price - line2_discount
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 2 - Add Lines
+    lines = [
+        {
+            "variantId": product3_variant_id,
+            "quantity": product3_quantity,
+        },
+        {
+            "variantId": product4_variant_id,
+            "quantity": product4_quantity,
+        },
+    ]
+    checkout_data = checkout_lines_add(
+        e2e_not_logged_api_client,
+        checkout_id,
+        lines,
+    )
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["variant"]["id"] == product3_variant_id
+    assert checkout_line3["quantity"] == product3_quantity
+    line3_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line3_unit_price = product3_variant_price - line3_discount
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+
+    checkout_line4 = checkout_data["lines"][3]
+    assert checkout_line4["variant"]["id"] == product4_variant_id
+    assert checkout_line4["quantity"] == 1
+    line4_unit_price = product4_variant_price
+    assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
+    assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    calculated_subtotal = round(
+        product1_quantity * line1_unit_price
+        + product2_quantity * line2_unit_price
+        + product3_quantity * line3_unit_price
+        + product4_quantity * line4_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 3 - Remove lines
+    checkout_data = checkout_lines_delete(
+        e2e_not_logged_api_client, checkout_id, linesIds=[checkout_line1["id"]]
+    )
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    new_checkout_line1 = checkout_data["lines"][0]
+    new_checkout_line2 = checkout_data["lines"][1]
+    new_checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert new_checkout_line1["variant"]["id"] == product2_variant_id
+    assert new_checkout_line1["quantity"] == product2_quantity
+    line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product2_variant_price - line1_discount
+    assert new_checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert (
+        new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    )
+
+    assert new_checkout_line2["variant"]["id"] == product3_variant_id
+    assert new_checkout_line2["quantity"] == product3_quantity
+    line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert new_checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert (
+        new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    )
+
+    assert new_checkout_line3["variant"]["id"] == product4_variant_id
+    assert new_checkout_line3["quantity"] == 1
+    line3_unit_price = product4_variant_price
+    assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_subtotal = round(
+        +product2_quantity * line1_unit_price
+        + product3_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 4 - Update lines
+    lines = [
+        {
+            "quantity": product2_new_quantity,
+            "lineId": new_checkout_line1["id"],
+        },
+        {
+            "quantity": product3_new_quantity,
+            "lineId": new_checkout_line2["id"],
+        },
+    ]
+    checkout_data = checkout_lines_update(e2e_not_logged_api_client, checkout_id, lines)
+    checkout_data = checkout_data["checkout"]
+    assert len(checkout_data["lines"]) == 3
+    assert checkout_data["lines"][0]["id"] == checkout_line2["id"]
+    assert checkout_data["lines"][1]["id"] == checkout_line3["id"]
+    assert checkout_data["lines"][2]["id"] == checkout_line4["id"]
+
+    checkout_line1 = checkout_data["lines"][0]
+    checkout_line2 = checkout_data["lines"][1]
+    checkout_line3 = checkout_data["lines"][2]  # not on sale
+
+    assert checkout_line1["variant"]["id"] == product2_variant_id
+    assert checkout_line1["quantity"] == product2_new_quantity
+    line1_discount = round(product2_variant_price * sale_discount_value / 100, 2)
+    line1_unit_price = product2_variant_price - line1_discount
+    assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    calculated_line1_total = round(product2_new_quantity * line1_unit_price, 2)
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    assert checkout_line2["variant"]["id"] == product3_variant_id
+    assert checkout_line2["quantity"] == product3_new_quantity
+    line2_discount = round(product3_variant_price * sale_discount_value / 100, 2)
+    line2_unit_price = round(product3_variant_price - line2_discount, 2)
+    assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    calculated_line2_total = round(product3_new_quantity * line2_unit_price, 2)
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    assert checkout_line3["variant"]["id"] == product4_variant_id
+    assert checkout_line3["quantity"] == product4_quantity
+    line3_unit_price = product4_variant_price
+    assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    calculated_line3_total = round(product4_quantity * line3_unit_price, 2)
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    calculated_subtotal = round(
+        +product2_new_quantity * line1_unit_price
+        + product3_new_quantity * line2_unit_price
+        + product4_quantity * line3_unit_price,
+        2,
+    )
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+
+    # Step 5 - Add voucher code to checkout
+    checkout_data = checkout_add_promo_code(
+        e2e_not_logged_api_client, checkout_id, voucher_code
+    )
+    calculated_discount = voucher_discount_value
+    assert checkout_data["discount"]["amount"] == calculated_discount
+    assert checkout_data["voucherCode"] == voucher_code
+
+    # Assert lines after voucher code
+    assert len(checkout_data["lines"]) == 3
+    checkout_line1 = checkout_data["lines"][0]
+    assert checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line1["quantity"] == product2_new_quantity
+
+    calculated_line1_discount = round(
+        calculated_line1_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line1_total = round(
+        calculated_line1_total - calculated_line1_discount, 2
+    )
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+
+    checkout_line2 = checkout_data["lines"][1]
+    assert checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line2["quantity"] == product3_new_quantity
+
+    calculated_line2_discount = round(
+        calculated_line2_total / calculated_subtotal * calculated_discount, 2
+    )
+    calculated_line2_total = round(
+        calculated_line2_total - calculated_line2_discount, 2
+    )
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+
+    checkout_line3 = checkout_data["lines"][2]
+    assert checkout_line3["undiscountedUnitPrice"]["amount"] == product4_variant_price
+    assert checkout_line3["quantity"] == product4_quantity
+
+    calculated_line3_discount = round(
+        calculated_discount - calculated_line1_discount - calculated_line2_discount, 2
+    )
+    calculated_line3_total = round(
+        calculated_line3_total - calculated_line3_discount, 2
+    )
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+
+    # Assert total and subtotal after voucher code
+    calculated_subtotal = round(calculated_subtotal - calculated_discount, 2)
+    assert checkout_data["subtotalPrice"]["gross"]["amount"] == calculated_subtotal
+    calculated_total = calculated_subtotal
+    assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_total
+
+    # Step 6 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    calculated_total = calculated_subtotal + shipping_price
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    subtotal_gross_amount = checkout_data["subtotalPrice"]["gross"]["amount"]
+    assert total_gross_amount == calculated_total
+    assert subtotal_gross_amount == calculated_subtotal
+
+    # Step 7 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 8 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["subtotal"]["gross"]["amount"] == calculated_subtotal
+    assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price
+
+    assert order_data["discounts"][0]["type"] == "VOUCHER"
+    assert order_data["voucher"]["code"] == voucher_code
+    assert order_data["discounts"][0]["value"] == calculated_discount
+
+    assert len(order_data["lines"]) == 3
+    order_line1 = order_data["lines"][0]
+    order_line2 = order_data["lines"][1]
+    order_line3 = order_data["lines"][2]
+
+    assert order_line1["quantity"] == product2_new_quantity
+    assert order_line1["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
+    assert (
+        order_line1["undiscountedUnitPrice"]["gross"]["amount"]
+        == product2_variant_price
+    )
+    assert order_line1["totalPrice"]["gross"]["amount"] == calculated_line1_total
+    assert order_line1["unitDiscount"]["amount"] == round(
+        line1_discount + (calculated_line1_discount / product2_new_quantity), 2
+    )
+    assert order_line2["quantity"] == product3_new_quantity
+    assert order_line2["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code} & Sale: {sale_id}"
+    )
+    assert (
+        order_line2["undiscountedUnitPrice"]["gross"]["amount"]
+        == product3_variant_price
+    )
+    assert order_line2["totalPrice"]["gross"]["amount"] == calculated_line2_total
+    assert order_line2["unitDiscount"]["amount"] == round(
+        line2_discount + (calculated_line2_discount / product3_new_quantity), 2
+    )
+
+    assert order_line3["quantity"] == product4_quantity
+    assert order_line3["unitDiscountReason"] == (
+        f"Entire order voucher code: {voucher_code}"
+    )
+    assert (
+        order_line3["undiscountedUnitPrice"]["gross"]["amount"]
+        == product4_variant_price
+    )
+    assert order_line3["totalPrice"]["gross"]["amount"] == calculated_line3_total
+    assert order_line3["unitDiscount"]["amount"] == calculated_line3_discount

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
@@ -188,6 +188,9 @@ def test_checkout_calculate_discount_for_percentage_sale_and_percentage_voucher_
     line1_unit_price = product1_variant_price - line1_discount
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product1_quantity, 2
+    )
 
     assert checkout_line2["variant"]["id"] == product2_variant_id
     assert checkout_line2["quantity"] == product2_quantity
@@ -195,6 +198,10 @@ def test_checkout_calculate_discount_for_percentage_sale_and_percentage_voucher_
     line2_unit_price = product2_variant_price - line2_discount
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product2_quantity, 2
+    )
+
     calculated_subtotal = round(
         product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
     )
@@ -223,6 +230,9 @@ def test_checkout_calculate_discount_for_percentage_sale_and_percentage_voucher_
     line3_unit_price = product3_variant_price - line3_discount
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product3_quantity, 2
+    )
 
     checkout_line4 = checkout_data["lines"][3]
     assert checkout_line4["variant"]["id"] == product4_variant_id
@@ -230,6 +240,9 @@ def test_checkout_calculate_discount_for_percentage_sale_and_percentage_voucher_
     line4_unit_price = product4_variant_price
     assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
     assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    assert checkout_line4["totalPrice"]["gross"]["amount"] == round(
+        line4_unit_price * product4_quantity, 2
+    )
     calculated_subtotal = round(
         product1_quantity * line1_unit_price
         + product2_quantity * line2_unit_price
@@ -260,6 +273,9 @@ def test_checkout_calculate_discount_for_percentage_sale_and_percentage_voucher_
     assert (
         new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
     )
+    assert new_checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_quantity, 2
+    )
 
     assert new_checkout_line2["variant"]["id"] == product3_variant_id
     assert new_checkout_line2["quantity"] == product3_quantity
@@ -269,12 +285,19 @@ def test_checkout_calculate_discount_for_percentage_sale_and_percentage_voucher_
     assert (
         new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
     )
+    assert new_checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_quantity, 2
+    )
 
     assert new_checkout_line3["variant"]["id"] == product4_variant_id
     assert new_checkout_line3["quantity"] == 1
     line3_unit_price = product4_variant_price
     assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    assert new_checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
+
     calculated_subtotal = round(
         +product2_quantity * line1_unit_price
         + product3_quantity * line2_unit_price
@@ -584,6 +607,9 @@ def test_checkout_calculate_discount_for_fixed_sale_and_fixed_voucher_CORE_0114(
     line1_unit_price = product1_variant_price - line1_discount
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product1_quantity, 2
+    )
 
     assert checkout_line2["variant"]["id"] == product2_variant_id
     assert checkout_line2["quantity"] == product2_quantity
@@ -591,6 +617,10 @@ def test_checkout_calculate_discount_for_fixed_sale_and_fixed_voucher_CORE_0114(
     line2_unit_price = round(product2_variant_price - line2_discount, 2)
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product2_quantity, 2
+    )
+
     calculated_subtotal = round(
         product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
     )
@@ -619,6 +649,9 @@ def test_checkout_calculate_discount_for_fixed_sale_and_fixed_voucher_CORE_0114(
     line3_unit_price = round(product3_variant_price - line3_discount, 2)
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product3_quantity, 2
+    )
 
     checkout_line4 = checkout_data["lines"][3]
     assert checkout_line4["variant"]["id"] == product4_variant_id
@@ -626,6 +659,10 @@ def test_checkout_calculate_discount_for_fixed_sale_and_fixed_voucher_CORE_0114(
     line4_unit_price = product4_variant_price
     assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
     assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    assert checkout_line4["totalPrice"]["gross"]["amount"] == round(
+        line4_unit_price * product4_quantity, 2
+    )
+
     calculated_subtotal = round(
         product1_quantity * line1_unit_price
         + product2_quantity * line2_unit_price
@@ -656,6 +693,9 @@ def test_checkout_calculate_discount_for_fixed_sale_and_fixed_voucher_CORE_0114(
     assert (
         new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
     )
+    assert new_checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_quantity, 2
+    )
 
     assert new_checkout_line2["variant"]["id"] == product3_variant_id
     assert new_checkout_line2["quantity"] == product3_quantity
@@ -665,12 +705,19 @@ def test_checkout_calculate_discount_for_fixed_sale_and_fixed_voucher_CORE_0114(
     assert (
         new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
     )
+    assert new_checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_quantity, 2
+    )
 
     assert new_checkout_line3["variant"]["id"] == product4_variant_id
     assert new_checkout_line3["quantity"] == 1
     line3_unit_price = product4_variant_price
     assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    assert new_checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
+
     calculated_subtotal = round(
         +product2_quantity * line1_unit_price
         + product3_quantity * line2_unit_price
@@ -981,6 +1028,9 @@ def test_checkout_calculate_discount_for_fixed_sale_and_percentage_voucher_CORE_
     line1_unit_price = product1_variant_price - line1_discount
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product1_quantity, 2
+    )
 
     assert checkout_line2["variant"]["id"] == product2_variant_id
     assert checkout_line2["quantity"] == product2_quantity
@@ -988,6 +1038,10 @@ def test_checkout_calculate_discount_for_fixed_sale_and_percentage_voucher_CORE_
     line2_unit_price = product2_variant_price - line2_discount
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product2_quantity, 2
+    )
+
     calculated_subtotal = round(
         product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
     )
@@ -1016,6 +1070,9 @@ def test_checkout_calculate_discount_for_fixed_sale_and_percentage_voucher_CORE_
     line3_unit_price = product3_variant_price - line3_discount
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product3_quantity, 2
+    )
 
     checkout_line4 = checkout_data["lines"][3]
     assert checkout_line4["variant"]["id"] == product4_variant_id
@@ -1023,6 +1080,10 @@ def test_checkout_calculate_discount_for_fixed_sale_and_percentage_voucher_CORE_
     line4_unit_price = product4_variant_price
     assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
     assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    assert checkout_line4["totalPrice"]["gross"]["amount"] == round(
+        line4_unit_price * product4_quantity, 2
+    )
+
     calculated_subtotal = round(
         product1_quantity * line1_unit_price
         + product2_quantity * line2_unit_price
@@ -1053,6 +1114,9 @@ def test_checkout_calculate_discount_for_fixed_sale_and_percentage_voucher_CORE_
     assert (
         new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
     )
+    assert new_checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_quantity, 2
+    )
 
     assert new_checkout_line2["variant"]["id"] == product3_variant_id
     assert new_checkout_line2["quantity"] == product3_quantity
@@ -1062,12 +1126,19 @@ def test_checkout_calculate_discount_for_fixed_sale_and_percentage_voucher_CORE_
     assert (
         new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
     )
+    assert new_checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_quantity, 2
+    )
 
     assert new_checkout_line3["variant"]["id"] == product4_variant_id
     assert new_checkout_line3["quantity"] == 1
     line3_unit_price = product4_variant_price
     assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    assert new_checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
+
     calculated_subtotal = round(
         +product2_quantity * line1_unit_price
         + product3_quantity * line2_unit_price
@@ -1377,6 +1448,9 @@ def test_checkout_calculate_discount_for_percentage_sale_and_fixed_voucher_CORE_
     line1_unit_price = product1_variant_price - line1_discount
     assert checkout_line1["unitPrice"]["gross"]["amount"] == line1_unit_price
     assert checkout_line1["undiscountedUnitPrice"]["amount"] == product1_variant_price
+    assert checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product1_quantity, 2
+    )
 
     assert checkout_line2["variant"]["id"] == product2_variant_id
     assert checkout_line2["quantity"] == product2_quantity
@@ -1384,6 +1458,10 @@ def test_checkout_calculate_discount_for_percentage_sale_and_fixed_voucher_CORE_
     line2_unit_price = product2_variant_price - line2_discount
     assert checkout_line2["unitPrice"]["gross"]["amount"] == line2_unit_price
     assert checkout_line2["undiscountedUnitPrice"]["amount"] == product2_variant_price
+    assert checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product2_quantity, 2
+    )
+
     calculated_subtotal = round(
         product1_quantity * line1_unit_price + product2_quantity * line2_unit_price, 2
     )
@@ -1412,6 +1490,9 @@ def test_checkout_calculate_discount_for_percentage_sale_and_fixed_voucher_CORE_
     line3_unit_price = product3_variant_price - line3_discount
     assert checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert checkout_line3["undiscountedUnitPrice"]["amount"] == product3_variant_price
+    assert checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product3_quantity, 2
+    )
 
     checkout_line4 = checkout_data["lines"][3]
     assert checkout_line4["variant"]["id"] == product4_variant_id
@@ -1419,6 +1500,10 @@ def test_checkout_calculate_discount_for_percentage_sale_and_fixed_voucher_CORE_
     line4_unit_price = product4_variant_price
     assert checkout_line4["unitPrice"]["gross"]["amount"] == line4_unit_price
     assert checkout_line4["undiscountedUnitPrice"]["amount"] == line4_unit_price
+    assert checkout_line4["totalPrice"]["gross"]["amount"] == round(
+        line4_unit_price * product4_quantity, 2
+    )
+
     calculated_subtotal = round(
         product1_quantity * line1_unit_price
         + product2_quantity * line2_unit_price
@@ -1449,6 +1534,9 @@ def test_checkout_calculate_discount_for_percentage_sale_and_fixed_voucher_CORE_
     assert (
         new_checkout_line1["undiscountedUnitPrice"]["amount"] == product2_variant_price
     )
+    assert new_checkout_line1["totalPrice"]["gross"]["amount"] == round(
+        line1_unit_price * product2_quantity, 2
+    )
 
     assert new_checkout_line2["variant"]["id"] == product3_variant_id
     assert new_checkout_line2["quantity"] == product3_quantity
@@ -1458,12 +1546,19 @@ def test_checkout_calculate_discount_for_percentage_sale_and_fixed_voucher_CORE_
     assert (
         new_checkout_line2["undiscountedUnitPrice"]["amount"] == product3_variant_price
     )
+    assert new_checkout_line2["totalPrice"]["gross"]["amount"] == round(
+        line2_unit_price * product3_quantity, 2
+    )
 
     assert new_checkout_line3["variant"]["id"] == product4_variant_id
     assert new_checkout_line3["quantity"] == 1
     line3_unit_price = product4_variant_price
     assert new_checkout_line3["unitPrice"]["gross"]["amount"] == line3_unit_price
     assert new_checkout_line3["undiscountedUnitPrice"]["amount"] == line3_unit_price
+    assert new_checkout_line3["totalPrice"]["gross"]["amount"] == round(
+        line3_unit_price * product4_quantity, 2
+    )
+
     calculated_subtotal = round(
         +product2_quantity * line1_unit_price
         + product3_quantity * line2_unit_price

--- a/saleor/tests/e2e/checkout/utils/__init__.py
+++ b/saleor/tests/e2e/checkout/utils/__init__.py
@@ -12,6 +12,7 @@ from .checkout_create_from_order import checkout_create_from_order
 from .checkout_delivery_method_update import checkout_delivery_method_update
 from .checkout_email_update import checkout_update_email
 from .checkout_lines_add import checkout_lines_add
+from .checkout_lines_delete import checkout_lines_delete
 from .checkout_lines_update import checkout_lines_update
 from .checkout_payment_create import (
     checkout_dummy_payment_create,
@@ -42,4 +43,5 @@ __all__ = [
     "get_checkout",
     "checkout_remove_promo_code",
     "checkout_update_email",
+    "checkout_lines_delete",
 ]

--- a/saleor/tests/e2e/checkout/utils/checkout_add_promo_code.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_add_promo_code.py
@@ -36,6 +36,8 @@ mutation AddCheckoutPromoCode($checkoutId: ID!, $promoCode: String!) {
       }
       discountName
       lines {
+        id
+        quantity
         totalPrice {
           gross {
             amount

--- a/saleor/tests/e2e/checkout/utils/checkout_complete.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_complete.py
@@ -60,6 +60,7 @@ mutation CheckoutComplete($checkoutId: ID!) {
       }
       lines {
         id
+        quantity
         unitPrice {
           gross {
             amount

--- a/saleor/tests/e2e/checkout/utils/checkout_complete.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_complete.py
@@ -77,6 +77,11 @@ mutation CheckoutComplete($checkoutId: ID!) {
             amount
           }
         }
+        totalPrice {
+          gross {
+            amount
+          }
+        }
       }
       discounts {
         id

--- a/saleor/tests/e2e/checkout/utils/checkout_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create.py
@@ -83,6 +83,7 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
       }
       lines {
         id
+        quantity
         totalPrice {
           gross {
             amount

--- a/saleor/tests/e2e/checkout/utils/checkout_lines_add.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_lines_add.py
@@ -5,7 +5,11 @@ mutation checkoutLinesAdd($checkoutId: ID!, $lines: [CheckoutLineInput!]!) {
   checkoutLinesAdd(id: $checkoutId, lines: $lines) {
     checkout {
       lines {
+        id
         quantity
+        variant {
+          id
+        }
         totalPrice {
           gross {
             amount
@@ -22,6 +26,11 @@ mutation checkoutLinesAdd($checkoutId: ID!, $lines: [CheckoutLineInput!]!) {
       }
       availablePaymentGateways {
         id
+      }
+      subtotalPrice {
+        gross {
+          amount
+        }
       }
     }
     errors {

--- a/saleor/tests/e2e/checkout/utils/checkout_lines_delete.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_lines_delete.py
@@ -1,8 +1,8 @@
 from ...utils import get_graphql_content
 
-CHECKOUT_LINES_UPDATE_MUTATION = """
-mutation checkoutLinesUpdate($checkoutId: ID!, $lines: [CheckoutLineUpdateInput!]!) {
-  checkoutLinesUpdate(lines: $lines, checkoutId: $checkoutId) {
+CHECKOUT_LINES_DELETE_MUTATION = """
+mutation CheckoutLinesDelete($checkoutId: ID!, $linesIds: [ID!]!) {
+  checkoutLinesDelete(id: $checkoutId, linesIds: $linesIds) {
     checkout {
       discountName
       discount {
@@ -55,17 +55,18 @@ mutation checkoutLinesUpdate($checkoutId: ID!, $lines: [CheckoutLineUpdateInput!
 """
 
 
-def checkout_lines_update(
+def checkout_lines_delete(
     staff_api_client,
     checkout_id,
-    lines,
+    linesIds,
 ):
     variables = {
         "checkoutId": checkout_id,
-        "lines": lines,
+        "linesIds": linesIds,
     }
 
-    response = staff_api_client.post_graphql(CHECKOUT_LINES_UPDATE_MUTATION, variables)
+    response = staff_api_client.post_graphql(CHECKOUT_LINES_DELETE_MUTATION, variables)
     content = get_graphql_content(response)
 
-    return content["data"]["checkoutLinesUpdate"]
+    assert content["data"]["checkoutLinesDelete"]["errors"] == []
+    return content["data"]["checkoutLinesDelete"]["checkout"]

--- a/saleor/tests/e2e/product/utils/preparing_product.py
+++ b/saleor/tests/e2e/product/utils/preparing_product.py
@@ -114,3 +114,29 @@ def prepare_digital_product(
 
     product_variant_price = variant_listing["channelListings"][0]["price"]["amount"]
     return product_id, product_variant_id, product_variant_price
+
+
+def prepare_products(
+    e2e_staff_api_client,
+    warehouse_id,
+    channel_id,
+    prices,
+):
+    products_data = []
+
+    for i, variant_price in enumerate(prices):
+        product_id, variant_id, price = prepare_product(
+            e2e_staff_api_client,
+            warehouse_id,
+            channel_id,
+            variant_price,
+            product_type_slug=f"test-{i}",
+        )
+        product_data = {
+            "product_id": product_id,
+            "variant_id": variant_id,
+            "price": price,
+        }
+        products_data.append(product_data)
+
+    return products_data


### PR DESCRIPTION
I want to merge this change because some shops may be using the old sales and we want to ensure that the tests are more accurate to what the customers are doing.
Changes:
- add more products on sales to checkout
- add products not on sale to checkout
- use line update mutations instead of creating lines only in checkoutCreate
- split parametrized tests for combining sales and vouchers 

to do:
- [X] CORE_1004 [Should be able to buy products on percentage sale in checkout](https://saleor.testmo.net/repositories/5?group_id=132&case_id=2082)
- [x] CORE_1002 [Should be able to buy products on fixed sale in checkout](https://saleor.testmo.net/repositories/5?group_id=132&case_id=2080)
- [x] CORE_0114 [Checkout should calculate correct discount for sale and voucher](https://saleor.testmo.net/repositories/5?group_id=125&case_id=2364)




<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
