### PR TITLE
Generate sync webhook payloads in the dataloaders for filtering checkout shipping methods.

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -135,6 +135,7 @@ class CheckoutInfo:
     collection_point: Optional["Warehouse"] = None
     voucher: Optional["Voucher"] = None
     voucher_code: Optional["VoucherCode"] = None
+    pregenerated_payloads_for_excluded_shipping_method: Optional[dict] = None
 
     @cached_property
     def all_shipping_methods(self) -> list["ShippingMethodData"]:
@@ -147,7 +148,9 @@ class CheckoutInfo:
         )
         # Filter shipping methods using sync webhooks
         excluded_methods = self.manager.excluded_shipping_methods_for_checkout(
-            self.checkout, all_methods
+            self.checkout,
+            all_methods,
+            self.pregenerated_payloads_for_excluded_shipping_method,
         )
         initialize_shipping_method_active_status(all_methods, excluded_methods)
         return all_methods

--- a/saleor/graphql/checkout/dataloaders/checkout_infos.py
+++ b/saleor/graphql/checkout/dataloaders/checkout_infos.py
@@ -33,6 +33,9 @@ from ...tax.dataloaders import TaxClassByVariantIdLoader, TaxConfigurationByChan
 from ...warehouse.dataloaders import (
     WarehouseByIdLoader,
 )
+from ...webhook.dataloaders.pregenerated_payloads_for_checkout_filter_shipping_methods import (
+    PregeneratedCheckoutFilterShippingMethodPayloadsByCheckoutTokenLoader,
+)
 from .models import CheckoutByTokenLoader, CheckoutLinesByCheckoutTokenLoader
 from .promotion_rule_infos import VariantPromotionRuleInfoByCheckoutLineIdLoader
 
@@ -42,7 +45,13 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
 
     def batch_load(self, keys):
         def with_checkout(data):
-            checkouts, checkout_line_infos, checkout_discounts, manager = data
+            (
+                checkouts,
+                checkout_line_infos,
+                checkout_discounts,
+                manager,
+                pregenerated_payloads_for_excluded_shipping_methods,
+            ) = data
 
             channel_pks = [checkout.channel_id for checkout in checkouts]
 
@@ -131,12 +140,20 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
                     }
 
                     checkout_info_map = {}
-                    for key, checkout, channel, checkout_lines, discounts in zip(
+                    for (
+                        key,
+                        checkout,
+                        channel,
+                        checkout_lines,
+                        discounts,
+                        pregenerated_payloads_for_excluded_shipping_method,
+                    ) in zip(
                         keys,
                         checkouts,
                         channels,
                         checkout_line_infos,
                         checkout_discounts,
+                        pregenerated_payloads_for_excluded_shipping_methods,
                     ):
                         shipping_method = shipping_method_map.get(
                             checkout.shipping_method_id
@@ -174,6 +191,9 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
                             collection_point=collection_point,
                             voucher=voucher_code.voucher if voucher_code else None,
                             voucher_code=voucher_code,
+                            pregenerated_payloads_for_excluded_shipping_method=(
+                                pregenerated_payloads_for_excluded_shipping_method
+                            ),
                         )
                         checkout_info_map[key] = checkout_info
 
@@ -203,9 +223,20 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
         ).load_many(keys)
         discounts = CheckoutDiscountByCheckoutIdLoader(self.context).load_many(keys)
         manager = get_plugin_manager_promise(self.context)
-        return Promise.all([checkouts, checkout_line_infos, discounts, manager]).then(
-            with_checkout
+        pregenerated_payloads_for_excluded_shipping_methods_loader = (
+            PregeneratedCheckoutFilterShippingMethodPayloadsByCheckoutTokenLoader(
+                self.context
+            ).load_many(keys)
         )
+        return Promise.all(
+            [
+                checkouts,
+                checkout_line_infos,
+                discounts,
+                manager,
+                pregenerated_payloads_for_excluded_shipping_methods_loader,
+            ]
+        ).then(with_checkout)
 
 
 class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader[str, list[CheckoutLineInfo]]):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1,4 +1,5 @@
 import datetime
+from collections import defaultdict
 from decimal import Decimal
 from unittest import mock
 
