### PR TITLE
Fix circular import in webhooks module

### DIFF
--- a/saleor/graphql/app/mutations/reenable_sync_webhooks.py
+++ b/saleor/graphql/app/mutations/reenable_sync_webhooks.py
@@ -1,23 +1,18 @@
 import graphene
-from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from ....app.error_codes import AppErrorCode
 from ....graphql.app.types import App
 from ....permission.enums import AppPermission
+from ....webhook.transport.synchronous.circuit_breaker.breaker_board import (
+    initialize_breaker_board,
+)
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_APPS
 from ...core.mutations import BaseMutation
 from ...core.types import AppError
 
-# TODO: Remove the conditional when unit tests circular import is solved.
-breaker_board = None
-if settings.ENABLE_BREAKER_BOARD:
-    from ....webhook.transport.synchronous.circuit_breaker.breaker_board import (
-        initialize_breaker_board,
-    )
-
-    breaker_board = initialize_breaker_board()
+breaker_board = initialize_breaker_board()
 
 
 class ReenableSyncWebhooks(BaseMutation):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -994,13 +994,15 @@ warnings.filterwarnings("ignore", category=CacheKeyWarning)
 
 # Breaker board configuration
 ENABLE_BREAKER_BOARD = get_bool_from_env("ENABLE_BREAKER_BOARD", False)
+# Storage class string for the breaker board, for example:
+# "saleor.webhook.transport.synchronous.circuit_breaker.storage.InMemoryStorage"
 BREAKER_BOARD_STORAGE_CLASS_STRING = os.environ.get(
     "BREAKER_BOARD_STORAGE_CLASS_STRING"
 )
 BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE = int(
     os.environ.get("BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE", 50)
 )
-# minumum events count to consider the breaker board threshold percentage
+# Minimum events count to consider the breaker board threshold percentage
 BREAKER_BOARD_FAILURE_MIN_COUNT = int(
     os.environ.get("BREAKER_BOARD_FAILURE_MIN_COUNT", 10)
 )

--- a/saleor/webhook/observability/obfuscation.py
+++ b/saleor/webhook/observability/obfuscation.py
@@ -21,7 +21,6 @@ from graphql.validation import validate
 from graphql.validation.rules.base import ValidationRule
 from graphql.validation.validation import ValidationContext
 
-from ...graphql.api import schema
 from .sensitive_data import ALLOWED_HEADERS, SENSITIVE_HEADERS, SensitiveFieldsMap
 
 if TYPE_CHECKING:
@@ -201,6 +200,9 @@ def anonymize_event_payload(
 ) -> Any:
     if not subscription_query:
         return payload
+
+    from ...graphql.api import schema
+
     graphql_backend = get_default_backend()
     document = graphql_backend.document_from_string(schema, subscription_query)
     if _contain_sensitive_field(document, sensitive_fields):

--- a/saleor/webhook/transport/synchronous/circuit_breaker/breaker_board.py
+++ b/saleor/webhook/transport/synchronous/circuit_breaker/breaker_board.py
@@ -97,6 +97,7 @@ class BreakerBoard:
 def initialize_breaker_board():
     if not settings.ENABLE_BREAKER_BOARD:
         return None
+
     storage_class = import_string(settings.BREAKER_BOARD_STORAGE_CLASS_STRING)  # type: ignore[arg-type]
     return BreakerBoard(
         storage=storage_class(),

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -8,10 +8,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import transaction
 
-from saleor.webhook.transport.synchronous.circuit_breaker.breaker_board import (
-    initialize_breaker_board,
-)
-
 from ....celeryconf import app
 from ....core import EventDeliveryStatus
 from ....core.db.connection import allow_writer
@@ -28,6 +24,9 @@ from ....payment.models import TransactionEvent
 from ....payment.utils import (
     create_transaction_event_from_request_and_webhook_response,
     recalculate_refundable_for_checkout,
+)
+from ....webhook.transport.synchronous.circuit_breaker.breaker_board import (
+    initialize_breaker_board,
 )
 from ... import observability
 from ...const import WEBHOOK_CACHE_DEFAULT_TIMEOUT


### PR DESCRIPTION
Fixed import of GraphQL schema in `anonymize_event_payload`, which should be a local one (as all other imports of the schema in Saleor).

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
