### PR TITLE
Fix for fetching all translations when using translate bulk mutation

### DIFF
--- a/saleor/graphql/translations/mutations/utils.py
+++ b/saleor/graphql/translations/mutations/utils.py
@@ -225,28 +225,37 @@ class BaseBulkTranslateMutation(BaseMutation):
     @classmethod
     def get_base_objects(cls, cleaned_inputs_map: dict):
         lookup = Q()
+        pks_to_get = set()
+        external_reference_to_get = set()
         for data in cleaned_inputs_map.values():
             if not data:
                 continue
 
             if pk := data.get("id"):
-                lookup |= Q(pk=pk)
+                pks_to_get.add(pk)
             else:
-                lookup |= Q(external_reference=data.get("external_reference"))
+                external_reference_to_get.add(data.get("external_reference"))
 
-        attributes = cls._meta.base_model.objects.filter(lookup)
-        return list(attributes)
+        if pks_to_get:
+            lookup |= Q(pk__in=pks_to_get)
+        if external_reference_to_get:
+            lookup |= Q(external_reference__in=external_reference_to_get)
+
+        base_objects = cls._meta.base_model.objects.filter(lookup)
+        return list(base_objects)
 
     @classmethod
     def get_translations(cls, cleaned_inputs_map: dict, base_objects: list):
         lookup = Q(**{f"{cls._meta.base_model_relation_field}__in": base_objects})
 
+        language_code_to_get = set()
         for data in cleaned_inputs_map.values():
             if not data:
                 continue
+            if language_code := data.get("language_code"):
+                language_code_to_get.add(language_code)
 
