### PR TITLE
deps: upgrade requests-hardened to latest version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2901,22 +2901,50 @@ files = [
     {file = "pillow_avif_plugin-1.4.6-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:b4f08c341d8aed2d7762589fdd99c4d3e191d4976dab59516b522704a67a281d"},
     {file = "pillow_avif_plugin-1.4.6-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:b95c477fc619a82a68800ff18599e2704aec6fcf9aa65898b02f0240feeb0af5"},
     {file = "pillow_avif_plugin-1.4.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c96ee1d1b504a2efa80c9d6d3b71a9884c724dc34d6e67131a64678e09c7a81c"},
+    {file = "pillow_avif_plugin-1.4.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa2fcd16cb42e8831b898266b8055caa0a83813dcb5cd1a75f9026670c8143ee"},
     {file = "pillow_avif_plugin-1.4.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0014a215e197c52520d3946f3704c8c0932a170cc5783f96d2385f55191dce29"},
     {file = "pillow_avif_plugin-1.4.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c5e6575e0ca0cd292d459cf627a27a505f38a6edad6f35fd9c4bce4a2cccef3"},
+    {file = "pillow_avif_plugin-1.4.6-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee90677fdfdaacdf653ef88370f0663c6a4d0d0225b898337e5989de227c6c21"},
     {file = "pillow_avif_plugin-1.4.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:963ce7b93340f235db5c7f16b46835c72681896052dcbf1652a01946e7b9103e"},
+    {file = "pillow_avif_plugin-1.4.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:370de32c70e88a28ed14045a92efe3f0e9b85e082399c80e677b8898a05bcf93"},
+    {file = "pillow_avif_plugin-1.4.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e74ec744167412977d5ccd43757aaef143e4290717efc16d60646a62e86f2d19"},
     {file = "pillow_avif_plugin-1.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:c8b9347a91acd183db302e198cf582127eb3de98ad185bf9aff773c99e415320"},
     {file = "pillow_avif_plugin-1.4.6-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:dec8a348e46266dd0bf20a6edd01b96b0a11042e8654d701444e4a5cebf7f44b"},
     {file = "pillow_avif_plugin-1.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91537935612d8fb4b8f621a912ce0eb4e363fdf615d472b20a043a7a18efb461"},
+    {file = "pillow_avif_plugin-1.4.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:162b2725fb7c1e2a97dd3e6295f478a51acba5b0ce71535ab3b5fe07075c1990"},
     {file = "pillow_avif_plugin-1.4.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1cd659136fca622a9324fa7efa56f711f2e576206754c284b80aa5504fb96e4"},
     {file = "pillow_avif_plugin-1.4.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60699d10679c8361690703b79abde4a2e7b8047540f0c58fd5da0ac672a15321"},
+    {file = "pillow_avif_plugin-1.4.6-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7228715ce0ced5e06cb116c12a48d101b4148714b352ffaebb2f12378483b530"},
     {file = "pillow_avif_plugin-1.4.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:323804efe752cf4d15fdcf770749ba23d727f8ea94b95cfe42bec597f3b9bbbb"},
+    {file = "pillow_avif_plugin-1.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bb5588a204f7e6b42e0c4306459d34562d881e504202c5eed34c19fe86e6893e"},
+    {file = "pillow_avif_plugin-1.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3443da3be828029500c26ba4f41cabec1450eac8d8cb49aedf56d19e0200a3ee"},
     {file = "pillow_avif_plugin-1.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:584469ea7dedd8ca4f579917cf22f25e8ab980e1b98bbe212cbd7395f881cd42"},
     {file = "pillow_avif_plugin-1.4.6-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:e2087daa49881421a5e703fcff80aa2cbcb5a455cf73114ed5f0ea2a697794c8"},
+    {file = "pillow_avif_plugin-1.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cc3256fd23f5c7bef4bcc562db9d2cd04634a7b01dee41ea35e8e92a2334a949"},
     {file = "pillow_avif_plugin-1.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5bacc0802516f054f98d9f218ada17b2e8a756e35cb71e7401bb8422848fe796"},
+    {file = "pillow_avif_plugin-1.4.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cbd9a1a45d982e346063ec4f4ce100021c565ee3102f9ff7f678019d5febada8"},
     {file = "pillow_avif_plugin-1.4.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e74e53951228c3e6ff5141121bd2876e8aecdb27d5f12d01cc519258e0073d8b"},
     {file = "pillow_avif_plugin-1.4.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b37e1314500cec3457210f4c8a7583afe35751f076efa8122faa0f205403d645"},
+    {file = "pillow_avif_plugin-1.4.6-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3008acd3edf86e8e2291d40e9f9eae86f5140415431d21f219df5ca8e8210115"},
     {file = "pillow_avif_plugin-1.4.6-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:d643db246d6c07994fbb98b5fa6c6ae8f9b19b4ed24566bc06942b7dad10ad47"},
+    {file = "pillow_avif_plugin-1.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d0d96859d1ebfd7c6c8daa761a05ee9df0a70278ec3011b3b5c6e56ac4996fa7"},
+    {file = "pillow_avif_plugin-1.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d1654a1048ad09b6e7553d4eb6e6bd3848be512bab2e283275585609dbda8b0"},
     {file = "pillow_avif_plugin-1.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:f262547edeec00ad287c8845ac6c9d7d822ef4b00d1832175c4c8fd692e34eba"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1d43a5de556e2ab8437e9d8b07da96e968e0498cb3c0d448c34198c7bac0387c"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8ce3fd54c76845c24dcd1cbc73fa5c72969df191bf7cd388a446f2f38342885c"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3c8d4f32a36ef4c345660a708067b6074dd380d0585589867333f7cb350bb9d"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f4563e5cd130016f8ea17602422b36abe4f63d2073ba98f2dbed42377b2f91c"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:070b07e47012a3490ab56e62dd629cbe694240159df333f01692c3e5fb8acff8"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:57e883963205b7cfe2981ca98db6554c488fbff2b5a6751cfcf065c6e657a922"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba1ae4dd323f019e0a1750555b02d91934724e4d556638baa60b5ca62e30f353"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:73b840b612a6ce840e2206a9f097f4ad07c1ca4ed99a3b0d14444224daf55e88"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:a79fc89bae89be6bede9b4b01aff3967cd009c02edec1e70e6de8e52ef93b5fc"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b1461731cde80ea246bce6ff87320367dbba206ee51a3370d99e679540dbcc17"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fe32db84ba0c9d9b364e2b36a55620d6112133107f82854f19a4fdaa93fce66b"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ac4e238f172806b2f75a719895414ff8c67500ab0bfa691e53ee2a99cb85722"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38a3934bcce34eb1f457434b336e4df8da1cf1eaea9306ca9f12ab5fa466e5a9"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:70b4e26bc604d7af87a5e5605b3480db9832eab0dbcf0b86565a813716653cce"},
+    {file = "pillow_avif_plugin-1.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:10e9b2ef297a9825b461715359ae233d6518d9863c877a8652c14d6acae6e9f0"},
     {file = "pillow_avif_plugin-1.4.6-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:09a7e4b00b18df55b9f34d4f031060ca46d8f5f5e0ba347dda600dcb5172e5f2"},
     {file = "pillow_avif_plugin-1.4.6-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:7d2e933e9b197e9a51c3fbfce389a70201fbce1b7c60172f790760217d7927f8"},
     {file = "pillow_avif_plugin-1.4.6-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:56be2604b734caf23788922dbcc92d880d241d02b444c7a8367a65bb25b16aac"},
@@ -2931,8 +2959,17 @@ files = [
     {file = "pillow_avif_plugin-1.4.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:df9a1e569543006abe0c534a3fa66ee1d72393644fd0d5bc74de57bfdb619573"},
     {file = "pillow_avif_plugin-1.4.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6556cbee2d755dc99a99a5a85c302393e58bcbbf675bc93fa9ab283904dadbfc"},
     {file = "pillow_avif_plugin-1.4.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc73ea62605c8725aba2422de1b546a5c4a6e5e73dcf66f9e22102249342d6b"},
+    {file = "pillow_avif_plugin-1.4.6-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:65eb8c6e572f24abadf1cd64516d41b18cef6defbcbb8bf68db286ad0053d2e6"},
     {file = "pillow_avif_plugin-1.4.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:334e1d39e8b3b4548db690df3735039378e96e1497fd8ba0e25a5e21561b7cf5"},
+    {file = "pillow_avif_plugin-1.4.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d2f418adafb584ce878b60c0bf86e55ac2714277beb09127bdb6f1d65f46ddb7"},
+    {file = "pillow_avif_plugin-1.4.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:fe06bdb3ec104f5e1b8c03a0bfb22e3d23b4e94591ae73caec1940ce54eccc67"},
     {file = "pillow_avif_plugin-1.4.6-cp39-cp39-win_amd64.whl", hash = "sha256:b7c2e4adcdf7341dc05f31f13d85b6c4eed0e08daafc836e7b3317df41074bab"},
+    {file = "pillow_avif_plugin-1.4.6-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:cbe7ef581068620aa82fec573be7e3ac00deb9b19e5f0aeb0b8363c2f3f9194a"},
+    {file = "pillow_avif_plugin-1.4.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d650df98a3ad35685809a28676d975db28425ff98ebf0d2ce603984e1296daf8"},
+    {file = "pillow_avif_plugin-1.4.6-pp310-pypy310_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cb10b5ce2cf81f9f03c6c8c682a8ebeb9d9052f7725ec5fb46b8adacb7f70a8d"},
+    {file = "pillow_avif_plugin-1.4.6-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f79f7d00fad620ec4a35c80f284aeffb84d110955b1360b28866152c796cc75e"},
+    {file = "pillow_avif_plugin-1.4.6-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b56dfc8d6d88253bdd8fc747b38548ef4730a9f1e03780cd96455f44e5e13ae5"},
+    {file = "pillow_avif_plugin-1.4.6-pp39-pypy39_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:142d51990b6784ebde4aaecaab5e7f1c65a43ad0f06f7ea990da072e7277e90b"},
 ]
 
 [[package]]
@@ -3910,19 +3947,16 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-hardened"
-version = "1.0.0b4"
+version = "1.0.0b5"
 description = "A library that overrides the default behaviors of the requests library, and adds new security features."
 optional = false
-python-versions = ">=3.8"
+python-versions = "<4.0,>=3.8"
 files = [
-    {file = "requests_hardened-1.0.0b4.tar.gz", hash = "sha256:1fc29dbae273a61980d015f1948404374ee1f7b0f9e464a564af12b9d0c5ebde"},
+    {file = "requests_hardened-1.0.0b5.tar.gz", hash = "sha256:98736b46f7793605da5b8b53ecacdb00fbc3b3c099f0e1730701b6f40fca7cd9"},
 ]
 
 [package.dependencies]
-requests = ">=2.0.1,<3.0.0"
-
-[package.extras]
-dev = ["mypy (>=1.5.1,<1.6.0)", "pytest (>=7.4.0,<7.5.0)", "trustme (>=1.1.0,<2.0.0)", "types-requests (>=2.0.1,<3.0.0)"]
+requests = ">=2.32.3,<3.0.0"
 
 [[package]]
 name = "rich"
@@ -5239,4 +5273,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "e40ff0c714c2f31dd634b8f05d84deb67d850dfbdbd587305532308d2c540a3e"
+content-hash = "a9f78150c9101c95dbc158373db50d3392fb1b98f1dd679e02e62df083c93725"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ package-mode = false
   razorpay = "^1.2"
   redis = "^5.0.1"
   requests = "^2.32"
-  requests-hardened = "1.0.0b4"
+  requests-hardened = "1.0.0b5"
   Rx = "^1.6.3"
   semantic-version = "^2.10.0"
   sendgrid = "^6.7.1"
@@ -131,7 +131,7 @@ package-mode = false
   types-setuptools = "^74.1.0.20240907"
   types-python-dateutil = "^2.8.19"
   types-redis = "^4.6.0"
-  types-requests = "^2.31.0"
+  types-requests = "^2.31.0" # Cannot upgrade due to using an old version of urllib3 (https://github.com/saleor/saleor/issues/17130)
   types-six = "^1.16.17"
   vcrpy = ">=4.0,<7.0"
 

--- a/saleor/core/tests/cassettes/test_http_client/test_http_client_disallows_private_ip_ranges[http].yaml
+++ b/saleor/core/tests/cassettes/test_http_client/test_http_client_disallows_private_ip_ranges[http].yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Host:
+      - example.com
+      User-Agent:
+      - Saleor/3.21
+    method: GET
+    uri: http://93.184.215.14/
+  response:
+    body:
+      string: !!binary |
+        H4sIAMIVqF0AA31UTXPbIBC9+1ds1UsyIyQnaRqPLWn6mWkPaQ9pDz0SsbKYCFAByfZ08t+7Qo4j
+        N5makYFdeLvvsZC9Eqb0uxah9qopZtljh1wUM6Bf5qVvsPi85aptED4ZxaXO0tE6G5co9BzKmluH
+        Po86X7FFBGkxcdbetwx/d7LPo49Ge9SeDWEjKMdZHnnc+nQIvzpAvYSkucI86iVuWmP9ZP9GCl/n
+        AntZIguTGKSWXvKGuZI3mJ89QTm/IzJDBvvApXPR6LszYgd/wjBMeXm/tqbTgpWmMXYJr6s5tfPV
+        YYnidi31EuZPppYLIfX6yFZRpqziSja7JTDekpzM7ZxHFcPYs07G8KGR+v6Gl7fBdE2bYohucW0Q
+        fn6NaPy9RQ23XLth8gWbHr0sOXzDDslyMMTw3hJ3wqalzKGV1VMuYfAQ/oXsJ3SDcEt4O5+32+cM
+        L1EB77x5geg5qtV/RRPUJhncGSvQMsuF7BzplFweAZgtczUXZkPI7RYu6Luibxjb9R0/mcehJfPz
+        09WEDF8O6sXU99JJj2JC7TGTi8WbxWKSyXD+TGBpLPfSEEttNE5B3ykUksOJ4lu21+dq0Od0An6s
+        4lFV/KPYROVjx8MkZJaGCi3CWWXpeB1n2VCbdDsp2L6O67NnN5NMo68tftTSgQh2oFFlLHQOYZg1
+        Tef8QLhHwBHBDQ56DjpF98kl8Mt0RGIXtnhCGqtlj6ahIXkJoLNIdHxtOg+tlRSiNHS0Ugcxgebc
+        3VOFhOgtWiWdI0eSpe0hz4weCItVHg3PhFum6WazSSTXPDF2nY4hXbpPMypujB1IEKAKQZKE0HgR
+        ELM0iJOle6nS8UH7CyjrfG/oBAAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '458251'
+      Cache-Control:
+      - max-age=604800
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '648'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Tue, 03 Dec 2024 09:52:20 GMT
+      Etag:
+      - '"3147526947"'
+      Expires:
+      - Tue, 10 Dec 2024 09:52:20 GMT
+      Last-Modified:
+      - Thu, 17 Oct 2019 07:18:26 GMT
+      Server:
+      - ECAcc (nyd/D188)
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - HIT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/core/tests/cassettes/test_http_client/test_http_client_disallows_private_ip_ranges[https].yaml
+++ b/saleor/core/tests/cassettes/test_http_client/test_http_client_disallows_private_ip_ranges[https].yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Host:
+      - example.com
+      User-Agent:
+      - Saleor/3.21
+    method: GET
+    uri: https://93.184.215.14/
+  response:
+    body:
+      string: !!binary |
+        H4sIAMIVqF0AA31UTXPbIBC9+1ds1UsyIyQnaRqPLWn6mWkPaQ9pDz0SsbKYCFAByfZ08t+7Qo4j
+        N5makYFdeLvvsZC9Eqb0uxah9qopZtljh1wUM6Bf5qVvsPi85aptED4ZxaXO0tE6G5co9BzKmluH
+        Po86X7FFBGkxcdbetwx/d7LPo49Ge9SeDWEjKMdZHnnc+nQIvzpAvYSkucI86iVuWmP9ZP9GCl/n
+        AntZIguTGKSWXvKGuZI3mJ89QTm/IzJDBvvApXPR6LszYgd/wjBMeXm/tqbTgpWmMXYJr6s5tfPV
+        YYnidi31EuZPppYLIfX6yFZRpqziSja7JTDekpzM7ZxHFcPYs07G8KGR+v6Gl7fBdE2bYohucW0Q
+        fn6NaPy9RQ23XLth8gWbHr0sOXzDDslyMMTw3hJ3wqalzKGV1VMuYfAQ/oXsJ3SDcEt4O5+32+cM
+        L1EB77x5geg5qtV/RRPUJhncGSvQMsuF7BzplFweAZgtczUXZkPI7RYu6Luibxjb9R0/mcehJfPz
+        09WEDF8O6sXU99JJj2JC7TGTi8WbxWKSyXD+TGBpLPfSEEttNE5B3ykUksOJ4lu21+dq0Od0An6s
+        4lFV/KPYROVjx8MkZJaGCi3CWWXpeB1n2VCbdDsp2L6O67NnN5NMo68tftTSgQh2oFFlLHQOYZg1
+        Tef8QLhHwBHBDQ56DjpF98kl8Mt0RGIXtnhCGqtlj6ahIXkJoLNIdHxtOg+tlRSiNHS0Ugcxgebc
+        3VOFhOgtWiWdI0eSpe0hz4weCItVHg3PhFum6WazSSTXPDF2nY4hXbpPMypujB1IEKAKQZKE0HgR
+        ELM0iJOle6nS8UH7CyjrfG/oBAAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '400176'
+      Cache-Control:
+      - max-age=604800
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '648'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Tue, 03 Dec 2024 09:52:42 GMT
+      Etag:
+      - '"3147526947+gzip"'
+      Expires:
+      - Tue, 10 Dec 2024 09:52:42 GMT
+      Last-Modified:
+      - Thu, 17 Oct 2019 07:18:26 GMT
+      Server:
+      - ECAcc (nyd/D120)
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - HIT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/core/tests/test_http_client.py
+++ b/saleor/core/tests/test_http_client.py
@@ -1,16 +1,10 @@
+import pytest
 import requests_hardened
-from django.conf import settings
 from requests import Request
+from requests_hardened.ip_filter import InvalidIPAddress
 
 from ... import user_agent_version
-
-HTTPConfig = requests_hardened.Config(
-    ip_filter_enable=settings.HTTP_IP_FILTER_ENABLED,
-    ip_filter_allow_loopback_ips=settings.HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS,
-    never_redirect=True,
-    default_timeout=(2, 10),
-    user_agent_override=user_agent_version,
-)
+from ..http_client import HTTPClient, HTTPConfig
 
 
 def test_user_agent_override():
@@ -25,3 +19,26 @@ def test_user_agent_override():
 
     # then
     assert request.headers.get("User-Agent") == user_agent_version
+
+
+@pytest.mark.vcr(record_mode="once")
+@pytest.mark.parametrize("protocol", ["https", "http"])
+def test_http_client_disallows_private_ip_ranges(protocol):
+    """Ensure requests made to private IP address ranges leads to an error to be raised.
+
+    This test ensures that the requests-hardened library works correctly,
+    especially when using untested 'requests' and 'urllib3' versions
+    that may potentially be unsupported by this library.
+    """
+
+    # Enable IP filtering (disabled by default in tests)
+    http_manager = HTTPClient.clone()
+    http_manager.config.ip_filter_enable = True  # Block private ranges.
+
+    # Should reject the IP address (expect error to be raised)
+    with pytest.raises(InvalidIPAddress, match="10.0.0.1"):
+        http_manager.send_request("GET", f"{protocol}://10.0.0.1", timeout=0.1)
+
+    # Should not reject public IP ranges (sanity check).
+    response = http_manager.send_request("GET", f"{protocol}://example.com")
+    assert response.status_code == 200


### PR DESCRIPTION
This upgrades requests-hardened to latest version (1.0.0b4 -> 1.0.0b5) which fixes issues with request URLs (such as webhooks) being logged and traced using the IP addresses instead of their domain names (thus reducing observability and making troubleshooting harder).

The requests-hardened library no longer rewrites URLs, and instead pins the IP address at the socket-level thus this commit also added an additional test to ensure the behavior is remains consistent when urllib3 and requests libraries are updated due to the logic happening much deeper inside the libraries thus making the IP filtering feature more sensitive to transient dependencies breaking changes.

See also https://github.com/saleor/requests-hardened/issues/12

## Example

| Before | After |
| --- | --- |
| <img width="auto" alt="Before the changes: shows IP address instead of the domain name" src="https://github.com/user-attachments/assets/6e790e64-14bd-46bf-b66a-2c47d349f116"> | <img width="auto" alt="Screenshot 2024-12-02 at 12 35 10 PM" src="https://github.com/user-attachments/assets/2f3e9fef-1cf8-48c2-b27f-cdd949b92c64"> |




## Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

## Docs

- [ ] Link to documentation: TBD - will open a subsequent PR in saleor-docs repository in order to improve our current docs, but there is no breaking change nor any behavior difference to document.

## Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
