### PR TITLE
Prevent creation of fulfillment in case of race thread

### DIFF
--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -4,12 +4,12 @@ from uuid import UUID
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.template.defaultfilters import pluralize
 
 from ....core.exceptions import InsufficientStock
 from ....order import models as order_models
 from ....order.actions import OrderFulfillmentLineInfo, create_fulfillments
 from ....order.error_codes import OrderErrorCode
+from ....order.utils import clean_order_line_quantities
 from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
@@ -127,29 +127,7 @@ class OrderFulfill(BaseMutation):
 
     @classmethod
     def clean_lines(cls, order_lines, quantities_for_lines):
-        for order_line, line_quantities in zip(order_lines, quantities_for_lines):
-            line_total_quantity = sum(line_quantities)
-            line_quantity_unfulfilled = order_line.quantity_unfulfilled
-
-            if line_total_quantity > line_quantity_unfulfilled:
-                msg = (
-                    "Only %(quantity)d item%(item_pluralize)s remaining to fulfill."
-                ) % {
-                    "quantity": line_quantity_unfulfilled,
-                    "item_pluralize": pluralize(line_quantity_unfulfilled),
-                }
-                order_line_global_id = graphene.Node.to_global_id(
-                    "OrderLine", order_line.pk
-                )
-                raise ValidationError(
-                    {
-                        "order_line_id": ValidationError(
-                            msg,
-                            code=OrderErrorCode.FULFILL_ORDER_LINE.value,
-                            params={"order_lines": [order_line_global_id]},
-                        )
-                    }
-                )
+        clean_order_line_quantities(order_lines, quantities_for_lines)
 
     @classmethod
     def check_warehouses_for_duplicates(cls, warehouse_ids):

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -1,5 +1,6 @@
 from unittest.mock import ANY, call, patch
 
+import before_after
 import graphene
 import pytest
 from django.test import override_settings
@@ -1659,3 +1660,48 @@ def test_order_fulfill_triggers_webhooks(
         any_order=True,
     )
     assert wrapped_call_order_events.called
+
+
+def test_order_fulfill_fulfilled_order_race_condition(
+    staff_api_client,
+    staff_user,
+    order_with_lines,
+    permission_group_manage_orders,
+    warehouse,
+):
+    # given
+    query = ORDER_FULFILL_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order_id = graphene.Node.to_global_id("Order", order_with_lines.id)
+    order_line = order_with_lines.lines.first()
+    order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    variables = {
+        "order": order_id,
+        "input": {
+            "lines": [
+                {
+                    "orderLineId": order_line_id,
+                    "stocks": [{"quantity": 100, "warehouse": warehouse_id}],
+                }
+            ]
+        },
+    }
+
+    def fulfill_line():
+        order_line.quantity_fulfilled = 100
+        order_line.save()
+
+    # when
+    with before_after.before("saleor.order.actions.create_fulfillments", fulfill_line):
+        response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["orderFulfill"]
+    assert data["errors"]
+    error = data["errors"][0]
+    assert error["field"] == "orderLineId"
+    assert error["code"] == OrderErrorCode.FULFILL_ORDER_LINE.name
+    assert error["orderLines"] == [order_line_id]
+    assert not error["warehouse"]

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
@@ -13,8 +13,8 @@ from ....core.postgres import FlatConcatSearchVector
 from ....core.tracing import traced_atomic_transaction
 from ....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
 from ....order import events as order_events
-from ....order import models as order_models
 from ....order.tasks import recalculate_orders_task
+from ....order.utils import order_lines_qs_select_for_update
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....product.search import prepare_product_search_vector_value
@@ -121,7 +121,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             response = super().perform_mutation(_root, info, ids=ids, **data)
 
             # delete order lines for deleted variants, they are ordered by Meta
