### PR TITLE
Use denormalized prices during order update for catalogue discounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,4 +54,3 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix checkout funds releasing task - #17198 by @IKarbowiak
 - Fixed 'healthcheck' middleware (`/health/` endpoint) not forwarding incoming traffic whenever the protocol wasn't HTTP (such as WebSocket or Lifespan) - #17248 by @NyanKiyoshi
 - Use denormalized discount prices during order update - #17160 by @zedzior
-- Use denormalized prices during order update for catalogue discounts - #17125 by @zedzior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix checkout funds releasing task - #17198 by @IKarbowiak
 - Fixed 'healthcheck' middleware (`/health/` endpoint) not forwarding incoming traffic whenever the protocol wasn't HTTP (such as WebSocket or Lifespan) - #17248 by @NyanKiyoshi
 - Use denormalized discount prices during order update - #17160 by @zedzior
+- Use denormalized prices during order update for catalogue discounts - #17125 by @zedzior

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -13,7 +13,11 @@ from ..core.prices import quantize_price
 from ..core.pricing.interface import LineInfo
 from ..core.taxes import zero_money
 from ..discount import VoucherType
-from ..discount.interface import fetch_variant_rules_info, fetch_voucher_info
+from ..discount.interface import (
+    VariantPromotionRuleInfo,
+    fetch_variant_rules_info,
+    fetch_voucher_info,
+)
 from ..shipping.interface import ShippingMethodData
 from ..shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ..shipping.utils import (
@@ -52,6 +56,9 @@ class CheckoutLineInfo(LineInfo):
     product: "Product"
     product_type: "ProductType"
     discounts: list["CheckoutLineDiscount"]
+    rules_info: list["VariantPromotionRuleInfo"]
+    channel_listing: Optional["ProductVariantChannelListing"]
+
     tax_class: Optional["TaxClass"] = None
 
     @cached_property

--- a/saleor/core/pricing/interface.py
+++ b/saleor/core/pricing/interface.py
@@ -7,7 +7,6 @@ from ...discount import DiscountType
 if TYPE_CHECKING:
     from ...channel.models import Channel
     from ...checkout.models import CheckoutLine
-    from ...discount.interface import VariantPromotionRuleInfo
     from ...discount.models import CheckoutLineDiscount, OrderLineDiscount, Voucher
     from ...order.models import OrderLine
     from ...product.models import (
@@ -15,7 +14,6 @@ if TYPE_CHECKING:
         Product,
         ProductType,
         ProductVariant,
-        ProductVariantChannelListing,
     )
 
 
@@ -26,10 +24,8 @@ class LineInfo:
     product: Optional["Product"]
     product_type: Optional["ProductType"]
     collections: list["Collection"]
-    channel_listing: Optional["ProductVariantChannelListing"]
     channel: "Channel"
     discounts: Iterable[Union["OrderLineDiscount", "CheckoutLineDiscount"]]
-    rules_info: list["VariantPromotionRuleInfo"]
     voucher: Optional["Voucher"]
     voucher_code: str | None
 

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -2303,7 +2303,7 @@ def test_create_checkout_line_discount_objects_for_catalogue_promotions_race_con
         create_checkout_line_discount_objects_for_catalogue_promotions(lines_info)
 
     with race_condition.RunBefore(
-        "saleor.discount.utils.promotion.prepare_line_discount_objects_for_catalogue_promotions",
+        "saleor.discount.utils.checkout.prepare_checkout_line_discount_objects_for_catalogue_promotions",
         call_before_creating_catalogue_line_discount,
     ):
         lines_info, _ = fetch_checkout_lines(checkout)

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_order.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_order.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 
 import graphene
 import pytest
-from django.db import IntegrityError
 
 from ....order.fetch import fetch_draft_order_lines_info
 from ....product.models import (
@@ -545,7 +544,7 @@ def test_update_gift_discount_new_gift_available(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_create_multiple_catalogue_discounts_for_the_same_line_raise_unique_error(
+def test_create_multiple_catalogue_discounts_for_the_same_line_is_not_allowed(
     order_line,
     catalogue_promotion,
     promotion_translation_fr,
@@ -603,9 +602,10 @@ def test_create_multiple_catalogue_discounts_for_the_same_line_raise_unique_erro
         ),
     ]
 
-    # when & then
-    # TODO zedzior: sprawdz czy w funkcji nie trzeba dodac ignore_conflicts=True
-    with pytest.raises(IntegrityError):
-        create_order_line_discount_objects_for_catalogue_promotions(
-            order_line, rules_info, order.channel
-        )
+    # when
+    create_order_line_discount_objects_for_catalogue_promotions(
+        order_line, rules_info, order.channel
+    )
+
+    # then
+    assert order_line.discounts.count() == 1

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_order.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_order.py
@@ -12,7 +12,7 @@ from ... import DiscountType, RewardType, RewardValueType
 from ...interface import VariantPromotionRuleInfo, fetch_variant_rules_info
 from ...models import OrderDiscount, OrderLineDiscount
 from ...utils.order import (
-    create_or_update_discount_objects_from_promotion_for_order,
+    create_order_discount_objects_for_order_promotions,
     create_order_line_discount_objects_for_catalogue_promotions,
 )
 
@@ -158,7 +158,7 @@ def test_create_order_discount_subtotal_fixed(
     lines_info = fetch_draft_order_lines_info(order)
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     assert OrderDiscount.objects.count() == 1
@@ -198,7 +198,7 @@ def test_create_order_discount_subtotal_percentage(
     lines_info = fetch_draft_order_lines_info(order)
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     assert OrderDiscount.objects.count() == 1
@@ -238,7 +238,7 @@ def test_create_order_discount_gift(
     lines_info = fetch_draft_order_lines_info(order)
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     assert OrderLineDiscount.objects.count() == 1
@@ -290,7 +290,7 @@ def test_multiple_rules_subtotal_and_catalogue_discount_applied(
     )
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     order.refresh_from_db()
@@ -329,7 +329,7 @@ def test_multiple_rules_gift_and_catalogue_discount_applied(draft_order_and_prom
     )
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     order.refresh_from_db()
@@ -391,7 +391,7 @@ def test_multiple_rules_no_discount_applied(
     lines_info = fetch_draft_order_lines_info(order)
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     assert not OrderLineDiscount.objects.exists()
@@ -422,7 +422,7 @@ def test_update_order_discount_subtotal(
     lines_info = fetch_draft_order_lines_info(order)
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     assert OrderDiscount.objects.count() == 1
@@ -457,7 +457,7 @@ def test_update_gift_discount_new_gift_available(
     lines_info = fetch_draft_order_lines_info(order)
 
     # when
-    create_or_update_discount_objects_from_promotion_for_order(order, lines_info)
+    create_order_discount_objects_for_order_promotions(order, lines_info)
 
     # then
     assert OrderLineDiscount.objects.count() == 1

--- a/saleor/discount/utils/checkout.py
+++ b/saleor/discount/utils/checkout.py
@@ -15,9 +15,14 @@ from ..models import (
     CheckoutLineDiscount,
 )
 from .promotion import (
+    _get_discount_reason,
+    _get_rule_discount_amount,
+    _is_discounted_line_by_catalogue_promotion,
+    _update_catalogue_promotion_discount,
     create_discount_objects_for_order_promotions,
     delete_gift_line,
-    prepare_line_discount_objects_for_catalogue_promotions,
+    get_discount_name,
+    get_discount_translated_name,
 )
 from .shared import update_line_info_cached_discounts
 
@@ -39,7 +44,9 @@ def create_or_update_discount_objects_from_promotion_for_checkout(
 def create_checkout_line_discount_objects_for_catalogue_promotions(
     lines_info: list["CheckoutLineInfo"],
 ):
-    discount_data = prepare_line_discount_objects_for_catalogue_promotions(lines_info)
+    discount_data = prepare_checkout_line_discount_objects_for_catalogue_promotions(
+        lines_info
+    )
     if not discount_data or not lines_info:
         return
 
@@ -83,6 +90,96 @@ def create_checkout_line_discount_objects_for_catalogue_promotions(
 
     update_line_info_cached_discounts(
         lines_info, new_line_discounts, discounts_to_update, discount_ids_to_remove
+    )
+
+
+def prepare_checkout_line_discount_objects_for_catalogue_promotions(lines_info):
+    line_discounts_to_create_inputs: list[dict] = []
+    line_discounts_to_update: list[CheckoutLineDiscount] = []
+    line_discounts_to_remove: list[CheckoutLineDiscount] = []
+    updated_fields: list[str] = []
+
+    if not lines_info:
+        return None
+
+    for line_info in lines_info:
+        line = line_info.line
+
+        # if channel_listing is not present, we can't close the checkout. User needs to
+        # remove the line for the checkout first. Until that moment, we return the same
+        # price as we did when listing was present - including line discount.
+        if not line_info.channel_listing:
+            continue
+
+        # get the existing catalogue discount for the line
+        discount_to_update = None
+        if discounts_to_update := line_info.get_catalogue_discounts():
+            discount_to_update = discounts_to_update[0]
+            # Line should never have multiple catalogue discounts associated. Before
+            # introducing unique_type on discount models, there was such a possibility.
+            line_discounts_to_remove.extend(discounts_to_update[1:])
+
+        # manual line discount do not stack with other line discounts
+        if [
+            discount
+            for discount in line_info.discounts
+            if discount.type == DiscountType.MANUAL
+        ]:
+            line_discounts_to_remove.extend(discounts_to_update)
+            continue
+
+        # check if the line price is discounted by catalogue promotion
+        discounted_line = _is_discounted_line_by_catalogue_promotion(
+            line_info.channel_listing
+        )
+
+        # delete all existing discounts if the line is not discounted or it is a gift
+        if not discounted_line or line.is_gift:
+            line_discounts_to_remove.extend(discounts_to_update)
+            continue
+
+        if line_info.rules_info:
+            rule_info = line_info.rules_info[0]
+            rule = rule_info.rule
+            rule_discount_amount = _get_rule_discount_amount(
+                line, rule_info, line_info.channel
+            )
+            discount_name = get_discount_name(rule, rule_info.promotion)
+            translated_name = get_discount_translated_name(rule_info)
+            reason = _get_discount_reason(rule)
+            if not discount_to_update:
+                line_discount_input = {
+                    "line": line,
+                    "type": DiscountType.PROMOTION,
+                    "value_type": rule.reward_value_type,
+                    "value": rule.reward_value,
+                    "amount_value": rule_discount_amount,
+                    "currency": line.currency,
+                    "name": discount_name,
+                    "translated_name": translated_name,
+                    "reason": reason,
+                    "promotion_rule": rule,
+                    "unique_type": DiscountType.PROMOTION,
+                }
+                line_discounts_to_create_inputs.append(line_discount_input)
+            else:
+                _update_catalogue_promotion_discount(
+                    rule,
+                    rule_info,
+                    rule_discount_amount,
+                    discount_to_update,
+                    updated_fields,
+                )
+                line_discounts_to_update.append(discount_to_update)
+        else:
+            # Fallback for unlike mismatch between discount_amount and rules_info
+            line_discounts_to_remove.extend(discounts_to_update)
+
+    return (
+        line_discounts_to_create_inputs,
+        line_discounts_to_update,
+        line_discounts_to_remove,
+        updated_fields,
     )
 
 

--- a/saleor/discount/utils/checkout.py
+++ b/saleor/discount/utils/checkout.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
 from django.db import transaction
@@ -93,7 +93,11 @@ def create_checkout_line_discount_objects_for_catalogue_promotions(
     )
 
 
-def prepare_checkout_line_discount_objects_for_catalogue_promotions(lines_info):
+def prepare_checkout_line_discount_objects_for_catalogue_promotions(
+    lines_info: list["CheckoutLineInfo"],
+) -> Optional[
+    tuple[list[dict], list[CheckoutLineDiscount], list[CheckoutLineDiscount], list[str]]
+]:
     line_discounts_to_create_inputs: list[dict] = []
     line_discounts_to_update: list[CheckoutLineDiscount] = []
     line_discounts_to_remove: list[CheckoutLineDiscount] = []

--- a/saleor/discount/utils/checkout.py
+++ b/saleor/discount/utils/checkout.py
@@ -15,14 +15,14 @@ from ..models import (
     CheckoutLineDiscount,
 )
 from .promotion import (
-    _get_discount_reason,
     _get_rule_discount_amount,
     _is_discounted_line_by_catalogue_promotion,
-    _update_catalogue_promotion_discount,
+    _update_promotion_discount,
     create_discount_objects_for_order_promotions,
     delete_gift_line,
     get_discount_name,
     get_discount_translated_name,
+    prepare_promotion_discount_reason,
 )
 from .shared import update_line_info_cached_discounts
 
@@ -146,7 +146,7 @@ def prepare_checkout_line_discount_objects_for_catalogue_promotions(lines_info):
             )
             discount_name = get_discount_name(rule, rule_info.promotion)
             translated_name = get_discount_translated_name(rule_info)
-            reason = _get_discount_reason(rule)
+            reason = prepare_promotion_discount_reason(rule)
             if not discount_to_update:
                 line_discount_input = {
                     "line": line,
@@ -163,7 +163,7 @@ def prepare_checkout_line_discount_objects_for_catalogue_promotions(lines_info):
                 }
                 line_discounts_to_create_inputs.append(line_discount_input)
             else:
-                _update_catalogue_promotion_discount(
+                _update_promotion_discount(
                     rule,
                     rule_info,
                     rule_discount_amount,

--- a/saleor/discount/utils/checkout.py
+++ b/saleor/discount/utils/checkout.py
@@ -17,12 +17,12 @@ from ..models import (
 from .promotion import (
     _get_rule_discount_amount,
     _is_discounted_line_by_catalogue_promotion,
-    _update_promotion_discount,
     create_discount_objects_for_order_promotions,
     delete_gift_line,
     get_discount_name,
     get_discount_translated_name,
     prepare_promotion_discount_reason,
+    update_promotion_discount,
 )
 from .shared import update_line_info_cached_discounts
 
@@ -163,7 +163,7 @@ def prepare_checkout_line_discount_objects_for_catalogue_promotions(lines_info):
                 }
                 line_discounts_to_create_inputs.append(line_discount_input)
             else:
-                _update_promotion_discount(
+                update_promotion_discount(
                     rule,
                     rule_info,
                     rule_discount_amount,

--- a/saleor/discount/utils/checkout.py
+++ b/saleor/discount/utils/checkout.py
@@ -151,7 +151,7 @@ def prepare_checkout_line_discount_objects_for_catalogue_promotions(
             )
             discount_name = get_discount_name(rule, rule_info.promotion)
             translated_name = get_discount_translated_name(rule_info)
-            reason = prepare_promotion_discount_reason(rule)
+            reason = prepare_promotion_discount_reason(rule_info.promotion)
             if not discount_to_update:
                 line_discount_input = {
                     "line": line,

--- a/saleor/discount/utils/checkout.py
+++ b/saleor/discount/utils/checkout.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.db import transaction
@@ -95,9 +95,10 @@ def create_checkout_line_discount_objects_for_catalogue_promotions(
 
 def prepare_checkout_line_discount_objects_for_catalogue_promotions(
     lines_info: list["CheckoutLineInfo"],
-) -> Optional[
+) -> (
     tuple[list[dict], list[CheckoutLineDiscount], list[CheckoutLineDiscount], list[str]]
-]:
+    | None
+):
     line_discounts_to_create_inputs: list[dict] = []
     line_discounts_to_update: list[CheckoutLineDiscount] = []
     line_discounts_to_remove: list[CheckoutLineDiscount] = []

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -379,7 +379,5 @@ def create_order_line_discount_objects_for_catalogue_promotions(
                     for input in line_discounts_to_create_inputs
                 ]
 
-                return OrderLineDiscount.objects.bulk_create(
-                    new_line_discounts, ignore_conflicts=True
-                )
+                return OrderLineDiscount.objects.bulk_create(new_line_discounts)
     return []

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -317,8 +317,6 @@ def create_or_update_line_discount_objects_for_manual_discounts(lines_info):
         OrderLineDiscount.objects.bulk_update(discount_to_update, ["amount_value"])
 
 
-# TODO zedzior sprawdz czy nie trzeba zrobic checka czy juz istnieje catalogowa promka
-# dodaj test na race condition
 def create_order_line_discount_objects_for_catalogue_promotions(
     line: "OrderLine",
     rules_info: Iterable[VariantPromotionRuleInfo],

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -382,5 +382,7 @@ def create_order_line_discount_objects_for_catalogue_promotions(
                     for input in line_discounts_to_create_inputs
                 ]
 
-                return OrderLineDiscount.objects.bulk_create(new_line_discounts)
+                return OrderLineDiscount.objects.bulk_create(
+                    new_line_discounts, ignore_conflicts=True
+                )
     return []

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -114,6 +114,8 @@ def create_order_line_discount_objects(
         list[str],
     ],
 ) -> None | list["EditableOrderLineInfo"]:
+    from ...order.utils import order_qs_select_for_update
+
     if not discount_data or not lines_info:
         return None
 
@@ -130,9 +132,7 @@ def create_order_line_discount_objects(
             # Protect against potential thread race. OrderLine object can have only
             # single catalogue discount applied.
             order_id = lines_info[0].line.order_id
-            _order_lock = list(
-                Order.objects.filter(id=order_id).select_for_update(of=(["self"]))
-            )
+            _order_lock = list(order_qs_select_for_update().filter(id=order_id))
 
             if discount_ids_to_remove := [
                 discount.id for discount in discount_to_remove

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -20,12 +20,12 @@ from ..models import (
 )
 from .manual_discount import apply_discount_to_value
 from .promotion import (
-    _get_discount_reason,
     _get_rule_discount_amount,
     create_discount_objects_for_order_promotions,
     delete_gift_line,
     get_discount_name,
     get_discount_translated_name,
+    prepare_promotion_discount_reason,
 )
 from .shared import update_line_info_cached_discounts
 from .voucher import create_or_update_discount_objects_from_voucher
@@ -114,7 +114,7 @@ def prepare_order_line_discount_objects_for_catalogue_promotions(lines_info):
                 )
                 discount_name = get_discount_name(rule, rule_info.promotion)
                 translated_name = get_discount_translated_name(rule_info)
-                reason = _get_discount_reason(rule)
+                reason = prepare_promotion_discount_reason(rule)
 
                 line_discount_input = {
                     "line": line,

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -98,7 +98,7 @@ def update_order_line_discount_objects_for_catalogue_promotions(
             continue
 
         if discount_to_update and _update_catalogue_promotion_discount_for_order(
-            discount_to_update, line_info.line, updated_fields
+            discount_to_update, line_info, updated_fields
         ):
             line_discounts_to_update.append(discount_to_update)
 
@@ -179,7 +179,7 @@ def create_order_line_discount_objects(
 
 def _update_catalogue_promotion_discount_for_order(
     discount_to_update: "OrderLineDiscount",
-    line: "OrderLine",
+    line_info: "EditableOrderLineInfo",
     updated_fields: list[str],
 ) -> bool:
     """Update catalogue promotion discount amount in case of line quantity update.
@@ -189,6 +189,7 @@ def _update_catalogue_promotion_discount_for_order(
     # TODO zedzior: jesli to tylko w przy quantity to moze lepiej przeniesc do mutacji
     # we can't simply get difference between undiscounted price and base price,
     # because base price can have other line-level discount included, ie. voucher
+    line = line_info.line
     undiscounted_unit_price = line.undiscounted_base_unit_price
     unit_price = apply_discount_to_value(
         discount_to_update.value,

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -339,6 +339,8 @@ def create_or_update_line_discount_objects_for_manual_discounts(lines_info):
         OrderLineDiscount.objects.bulk_update(discount_to_update, ["amount_value"])
 
 
+# TODO zedzior sprawdz czy nie trzeba zrobic checka czy juz istnieje catalogowa promka
+# dodaj test na race condition
 def create_order_line_discount_objects_for_catalogue_promotions(
     line: "OrderLine",
     rules_info: Iterable[VariantPromotionRuleInfo],

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -278,7 +278,7 @@ def create_order_line_discount_objects_for_catalogue_promotions(
         rule_discount_amount = _get_rule_discount_amount(line, rule_info, channel)
         discount_name = get_discount_name(rule, rule_info.promotion)
         translated_name = get_discount_translated_name(rule_info)
-        reason = prepare_promotion_discount_reason(rule)
+        reason = prepare_promotion_discount_reason(rule_info.promotion)
 
         line_discount_input = {
             "line": line,

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -17,6 +17,7 @@ from ...checkout.fetch import CheckoutLineInfo
 from ...checkout.models import Checkout, CheckoutLine
 from ...core.db.connection import allow_writer
 from ...core.exceptions import InsufficientStock
+from ...core.prices import quantize_price
 from ...core.taxes import zero_money
 from ...order.fetch import EditableOrderLineInfo
 from ...order.models import Order
@@ -44,6 +45,7 @@ from ..models import (
     Promotion,
     PromotionRule,
 )
+from .manual_discount import apply_discount_to_value
 from .shared import update_discount
 
 if TYPE_CHECKING:
@@ -205,26 +207,22 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
             line_discounts_to_remove.extend(discounts_to_update)
             continue
 
-        # check if the line price is discounted by catalogue promotion
-        discounted_line = _is_discounted_line_by_catalogue_promotion(
-            line_info.channel_listing
-        )
-
-        # delete all existing discounts if the line is not discounted or it is a gift
-        if not discounted_line or line.is_gift:
+        # delete all existing discounts if the line is a gift
+        if line.is_gift:
             line_discounts_to_remove.extend(discounts_to_update)
             continue
 
-        if line_info.rules_info:
-            rule_info = line_info.rules_info[0]
-            rule = rule_info.rule
-            rule_discount_amount = _get_rule_discount_amount(
-                line, rule_info, line_info.channel
-            )
-            discount_name = get_discount_name(rule, rule_info.promotion)
-            translated_name = get_discount_translated_name(rule_info)
-            reason = _get_discount_reason(rule)
-            if not discount_to_update:
+        if not discount_to_update:
+            if line_info.rules_info:
+                rule_info = line_info.rules_info[0]
+                rule = rule_info.rule
+                rule_discount_amount = _get_rule_discount_amount(
+                    line, rule_info, line_info.channel
+                )
+                discount_name = get_discount_name(rule, rule_info.promotion)
+                translated_name = get_discount_translated_name(rule_info)
+                reason = _get_discount_reason(rule)
+
                 line_discount_input = {
                     "line": line,
                     "type": DiscountType.PROMOTION,
@@ -239,20 +237,12 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
                     "unique_type": DiscountType.PROMOTION,
                 }
                 line_discounts_to_create_inputs.append(line_discount_input)
-            else:
-                # TODO zedzior update amount only (except variant
-                # _update_catalogue_promotion_amount(discount_to_update, line_info.line)
-                _update_promotion_discount(
-                    rule,
-                    rule_info,
-                    rule_discount_amount,
-                    discount_to_update,
-                    updated_fields,
-                )
-                line_discounts_to_update.append(discount_to_update)
+
         else:
-            # Fallback for unlike mismatch between discount_amount and rules_info
-            line_discounts_to_remove.extend(discounts_to_update)
+            if _update_catalogue_promotion_discount(
+                discount_to_update, line_info.line, updated_fields
+            ):
+                line_discounts_to_update.append(discount_to_update)
 
     return (
         line_discounts_to_create_inputs,
@@ -371,6 +361,40 @@ def _update_promotion_discount(
         updated_fields=updated_fields,
         voucher_code=None,
     )
+
+
+def _update_catalogue_promotion_discount(
+    discount_to_update: Union["CheckoutLineDiscount", "OrderLineDiscount"],
+    line: Union["CheckoutLine", "OrderLine"],
+    updated_fields: list[str],
+) -> bool:
+    """Update catalogue promotion discount amount in case of line quantity update.
+
+    Return True if the discount requires update.
+    """
+    # TODO zedzior: jesli to tylko w przy quantity to moze lepiej przeniesc do mutacji
+    # we can't simply get difference between undiscounted price and base price,
+    # because base price can have other line-level disocunt included, ie. voucher
+
+    if isinstance(line, CheckoutLine):
+        undiscounted_unit_price = line.undiscounted_unit_price
+    else:
+        undiscounted_unit_price = line.undiscounted_base_unit_price
+
+    unit_discount = apply_discount_to_value(
+        discount_to_update.value,
+        discount_to_update.value_type,
+        line.currency,
+        undiscounted_unit_price,
+    )
+    discount_amount = quantize_price(unit_discount * line.quantity, line.currency)
+    if discount_amount != discount_to_update.amount:
+        discount_to_update.amount_value = discount_amount.amount
+        if "amount_value" not in updated_fields:
+            updated_fields.append("amount_value")
+        return True
+
+    return False
 
 
 def get_best_rule(

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -3,8 +3,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator
 from decimal import Decimal
 from itertools import chain
-from typing import TYPE_CHECKING, NamedTuple, Union, overload
-from typing import TYPE_CHECKING, Callable, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, NamedTuple, Union
 from uuid import UUID
 
 import graphene

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -60,8 +60,11 @@ CatalogueInfo = defaultdict[str, set[int | str]]
 CATALOGUE_FIELDS = ["categories", "collections", "products", "variants"]
 
 
-def prepare_promotion_discount_reason(promotion: "Promotion", sale_id: str):
-    return f"{'Sale' if promotion.old_sale_id else 'Promotion'}: {sale_id}"
+def prepare_promotion_discount_reason(rule: PromotionRule):
+    promotion = rule.promotion
+    if promotion.old_sale_id:
+        return f"Sale: {graphene.Node.to_global_id('Sale', promotion.old_sale_id)}"
+    return f"Promotion: {graphene.Node.to_global_id('Promotion', promotion.id)}"
 
 
 def get_sale_id(promotion: "Promotion"):
@@ -216,13 +219,6 @@ def get_discount_name(rule: "PromotionRule", promotion: "Promotion"):
     return rule.name or promotion.name
 
 
-def _get_discount_reason(rule: PromotionRule):
-    promotion = rule.promotion
-    if promotion.old_sale_id:
-        return f"Sale: {graphene.Node.to_global_id('Sale', promotion.old_sale_id)}"
-    return f"Promotion: {graphene.Node.to_global_id('Promotion', promotion.id)}"
-
-
 def get_discount_translated_name(rule_info: "VariantPromotionRuleInfo"):
     promotion_translation = rule_info.promotion_translation
     rule_translation = rule_info.rule_translation
@@ -246,9 +242,7 @@ def _update_promotion_discount(
 ):
     discount_name = get_discount_name(rule, rule_info.promotion)
     translated_name = get_discount_translated_name(rule_info)
-    reason = prepare_promotion_discount_reason(
-        rule_info.promotion, get_sale_id(rule_info.promotion)
-    )
+    reason = prepare_promotion_discount_reason(rule_info.rule)
     # gift rule has empty reward_value_type
     value_type = rule.reward_value_type or RewardValueType.FIXED
     # gift rule has empty reward_value
@@ -761,7 +755,7 @@ def create_discount_objects_for_order_promotions(
         "currency": currency,
         "name": get_discount_name(best_rule, promotion),
         "translated_name": get_discount_translated_name(rule_info),
-        "reason": prepare_promotion_discount_reason(promotion, get_sale_id(promotion)),
+        "reason": prepare_promotion_discount_reason(rule_info.rule),
     }
     if gift_listing:
         _handle_gift_reward(
@@ -798,7 +792,7 @@ def _handle_order_promotion(
 
     if not created:
         fields_to_update: list[str] = []
-        _update_catalogue_promotion_discount(
+        _update_promotion_discount(
             discount_object_defaults["promotion_rule"],
             rule_info,
             discount_amount,
@@ -842,7 +836,7 @@ def _handle_gift_reward(
         if line_discount.line_id != line.id:
             line_discount.line = line
             fields_to_update.append("line_id")
-        _update_catalogue_promotion_discount(
+        _update_promotion_discount(
             discount_object_defaults["promotion_rule"],
             rule_info,
             discount_object_defaults["amount_value"],

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable, Iterator
 from decimal import Decimal
 from itertools import chain
 from typing import TYPE_CHECKING, NamedTuple, Union, overload
+from typing import TYPE_CHECKING, Callable, NamedTuple, Optional, Union
 from uuid import UUID
 
 import graphene
@@ -49,6 +50,7 @@ from .manual_discount import apply_discount_to_value
 from .shared import update_discount
 
 if TYPE_CHECKING:
+    from ...checkout.fetch import CheckoutLineInfo
     from ...order.fetch import EditableOrderLineInfo
     from ...order.models import OrderLine
     from ...product.managers import ProductVariantQueryset
@@ -154,102 +156,6 @@ def get_product_discount_on_promotion(
     if channel.id in rule_info.channel_ids:
         return rule_info.rule.id, rule_info.rule.get_discount(channel.currency_code)
     raise NotApplicable("Promotion rule not applicable for this product")
-
-
-@overload
-def prepare_line_discount_objects_for_catalogue_promotions(
-    lines_info: list["CheckoutLineInfo"],
-) -> tuple[
-    list[dict], list["CheckoutLineDiscount"], list["CheckoutLineDiscount"], list[str]
-]: ...
-
-
-@overload
-def prepare_line_discount_objects_for_catalogue_promotions(
-    lines_info: list["EditableOrderLineInfo"],
-) -> tuple[
-    list[dict], list["OrderLineDiscount"], list["OrderLineDiscount"], list[str]
-]: ...
-
-
-def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
-    line_discounts_to_create_inputs: list[dict] = []
-    line_discounts_to_update: list[CheckoutLineDiscount | OrderLineDiscount] = []
-    line_discounts_to_remove: list[CheckoutLineDiscount | OrderLineDiscount] = []
-    updated_fields: list[str] = []
-
-    if not lines_info:
-        return None
-
-    for line_info in lines_info:
-        line = line_info.line
-
-        # if channel_listing is not present, we can't close the checkout. User needs to
-        # remove the line for the checkout first. Until that moment, we return the same
-        # price as we did when listing was present - including line discount.
-        if isinstance(line_info, CheckoutLineInfo) and not line_info.channel_listing:
-            continue
-
-        # get the existing catalogue discount for the line
-        discount_to_update = None
-        if discounts_to_update := line_info.get_catalogue_discounts():
-            discount_to_update = discounts_to_update[0]
-            # Line should never have multiple catalogue discounts associated. Before
-            # introducing unique_type on discount models, there was such a possibility.
-            line_discounts_to_remove.extend(discounts_to_update[1:])
-
-        # manual line discount do not stack with other line discounts
-        if [
-            discount
-            for discount in line_info.discounts
-            if discount.type == DiscountType.MANUAL
-        ]:
-            line_discounts_to_remove.extend(discounts_to_update)
-            continue
-
-        # delete all existing discounts if the line is a gift
-        if line.is_gift:
-            line_discounts_to_remove.extend(discounts_to_update)
-            continue
-
-        if not discount_to_update:
-            if line_info.rules_info:
-                rule_info = line_info.rules_info[0]
-                rule = rule_info.rule
-                rule_discount_amount = _get_rule_discount_amount(
-                    line, rule_info, line_info.channel
-                )
-                discount_name = get_discount_name(rule, rule_info.promotion)
-                translated_name = get_discount_translated_name(rule_info)
-                reason = _get_discount_reason(rule)
-
-                line_discount_input = {
-                    "line": line,
-                    "type": DiscountType.PROMOTION,
-                    "value_type": rule.reward_value_type,
-                    "value": rule.reward_value,
-                    "amount_value": rule_discount_amount,
-                    "currency": line.currency,
-                    "name": discount_name,
-                    "translated_name": translated_name,
-                    "reason": reason,
-                    "promotion_rule": rule,
-                    "unique_type": DiscountType.PROMOTION,
-                }
-                line_discounts_to_create_inputs.append(line_discount_input)
-
-        else:
-            if _update_catalogue_promotion_discount(
-                discount_to_update, line_info.line, updated_fields
-            ):
-                line_discounts_to_update.append(discount_to_update)
-
-    return (
-        line_discounts_to_create_inputs,
-        line_discounts_to_update,
-        line_discounts_to_remove,
-        updated_fields,
-    )
 
 
 def _is_discounted_line_by_catalogue_promotion(
@@ -892,7 +798,7 @@ def _handle_order_promotion(
 
     if not created:
         fields_to_update: list[str] = []
-        _update_promotion_discount(
+        _update_catalogue_promotion_discount(
             discount_object_defaults["promotion_rule"],
             rule_info,
             discount_amount,
@@ -936,7 +842,7 @@ def _handle_gift_reward(
         if line_discount.line_id != line.id:
             line_discount.line = line
             fields_to_update.append("line_id")
-        _update_promotion_discount(
+        _update_catalogue_promotion_discount(
             discount_object_defaults["promotion_rule"],
             rule_info,
             discount_object_defaults["amount_value"],

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -240,6 +240,8 @@ def prepare_line_discount_objects_for_catalogue_promotions(lines_info):
                 }
                 line_discounts_to_create_inputs.append(line_discount_input)
             else:
+                # TODO zedzior update amount only (except variant
+                # _update_catalogue_promotion_amount(discount_to_update, line_info.line)
                 _update_promotion_discount(
                     rule,
                     rule_info,

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -231,7 +231,7 @@ def get_discount_translated_name(rule_info: "VariantPromotionRuleInfo"):
     return None
 
 
-def _update_promotion_discount(
+def update_promotion_discount(
     rule: PromotionRule,
     rule_info: VariantPromotionRuleInfo,
     rule_discount_amount: Decimal,
@@ -792,7 +792,7 @@ def _handle_order_promotion(
 
     if not created:
         fields_to_update: list[str] = []
-        _update_promotion_discount(
+        update_promotion_discount(
             discount_object_defaults["promotion_rule"],
             rule_info,
             discount_amount,
@@ -836,7 +836,7 @@ def _handle_gift_reward(
         if line_discount.line_id != line.id:
             line_discount.line = line
             fields_to_update.append("line_id")
-        _update_promotion_discount(
+        update_promotion_discount(
             discount_object_defaults["promotion_rule"],
             rule_info,
             discount_object_defaults["amount_value"],

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -854,15 +854,15 @@ def _handle_gift_reward(
             "product": variant.product,
             "product_type": variant.product.product_type,
             "collections": [],
-            "channel_listing": gift_listing,
             "discounts": [line_discount],
-            "rules_info": [rule_info],
             "channel": channel,
             "voucher": None,
             "voucher_code": None,
         }
         gift_line_info: CheckoutLineInfo | EditableOrderLineInfo
         if isinstance(order_or_checkout, Checkout):
+            init_values["channel_listing"] = gift_listing
+            init_values["rules_info"] = [rule_info]
             gift_line_info = CheckoutLineInfo(**init_values)
         else:
             gift_line_info = EditableOrderLineInfo(**init_values)

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -304,15 +304,6 @@ def get_products_voucher_discount(
     return total_amount
 
 
-def create_or_update_discount_objects_from_voucher(
-    order, lines_info, database_connection_name
-):
-    create_or_update_discount_object_from_order_level_voucher(
-        order, database_connection_name
-    )
-    create_or_update_line_discount_objects_from_voucher(lines_info)
-
-
 def create_or_update_discount_object_from_order_level_voucher(
     order, database_connection_name
 ):

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -227,7 +227,6 @@ def _get_the_cheapest_line(
 ) -> Optional["LineInfo"]:
     if not lines_info:
         return None
-
     return min(lines_info, key=lambda line_info: line_info.variant_discounted_price)
 
 

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -227,6 +227,7 @@ def _get_the_cheapest_line(
 ) -> Optional["LineInfo"]:
     if not lines_info:
         return None
+
     return min(lines_info, key=lambda line_info: line_info.variant_discounted_price)
 
 

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -1147,7 +1147,7 @@ def test_add_checkout_lines_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(94):
+    with django_assert_num_queries(93):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1233,7 +1233,7 @@ def test_add_checkout_lines_multiple_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(94):
+    with django_assert_num_queries(93):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -99,6 +99,7 @@ class DraftOrderInput(BaseInputObjectType):
         description="Customer associated with the draft order.", name="user"
     )
     user_email = graphene.String(description="Email address of the customer.")
+    # TODO zedzior: what is this field for?
     discount = PositiveDecimal(description="Discount amount for the order.")
     shipping_address = AddressInput(description="Shipping address of the customer.")
     shipping_method = graphene.ID(

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Optional
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -148,8 +147,8 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
     def add_lines_to_order(
         order: order_models.Order,
         lines_data: list[OrderLineData],
-        user: Optional[User],
-        app: Optional[App],
+        user: User | None,
+        app: App | None,
         manager: PluginsManager,
     ):
         added_lines: list[order_models.OrderLine] = []

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -201,7 +201,6 @@ def get_variant_rule_info_map(
     variants = product_models.ProductVariant.objects.filter(
         pk__in=variant_ids
     ).prefetch_related(
-        "channel_listings__variantlistingpromotionrule__promotion_rule__promotion",
         "channel_listings__variantlistingpromotionrule__promotion_rule__promotion__translations",
         "channel_listings__variantlistingpromotionrule__promotion_rule__translations",
     )

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -2863,6 +2863,9 @@ def test_draft_order_create_product_catalogue_promotion(
 
     reward_value = Decimal("1.0")
     rule = promotion.rules.first()
+    rule.reward_value = reward_value
+    rule.save(update_fields=["reward_value"])
+
     variant_channel_listing = variant.channel_listings.get(channel=channel_USD)
 
     variant_channel_listing.discounted_price_amount = (
@@ -2994,6 +2997,8 @@ def test_draft_order_create_product_catalogue_promotion_flat_taxes(
 
     reward_value = Decimal("1.0")
     rule = promotion.rules.first()
+    rule.reward_value = reward_value
+    rule.save(update_fields=["reward_value"])
     variant_channel_listing = variant.channel_listings.get(channel=channel_USD)
 
     variant_channel_listing.discounted_price_amount = (

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -14,7 +14,8 @@ from .....order import events as order_events
 from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent, OrderLine
-from .....product.models import ProductVariant
+from .....product.models import Product, ProductVariant
+from .....product.utils.variant_prices import update_discounted_prices_for_promotion
 from .....warehouse.models import Allocation, Stock
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -1173,6 +1174,8 @@ def test_order_lines_create_with_custom_price_force_new_line_and_catalogue_disco
     promotion_rule.reward_value = reward_value
     promotion_rule.reward_value_type = RewardValueType.FIXED
     promotion_rule.save(update_fields=["reward_value", "reward_value_type"])
+
+    update_discounted_prices_for_promotion(Product.objects.all())
 
     quantity = 1
     order_id = graphene.Node.to_global_id("Order", order.id)

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -1120,7 +1120,6 @@ def test_order_lines_create_with_custom_price_and_catalogue_discount(
     order.status = OrderStatus.DRAFT
     order.save(update_fields=["status"])
 
-    order_line = order.lines.first()
     old_qty = order_line.quantity
 
     lines_count = len(order.lines.all())

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -5,23 +5,20 @@ from typing import Optional
 from uuid import UUID
 
 from django.db.models import prefetch_related_objects
+from prices import Money
 
 from ..channel.models import Channel
 from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
 from ..core.pricing.interface import LineInfo
-from ..core.taxes import zero_money
 from ..discount import DiscountType, VoucherType
-from ..discount.interface import fetch_variant_rules_info, fetch_voucher_info
+from ..discount.interface import fetch_voucher_info
 from ..discount.models import OrderLineDiscount
+from ..discount.utils.manual_discount import apply_discount_to_value
 from ..discount.utils.voucher import apply_voucher_to_line
 from ..graphql.core.types import Money
 from ..payment.models import Payment
-from ..product.models import (
-    DigitalContent,
-    ProductVariant,
-    ProductVariantChannelListing,
-)
+from ..product.models import DigitalContent, ProductVariant
 from .models import Order, OrderLine
 
 
@@ -86,23 +83,17 @@ class EditableOrderLineInfo(LineInfo):
 
     @cached_property
     def variant_discounted_price(self) -> Money:
-        """Return the discounted variant price.
-
-        If listing is present return the discounted price from the listing.
-        if listing is not present, calculate current unit price based on the details
-        assigned to the line. We want to show the same prices as they were
-        before removing listing.
-        """
-        if self.channel_listing and self.channel_listing.discounted_price is not None:
-            return self.channel_listing.discounted_price
-
-        catalogue_discounts = self.get_catalogue_discounts()
-        total_price = self.line.undiscounted_base_unit_price * self.line.quantity
-        for discount in catalogue_discounts:
-            total_price -= discount.amount
-        unit_price = max(
-            total_price / self.line.quantity, zero_money(self.line.currency)
-        )
+        """Return the variant price discounted by catalogue promotion."""
+        undiscounted_unit_price = self.line.undiscounted_base_unit_price
+        if catalogue_discounts := self.get_catalogue_discounts():
+            unit_price = apply_discount_to_value(
+                catalogue_discounts[0].value,
+                catalogue_discounts[0].value_type,
+                self.line.currency,
+                undiscounted_unit_price,
+            )
+        else:
+            unit_price = undiscounted_unit_price
         return quantize_price(unit_price, self.line.currency)
 
     def get_manual_line_discount(
@@ -119,8 +110,6 @@ def fetch_draft_order_lines_info(
 ) -> list[EditableOrderLineInfo]:
     prefetch_related_fields = [
         "discounts__promotion_rule__promotion",
-        "variant__channel_listings__variantlistingpromotionrule__promotion_rule__promotion__translations",
-        "variant__channel_listings__variantlistingpromotionrule__promotion_rule__translations",
         "variant__product__collections",
         "variant__product__product_type",
     ]
@@ -142,15 +131,7 @@ def fetch_draft_order_lines_info(
         if not variant:
             continue
         product = variant.product
-        variant_channel_listing = get_prefetched_variant_listing(variant, channel.id)
-        if not variant_channel_listing:
-            continue
 
-        rules_info = (
-            fetch_variant_rules_info(variant_channel_listing, order.language_code)
-            if not line.is_gift
-            else []
-        )
         lines_info.append(
             EditableOrderLineInfo(
                 line=line,
@@ -158,9 +139,7 @@ def fetch_draft_order_lines_info(
                 product=product,
                 product_type=product.product_type,
                 collections=list(product.collections.all()) if product else [],
-                channel_listing=variant_channel_listing,
                 discounts=list(line.discounts.all()),
-                rules_info=rules_info,
                 channel=channel,
                 voucher=None,
                 voucher_code=None,
@@ -173,14 +152,3 @@ def fetch_draft_order_lines_info(
         voucher_info = fetch_voucher_info(voucher, order.voucher_code)
         apply_voucher_to_line(voucher_info, lines_info)
     return lines_info
-
-
-def get_prefetched_variant_listing(
-    variant: ProductVariant | None, channel_id: int
-) -> ProductVariantChannelListing | None:
-    if not variant:
-        return None
-    for channel_listing in variant.channel_listings.all():
-        if channel_listing.channel_id == channel_id:
-            return channel_listing
-    return None

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -5,7 +5,6 @@ from typing import Optional
 from uuid import UUID
 
 from django.db.models import prefetch_related_objects
-from prices import Money
 
 from ..channel.models import Channel
 from ..core.db.connection import allow_writer

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -11,10 +11,10 @@ from ..channel.models import Channel
 from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
 from ..core.pricing.interface import LineInfo
+from ..core.taxes import zero_money
 from ..discount import DiscountType, VoucherType
 from ..discount.interface import fetch_voucher_info
 from ..discount.models import OrderLineDiscount
-from ..discount.utils.manual_discount import apply_discount_to_value
 from ..discount.utils.voucher import apply_voucher_to_line
 from ..graphql.core.types import Money
 from ..payment.models import Payment
@@ -84,16 +84,13 @@ class EditableOrderLineInfo(LineInfo):
     @cached_property
     def variant_discounted_price(self) -> Money:
         """Return the variant price discounted by catalogue promotion."""
-        undiscounted_unit_price = self.line.undiscounted_base_unit_price
-        if catalogue_discounts := self.get_catalogue_discounts():
-            unit_price = apply_discount_to_value(
-                catalogue_discounts[0].value,
-                catalogue_discounts[0].value_type,
-                self.line.currency,
-                undiscounted_unit_price,
-            )
-        else:
-            unit_price = undiscounted_unit_price
+        catalogue_discounts = self.get_catalogue_discounts()
+        total_price = self.line.undiscounted_base_unit_price * self.line.quantity
+        for discount in catalogue_discounts:
+            total_price -= discount.amount
+        unit_price = max(
+            total_price / self.line.quantity, zero_money(self.line.currency)
+        )
         return quantize_price(unit_price, self.line.currency)
 
     def get_manual_line_discount(

--- a/saleor/order/tests/benchmark/test_fetch_order_prices.py
+++ b/saleor/order/tests/benchmark/test_fetch_order_prices.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ....discount.models import OrderLineDiscount
 from ... import OrderStatus
 from ...calculations import fetch_order_prices_if_expired
 
@@ -15,10 +14,9 @@ def test_fetch_order_prices(
     count_queries,
 ):
     # given
-    OrderLineDiscount.objects.all().delete()
     order = order_with_lines
     order.status = OrderStatus.UNCONFIRMED
 
     # when & then
-    with django_assert_num_queries(39):
+    with django_assert_num_queries(36):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)

--- a/saleor/order/tests/benchmark/test_fetch_order_prices.py
+++ b/saleor/order/tests/benchmark/test_fetch_order_prices.py
@@ -1,144 +1,24 @@
-from decimal import Decimal
-
 import pytest
-from prices import Money, TaxedMoney
 
-from ....discount import RewardValueType
-from ....discount.models import OrderDiscount, OrderLineDiscount, PromotionRule
-from ....product.models import Product
-from ....product.utils.variant_prices import update_discounted_prices_for_promotion
-from ....product.utils.variants import fetch_variants_for_promotion_rules
-from ....tax import TaxCalculationStrategy
-from ....warehouse.models import Stock
+from ....discount.models import OrderLineDiscount
 from ... import OrderStatus
 from ...calculations import fetch_order_prices_if_expired
-from ...models import OrderLine
-
-
-@pytest.fixture
-def order_with_lines(order_with_lines):
-    order_with_lines.status = OrderStatus.UNCONFIRMED
-    return order_with_lines
 
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_fetch_order_prices_catalogue_discount(
-    order_with_lines_and_catalogue_promotion,
+def test_fetch_order_prices(
+    order_with_lines,
     plugins_manager,
     django_assert_num_queries,
+    tax_configuration_flat_rates,
     count_queries,
 ):
     # given
     OrderLineDiscount.objects.all().delete()
-    order = order_with_lines_and_catalogue_promotion
-    channel = order.channel
-
-    tc = channel.tax_configuration
-    tc.country_exceptions.all().delete()
-    tc.prices_entered_with_tax = False
-    tc.tax_calculation_strategy = TaxCalculationStrategy.FLAT_RATES
-    tc.save()
-
-    # when
-    with django_assert_num_queries(44):
-        fetch_order_prices_if_expired(order, plugins_manager, None, True)
-
-    # then
-    assert OrderLineDiscount.objects.count() == 1
-    assert not OrderDiscount.objects.exists()
-
-
-@pytest.mark.django_db
-@pytest.mark.count_queries(autouse=False)
-def test_fetch_order_prices_multiple_catalogue_discounts(
-    order_with_lines,
-    catalogue_promotion_without_rules,
-    plugins_manager,
-    product_variant_list,
-    django_assert_num_queries,
-    count_queries,
-):
-    # given
-    Stock.objects.update(quantity=100)
     order = order_with_lines
-    channel = order.channel
+    order.status = OrderStatus.UNCONFIRMED
 
-    variants = product_variant_list
-    variants.extend(line.variant for line in order.lines.all())
-    variant_global_ids = [variant.get_global_id() for variant in variants]
-
-    # create many rules
-    promotion = catalogue_promotion_without_rules
-    rules = []
-    catalogue_predicate = {"variantPredicate": {"ids": variant_global_ids}}
-    for idx in range(5):
-        reward_value = 2 + idx
-        rules.append(
-            PromotionRule(
-                name=f"Catalogue rule fixed {reward_value}",
-                promotion=promotion,
-                catalogue_predicate=catalogue_predicate,
-                reward_value_type=RewardValueType.FIXED,
-                reward_value=Decimal(reward_value),
-            )
-        )
-    for idx in range(5):
-        reward_value = idx * 10 + 25
-        rules.append(
-            PromotionRule(
-                name=f"Catalogue rule percentage {reward_value}",
-                promotion=promotion,
-                catalogue_predicate=catalogue_predicate,
-                reward_value_type=RewardValueType.PERCENTAGE,
-                reward_value=Decimal(reward_value),
-            )
-        )
-    rules = PromotionRule.objects.bulk_create(rules)
-    for rule in rules:
-        rule.channels.add(channel)
-
-    fetch_variants_for_promotion_rules(PromotionRule.objects.all())
-
-    # update prices
-    update_discounted_prices_for_promotion(Product.objects.all())
-
-    # create lines
-    new_order_lines = []
-    for idx, variant in enumerate(product_variant_list):
-        base_price = variant.channel_listings.first().discounted_price
-        currency = base_price.currency
-        gross = Money(amount=base_price.amount * Decimal(1.23), currency=currency)
-        quantity = 4 + idx
-        unit_price = TaxedMoney(net=base_price, gross=gross)
-        new_order_lines.append(
-            OrderLine(
-                order=order,
-                product_name=str(variant.product),
-                variant_name=str(variant),
-                product_sku=variant.sku,
-                product_variant_id=variant.get_global_id(),
-                is_shipping_required=variant.is_shipping_required(),
-                is_gift_card=variant.is_gift_card(),
-                quantity=quantity,
-                variant=variant,
-                unit_price=unit_price,
-                total_price=unit_price * quantity,
-                tax_rate=Decimal("0.23"),
-            )
-        )
-    OrderLine.objects.bulk_create(new_order_lines)
-
-    tc = channel.tax_configuration
-    tc.country_exceptions.all().delete()
-    tc.prices_entered_with_tax = False
-    tc.tax_calculation_strategy = TaxCalculationStrategy.FLAT_RATES
-    tc.save()
-
-    # when
-    with django_assert_num_queries(44):
+    # when & then
+    with django_assert_num_queries(39):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)
-
-    # then
-    assert OrderLineDiscount.objects.count() == 7
-    assert not OrderDiscount.objects.exists()

--- a/saleor/order/tests/fixtures/draft_order.py
+++ b/saleor/order/tests/fixtures/draft_order.py
@@ -6,6 +6,7 @@ import pytest
 from django.conf import settings
 from prices import Money, TaxedMoney, fixed_discount
 
+from ....core.prices import quantize_price
 from ....core.taxes import zero_money
 from ....discount import DiscountType, DiscountValueType, RewardType, RewardValueType
 from ....discount.interface import fetch_variant_rules_info
@@ -183,6 +184,7 @@ def draft_order_and_promotions(
     catalogue_promotion = catalogue_promotion_without_rules
     variant_1 = line_1.variant
     variant_2 = line_2.variant
+    catalogue_reward = Decimal(3)
     rule_catalogue = catalogue_promotion.rules.create(
         name="Catalogue rule fixed",
         catalogue_predicate={
@@ -191,7 +193,7 @@ def draft_order_and_promotions(
             }
         },
         reward_value_type=RewardValueType.FIXED,
-        reward_value=Decimal(3),
+        reward_value=catalogue_reward,
     )
     rule_catalogue.channels.add(channel_USD)
 
@@ -203,7 +205,7 @@ def draft_order_and_promotions(
     VariantChannelListingPromotionRule.objects.create(
         variant_channel_listing=listing,
         promotion_rule=rule_catalogue,
-        discount_amount=Decimal(3),
+        discount_amount=catalogue_reward,
         currency=currency,
     )
 
@@ -211,6 +213,21 @@ def draft_order_and_promotions(
     rules_info = fetch_variant_rules_info(listing, "en")
     create_order_line_discount_objects_for_catalogue_promotions(
         line_2, rules_info, channel_USD
+    )
+
+    # update base price with catalogue promotion
+    line_2.base_unit_price_amount = (
+        line_2.undiscounted_base_unit_price_amount - catalogue_reward
+    )
+    total = quantize_price(line_2.base_unit_price_amount * line_2.quantity, currency)
+    line_2.total_price_net_amount = total
+    line_2.total_price_gross_amount = quantize_price(total * Decimal("1.23"), currency)
+    line_2.save(
+        update_fields=[
+            "base_unit_price_amount",
+            "total_price_net_amount",
+            "total_price_gross_amount",
+        ]
     )
 
     # prepare order promotion - subtotal

--- a/saleor/order/tests/fixtures/draft_order.py
+++ b/saleor/order/tests/fixtures/draft_order.py
@@ -8,7 +8,11 @@ from prices import Money, TaxedMoney, fixed_discount
 
 from ....core.taxes import zero_money
 from ....discount import DiscountType, DiscountValueType, RewardType, RewardValueType
+from ....discount.interface import fetch_variant_rules_info
 from ....discount.models import VoucherCode
+from ....discount.utils.order import (
+    create_order_line_discount_objects_for_catalogue_promotions,
+)
 from ....discount.utils.voucher import (
     create_or_update_discount_object_from_order_level_voucher,
 )
@@ -201,6 +205,12 @@ def draft_order_and_promotions(
         promotion_rule=rule_catalogue,
         discount_amount=Decimal(3),
         currency=currency,
+    )
+
+    # create catalogue discount
+    rules_info = fetch_variant_rules_info(listing, "en")
+    create_order_line_discount_objects_for_catalogue_promotions(
+        line_2, rules_info, channel_USD
     )
 
     # prepare order promotion - subtotal

--- a/saleor/order/tests/fixtures/order.py
+++ b/saleor/order/tests/fixtures/order.py
@@ -10,6 +10,7 @@ from prices import Money, TaxedMoney
 
 from ....checkout.utils import get_prices_of_discounted_specific_product
 from ....core import JobStatus
+from ....core.prices import quantize_price
 from ....core.taxes import zero_money
 from ....discount import DiscountType, RewardType, RewardValueType, VoucherType
 from ....discount.models import NotApplicable, Voucher
@@ -517,6 +518,7 @@ def order_with_lines_and_catalogue_promotion(
     order_with_lines, channel_USD, catalogue_promotion_without_rules
 ):
     order = order_with_lines
+    currency = order.currency
     promotion = catalogue_promotion_without_rules
     line = order.lines.get(quantity=3)
     variant = line.variant
@@ -539,7 +541,7 @@ def order_with_lines_and_catalogue_promotion(
     listing.variantlistingpromotionrule.create(
         promotion_rule=rule,
         discount_amount=reward_value,
-        currency=order.currency,
+        currency=currency,
     )
 
     line.discounts.create(
@@ -547,9 +549,23 @@ def order_with_lines_and_catalogue_promotion(
         value_type=RewardValueType.FIXED,
         value=reward_value,
         amount_value=reward_value * line.quantity,
-        currency=order.currency,
+        currency=currency,
         promotion_rule=rule,
         reason=f"Promotion: {graphene.Node.to_global_id("Promotion", promotion.id)}",
+    )
+
+    line.base_unit_price_amount = (
+        line.undiscounted_base_unit_price_amount - reward_value
+    )
+    total = quantize_price(line.base_unit_price_amount * line.quantity, currency)
+    line.total_price_net_amount = total
+    line.total_price_gross_amount = quantize_price(total * Decimal("1.23"), currency)
+    line.save(
+        update_fields=[
+            "base_unit_price_amount",
+            "total_price_net_amount",
+            "total_price_gross_amount",
+        ]
     )
     return order
 

--- a/saleor/order/tests/fixtures/order.py
+++ b/saleor/order/tests/fixtures/order.py
@@ -551,7 +551,7 @@ def order_with_lines_and_catalogue_promotion(
         amount_value=reward_value * line.quantity,
         currency=currency,
         promotion_rule=rule,
-        reason=f"Promotion: {graphene.Node.to_global_id("Promotion", promotion.id)}",
+        reason=f"Promotion: {graphene.Node.to_global_id('Promotion', promotion.id)}",
     )
 
     line.base_unit_price_amount = (

--- a/saleor/order/tests/fixtures/order.py
+++ b/saleor/order/tests/fixtures/order.py
@@ -549,6 +549,7 @@ def order_with_lines_and_catalogue_promotion(
         amount_value=reward_value * line.quantity,
         currency=order.currency,
         promotion_rule=rule,
+        reason=f"Promotion: {graphene.Node.to_global_id("Promotion", promotion.id)}",
     )
     return order
 

--- a/saleor/order/tests/test_fetch.py
+++ b/saleor/order/tests/test_fetch.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 
 import pytest
 
-from ...product.models import ProductVariantChannelListing
 from ..fetch import EditableOrderLineInfo, fetch_draft_order_lines_info
 
 
@@ -17,6 +16,7 @@ def test_fetch_draft_order_lines_info(
     lines = order.lines.all()
     line_1 = [line for line in lines if line.quantity == 3][0]
     line_2 = [line for line in lines if line.quantity == 2][0]
+    catalogue_discount = line_2.discounts.get()
 
     manual_discount = line_1.discounts.create(
         value=Decimal(1),
@@ -34,7 +34,7 @@ def test_fetch_draft_order_lines_info(
     )
 
     # when
-    with django_assert_num_queries(12):
+    with django_assert_num_queries(8):
         lines_info = fetch_draft_order_lines_info(order)
 
     # then
@@ -43,34 +43,15 @@ def test_fetch_draft_order_lines_info(
 
     variant_1 = line_1.variant
     assert line_info_1.variant == variant_1
-    assert (
-        line_info_1.channel_listing
-        == ProductVariantChannelListing.objects.filter(
-            channel=channel, variant=variant_1
-        ).first()
-    )
     assert line_info_1.discounts == [manual_discount]
     assert line_info_1.channel == channel
     assert line_info_1.voucher is None
-    assert line_info_1.rules_info == []
 
     variant_2 = line_2.variant
     assert line_info_2.variant == variant_2
-    assert (
-        line_info_2.channel_listing
-        == ProductVariantChannelListing.objects.filter(
-            channel=channel, variant=variant_2
-        ).first()
-    )
-    assert line_info_2.discounts == []
+    assert line_info_2.discounts == [catalogue_discount]
     assert line_info_2.channel == channel
     assert line_info_2.voucher is None
-    rule_info_2 = line_info_2.rules_info[0]
-    assert rule_info_2.rule == rule_catalogue
-    assert rule_info_2.variant_listing_promotion_rule
-    assert rule_info_2.promotion == rule_catalogue.promotion
-    assert rule_info_2.promotion_translation.name == promotion_translation
-    assert rule_info_2.rule_translation.name == rule_translation
 
 
 def test_editable_order_line_info_variant_discounted_price(
@@ -93,85 +74,10 @@ def test_editable_order_line_info_variant_discounted_price(
     order_line_info = EditableOrderLineInfo(
         line=order_line,
         variant=variant,
-        channel_listing=variant_channel_listing,
         product=product,
         product_type=product_type,
         collections=[],
         discounts=discounts,
-        rules_info=[],
-        channel=channel,
-        voucher=None,
-        voucher_code=None,
-    )
-    # then
-    assert order_line_info.variant_discounted_price == expected_discounted_variant_price
-
-
-def test_editable_order_line_info_variant_discounted_price_without_listing(
-    order_with_lines_and_catalogue_promotion,
-):
-    # given
-    order_line = order_with_lines_and_catalogue_promotion.lines.get(quantity=3)
-    order = order_with_lines_and_catalogue_promotion
-    channel = order.channel
-    variant = order_line.variant
-    variant_channel_listing = variant.channel_listings.get(channel_id=channel.id)
-    product = variant.product
-    product_type = product.product_type
-    discounts = order_line.discounts.all()
-
-    expected_discounted_variant_price = variant_channel_listing.discounted_price
-    assert variant_channel_listing.discounted_price != variant_channel_listing.price
-
-    variant.channel_listings.all().delete()
-
-    # when
-    order_line_info = EditableOrderLineInfo(
-        line=order_line,
-        variant=variant,
-        channel_listing=None,
-        product=product,
-        product_type=product_type,
-        collections=[],
-        discounts=discounts,
-        rules_info=[],
-        channel=channel,
-        voucher=None,
-        voucher_code=None,
-    )
-    # then
-    assert order_line_info.variant_discounted_price == expected_discounted_variant_price
-
-
-def test_editable_order_line_info_variant_discounted_price_when_listing_without_price(
-    order_with_lines_and_catalogue_promotion,
-):
-    # given
-    order_line = order_with_lines_and_catalogue_promotion.lines.get(quantity=3)
-    order = order_with_lines_and_catalogue_promotion
-    channel = order.channel
-    variant = order_line.variant
-    variant_channel_listing = variant.channel_listings.get(channel_id=channel.id)
-    product = variant.product
-    product_type = product.product_type
-    discounts = order_line.discounts.all()
-
-    expected_discounted_variant_price = variant_channel_listing.discounted_price
-    assert variant_channel_listing.discounted_price != variant_channel_listing.price
-
-    variant_channel_listing.discounted_price_amount = None
-    variant_channel_listing.save(update_fields=["discounted_price_amount"])
-
-    # when
-    order_line_info = EditableOrderLineInfo(
-        line=order_line,
-        variant=variant,
-        channel_listing=variant_channel_listing,
-        product=product,
-        product_type=product_type,
-        collections=[],
-        discounts=discounts,
-        rules_info=[],
         channel=channel,
         voucher=None,
         voucher_code=None,

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -11,10 +11,10 @@ from ...discount.models import (
     OrderLineDiscount,
     PromotionRule,
 )
-from ...tests import race_condition
 from ...product.models import Product
 from ...product.utils.variant_prices import update_discounted_prices_for_promotion
 from ...product.utils.variants import fetch_variants_for_promotion_rules
+from ...tests import race_condition
 from ...tests.utils import round_down, round_up
 from .. import OrderStatus, calculations
 

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -3097,6 +3097,7 @@ def test_fetch_order_prices_voucher_shipping_and_manual_discount_fixed_exceed_to
     #     (undiscounted_subtotal + undiscounted_shipping_price) * tax_rate, 2
     # )
 
+
 def test_fetch_order_prices_catalogue_discount_prices_entered_with_tax_tax_exemption(
     order_with_lines_and_catalogue_promotion,
     plugins_manager,

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -22,7 +22,7 @@ from ..utils import (
     add_variant_to_order,
     calculate_order_granted_refund_status,
     change_order_line_quantity,
-    create_order_line_discounts,
+    create_order_line_catalogue_discounts,
     get_order_country,
     get_total_order_discount_excluding_shipping,
     get_valid_shipping_methods_for_order,
@@ -638,7 +638,7 @@ def test_create_order_line_discounts(
     ]
 
     # when
-    line_discounts = create_order_line_discounts(order_line, rules_info)
+    line_discounts = create_order_line_catalogue_discounts(order_line, rules_info)
 
     # then
     assert len(line_discounts) == 2

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -277,7 +277,7 @@ def create_order_line(
             promotion = rules_info[0].promotion
             line.sale_id = get_sale_id(promotion)
             line.unit_discount_reason = (
-                prepare_promotion_discount_reason(promotion, line.sale_id)
+                prepare_promotion_discount_reason(rules_info[0].rule)
                 if line_discounts
                 else None
             )

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -339,11 +339,13 @@ def add_variant_to_order(
     channel = order.channel
 
     if line_data.line_id:
+        # TODO zedzior: obczaj co tu sie odpierdala
         line = order.lines.get(pk=line_data.line_id)
         old_quantity = line.quantity
         new_quantity = old_quantity + line_data.quantity
         line_info = OrderLineInfo(line=line, quantity=old_quantity)
         update_fields: list[str] = []
+        # TODO zedzior: a jak nie ma nowego quantity to juz nie musimy updatowac cen?
         if new_quantity and line_data.price_override is not None:
             update_line_base_unit_prices_with_custom_price(
                 order, line_data, line, update_fields
@@ -369,6 +371,7 @@ def add_variant_to_order(
                 [
                     OrderLineInfo(
                         line=line,
+                        # TODO zedzior: czy to nie powinna byc roznica miedzy quantity?
                         quantity=line_data.quantity,
                         variant=line_data.variant,
                         warehouse_pk=None,

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -341,13 +341,11 @@ def add_variant_to_order(
 
     if line_data.line_id:
         # It means there is an update of the order line with new quantity
-        # TODO zedzior: obczaj co tu sie odpierdala
         line = order.lines.get(pk=line_data.line_id)
         old_quantity = line.quantity
         new_quantity = old_quantity + line_data.quantity
         line_info = OrderLineInfo(line=line, quantity=old_quantity)
         update_fields: list[str] = []
-        # TODO zedzior: a jak nie ma nowego quantity to juz nie musimy updatowac cen?
         if new_quantity and line_data.price_override is not None:
             update_line_base_unit_prices_with_custom_price(
                 order, line_data, line, update_fields

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -371,7 +371,6 @@ def add_variant_to_order(
                 [
                     OrderLineInfo(
                         line=line,
-                        # TODO zedzior: czy to nie powinna byc roznica miedzy quantity?
                         quantity=line_data.quantity,
                         variant=line_data.variant,
                         warehouse_pk=None,

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -249,6 +249,7 @@ def create_order_line(
         translated_product_name = ""
     if translated_variant_name == variant_name:
         translated_variant_name = ""
+    # TODO zedzior: this trigger multiple db calls for multiple lines
     line = order.lines.create(
         product_name=product_name,
         variant_name=variant_name,
@@ -273,6 +274,7 @@ def create_order_line(
     unit_discount = line.undiscounted_unit_price - line.unit_price
     if unit_discount.gross:
         if rules_info:
+            # TODO zedzior: this trigger multiple db calls for multiple lines
             line_discounts = (
                 create_order_line_discount_objects_for_catalogue_promotions(
                     line, rules_info, channel

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from ..app.models import App
     from ..channel.models import Channel
     from ..checkout.fetch import CheckoutInfo
+    from ..graphql.order.utils import OrderLineData
     from ..payment.models import Payment, TransactionItem
     from ..plugins.manager import PluginsManager
 
@@ -328,12 +329,12 @@ def create_order_line(
 
 @traced_atomic_transaction()
 def add_variant_to_order(
-    order,
-    line_data,
-    user,
-    app,
-    manager,
-    allocate_stock=False,
+    order: Order,
+    line_data: "OrderLineData",
+    user: Optional["User"],
+    app: Optional["App"],
+    manager: "PluginsManager",
+    allocate_stock: bool = False,
 ) -> OrderLine:
     """Add total_quantity of variant to order.
 
@@ -524,15 +525,15 @@ def _update_allocations_for_line(
 
 
 def change_order_line_quantity(
-    user,
-    app,
-    line_info,
+    user: Optional["User"],
+    app: Optional["App"],
+    line_info: OrderLineInfo,
     old_quantity: int,
     new_quantity: int,
     channel: "Channel",
     manager: "PluginsManager",
-    send_event=True,
-    update_fields=None,
+    send_event: bool = True,
+    update_fields: Optional[list[str]] = None,
 ):
     """Change the quantity of ordered items in a order line."""
     line = line_info.line

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -1253,16 +1253,6 @@ def order_info_for_logs(order: Order, lines: Iterable[OrderLine]):
                 "total_price_net_amount": line_info.line.total_price_net_amount,
                 "total_price_gross_amount": line_info.line.total_price_gross_amount,
                 "has_voucher_code": bool(line_info.line.voucher_code),
-                "variant_listing_price": (
-                    line_info.channel_listing.price_amount
-                    if line_info.channel_listing
-                    else None
-                ),
-                "variant_listing_discounted_price": (
-                    line_info.channel_listing.discounted_price_amount
-                    if line_info.channel_listing
-                    else None
-                ),
                 "unit_discount_amount": line_info.line.unit_discount_amount,
                 "unit_discount_type": line_info.line.unit_discount_type,
                 "unit_discount_reason": line_info.line.unit_discount_reason,

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -533,7 +533,7 @@ def change_order_line_quantity(
     channel: "Channel",
     manager: "PluginsManager",
     send_event: bool = True,
-    update_fields: Optional[list[str]] = None,
+    update_fields: list[str] | None = None,
 ):
     """Change the quantity of ordered items in a order line."""
     line = line_info.line

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -195,10 +195,7 @@ def update_variant_relations_for_active_promotion_rules_task():
         # in the promotion as dirty
         existing_variant_relation = _get_existing_rule_variant_list(rules)
 
-        new_rule_to_variant_list = fetch_variants_for_promotion_rules(
-            rules=rules,
-            database_connection_name=settings.DATABASE_CONNECTION_REPLICA_NAME,
-        )
+        new_rule_to_variant_list = fetch_variants_for_promotion_rules(rules=rules)
         channel_to_product_map = _get_channel_to_products_map(
             existing_variant_relation + new_rule_to_variant_list
         )

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -64,7 +64,7 @@ def fetch_variants_for_promotion_rules(
     for rule in rules.iterator():
         variants = get_variants_for_catalogue_predicate(
             rule.catalogue_predicate,
-            database_connection_name=settings.DATABASE_CONNECTION_REPLICA_NAME,
+            database_connection_name=database_connection_name,
         )
         new_rules_variants.extend(
             [

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -53,10 +53,7 @@ def get_variant_selection_attributes(
     ]
 
 
-def fetch_variants_for_promotion_rules(
-    rules: QuerySet[PromotionRule],
-    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
-):
+def fetch_variants_for_promotion_rules(rules: QuerySet[PromotionRule]):
     from ...graphql.discount.utils import get_variants_for_catalogue_predicate
 
     PromotionRuleVariant = PromotionRule.variants.through
@@ -64,7 +61,7 @@ def fetch_variants_for_promotion_rules(
     for rule in rules.iterator():
         variants = get_variants_for_catalogue_predicate(
             rule.catalogue_predicate,
-            database_connection_name=database_connection_name,
+            database_connection_name=settings.DATABASE_CONNECTION_REPLICA_NAME,
         )
         new_rules_variants.extend(
             [

--- a/saleor/tests/e2e/orders/test_draft_order_update_uses_denormalized_prices.py
+++ b/saleor/tests/e2e/orders/test_draft_order_update_uses_denormalized_prices.py
@@ -1,0 +1,353 @@
+from decimal import Decimal
+
+import pytest
+
+from ....core.prices import quantize_price
+from ....discount.models import PromotionRule
+from ....product.models import Product
+from ....product.utils.variant_prices import update_discounted_prices_for_promotion
+from ....product.utils.variants import fetch_variants_for_promotion_rules
+from .. import DEFAULT_ADDRESS
+from ..product.utils import create_product_variant_channel_listing
+from ..product.utils.preparing_product import prepare_product
+from ..promotions.utils import (
+    create_promotion,
+    create_promotion_rule,
+    update_promotion_rule,
+)
+from ..shipping_zone.utils import (
+    create_shipping_method,
+    create_shipping_method_channel_listing,
+)
+from ..shop.utils import prepare_shop
+from ..taxes.utils import update_country_tax_rates
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_create,
+    draft_order_update,
+    order_line_delete,
+    order_lines_create,
+)
+
+
+@pytest.mark.e2e
+def test_draft_order_update_uses_denormalized_prices_CORE_0251(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "prices_entered_with_tax": False,
+    }
+    initial_shipping_price = Decimal(10)
+    currency = "USD"
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "Inpost",
+                                "add_channels": {"price": initial_shipping_price},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {
+                    "includeDraftOrderInVoucherUsage": True,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_zone_id = shop_data[0]["shipping_zones"][0]["id"]
+    initial_shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][
+        0
+    ]["id"]
+
+    tax_rate = Decimal("1.1")
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        "US",
+        [{"rate": (tax_rate - 1) * 100}],
+    )
+
+    (
+        product_id,
+        variant_id,
+        initial_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=Decimal(20)
+    )
+    initial_variant_price = Decimal(initial_variant_price)
+
+    promotion_name = "Promotion Fixed"
+    initial_discount_reward = Decimal(5)
+    discount_type = "FIXED"
+    promotion_rule_name = "rule for product"
+    promotion_type = "CATALOGUE"
+
+    promotion_data = create_promotion(
+        e2e_staff_api_client, promotion_name, promotion_type
+    )
+    promotion_id = promotion_data["id"]
+
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+    input = {
+        "promotion": promotion_id,
+        "channels": [channel_id],
+        "name": promotion_rule_name,
+        "cataloguePredicate": catalogue_predicate,
+        "rewardValue": initial_discount_reward,
+        "rewardValueType": discount_type,
+    }
+    promotion_rule = create_promotion_rule(
+        e2e_staff_api_client,
+        input,
+    )
+    promotion_rule_id = promotion_rule["id"]
+
+    # update prices
+    fetch_variants_for_promotion_rules(PromotionRule.objects.all())
+    update_discounted_prices_for_promotion(Product.objects.all())
+
+    # Step 1 - Create a draft order for a product with fixed promotion
+    initial_quantity = Decimal(2)
+    input = {
+        "channelId": channel_id,
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "shippingMethod": initial_shipping_method_id,
+        "lines": [{"variantId": variant_id, "quantity": initial_quantity}],
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+
+    undisocunted_unit_price = initial_variant_price
+    unit_price = undisocunted_unit_price - initial_discount_reward
+    undiscounted_line_total = quantize_price(
+        undisocunted_unit_price * initial_quantity, currency
+    )
+    line_total = quantize_price(unit_price * initial_quantity, currency)
+    undiscounted_total = undiscounted_line_total + initial_shipping_price
+    total = line_total + initial_shipping_price
+
+    order_data = data["order"]
+    order_id = order_data["id"]
+    assert not order_data["discounts"]
+    assert order_data["shippingPrice"]["net"]["amount"] == initial_shipping_price
+    assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
+        initial_shipping_price * tax_rate, currency
+    )
+    assert order_data["total"]["net"]["amount"] == total
+    assert order_data["total"]["gross"]["amount"] == quantize_price(
+        total * tax_rate, currency
+    )
+    assert order_data["undiscountedTotal"]["net"]["amount"] == undiscounted_total
+    assert order_data["undiscountedTotal"]["gross"]["amount"] == quantize_price(
+        undiscounted_total * tax_rate, currency
+    )
+
+    assert len(order_data["lines"]) == 1
+    line_data = order_data["lines"][0]
+    line_id = line_data["id"]
+    assert line_data["unitPrice"]["net"]["amount"] == unit_price
+    assert line_data["unitPrice"]["gross"]["amount"] == quantize_price(
+        unit_price * tax_rate, currency
+    )
+    assert (
+        line_data["undiscountedUnitPrice"]["net"]["amount"] == undisocunted_unit_price
+    )
+    assert line_data["undiscountedUnitPrice"]["gross"]["amount"] == quantize_price(
+        undisocunted_unit_price * tax_rate, currency
+    )
+    assert line_data["totalPrice"]["net"]["amount"] == line_total
+    assert line_data["totalPrice"]["gross"]["amount"] == quantize_price(
+        line_total * tax_rate, currency
+    )
+    assert (
+        line_data["undiscountedTotalPrice"]["net"]["amount"] == undiscounted_line_total
+    )
+    assert line_data["undiscountedTotalPrice"]["gross"]["amount"] == quantize_price(
+        undiscounted_line_total * tax_rate, currency
+    )
+    assert line_data["unitDiscount"]["amount"] == initial_discount_reward
+    assert line_data["unitDiscountReason"] == f"Promotion: {promotion_id}"
+
+    # Step 2 - Update channel listing for variant
+    new_variant_price = initial_variant_price - Decimal(2)
+    data = create_product_variant_channel_listing(
+        e2e_staff_api_client, variant_id, channel_id, new_variant_price
+    )
+    assert data["channelListings"][0]["price"]["amount"] != initial_variant_price
+    assert data["channelListings"][0]["channel"]["id"] == channel_id
+
+    # Step 3 - Update promotion rule reward
+    new_discount_reward = Decimal(7)
+    input = {"rewardValue": new_discount_reward}
+    update_promotion_rule(e2e_staff_api_client, promotion_rule_id, input)
+
+    fetch_variants_for_promotion_rules(PromotionRule.objects.all())
+    update_discounted_prices_for_promotion(Product.objects.all())
+
+    # Step 4 - Create new shipping method
+    data = create_shipping_method(e2e_staff_api_client, shipping_zone_id)
+    new_shipping_method_id = data["id"]
+
+    # Step 5 - Update new shipping method price
+    new_shipping_price = Decimal(15)
+    data = create_shipping_method_channel_listing(
+        e2e_staff_api_client,
+        new_shipping_method_id,
+        channel_id,
+        {"price": new_shipping_price},
+    )
+    assert data["channelListings"][0]["price"]["amount"] == new_shipping_price
+
+    # Step 6 - Update order shipping method what leads to price recalculation.
+    # Base variant prices shouldn't be updated
+    data = draft_order_update(
+        e2e_staff_api_client, order_id, {"shippingMethod": new_shipping_method_id}
+    )
+    undisocunted_unit_price = initial_variant_price
+    unit_price = undisocunted_unit_price - initial_discount_reward
+    undiscounted_line_total = quantize_price(
+        undisocunted_unit_price * initial_quantity, currency
+    )
+    line_total = quantize_price(unit_price * initial_quantity, currency)
+    undiscounted_total = undiscounted_line_total + new_shipping_price
+    total = line_total + new_shipping_price
+
+    order_data = data["order"]
+    assert not order_data["discounts"]
+    assert order_data["shippingPrice"]["net"]["amount"] == new_shipping_price
+    assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
+        new_shipping_price * tax_rate, currency
+    )
+    assert order_data["total"]["net"]["amount"] == total
+    assert order_data["total"]["gross"]["amount"] == quantize_price(
+        total * tax_rate, currency
+    )
+    assert order_data["undiscountedTotal"]["net"]["amount"] == undiscounted_total
+    assert order_data["undiscountedTotal"]["gross"]["amount"] == quantize_price(
+        undiscounted_total * tax_rate, currency
+    )
+
+    assert len(order_data["lines"]) == 1
+    line_data = order_data["lines"][0]
+    assert line_data["unitPrice"]["net"]["amount"] == unit_price
+    assert line_data["unitPrice"]["gross"]["amount"] == quantize_price(
+        unit_price * tax_rate, currency
+    )
+    assert (
+        line_data["undiscountedUnitPrice"]["net"]["amount"] == undisocunted_unit_price
+    )
+    assert line_data["undiscountedUnitPrice"]["gross"]["amount"] == quantize_price(
+        undisocunted_unit_price * tax_rate, currency
+    )
+    assert line_data["totalPrice"]["net"]["amount"] == line_total
+    assert line_data["totalPrice"]["gross"]["amount"] == quantize_price(
+        line_total * tax_rate, currency
+    )
+    assert (
+        line_data["undiscountedTotalPrice"]["net"]["amount"] == undiscounted_line_total
+    )
+    assert line_data["undiscountedTotalPrice"]["gross"]["amount"] == quantize_price(
+        undiscounted_line_total * tax_rate, currency
+    )
+    assert line_data["unitDiscount"]["amount"] == initial_discount_reward
+    assert line_data["unitDiscountReason"] == f"Promotion: {promotion_id}"
+
+    # Step 7 - Delete the order line
+    data = order_line_delete(e2e_staff_api_client, line_id)
+
+    undiscounted_total = new_shipping_price
+    total = new_shipping_price
+
+    order_data = data["order"]
+    assert order_data["shippingPrice"]["net"]["amount"] == new_shipping_price
+    assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
+        new_shipping_price * tax_rate, currency
+    )
+    assert order_data["total"]["net"]["amount"] == total
+    assert order_data["total"]["gross"]["amount"] == quantize_price(
+        total * tax_rate, currency
+    )
+    assert order_data["undiscountedTotal"]["net"]["amount"] == undiscounted_total
+    assert order_data["undiscountedTotal"]["gross"]["amount"] == quantize_price(
+        undiscounted_total * tax_rate, currency
+    )
+    assert not order_data["lines"]
+
+    # Step 8 - Add the order line again. Prices should be taken from current
+    # channel listing values
+    new_quantity = 3
+    lines = [
+        {"variantId": variant_id, "quantity": new_quantity},
+    ]
+    data = order_lines_create(e2e_staff_api_client, order_id, lines)
+
+    undisocunted_unit_price = new_variant_price
+    unit_price = undisocunted_unit_price - new_discount_reward
+    undiscounted_line_total = quantize_price(
+        undisocunted_unit_price * new_quantity, currency
+    )
+    line_total = quantize_price(unit_price * new_quantity, currency)
+    undiscounted_total = undiscounted_line_total + new_shipping_price
+    total = line_total + new_shipping_price
+
+    order_data = data["order"]
+    assert not order_data["discounts"]
+    assert order_data["shippingPrice"]["net"]["amount"] == new_shipping_price
+    assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
+        new_shipping_price * tax_rate, currency
+    )
+    assert order_data["total"]["net"]["amount"] == total
+    assert Decimal(str(order_data["total"]["gross"]["amount"])) == quantize_price(
+        total * tax_rate, currency
+    )
+    assert order_data["undiscountedTotal"]["net"]["amount"] == undiscounted_total
+    assert Decimal(
+        str(order_data["undiscountedTotal"]["gross"]["amount"])
+    ) == quantize_price(undiscounted_total * tax_rate, currency)
+
+    assert len(order_data["lines"]) == 1
+    line_data = order_data["lines"][0]
+    assert line_data["unitPrice"]["net"]["amount"] == unit_price
+    assert Decimal(str(line_data["unitPrice"]["gross"]["amount"])) == quantize_price(
+        unit_price * tax_rate, currency
+    )
+    assert (
+        line_data["undiscountedUnitPrice"]["net"]["amount"] == undisocunted_unit_price
+    )
+    assert Decimal(
+        str(line_data["undiscountedUnitPrice"]["gross"]["amount"])
+    ) == quantize_price(undisocunted_unit_price * tax_rate, currency)
+    assert line_data["totalPrice"]["net"]["amount"] == line_total
+    assert Decimal(str(line_data["totalPrice"]["gross"]["amount"])) == quantize_price(
+        line_total * tax_rate, currency
+    )
+    assert (
+        line_data["undiscountedTotalPrice"]["net"]["amount"] == undiscounted_line_total
+    )
+    assert Decimal(
+        str(line_data["undiscountedTotalPrice"]["gross"]["amount"])
+    ) == quantize_price(undiscounted_line_total * tax_rate, currency)
+    assert line_data["unitDiscount"]["amount"] == new_discount_reward
+    assert line_data["unitDiscountReason"] == f"Promotion: {promotion_id}"

--- a/saleor/tests/e2e/orders/test_draft_order_update_uses_denormalized_prices.py
+++ b/saleor/tests/e2e/orders/test_draft_order_update_uses_denormalized_prices.py
@@ -314,6 +314,7 @@ def test_draft_order_update_uses_denormalized_prices_CORE_0251(
 
     order_data = data["order"]
     assert not order_data["discounts"]
+    # TODO zedzior: check if shipping price should 0 for orders without lines
     assert order_data["shippingPrice"]["net"]["amount"] == new_shipping_price
     assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
         new_shipping_price * tax_rate, currency

--- a/saleor/tests/e2e/orders/utils/draft_order_create.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_create.py
@@ -46,6 +46,7 @@ mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
         ... BaseTaxedMoney
       }
       lines {
+        id
         productVariantId
         quantity
         undiscountedUnitPrice {
@@ -60,6 +61,10 @@ mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
         totalPrice {
           ... BaseTaxedMoney
         }
+        unitDiscount {
+            amount
+        }
+        unitDiscountReason
       }
     }
   }

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -12,11 +12,20 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
       id
       lines {
         id
-        totalPrice {
-          ...BaseTaxedMoney
+        undiscountedUnitPrice {
+          ... BaseTaxedMoney
         }
         unitPrice {
-          ...BaseTaxedMoney
+          ... BaseTaxedMoney
+        }
+        undiscountedTotalPrice {
+          ... BaseTaxedMoney
+        }
+        totalPrice {
+          ... BaseTaxedMoney
+        }
+        unitDiscount {
+            amount
         }
         unitDiscountReason
       }

--- a/saleor/tests/e2e/orders/utils/order_line_delete.py
+++ b/saleor/tests/e2e/orders/utils/order_line_delete.py
@@ -21,6 +21,9 @@ mutation orderLineDelete($lineId: ID!) {
         ...BaseTaxedMoney
       }
       isShippingRequired
+      shippingPrice {
+        ...BaseTaxedMoney
+      }
       lines {
         id
         quantity

--- a/saleor/tests/e2e/orders/utils/order_lines_create.py
+++ b/saleor/tests/e2e/orders/utils/order_lines_create.py
@@ -23,6 +23,9 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
       subtotal {
         ...BaseTaxedMoney
       }
+      undiscountedTotal {
+        ...BaseTaxedMoney
+      }
       isShippingRequired
       lines {
         id
@@ -43,9 +46,10 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
           amount
         }
         undiscountedUnitPrice {
-          gross {
-            amount
-          }
+          ...BaseTaxedMoney
+        }
+        undiscountedTotalPrice {
+          ...BaseTaxedMoney
         }
         undiscountedTotalPrice {
           gross {


### PR DESCRIPTION
Part of: https://github.com/saleor/saleor/pull/17160

I want to merge this change because we shouldn't refresh order base variant prices during the order update. By base variant price I mean the channel listing price with eventual catalogue discount. This price should be constant during the entire order lifecycle.

The main assumption of the PR is that we should retrieve order line's variant price (from channel listings) only when adding new line. All future recalculations should use denormalised price. Same for the catalog promotions. Only the amount of the catalogue discount can be refreshed when updating order line with new quantity or custom price. This means that we don't need to retrieve actual channel listings and promotion rules every time we trigger `fetch_order_prices_if_expired`. The whole logic for creating/updating catalogue promotion is moved to mutations which allow to add new order line. The logic for checkout remains the same.

This PR makes quite a lot of changes to existing fixtures. It is because the order line with the properly applied catalog discount should have:
- `orderLineDiscount` object updated
- `VariantChannelListingPromotionRule` object updated
- `VariantChannelListing` object updated
- `line.base_unit_price` updated

Internal issue: https://linear.app/saleor/issue/SHOPX-1672

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
