### PR TITLE
Update unit discount fields description

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -805,9 +805,6 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     quantity_fulfilled = graphene.Int(
         required=True, description="Number of variant items fulfilled."
     )
-    unit_discount_reason = graphene.String(
-        description="Reason for any discounts applied on a product in the order."
-    )
     tax_rate = graphene.Float(
         required=True, description="Rate of tax applied on product variant."
     )
@@ -815,26 +812,54 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     thumbnail = ThumbnailField()
     unit_price = graphene.Field(
         TaxedMoney,
-        description="Price of the single item in the order line.",
+        description=(
+            "Price of the single item in the order line with all the line-level "
+            "discounts and order-level discount portions applied."
+        ),
         required=True,
     )
     undiscounted_unit_price = graphene.Field(
         TaxedMoney,
         description=(
-            "Price of the single item in the order line without applied an order line "
-            "discount."
+            "Price of the single item in the order line without any discount applied."
         ),
         required=True,
     )
     unit_discount = graphene.Field(
         Money,
-        description="The discount applied to the single order line.",
+        description=(
+            "Sum of the line-level discounts applied to the order line. "
+            "Order-level discounts which affect the line are not visible in this field."
+            " For order-level discount portion (if any), please query `order.discounts`"
+            " field."
+        ),
         required=True,
+    )
+    unit_discount_reason = graphene.String(
+        description=(
+            "Reason for line-level discounts applied on the order line. Order-level "
+            "discounts which affect the line are not visible in this field. For "
+            "order-level discount reason (if any), please query `order.discounts` "
+            "field."
+        )
     )
     unit_discount_value = graphene.Field(
         PositiveDecimal,
-        description="Value of the discount. Can store fixed value or percent value",
+        description=(
+            "Value of the discount. Can store fixed value or percent value. "
+            "This field shouldn't be used when multiple discounts affect the line. "
+            "There is a limitation, that after running `checkoutComplete` mutation "
+            "the field always stores fixed value."
+        ),
         required=True,
+    )
+    unit_discount_type = graphene.Field(
+        DiscountValueTypeEnum,
+        description=(
+            "Type of the discount: `fixed` or `percent`. This field shouldn't be used "
+            "when multiple discounts affect the line. There is a limitation, that after"
+            " running `checkoutComplete` mutation the field is always set to `fixed`."
+        ),
     )
     total_price = graphene.Field(
         TaxedMoney, description="Price of the order line.", required=True
@@ -882,10 +907,6 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     quantity_to_fulfill = graphene.Int(
         required=True,
         description="A quantity of items remaining to be fulfilled." + ADDED_IN_31,
-    )
-    unit_discount_type = graphene.Field(
-        DiscountValueTypeEnum,
-        description="Type of the discount: fixed or percent",
     )
     tax_class = PermissionsField(
         TaxClass,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12251,9 +12251,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Number of variant items fulfilled."""
   quantityFulfilled: Int!
 
-  """Reason for any discounts applied on a product in the order."""
-  unitDiscountReason: String
-
   """Rate of tax applied on product variant."""
   taxRate: Float!
   digitalContentUrl: DigitalContentUrl
@@ -12271,19 +12268,35 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
     format: ThumbnailFormatEnum = ORIGINAL
   ): Image
 
-  """Price of the single item in the order line."""
+  """
+  Price of the single item in the order line with all the line-level discounts and order-level discount portions applied.
+  """
   unitPrice: TaxedMoney!
 
   """
-  Price of the single item in the order line without applied an order line discount.
+  Price of the single item in the order line without any discount applied.
   """
   undiscountedUnitPrice: TaxedMoney!
 
-  """The discount applied to the single order line."""
+  """
+  Sum of the line-level discounts applied to the order line. Order-level discounts which affect the line are not visible in this field. For order-level discount portion (if any), please query `order.discounts` field.
+  """
   unitDiscount: Money!
 
-  """Value of the discount. Can store fixed value or percent value"""
+  """
+  Reason for line-level discounts applied on the order line. Order-level discounts which affect the line are not visible in this field. For order-level discount reason (if any), please query `order.discounts` field.
+  """
+  unitDiscountReason: String
+
+  """
+  Value of the discount. Can store fixed value or percent value. This field shouldn't be used when multiple discounts affect the line. There is a limitation, that after running `checkoutComplete` mutation the field always stores fixed value.
+  """
   unitDiscountValue: PositiveDecimal!
+
+  """
+  Type of the discount: `fixed` or `percent`. This field shouldn't be used when multiple discounts affect the line. There is a limitation, that after running `checkoutComplete` mutation the field is always set to `fixed`.
+  """
+  unitDiscountType: DiscountValueTypeEnum
 
   """Price of the order line."""
   totalPrice: TaxedMoney!
@@ -12329,9 +12342,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Added in Saleor 3.1.
   """
   quantityToFulfill: Int!
-
-  """Type of the discount: fixed or percent"""
-  unitDiscountType: DiscountValueTypeEnum
 
   """
   Denormalized tax class of the product in this order line.


### PR DESCRIPTION
Port: https://github.com/saleor/saleor/pull/17048

We should explicitly describe that unitDiscount and unitDiscountReason fields contain only line-level discounts

unitDiscountType and unitDiscountValue are legacy fields which only have sense when single discount affect the line. Furthermore, there is known issue that after running checkoutComplete mutation the fields always represent fixed values. We don't want to change this behaviour to not break potential integrations. In the future we will deprecate those fields and expose all the line-level discount details over orderLine.discounts field

Internal issue: https://linear.app/saleor/issue/SHOPX-1612/update-unitdiscount-fields-description

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