-            order_models.OrderLine.objects.select_for_update(of=("self",)).filter(
+            order_lines_qs_select_for_update().filter(
                 pk__in=draft_order_lines_data.line_pks
             ).delete()
 

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -20,6 +20,7 @@ from ..core.utils.events import (
     webhook_async_event_requires_sync_webhooks_to_trigger,
 )
 from ..giftcard import GiftCardLineData
+from ..order.utils import order_lines_qs_select_for_update
 from ..payment import (
     ChargeStatus,
     CustomPaymentChoices,
@@ -70,6 +71,7 @@ from .notifications import (
     send_payment_confirmation,
 )
 from .utils import (
+    clean_order_line_quantities,
     get_valid_shipping_methods_for_order,
     order_line_needs_automatic_fulfillment,
     restock_fulfillment_lines,
@@ -1299,7 +1301,23 @@ def create_fulfillments(
         if approved
         else FulfillmentStatus.WAITING_FOR_APPROVAL
     )
+
+    order_line_quantities_to_fulfill: defaultdict[UUID, list[int]] = defaultdict(list)
+    for _, lines in fulfillment_lines_for_warehouses.items():
+        for line in lines:
+            order_line = line["order_line"]
+            order_line_quantities_to_fulfill[order_line.pk].append(line["quantity"])
+
     with traced_atomic_transaction():
+        # refresh order lines from db to prevent race condition
+        order_lines = order_lines_qs_select_for_update().filter(
+            pk__in=order_line_quantities_to_fulfill.keys()
+        )
+        quantities_for_lines: list[list[int]] = [
+            order_line_quantities_to_fulfill[line.pk] for line in order_lines
+        ]
+        clean_order_line_quantities(order_lines, quantities_for_lines)
+
         for warehouse_pk in fulfillment_lines_for_warehouses:
             fulfillment = Fulfillment.objects.create(
                 order=order, status=status, tracking_number=tracking_number

--- a/saleor/order/tests/test_fulfillments_actions.py
+++ b/saleor/order/tests/test_fulfillments_actions.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 
 from ...core.exceptions import InsufficientStock
 from ...order import OrderEvents
@@ -748,3 +749,34 @@ def test_create_fulfillments_quantity_allocated_lower_than_line_quantity(
     mock_email_fulfillment.assert_called_once_with(
         order, order.fulfillments.get(), staff_user, None, manager
     )
+
+
+def test_create_fulfillments_validate_lines_raise_error(
+    staff_user,
+    order_with_lines,
+    warehouse,
+    site_settings,
+):
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    order_line1.quantity_fulfilled = 3
+    order_line1.save()
+    order_line2.quantity_fulfilled = 2
+    order_line2.save()
+    fulfillment_lines_for_warehouses = {
+        warehouse.pk: [
+            {"order_line": order_line1, "quantity": 3},
+            {"order_line": order_line2, "quantity": 2},
+        ]
+    }
+    manager = get_plugins_manager(allow_replica=False)
+    with pytest.raises(ValidationError):
+        create_fulfillments(
+            staff_user,
+            None,
+            order,
+            fulfillment_lines_for_warehouses,
+            manager,
+            site_settings,
+            True,
+        )

--- a/saleor/order/tests/test_fulfillments_actions.py
+++ b/saleor/order/tests/test_fulfillments_actions.py
@@ -757,6 +757,7 @@ def test_create_fulfillments_validate_lines_raise_error(
     warehouse,
     site_settings,
 ):
+    # given
     order = order_with_lines
     order_line1, order_line2 = order.lines.all()
     order_line1.quantity_fulfilled = 3
@@ -770,6 +771,7 @@ def test_create_fulfillments_validate_lines_raise_error(
         ]
     }
     manager = get_plugins_manager(allow_replica=False)
+    # when & then
     with pytest.raises(ValidationError):
         create_fulfillments(
             staff_user,

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING, Optional, cast
 
 import graphene
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db.models import QuerySet, Sum
+from django.template.defaultfilters import pluralize
 from django.utils import timezone
 from prices import Money, TaxedMoney
 
@@ -54,6 +56,7 @@ from . import (
     OrderStatus,
     events,
 )
+from .error_codes import OrderErrorCode
 from .fetch import OrderLineInfo, fetch_draft_order_lines_info
 from .models import Order, OrderGrantedRefund, OrderLine
 
@@ -66,6 +69,10 @@ if TYPE_CHECKING:
     from ..plugins.manager import PluginsManager
 
 logger = logging.getLogger(__name__)
+
+
+def order_lines_qs_select_for_update():
+    return OrderLine.objects.order_by("pk").select_for_update(of=["self"])
 
 
 def get_order_country(order: Order) -> str:
@@ -1286,3 +1293,27 @@ def order_info_for_logs(order: Order, lines: Iterable[OrderLine]):
             for line_info in lines_info
         ],
     }
+
+
+def clean_order_line_quantities(order_lines, quantities_for_lines):
+    for order_line, line_quantities in zip(order_lines, quantities_for_lines):
+        line_total_quantity = sum(line_quantities)
+        line_quantity_unfulfilled = order_line.quantity_unfulfilled
+
+        if line_total_quantity > line_quantity_unfulfilled:
+            msg = ("Only %(quantity)d item%(item_pluralize)s remaining to fulfill.") % {
+                "quantity": line_quantity_unfulfilled,
+                "item_pluralize": pluralize(line_quantity_unfulfilled),
+            }
+            order_line_global_id = graphene.Node.to_global_id(
+                "OrderLine", order_line.pk
+            )
+            raise ValidationError(
+                {
+                    "order_line_id": ValidationError(
+                        msg,
+                        code=OrderErrorCode.FULFILL_ORDER_LINE.value,
+                        params={"order_lines": [order_line_global_id]},
+                    )
+                }
+            )


### PR DESCRIPTION
This pr also unify the way to setup the lock on `order_lines` 
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