@@ -226,6 +227,7 @@ def test_checkout_available_payment_gateways_valid_info_sent(
     api_client.post_graphql(query, variables)
 
     # then
+    checkout_info.pregenerated_payloads_for_excluded_shipping_method = defaultdict(dict)
     mocked_list_gateways.assert_called_with(
         currency=currency,
         checkout_info=checkout_info,

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -83,7 +83,9 @@ from ..tax.dataloaders import (
 from ..utils import get_user_or_app_from_context
 from ..warehouse.dataloaders import StocksReservationsByCheckoutTokenLoader
 from ..warehouse.types import Warehouse
-from ..webhook.dataloaders import PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader
+from ..webhook.dataloaders.pregenerated_payload_for_checkout_tax import (
+    PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader,
+)
 from .dataloaders import (
     CheckoutByTokenLoader,
     CheckoutInfoByCheckoutTokenLoader,

--- a/saleor/graphql/webhook/dataloaders/__init__.py
+++ b/saleor/graphql/webhook/dataloaders/__init__.py
@@ -2,14 +2,14 @@ from .models import (
     PayloadByIdLoader,
     WebhookEventsByWebhookIdLoader,
     WebhooksByAppIdLoader,
+    WebhooksByEventTypeLoader,
 )
-from .pregenerated_payload_for_checkout_tax import (
-    PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader,
-)
+from .request_context import PayloadsRequestContextByEventTypeLoader
 
 __all__ = [
     "PayloadByIdLoader",
-    "PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader",
+    "PayloadsRequestContextByEventTypeLoader",
     "WebhookEventsByWebhookIdLoader",
     "WebhooksByAppIdLoader",
+    "WebhooksByEventTypeLoader",
 ]

--- a/saleor/graphql/webhook/dataloaders/models.py
+++ b/saleor/graphql/webhook/dataloaders/models.py
@@ -1,7 +1,11 @@
 from collections import defaultdict
 
 from ....core.models import EventPayload
+from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.models import Webhook, WebhookEvent
+from ....webhook.utils import (
+    calculate_webhooks_for_multiple_events,
+)
 from ...core.dataloaders import DataLoader
 
 
@@ -45,3 +49,98 @@ class WebhooksByAppIdLoader(DataLoader):
         for webhook in webhooks:
             webhooks_by_app_map[webhook.app_id].append(webhook)
         return [webhooks_by_app_map.get(app_id, []) for app_id in keys]
+
+
+class WebhookEventsByEventTypeLoader(DataLoader):
+    context_key = "webhook_events_by_event_type"
+
+    def batch_load(self, keys):
+        webhook_events_by_event_type: dict[str, list[WebhookEvent]] = defaultdict(list)
+        webhooks_events = WebhookEvent.objects.using(
+            self.database_connection_name
+        ).filter(event_type__in=keys)
+        for webhook_event in webhooks_events:
+            webhook_events_by_event_type[webhook_event.event_type].append(webhook_event)
+        return [webhook_events_by_event_type[event_type] for event_type in keys]
+
+
+class ActiveWebhooksByIdLoader(DataLoader):
+    context_key = "active_webhooks_by_id"
+
+    def batch_load(self, keys):
+        webhooks_map = (
+            Webhook.objects.using(self.database_connection_name)
+            .filter(is_active=True)
+            .in_bulk(keys)
+        )
+        return [webhooks_map.get(webhook_id) for webhook_id in keys]
+
+
+class WebhooksByEventTypeLoader(DataLoader):
+    context_key = "webhooks_by_event_type"
+
+    def batch_load(self, keys):
+        set_event_types = set(keys)
+        if set_event_types.intersection(WebhookEventAsyncType.ALL):
+            set_event_types.add(WebhookEventAsyncType.ANY)
+
+        def fetch_webhooks(
+            webhook_events_by_event_types, set_event_types=set_event_types
+        ):
+            events_types_by_webhook_id_map: dict[int, set[str]] = defaultdict(set)
+            webhooks_ids = set()
+            for webhook_events_by_event_type in webhook_events_by_event_types:
+                for webhook_event in webhook_events_by_event_type:
+                    webhooks_id = webhook_event.webhook_id
+                    events_types_by_webhook_id_map[webhook_event.webhook_id].add(
+                        webhook_event.event_type
+                    )
+                    webhooks_ids.add(webhooks_id)
+
+            def fetch_apps(
+                webhooks,
+                set_event_types=set_event_types,
+                events_types_by_webhook_id_map=events_types_by_webhook_id_map,
+            ):
+                # Filter out None values due to webhooks that are not active.
+                webhooks = [webhook for webhook in webhooks if webhook]
+                app_ids = {webhook.app_id for webhook in webhooks}
+
+                def return_webhooks_by_event_type(
+                    apps,
+                    set_event_types=set_event_types,
+                    events_types_by_webhook_id_map=events_types_by_webhook_id_map,
+                    webhooks=webhooks,
+                ):
+                    apps_by_id = {app.id: app for app in apps if app}
+                    webhooks_by_event_type_map = calculate_webhooks_for_multiple_events(
+                        set_event_types,
+                        apps_by_id,
+                        webhooks,
+                        events_types_by_webhook_id_map,
+                    )
+                    return [
+                        webhooks_by_event_type_map.get(event_type, [])
+                        for event_type in keys
+                    ]
+
+                # Avoiding circular import
+                from ...app.dataloaders import ActiveAppByIdLoader
+
+                return (
+                    ActiveAppByIdLoader(self.context)
+                    .load_many(app_ids)
+                    .then(return_webhooks_by_event_type)
+                )
+
+            return (
+                ActiveWebhooksByIdLoader(self.context)
+                .load_many(webhooks_ids)
+                .then(fetch_apps)
+            )
+
+        return (
+            WebhookEventsByEventTypeLoader(self.context)
+            .load_many(set_event_types)
+            .then(fetch_webhooks)
+        )

--- a/saleor/graphql/webhook/dataloaders/pregenerated_payload_for_checkout_tax.py
+++ b/saleor/graphql/webhook/dataloaders/pregenerated_payload_for_checkout_tax.py
@@ -11,19 +11,18 @@ from ....tax.utils import (
     get_tax_configuration_for_checkout,
 )
 from ....webhook.event_types import WebhookEventSyncType
-from ....webhook.utils import get_webhooks_for_event
-from ...app.dataloaders import AppByIdLoader
-from ...checkout.dataloaders import (
+from ...app.dataloaders import AppsByEventTypeLoader
+from ...checkout.dataloaders.checkout_infos import (
     CheckoutInfoByCheckoutTokenLoader,
     CheckoutLinesInfoByCheckoutTokenLoader,
 )
 from ...core.dataloaders import DataLoader
-from ...utils import get_user_or_app_from_context
-from ..subscription_payload import (
-    generate_payload_promise_from_subscription,
-    initialize_request,
-)
+from ..subscription_payload import generate_payload_promise_from_subscription
 from ..utils import get_subscription_query_hash
+from .models import WebhooksByEventTypeLoader
+from .request_context import (
+    PayloadsRequestContextByEventTypeLoader,
+)
 
 
 class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
@@ -53,18 +52,9 @@ class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
         )
 
         event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
-        requestor = get_user_or_app_from_context(self.context)
-        request_context = initialize_request(
-            requestor,
-            sync_event=True,
-            allow_replica=False,
-            event_type=event_type,
-        )
-        webhooks = get_webhooks_for_event(event_type)
-        apps_ids = [webhook.app_id for webhook in webhooks]
 
         def generate_payloads(data):
-            checkouts_info, checkout_lines_info, apps = data
+            checkouts_info, checkout_lines_info, apps, request_context, webhooks = data
             apps_map = {app.id: app for app in apps}
             promises = []
             for checkout_info, lines_info in zip(checkouts_info, checkout_lines_info):
@@ -130,5 +120,11 @@ class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
 
         checkouts_info = CheckoutInfoByCheckoutTokenLoader(self.context).load_many(keys)
         lines = CheckoutLinesInfoByCheckoutTokenLoader(self.context).load_many(keys)
-        apps = AppByIdLoader(self.context).load_many(apps_ids)
-        return Promise.all([checkouts_info, lines, apps]).then(generate_payloads)
+        apps = AppsByEventTypeLoader(self.context).load(event_type)
+        request_context = PayloadsRequestContextByEventTypeLoader(self.context).load(
+            event_type
+        )
+        webhooks = WebhooksByEventTypeLoader(self.context).load(event_type)
+        return Promise.all(
+            [checkouts_info, lines, apps, request_context, webhooks]
+        ).then(generate_payloads)

--- a/saleor/graphql/webhook/dataloaders/pregenerated_payloads_for_checkout_filter_shipping_methods.py
+++ b/saleor/graphql/webhook/dataloaders/pregenerated_payloads_for_checkout_filter_shipping_methods.py
@@ -1,0 +1,96 @@
+from collections import defaultdict
+from typing import Any
+
+from promise import Promise
+
+from ....webhook.event_types import WebhookEventSyncType
+from ...app.dataloaders import AppsByEventTypeLoader
+from ...checkout.dataloaders.models import CheckoutByTokenLoader
+from ...core.dataloaders import DataLoader
+from ..subscription_payload import (
+    generate_payload_promise_from_subscription,
+)
+from ..utils import get_subscription_query_hash
+from .models import WebhooksByEventTypeLoader
+from .request_context import (
+    PayloadsRequestContextByEventTypeLoader,
+)
+
+
+class PregeneratedCheckoutFilterShippingMethodPayloadsByCheckoutTokenLoader(DataLoader):
+    context_key = (
+        "pregenerated_checkout_filter_shipping_method_payloads_by_checkout_token"
+    )
+
+    def batch_load(self, keys):
+        """Fetch pregenerated tax payloads for checkout shipping method filtering.
+
+        This loader is used to fetch pregenerated payloads for checkouts shipping method filtering.
+
+        return: A dict of shipping method filtering payloads for checkouts.
+
+        Example:
+        {
+            "checkout_token": {
+                "app_id": {
+                    "query_hash": {
+                        <payload>
+                    }
+                }
+            }
+        }
+
+        """
+
+        results: dict[str, dict[int, dict[str, dict[str, Any]]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+
+        event_type = WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS
+
+        def generate_payloads(data):
+            checkouts, apps, request_context, webhooks = data
+            apps_map = {app.id: app for app in apps}
+            promises = []
+            for checkout in checkouts:
+                for webhook in webhooks:
+                    if not webhook.subscription_query:
+                        continue
+                    query_hash = get_subscription_query_hash(webhook.subscription_query)
+                    app_id = webhook.app_id
+                    app = apps_map[app_id]
+                    checkout_token = str(checkout.token)
+                    promise_payload = generate_payload_promise_from_subscription(
+                        event_type=event_type,
+                        subscribable_object=checkout,
+                        subscription_query=webhook.subscription_query,
+                        request=request_context,
+                        app=app,
+                    )
+                    promises.append(promise_payload)
+
+                    def store_payload(
+                        payload,
+                        checkout_token=checkout_token,
+                        app_id=app_id,
+                        query_hash=query_hash,
+                    ):
+                        if payload:
+                            results[checkout_token][app_id][query_hash] = payload
+
+                    promise_payload.then(store_payload)
+
+            def return_payloads(_payloads):
+                return [results[str(checkout.token)] for checkout in checkouts]
+
+            return Promise.all(promises).then(return_payloads)
+
+        checkouts = CheckoutByTokenLoader(self.context).load_many(keys)
+        apps = AppsByEventTypeLoader(self.context).load(event_type)
+        request_context = PayloadsRequestContextByEventTypeLoader(self.context).load(
+            event_type
+        )
+        webhooks = WebhooksByEventTypeLoader(self.context).load(event_type)
+        return Promise.all([checkouts, apps, request_context, webhooks]).then(
+            generate_payloads
+        )

--- a/saleor/graphql/webhook/dataloaders/request_context.py
+++ b/saleor/graphql/webhook/dataloaders/request_context.py
@@ -1,0 +1,25 @@
+from collections import defaultdict
+from typing import Optional
+
+from ...core import SaleorContext
+from ...core.dataloaders import DataLoader
+from ...utils import get_user_or_app_from_context
+from ..subscription_payload import initialize_request
+
+
+class PayloadsRequestContextByEventTypeLoader(DataLoader):
+    context_key = "payloads_request_context_by_event_type"
+
+    def batch_load(self, keys):
+        request_context_by_event_type: dict[
+            str, Optional[SaleorContext]
+        ] = defaultdict()
+        requestor = get_user_or_app_from_context(self.context)
+        for event_type in keys:
+            request_context_by_event_type[event_type] = initialize_request(
+                requestor,
+                sync_event=True,
+                allow_replica=False,
+                event_type=event_type,
+            )
+        return [request_context_by_event_type.get(event_type) for event_type in keys]

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -4,8 +4,22 @@ from unittest import mock
 from django.test import override_settings
 from django.utils import timezone
 
+from .....shipping.models import ShippingMethod
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
+
+_line_tax_data = {
+    "total_gross_amount": 2.5,
+    "total_net_amount": 2,
+    "tax_rate": 20,
+}
+TAX_DATA_RESPONSE = {
+    "currency": "USD",
+    "shipping_price_gross_amount": 10,
+    "shipping_price_net_amount": 8,
+    "shipping_tax_rate": 20,
+    "lines": [_line_tax_data for _ in range(4)],
+}
 
 
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
@@ -16,12 +30,12 @@ from ....tests.utils import get_graphql_content
 def test_checkout_total_price_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
+    checkout = checkout_with_shipping_address
     checkout.price_expiration = timezone.now() - timedelta(days=1)
     checkout.save()
     checkout_global_id = to_global_id_or_none(checkout)
@@ -42,7 +56,7 @@ def test_checkout_total_price_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -52,6 +66,8 @@ def test_checkout_total_price_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["totalPrice"]["net"]["amount"] == 16
+    assert content["data"]["checkout"]["totalPrice"]["gross"]["amount"] == 20
 
 
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
@@ -62,12 +78,12 @@ def test_checkout_total_price_use_pregenerated_payload(
 def test_checkout_subtotal_price_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
+    checkout = checkout_with_shipping_address
     checkout.price_expiration = timezone.now() - timedelta(days=1)
     checkout.save()
     checkout_global_id = to_global_id_or_none(checkout)
@@ -88,7 +104,7 @@ def test_checkout_subtotal_price_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -98,6 +114,8 @@ def test_checkout_subtotal_price_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["subtotalPrice"]["net"]["amount"] == 8
+    assert content["data"]["checkout"]["subtotalPrice"]["gross"]["amount"] == 10
 
 
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
@@ -108,12 +126,12 @@ def test_checkout_subtotal_price_use_pregenerated_payload(
 def test_checkout_total_balance_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
+    checkout = checkout_with_shipping_address
     checkout.price_expiration = timezone.now() - timedelta(days=1)
     checkout.save()
     checkout_global_id = to_global_id_or_none(checkout)
@@ -129,7 +147,7 @@ def test_checkout_total_balance_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -139,6 +157,7 @@ def test_checkout_total_balance_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["totalBalance"]["amount"] == -20
 
 
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
@@ -149,12 +168,12 @@ def test_checkout_total_balance_use_pregenerated_payload(
 def test_checkout_shipping_price_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
+    checkout = checkout_with_shipping_address
     checkout.price_expiration = timezone.now() - timedelta(days=1)
     checkout.save()
     checkout_global_id = to_global_id_or_none(checkout)
@@ -178,7 +197,7 @@ def test_checkout_shipping_price_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -188,6 +207,8 @@ def test_checkout_shipping_price_use_pregenerated_payload(
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
     assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["shippingPrice"]["net"]["amount"] == 8
+    assert content["data"]["checkout"]["shippingPrice"]["gross"]["amount"] == 10
 
 
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
@@ -198,12 +219,12 @@ def test_checkout_shipping_price_use_pregenerated_payload(
 def test_checkout_authorize_status_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
+    checkout = checkout_with_shipping_address
     checkout.price_expiration = timezone.now() - timedelta(days=1)
     checkout.save()
     checkout_global_id = to_global_id_or_none(checkout)
@@ -217,7 +238,7 @@ def test_checkout_authorize_status_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -237,12 +258,12 @@ def test_checkout_authorize_status_use_pregenerated_payload(
 def test_checkout_charge_status_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
+    checkout = checkout_with_shipping_address
     checkout.price_expiration = timezone.now() - timedelta(days=1)
     checkout.save()
     checkout_global_id = to_global_id_or_none(checkout)
@@ -256,7 +277,7 @@ def test_checkout_charge_status_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -276,15 +297,15 @@ def test_checkout_charge_status_use_pregenerated_payload(
 def test_checkout_line_unit_price_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout_with_item,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
-    checkout_with_item.price_expiration = timezone.now() - timedelta(days=1)
-    checkout_with_item.save()
-    checkout_global_id = to_global_id_or_none(checkout_with_item)
+    checkout = checkout_with_shipping_address
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
     checkout_total_price_query = """
         query getCheckout($id: ID!) {
             checkout(id: $id) {
@@ -307,7 +328,7 @@ def test_checkout_line_unit_price_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -315,6 +336,15 @@ def test_checkout_line_unit_price_use_pregenerated_payload(
 
     # then
     assert content["data"]["checkout"]["id"] == checkout_global_id
+    lines_data = content["data"]["checkout"]["lines"]
+    assert lines_data[0]["unitPrice"]["net"]["amount"] == 2
+    assert lines_data[0]["unitPrice"]["gross"]["amount"] == 2.5
+    assert lines_data[1]["unitPrice"]["net"]["amount"] == 0.2
+    assert lines_data[1]["unitPrice"]["gross"]["amount"] == 0.25
+    assert lines_data[2]["unitPrice"]["net"]["amount"] == 0.67
+    assert lines_data[2]["unitPrice"]["gross"]["amount"] == 0.83
+    assert lines_data[3]["unitPrice"]["net"]["amount"] == 0.4
+    assert lines_data[3]["unitPrice"]["gross"]["amount"] == 0.5
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
 
@@ -327,15 +357,15 @@ def test_checkout_line_unit_price_use_pregenerated_payload(
 def test_checkout_line_total_price_use_pregenerated_payload(
     mock_generate_payload,
     mock_request,
-    checkout_with_item,
+    checkout_with_shipping_address,
     api_client,
-    tax_data_response,
     tax_app,
 ):
     # given
-    checkout_with_item.price_expiration = timezone.now() - timedelta(days=1)
-    checkout_with_item.save()
-    checkout_global_id = to_global_id_or_none(checkout_with_item)
+    checkout = checkout_with_shipping_address
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
     checkout_total_price_query = """
         query getCheckout($id: ID!) {
             checkout(id: $id) {
@@ -358,7 +388,7 @@ def test_checkout_line_total_price_use_pregenerated_payload(
     """
     variables = {"id": checkout_global_id}
 
-    mock_request.return_value = tax_data_response
+    mock_request.return_value = TAX_DATA_RESPONSE
 
     # when
     response = api_client.post_graphql(checkout_total_price_query, variables)
@@ -366,5 +396,227 @@ def test_checkout_line_total_price_use_pregenerated_payload(
 
     # then
     assert content["data"]["checkout"]["id"] == checkout_global_id
+    for line_data in content["data"]["checkout"]["lines"]:
+        assert line_data["totalPrice"]["net"]["amount"] == 2
+        assert line_data["totalPrice"]["gross"]["amount"] == 2.5
     mock_generate_payload.assert_not_called()
     mock_request.assert_called_once()
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.trigger_webhook_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_shipping_methods_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout_with_shipping_address,
+    shipping_method,
+    api_client,
+    exclude_shipping_app_with_subscription,
+):
+    # given
+    checkout = checkout_with_shipping_address
+    checkout_global_id = to_global_id_or_none(checkout)
+    shipping_methods = ShippingMethod.objects.order_by("id").all()
+    shipping_method_global_ids = [
+        to_global_id_or_none(shipping_method) for shipping_method in shipping_methods
+    ]
+    exclude_msg = "Shipping method is excluded via metadata by external app."
+    checkout_shipping_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                shippingMethods {
+                    id
+                    name
+                    active
+                    message
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = {
+        "excluded_methods": [
+            {
+                "id": shipping_method_global_ids[1],
+                "reason": exclude_msg,
+            },
+        ]
+    }
+
+    # when
+    response = api_client.post_graphql(checkout_shipping_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["shippingMethods"] == [
+        {
+            "id": shipping_method_global_ids[0],
+            "name": "DHL",
+            "active": True,
+            "message": "",
+        },
+        {
+            "id": shipping_method_global_ids[1],
+            "name": "DHL",
+            "active": False,
+            "message": exclude_msg,
+        },
+    ]
+    mock_request.assert_called_once()
+    mock_generate_payload.assert_not_called()
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.trigger_webhook_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_available_shipping_methods_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_request,
+    checkout_with_shipping_address,
+    shipping_method,
+    api_client,
+    exclude_shipping_app_with_subscription,
+):
+    # given
+    checkout = checkout_with_shipping_address
+    checkout_global_id = to_global_id_or_none(checkout)
+    shipping_methods = ShippingMethod.objects.order_by("id").all()
+    shipping_method_global_ids = [
+        to_global_id_or_none(shipping_method) for shipping_method in shipping_methods
+    ]
+    exclude_msg = "Shipping method is excluded via metadata by external app."
+    checkout_shipping_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                availableShippingMethods {
+                    id
+                    name
+                    active
+                    message
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = {
+        "excluded_methods": [
+            {
+                "id": shipping_method_global_ids[1],
+                "reason": exclude_msg,
+            },
+        ]
+    }
+
+    # when
+    response = api_client.post_graphql(checkout_shipping_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["availableShippingMethods"] == [
+        {
+            "id": shipping_method_global_ids[0],
+            "name": "DHL",
+            "active": True,
+            "message": "",
+        }
+    ]
+    mock_request.assert_called_once()
+    mock_generate_payload.assert_not_called()
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@mock.patch("saleor.webhook.transport.synchronous.transport.trigger_webhook_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_shipping_methods_and_taxes_use_pregenerated_payload(
+    mock_generate_payload,
+    mock_shipping_request,
+    mock_tax_request,
+    checkout_with_shipping_address,
+    shipping_method,
+    api_client,
+    exclude_shipping_app_with_subscription,
+    tax_data_response,
+    tax_app,
+):
+    # given
+    checkout = checkout_with_shipping_address
+    checkout.price_expiration = timezone.now() - timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+    shipping_methods = ShippingMethod.objects.order_by("id").all()
+    shipping_method_global_ids = [
+        to_global_id_or_none(shipping_method) for shipping_method in shipping_methods
+    ]
+    exclude_msg = "Shipping method is excluded via metadata by external app."
+    checkout_shipping_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                totalPrice {
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+                shippingMethods {
+                    id
+                    name
+                    active
+                    message
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_shipping_request.return_value = {
+        "excluded_methods": [
+            {
+                "id": shipping_method_global_ids[1],
+                "reason": exclude_msg,
+            },
+        ]
+    }
+    mock_tax_request.return_value = TAX_DATA_RESPONSE
+
+    # when
+    response = api_client.post_graphql(checkout_shipping_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["shippingMethods"] == [
+        {
+            "id": shipping_method_global_ids[0],
+            "name": "DHL",
+            "active": True,
+            "message": "",
+        },
+        {
+            "id": shipping_method_global_ids[1],
+            "name": "DHL",
+            "active": False,
+            "message": exclude_msg,
+        },
+    ]
+    assert content["data"]["checkout"]["totalPrice"]["net"]["amount"] == 16
+    assert content["data"]["checkout"]["totalPrice"]["gross"]["amount"] == 20
+    mock_tax_request.assert_called_once()
+    mock_shipping_request.assert_called_once()
+    mock_generate_payload.assert_not_called()

--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_exclude_shipping_methods_pregenerated_payloads.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_exclude_shipping_methods_pregenerated_payloads.py
@@ -1,0 +1,76 @@
+from unittest import mock
+
+from django.test import override_settings
+
+from .....shipping.models import ShippingMethod
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+@mock.patch("saleor.webhook.transport.synchronous.transport.trigger_webhook_sync")
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_shipping_methods_use_pregenerated_payloads_app_without_subscription(
+    mock_generate_payload,
+    mock_request,
+    checkout_with_shipping_address,
+    shipping_method,
+    api_client,
+    exclude_shipping_app_without_subscription,
+):
+    # given
+    checkout = checkout_with_shipping_address
+    checkout_global_id = to_global_id_or_none(checkout)
+    shipping_methods = ShippingMethod.objects.order_by("id").all()
+    shipping_method_global_ids = [
+        to_global_id_or_none(shipping_method) for shipping_method in shipping_methods
+    ]
+    exclude_msg = "Shipping method is excluded via metadata by external app."
+    checkout_shipping_query = """
+        query getCheckout($id: ID!) {
+            checkout(id: $id) {
+                id
+                shippingMethods {
+                    id
+                    name
+                    active
+                    message
+                }
+            }
+        }
+    """
+    variables = {"id": checkout_global_id}
+
+    mock_request.return_value = {
+        "excluded_methods": [
+            {
+                "id": shipping_method_global_ids[1],
+                "reason": exclude_msg,
+            },
+        ]
+    }
+
+    # when
+    response = api_client.post_graphql(checkout_shipping_query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["checkout"]["id"] == checkout_global_id
+    assert content["data"]["checkout"]["shippingMethods"] == [
+        {
+            "id": shipping_method_global_ids[0],
+            "name": "DHL",
+            "active": True,
+            "message": "",
+        },
+        {
+            "id": shipping_method_global_ids[1],
+            "name": "DHL",
+            "active": False,
+            "message": exclude_msg,
+        },
+    ]
+    mock_request.assert_called_once()
+    mock_generate_payload.assert_not_called()

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2574,13 +2574,17 @@ class PluginsManager(PaymentInterface):
         self,
         checkout: "Checkout",
         available_shipping_methods: list["ShippingMethodData"],
+        pregenerated_subscription_payloads: Optional[dict] = None,
     ) -> list[ExcludedShippingMethod]:
+        if pregenerated_subscription_payloads is None:
+            pregenerated_subscription_payloads = {}
         return self.__run_method_on_plugins(
             "excluded_shipping_methods_for_checkout",
             [],
             checkout,
             available_shipping_methods,
             channel_slug=checkout.channel.slug,
+            pregenerated_subscription_payloads=pregenerated_subscription_payloads,
         )
 
     def perform_mutation(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3240,7 +3240,10 @@ class WebhookPlugin(BasePlugin):
         checkout: "Checkout",
         available_shipping_methods: list["ShippingMethodData"],
         previous_value: list[ExcludedShippingMethod],
+        pregenerated_subscription_payloads: Optional[dict] = None,
     ) -> list[ExcludedShippingMethod]:
+        if pregenerated_subscription_payloads is None:
+            pregenerated_subscription_payloads = {}
         generate_function = generate_excluded_shipping_methods_for_checkout_payload
         payload_function = lambda: generate_function(  # noqa: E731
             checkout,
@@ -3252,6 +3255,7 @@ class WebhookPlugin(BasePlugin):
             payload_fun=payload_function,
             subscribable_object=checkout,
             allow_replica=self.allow_replica,
+            pregenerated_subscription_payloads=pregenerated_subscription_payloads,
         )
 
     def is_event_active(self, event: str, channel=Optional[str]):

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -7,6 +7,7 @@ import pytest
 
 from ....core.models import EventDelivery
 from ....graphql.tests.utils import get_graphql_content
+from ....graphql.webhook.utils import get_subscription_query_hash
 from ....order import OrderStatus
 from ....webhook.const import CACHE_EXCLUDED_SHIPPING_TIME
 from ....webhook.event_types import WebhookEventSyncType
@@ -131,6 +132,7 @@ def test_excluded_shipping_methods_for_order(
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
     expected_cache_key = generate_cache_key_for_webhook(
         payload_dict,
@@ -222,6 +224,7 @@ def test_multiple_app_with_excluded_shipping_methods_for_order(
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
     mocked_webhook.assert_any_call(
         event_type,
@@ -232,7 +235,9 @@ def test_multiple_app_with_excluded_shipping_methods_for_order(
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
+    assert mocked_webhook.call_count == 2
     expected_cache_for_first_webhook_key = generate_cache_key_for_webhook(
         payload_dict,
         shipping_webhook.target_url,
@@ -351,6 +356,7 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_or
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
     mocked_webhook.assert_any_call(
         event_type,
@@ -361,7 +367,9 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_or
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
+    assert mocked_webhook.call_count == 2
 
     expected_cache_for_first_webhook_key = generate_cache_key_for_webhook(
         payload_dict,
@@ -690,7 +698,7 @@ def test_trigger_webhook_sync(mock_request, shipping_app):
     "saleor.plugins.webhook.plugin."
     "generate_excluded_shipping_methods_for_checkout_payload"
 )
-def test_excluded_shipping_methods_for_checkout_webhook(
+def test_excluded_shipping_methods_for_checkout_webhook_without_pregenerated_payload(
     mocked_payload,
     mocked_webhook,
     mocked_cache_set,
@@ -749,6 +757,7 @@ def test_excluded_shipping_methods_for_checkout_webhook(
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
     expected_cache_key = generate_cache_key_for_webhook(
         payload_dict,
@@ -762,6 +771,95 @@ def test_excluded_shipping_methods_for_checkout_webhook(
         webhook_response,
         timeout=CACHE_EXCLUDED_SHIPPING_TIME,
     )
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.cache.set")
+@mock.patch("saleor.webhook.transport.synchronous.transport.trigger_webhook_sync")
+@mock.patch(
+    "saleor.plugins.webhook.plugin."
+    "generate_excluded_shipping_methods_for_checkout_payload"
+)
+@mock.patch(
+    "saleor.webhook.transport.synchronous.transport.generate_payload_from_subscription"
+)
+def test_excluded_shipping_methods_for_checkout_webhook_with_subscription_base_pregenerated_payload(
+    mocked_subscription_payload,
+    mocked_static_payload,
+    mocked_webhook,
+    mocked_cache_set,
+    webhook_plugin,
+    checkout_with_items,
+    available_shipping_methods_factory,
+    exclude_shipping_app_with_subscription,
+    settings,
+):
+    # given
+    shipping_app = exclude_shipping_app_with_subscription
+    shipping_webhook = shipping_app.webhooks.get()
+    webhook_reason = "Checkout contains dangerous products."
+    other_reason = "Shipping is not applicable for this checkout."
+
+    webhook_response = {
+        "excluded_methods": [
+            {
+                "id": graphene.Node.to_global_id("ShippingMethod", "1"),
+                "reason": webhook_reason,
+            }
+        ]
+    }
+
+    mocked_webhook.return_value = webhook_response
+
+    payload_dict = {"checkout": {"id": 1, "some_field": "12"}}
+    query_hash = get_subscription_query_hash(shipping_webhook.subscription_query)
+    pregenerated_payloads = {shipping_app.id: {query_hash: payload_dict}}
+    payload = json.dumps(payload_dict)
+    mocked_static_payload.return_value = payload
+
+    plugin = webhook_plugin()
+    available_shipping_methods = available_shipping_methods_factory(num_methods=2)
+    previous_value = [
+        ExcludedShippingMethod(id="1", reason=other_reason),
+        ExcludedShippingMethod(id="2", reason=other_reason),
+    ]
+    # when
+    excluded_methods = plugin.excluded_shipping_methods_for_checkout(
+        checkout_with_items,
+        available_shipping_methods=available_shipping_methods,
+        previous_value=previous_value,
+        pregenerated_subscription_payloads=pregenerated_payloads,
+    )
+    # then
+    assert len(excluded_methods) == 2
+    em = excluded_methods[0]
+    assert em.id == "1"
+    assert webhook_reason in em.reason
+    assert other_reason in em.reason
+
+    mocked_webhook.assert_called_once_with(
+        WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+        payload,
+        shipping_webhook,
+        False,
+        subscribable_object=checkout_with_items,
+        timeout=settings.WEBHOOK_SYNC_TIMEOUT,
+        request=None,
+        requestor=None,
+        pregenerated_subscription_payload=payload_dict,
+    )
+    expected_cache_key = generate_cache_key_for_webhook(
+        payload_dict,
+        shipping_webhook.target_url,
+        WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+        shipping_app.id,
+    )
+
+    mocked_cache_set.assert_called_once_with(
+        expected_cache_key,
+        webhook_response,
+        timeout=CACHE_EXCLUDED_SHIPPING_TIME,
+    )
+    mocked_subscription_payload.assert_not_called()
 
 
 @mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
@@ -889,6 +987,7 @@ def test_multiple_app_with_excluded_shipping_methods_for_checkout(
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
     mocked_webhook.assert_any_call(
         event_type,
@@ -899,7 +998,9 @@ def test_multiple_app_with_excluded_shipping_methods_for_checkout(
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
+    assert mocked_webhook.call_count == 2
 
     expected_cache_for_first_webhook_key = generate_cache_key_for_webhook(
         payload_dict, shipping_webhook.target_url, event_type, shipping_app.id
@@ -1018,6 +1119,7 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_ch
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
     mocked_webhook.assert_any_call(
         event_type,
@@ -1028,7 +1130,9 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_ch
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         request=None,
         requestor=None,
+        pregenerated_subscription_payload=None,
     )
+    assert mocked_webhook.call_count == 2
 
     expected_cache_for_first_webhook_key = generate_cache_key_for_webhook(
         payload_dict, first_webhook.target_url, event_type, shipping_app.id

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -7737,6 +7737,51 @@ def list_stored_payment_methods_app(db, permission_manage_payments):
 
 
 @pytest.fixture
+def exclude_shipping_app_without_subscription(db, permission_manage_checkouts):
+    app = App.objects.create(name="Shipping App without subscription", is_active=True)
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_manage_checkouts)
+
+    webhook = Webhook.objects.create(
+        name="shipping-webhook-1",
+        app=app,
+        target_url="https://shipping-app.com/api/",
+    )
+    WebhookEvent.objects.create(
+        event_type=WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+        webhook=webhook,
+    )
+    return app
+
+
+@pytest.fixture
+def exclude_shipping_app_with_subscription(db, permission_manage_checkouts):
+    app = App.objects.create(name="Shipping App with subscription", is_active=True)
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_manage_checkouts)
+
+    webhook = Webhook.objects.create(
+        name="shipping-webhook-2",
+        app=app,
+        target_url="https://shipping-app.com/api/",
+        subscription_query="""
+        subscription {
+            event {
+                ... on CheckoutFilterShippingMethods {
+                __typename
+                }
+            }
+        }
+        """,
+    )
+    WebhookEvent.objects.create(
+        event_type=WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+        webhook=webhook,
+    )
+    return app
+
+
+@pytest.fixture
 def stored_payment_method_request_delete_app(db, permission_manage_payments):
     app = App.objects.create(
         name="Payment method request delete",

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -175,6 +175,7 @@ def trigger_webhook_sync_if_not_cached(
     cache_timeout=None,
     request=None,
     requestor=None,
+    pregenerated_subscription_payload: Optional[dict] = None,
 ) -> Optional[dict]:
     """Get response for synchronous webhook.
 
@@ -196,6 +197,7 @@ def trigger_webhook_sync_if_not_cached(
             timeout=request_timeout,
             request=request,
             requestor=requestor,
+            pregenerated_subscription_payload=pregenerated_subscription_payload,
         )
         if response_data is not None:
             cache.set(


### PR DESCRIPTION
I want to merge this change because generating sync webhook payloads in the dataloaders for filtering checkout shipping methods.

Port #16586 

Webhook name: `CHECKOUT_FILTER_SHIPPING_METHODS` 

Local performance comparison for 100 checkouts with one filter shipping method call for each. 

|                   | Old solution | New solution |
|-------------------|--------------|--------------|
| DB writer queries | 399          | 712          |
| DB reader queries | 6091         | 4433         |
| Request time(s)   | 20.39        | 18.15        |
| Generated spans   | 5235         | 1048         |
| Memory usage(MB)  | 1666         | 351          |
| Allocations       | 491098       | 364008       |
| Stack depth       | 403          | 89           |

Stack depth is measured from `handle_query` inside `dispatch` of `GraphQLView`.
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