-            single_lookup = Q(language_code=data.get("language_code"))
-            lookup |= single_lookup
+        lookup &= Q(language_code__in=language_code_to_get)
 
         if hasattr(cls._meta.base_model, "external_reference"):
             translations = cls._meta.translation_model.objects.filter(lookup).annotate(
@@ -420,11 +429,13 @@ class BaseBulkTranslateMutation(BaseMutation):
                 for data in instances_data_with_errors_list
             ]
         return [
-            cls._meta.result_type(
-                translation=data.get("instance"), errors=data.get("errors")
+            (
+                cls._meta.result_type(
+                    translation=data.get("instance"), errors=data.get("errors")
+                )
+                if data.get("instance")
+                else cls._meta.result_type(translation=None, errors=data.get("errors"))
             )
-            if data.get("instance")
-            else cls._meta.result_type(translation=None, errors=data.get("errors"))
             for data in instances_data_with_errors_list
         ]
 

--- a/saleor/graphql/translations/tests/mutations/test_attribute_bulk_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_attribute_bulk_translate.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
 import graphene
+import pytest
 
 from ....core.enums import LanguageCodeEnum, TranslationErrorCode
 from ....tests.utils import get_graphql_content
+from ...mutations import AttributeBulkTranslate
 
 ATTRIBUTE_BULK_TRANSLATE_MUTATION = """
     mutation AttributeBulkTranslate(
@@ -28,6 +30,64 @@ ATTRIBUTE_BULK_TRANSLATE_MUTATION = """
         }
     }
 """
+
+
+def test_attribute_bulk_translate_get_translations_returns_valid_translations(
+    color_attribute_with_translations, second_color_attribute_with_translations
+):
+    # given
+    requested_language_code = LanguageCodeEnum.PL.value
+    translations = {
+        0: {
+            "id": color_attribute_with_translations.id,
+            "language_code": requested_language_code,
+            "translation_fields": {
+                "name": "Czerwony",
+            },
+        },
+    }
+
+    # when
+    translations = AttributeBulkTranslate.get_translations(
+        cleaned_inputs_map=translations,
+        base_objects=[color_attribute_with_translations.id],
+    )
+
+    # then
+    for translation in translations:
+        assert translation.attribute_id == color_attribute_with_translations.id
+        assert translation.language_code == requested_language_code
+
+
+@pytest.mark.parametrize("identifier_field", ["external_reference", "id"])
+def test_attribute_bulk_translate_get_base_objects_returns_valid_objects(
+    identifier_field,
+    color_attribute_with_translations,
+    second_color_attribute_with_translations,
+):
+    # given
+    requested_language_code = LanguageCodeEnum.PL.value
+
+    color_attribute_with_translations.external_reference = "ext_ref"
+    color_attribute_with_translations.save()
+
+    translations = {
+        0: {
+            identifier_field: getattr(
+                color_attribute_with_translations, identifier_field
+            ),
+            "language_code": requested_language_code,
+            "translation_fields": {
+                "name": "Czerwony",
+            },
+        },
+    }
+
+    # when
+    base_objects = AttributeBulkTranslate.get_base_objects(translations)
+
+    # then
+    assert base_objects == [color_attribute_with_translations]
 
 
 @patch("saleor.plugins.manager.PluginsManager.translation_created")

--- a/saleor/graphql/translations/tests/mutations/test_product_bulk_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_product_bulk_translate.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
 import graphene
+import pytest
 
 from .....tests.utils import dummy_editorjs
 from ....core.enums import LanguageCodeEnum, TranslationErrorCode
 from ....tests.utils import get_graphql_content
+from ...mutations import ProductBulkTranslate
 
 PRODUCT_BULK_TRANSLATE_MUTATION = """
     mutation ProductBulkTranslate(
@@ -33,6 +35,73 @@ PRODUCT_BULK_TRANSLATE_MUTATION = """
 
 description_pl = dummy_editorjs("description PL", True)
 description_de = dummy_editorjs("description DE", True)
+
+
+def test_product_bulk_translate_get_translations_returns_valid_translations(
+    product_list,
+):
+    # given
+    first_product = product_list[0]
+    first_product.translations.create(language_code="pl", name="name-in-pl")
+    first_product.translations.create(language_code="de", name="name-in-de")
+
+    second_product = product_list[1]
+    second_product.translations.create(language_code="pl", name="name-in-pl")
+    second_product.translations.create(language_code="de", name="name-in-de")
+
+    requested_language_code = LanguageCodeEnum.PL.value
+
+    translations = {
+        0: {
+            "id": first_product.id,
+            "languageCode": requested_language_code,
+            "translationFields": {"name": "Product PL", "description": description_pl},
+        }
+    }
+
+    # when
+    translations = ProductBulkTranslate.get_translations(
+        cleaned_inputs_map=translations, base_objects=[first_product.id]
+    )
+
+    # then
+    for translation in translations:
+        assert translation.product_id == first_product.id
+        assert translation.language_code == requested_language_code
+
+
+@pytest.mark.parametrize("identifier_field", ["external_reference", "id"])
+def test_product_bulk_translate_get_base_objects_returns_valid_objects(
+    identifier_field,
+    product_list,
+):
+    # given
+    first_product = product_list[0]
+    first_product.translations.create(language_code="pl", name="name-in-pl")
+    first_product.translations.create(language_code="de", name="name-in-de")
+
+    second_product = product_list[1]
+    second_product.translations.create(language_code="pl", name="name-in-pl")
+    second_product.translations.create(language_code="de", name="name-in-de")
+
+    first_product.external_reference = "ext_ref"
+    first_product.save()
+
+    requested_language_code = LanguageCodeEnum.PL.value
+
+    translations = {
+        0: {
+            identifier_field: getattr(first_product, identifier_field),
+            "languageCode": requested_language_code,
+            "translationFields": {"name": "Product PL", "description": description_pl},
+        }
+    }
+
+    # when
+    base_objects = ProductBulkTranslate.get_base_objects(translations)
+
+    # then
+    assert base_objects == [first_product]
 
 
 @patch("saleor.plugins.manager.PluginsManager.translation_created")

--- a/saleor/graphql/translations/tests/mutations/test_product_variant_bulk_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_product_variant_bulk_translate.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
 import graphene
+import pytest
 
 from ....core.enums import LanguageCodeEnum, TranslationErrorCode
 from ....tests.utils import get_graphql_content
+from ...mutations import ProductVariantBulkTranslate
 
 PRODUCT_VARIANT_BULK_TRANSLATE_MUTATION = """
     mutation ProductVariantBulkTranslate(
@@ -28,6 +30,73 @@ PRODUCT_VARIANT_BULK_TRANSLATE_MUTATION = """
         }
     }
 """
+
+
+def test_product_variant_bulk_translate_get_translations_returns_valid_translations(
+    product_list,
+):
+    # given
+    first_variant = product_list[0].variants.first()
+    first_variant.translations.create(language_code="pl", name="name-in-pl")
+    first_variant.translations.create(language_code="de", name="name-in-de")
+
+    second_variant = product_list[1].variants.first()
+    second_variant.translations.create(language_code="pl", name="name-in-pl")
+    second_variant.translations.create(language_code="de", name="name-in-de")
+
+    requested_language_code = LanguageCodeEnum.PL.value
+
+    translations = {
+        0: {
+            "id": first_variant.id,
+            "languageCode": requested_language_code,
+            "translationFields": {"name": "Product PL"},
+        }
+    }
+
+    # when
+    translations = ProductVariantBulkTranslate.get_translations(
+        cleaned_inputs_map=translations, base_objects=[first_variant.id]
+    )
+
+    # then
+    for translation in translations:
+        assert translation.product_variant_id == first_variant.id
+        assert translation.language_code == requested_language_code
+
+
+@pytest.mark.parametrize("identifier_field", ["external_reference", "id"])
+def test_product_variant_bulk_translate_get_base_objects_returns_valid_objects(
+    identifier_field,
+    product_list,
+):
+    # given
+    first_variant = product_list[0].variants.first()
+    first_variant.translations.create(language_code="pl", name="name-in-pl")
+    first_variant.translations.create(language_code="de", name="name-in-de")
+
+    second_variant = product_list[1].variants.first()
+    second_variant.translations.create(language_code="pl", name="name-in-pl")
+    second_variant.translations.create(language_code="de", name="name-in-de")
+
+    first_variant.external_reference = "ext_ref"
+    first_variant.save()
+
+    requested_language_code = LanguageCodeEnum.PL.value
+
+    translations = {
+        0: {
+            identifier_field: getattr(first_variant, identifier_field),
+            "languageCode": requested_language_code,
+            "translationFields": {"name": "Product PL"},
+        }
+    }
+
+    # when
+    base_objects = ProductVariantBulkTranslate.get_base_objects(translations)
+
+    # then
+    assert base_objects == [first_variant]
 
 
 @patch("saleor.plugins.manager.PluginsManager.translation_created")

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2006,6 +2006,26 @@ def color_attribute_with_translations(db):
 
 
 @pytest.fixture
+def second_color_attribute_with_translations(db):
+    attribute = Attribute.objects.create(
+        slug="second-color",
+        name="Second color",
+        type=AttributeType.PRODUCT_TYPE,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+    )
+    value1 = AttributeValue.objects.create(attribute=attribute, name="Red", slug="red")
+    AttributeValue.objects.create(attribute=attribute, name="Blue", slug="blue")
+    attribute.translations.create(language_code="pl", name="Czerwony")
+    attribute.translations.create(language_code="de", name="Rot")
+    value1.translations.create(language_code="pl", plain_text="Old Kolor")
+    value1.translations.create(language_code="de", name="Rot", plain_text="Old Kolor")
+
+    return attribute
+
+
+@pytest.fixture
 def attribute_without_values():
     return Attribute.objects.create(
         slug="dropdown",


### PR DESCRIPTION
I want to merge this change because it fixes the bug where calling bulk translate mutation would fetch all existing translations for defined languageCode.
For example, updating the translation for product A and product B for language-code DE, would fetch all translations assigned to product A and product B, but also all translations existing in DB for DE language code.
This PR fixes this by always returning only the requested translations.

Additionally, I also cleaned up the get_base_objects method, to reduce the OR operations in generated DB query

Port of changes from: https://github.com/saleor/saleor/pull/17105

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
