### PR TITLE
Unify the lock logic for allocations and stocks

### DIFF
--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -45,6 +45,7 @@ from ....permission.enums import OrderPermissions
 from ....product.models import ProductVariant
 from ....shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ....tax.models import TaxClass
+from ....warehouse.management import stock_bulk_update
 from ....warehouse.models import Stock, Warehouse
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
@@ -2273,7 +2274,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
         )
         FulfillmentLine.objects.bulk_create(fulfillment_lines)
 
-        Stock.objects.bulk_update(stocks, ["quantity"])
+        stock_bulk_update(stocks, ["quantity"])
 
         transactions: list[TransactionItem] = sum(
             [

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_delete.py
@@ -5,6 +5,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....warehouse import models as warehouse_models
+from ....warehouse.management import delete_stocks
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
 from ...channel import ChannelContext
@@ -80,8 +81,7 @@ class ProductVariantStocksDelete(BaseMutation):
             cls.call_event(
                 manager.product_variant_out_of_stock, stock, webhooks=webhooks
             )
-
-        stocks_to_delete.delete()
+        delete_stocks([stock.id for stock in stocks_to_delete])
 
         StocksByProductVariantIdLoader(info.context).clear(variant.id)
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
@@ -7,6 +7,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....warehouse import models as warehouse_models
+from ....warehouse.management import stock_bulk_update
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
 from ...channel import ChannelContext
@@ -129,4 +130,4 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
             webhooks=webhooks_stock_update,
         )
 
-        warehouse_models.Stock.objects.bulk_update(stocks, ["quantity"])
+        stock_bulk_update(stocks, ["quantity"])

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -41,6 +41,57 @@ if TYPE_CHECKING:
 StockData = namedtuple("StockData", ["pk", "quantity"])
 
 
+def stock_select_for_update_for_existing_qs(qs):
+    return qs.order_by("pk").select_for_update(of=(["self"]))
+
+
+def stock_qs_select_for_update():
+    return stock_select_for_update_for_existing_qs(Stock.objects.all())
+
+
+def delete_stocks(stock_pks_to_delete: list[int]):
+    with transaction.atomic():
+        return Stock.objects.filter(
+            id__in=Stock.objects.order_by("pk")
+            .select_for_update(of=["self"])
+            .values_list("pk", flat=True)
+            .filter(id__in=stock_pks_to_delete)
+        ).delete()
+
+
+def stock_bulk_update(stocks: list[Stock], fields_to_update: list[str]):
+    with transaction.atomic():
+        _locked_stocks = list(
+            stock_qs_select_for_update()
+            .filter(id__in=[stock.id for stock in stocks])
+            .values_list("id", flat=True)
+        )
+        Stock.objects.bulk_update(stocks, fields_to_update)
+
+
+def allocation_with_stock_qs_select_for_update():
+    return (
+        Allocation.objects.select_related("stock")
+        .select_for_update(
+            of=(
+                "self",
+                "stock",
+            )
+        )
+        .order_by("stock__pk")
+    )
+
+
+def delete_allocations(allocation_pks_to_delete: list[int]):
+    with transaction.atomic():
+        return Allocation.objects.filter(
+            id__in=Allocation.objects.order_by("stock_id")
+            .select_for_update(of=["self"])
+            .values_list("pk", flat=True)
+            .filter(id__in=allocation_pks_to_delete)
+        ).delete()
+
+
 @traced_atomic_transaction()
 def allocate_stocks(
     order_lines_info: Iterable["OrderLineInfo"],
@@ -84,9 +135,8 @@ def allocate_stocks(
     )
 
     stocks = list(
-        stocks.select_for_update(of=("self",))
+        stock_select_for_update_for_existing_qs(stocks)
         .filter(**filter_lookup)
-        .order_by("pk")
         .values("id", "product_variant", "pk", "quantity", "warehouse_id")
     )
     stocks_id = (stock.pop("id") for stock in stocks)
@@ -289,16 +339,8 @@ def deallocate_stock(
     raise an exception.
     """
     lines = [line_info.line for line_info in order_lines_data]
-    lines_allocations = (
-        Allocation.objects.filter(order_line__in=lines)
-        .select_related("stock")
-        .select_for_update(
-            of=(
-                "self",
-                "stock",
-            )
-        )
-        .order_by("stock__pk")
+    lines_allocations = allocation_with_stock_qs_select_for_update().filter(
+        order_line__in=lines
     )
 
     line_to_allocations: dict[UUID, list[Allocation]] = defaultdict(list)
@@ -380,7 +422,7 @@ def increase_stock(
     """
     assert order_line.variant
     stock = (
-        Stock.objects.select_for_update(of=("self",))
+        stock_qs_select_for_update()
         .filter(warehouse=warehouse, product_variant=order_line.variant)
         .first()
     )
@@ -410,10 +452,11 @@ def increase_allocations(
     """Increase allocation for order lines with appropriate quantity."""
     line_pks = [info.line.pk for info in lines_info]
     allocations = list(
-        Allocation.objects.filter(order_line__in=line_pks)
-        .select_related("stock", "order_line")
-        .select_for_update(of=("self", "stock"))
+        allocation_with_stock_qs_select_for_update()
+        .select_related("order_line")
+        .filter(order_line__in=line_pks)
     )
+
     # evaluate allocations query to trigger select_for_update lock
     allocation_pks_to_delete = [alloc.pk for alloc in allocations]
     allocation_quantity_map: dict[UUID, list] = defaultdict(list)
@@ -477,16 +520,15 @@ def decrease_stock(
     try:
         deallocate_stock(order_lines_info, manager)
     except AllocationError as exc:
-        Allocation.objects.filter(order_line__in=exc.order_lines).update(
-            quantity_allocated=0
-        )
+        Allocation.objects.order_by("stock_id").filter(
+            order_line__in=exc.order_lines
+        ).update(quantity_allocated=0)
 
     stocks = (
-        Stock.objects.select_for_update(of=("self",))
+        stock_qs_select_for_update()
         .filter(product_variant__in=variants)
         .filter(warehouse_id__in=warehouse_pks)
         .select_related("product_variant", "warehouse")
-        .order_by("pk")
     )
 
     variant_and_warehouse_to_stock: dict[int, dict[UUID, Stock]] = defaultdict(dict)
@@ -598,9 +640,9 @@ def get_order_lines_with_track_inventory(
 def deallocate_stock_for_order(order: "Order", manager: PluginsManager):
     """Remove all allocations for given order."""
     lines = OrderLine.objects.filter(order_id=order.id)
-    allocations = Allocation.objects.filter(
+    allocations = allocation_with_stock_qs_select_for_update().filter(
         Exists(lines.filter(id=OuterRef("order_line_id"))), quantity_allocated__gt=0
-    ).select_related("stock")
+    )
 
     stocks_to_update = []
     for alloc in allocations:
@@ -608,7 +650,10 @@ def deallocate_stock_for_order(order: "Order", manager: PluginsManager):
         stock.quantity_allocated = F("quantity_allocated") - alloc.quantity_allocated
         stocks_to_update.append(stock)
 
-    for allocation in allocations.annotate_stock_available_quantity():
+    allocations_for_back_in_stock = Allocation.objects.filter(
+        id__in=[allocation.id for allocation in allocations]
+    )
+    for allocation in allocations_for_back_in_stock.annotate_stock_available_quantity():
         if allocation.stock_available_quantity <= 0:
             transaction.on_commit(
                 lambda: manager.product_variant_back_in_stock(allocation.stock)
@@ -622,9 +667,9 @@ def deallocate_stock_for_order(order: "Order", manager: PluginsManager):
 def deallocate_stock_for_orders(orders_id, manager: PluginsManager):
     """Remove all allocations for given order."""
     lines = OrderLine.objects.filter(order_id__in=orders_id)
-    allocations = Allocation.objects.filter(
+    allocations = allocation_with_stock_qs_select_for_update().filter(
         Exists(lines.filter(id=OuterRef("order_line_id"))), quantity_allocated__gt=0
-    ).select_related("stock")
+    )
 
     stocks_to_update = []
     for alloc in allocations:
@@ -632,7 +677,10 @@ def deallocate_stock_for_orders(orders_id, manager: PluginsManager):
         stock.quantity_allocated = F("quantity_allocated") - alloc.quantity_allocated
         stocks_to_update.append(stock)
 
-    for allocation in allocations.annotate_stock_available_quantity():
+    allocations_for_back_in_stock = Allocation.objects.filter(
+        id__in=[allocation.id for allocation in allocations]
+    )
+    for allocation in allocations_for_back_in_stock.annotate_stock_available_quantity():
         if allocation.stock_available_quantity <= 0:
             transaction.on_commit(
                 lambda: manager.product_variant_back_in_stock(allocation.stock)
@@ -902,7 +950,7 @@ def _get_stock_for_preorder_allocation(
         raise PreorderAllocationError(preorder_allocation.order_line)
 
     stock = list(
-        Stock.objects.select_for_update(of=("self",)).filter(
+        stock_qs_select_for_update().filter(
             warehouse=warehouse, product_variant=product_variant
         )
     )

--- a/saleor/warehouse/reservations.py
+++ b/saleor/warehouse/reservations.py
@@ -11,8 +11,8 @@ from django.utils import timezone
 from ..core.exceptions import InsufficientStock, InsufficientStockData
 from ..core.tracing import traced_atomic_transaction
 from ..product.models import ProductVariant, ProductVariantChannelListing
-from .management import sort_stocks
-from .models import Allocation, PreorderReservation, Reservation, Stock
+from .management import sort_stocks, stock_qs_select_for_update
+from .models import Allocation, PreorderReservation, Reservation
 
 if TYPE_CHECKING:
     from ..channel.models import Channel
@@ -103,7 +103,7 @@ def reserve_stocks(
         return
 
     stocks = list(
-        Stock.objects.select_for_update(of=("self",))
+        stock_qs_select_for_update()
         .get_variants_stocks_for_country(country_code, channel.slug, variants)
         .order_by("pk")
         .values("id", "product_variant", "pk", "quantity", "warehouse_id")

--- a/saleor/warehouse/tasks.py
+++ b/saleor/warehouse/tasks.py
@@ -4,6 +4,7 @@ from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from ..celeryconf import app
+from .management import delete_allocations, stock_bulk_update
 from .models import Allocation, PreorderReservation, Reservation, Stock
 
 task_logger = get_task_logger(__name__)
@@ -11,7 +12,10 @@ task_logger = get_task_logger(__name__)
 
 @app.task
 def delete_empty_allocations_task():
-    count, _ = Allocation.objects.filter(quantity_allocated=0).delete()
+    ids_to_delete = list(
+        Allocation.objects.filter(quantity_allocated=0).values_list("id", flat=True)
+    )
+    count, _ = delete_allocations(ids_to_delete)
     if count:
         task_logger.debug("Removed %s allocations", count)
 
@@ -52,7 +56,8 @@ def update_stocks_quantity_allocated_task():
         mismatched_stock.quantity_allocated = allocations_allocated
         stocks_to_update.append(mismatched_stock)
 
-    Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
+    stock_bulk_update(stocks_to_update, ["quantity_allocated"])
+
     task_logger.info(
         "Finished updating quantity_allocated on stocks, %d were corrected.",
         len(stocks_to_update),


### PR DESCRIPTION
I want to merge this change because it unifies the way how we apply the locks for `Allocation` and `Stock` models. 
In most places we were locking on `stock_id`, but some places didn't apply the same ordering, which could result in potential deadlock. 
The PR unifies the calls, and also adds the helper function that should be used in any potential places where applying the lock for Allocation/Stock is required.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
