### PR TITLE
Fix circular imports

### DIFF
--- a/saleor/core/payments.py
+++ b/saleor/core/payments.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
-from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
-
 if TYPE_CHECKING:
+    from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ..payment.interface import (
         CustomerSource,
         GatewayResponse,

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -47,7 +47,6 @@ from ..models import (
 from .shared import update_discount
 
 if TYPE_CHECKING:
-    from ...checkout.fetch import CheckoutLineInfo
     from ...order.fetch import EditableOrderLineInfo
     from ...order.models import OrderLine
     from ...product.managers import ProductVariantQueryset

--- a/saleor/graphql/webhook/mutations/webhook_trigger.py
+++ b/saleor/graphql/webhook/mutations/webhook_trigger.py
@@ -15,6 +15,12 @@ from ....permission.auth_filters import AuthorizationFilters
 from ....webhook.error_codes import WebhookTriggerErrorCode
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.models import Webhook
+from ....webhook.transport.asynchronous.transport import (
+    create_deliveries_for_subscriptions,
+    generate_deferred_payloads,
+    send_webhook_request_async,
+)
+from ....webhook.transport.utils import prepare_deferred_payload_data
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_WEBHOOKS
 from ...core.mutations import BaseMutation
@@ -148,13 +154,6 @@ class WebhookTrigger(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        from ....webhook.transport.asynchronous.transport import (
-            create_deliveries_for_subscriptions,
-            generate_deferred_payloads,
-            send_webhook_request_async,
-        )
-        from ....webhook.transport.utils import prepare_deferred_payload_data
-
         event_type, object, webhook = cls.validate_input(info, **data)
         delivery = None
         requestor = get_user_or_app_from_context(info.context)

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -102,6 +102,7 @@ from ...webhook.transport.shipping import (
 )
 from ...webhook.transport.synchronous.transport import (
     trigger_all_webhooks_sync,
+    trigger_transaction_request,
     trigger_webhook_sync,
     trigger_webhook_sync_if_not_cached,
 )
@@ -116,7 +117,6 @@ from ...webhook.transport.utils import (
     parse_list_payment_gateways_response,
     parse_payment_action_response,
     parse_tax_data,
-    trigger_transaction_request,
 )
 from ...webhook.utils import get_webhooks_for_event
 from ..base_plugin import BasePlugin, ExcludedShippingMethod

--- a/saleor/webhook/observability/obfuscation.py
+++ b/saleor/webhook/observability/obfuscation.py
@@ -20,7 +20,6 @@ from graphql.validation import validate
 from graphql.validation.rules.base import ValidationRule
 from graphql.validation.validation import ValidationContext
 
-from ...graphql.api import schema
 from .sensitive_data import ALLOWED_HEADERS, SENSITIVE_HEADERS, SensitiveFieldsMap
 
 if TYPE_CHECKING:
@@ -189,6 +188,9 @@ def anonymize_event_payload(
 ) -> Any:
     if not subscription_query:
         return payload
+
+    from ...graphql.api import schema
+
     graphql_backend = get_default_backend()
     document = graphql_backend.document_from_string(schema, subscription_query)
     if _contain_sensitive_field(document, sensitive_fields):

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -20,7 +20,6 @@ from .. import __version__
 from ..account.models import User
 from ..attribute.models import AttributeValueTranslation
 from ..checkout import base_calculations
-from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
 from ..checkout.models import Checkout
 from ..checkout.utils import get_checkout_metadata
 from ..core.db.connection import allow_writer
@@ -56,8 +55,10 @@ from .serializers import (
     serialize_product_attributes,
     serialize_variant_attributes,
 )
+from .transport.utils import from_payment_app_id
 
 if TYPE_CHECKING:
+    from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ..discount.models import Promotion
     from ..invoice.models import Invoice
     from ..payment.interface import (
@@ -1065,8 +1066,6 @@ def _generate_refund_data_payload(data):
 def generate_payment_payload(
     payment_data: "PaymentData", requestor: Optional["RequestorOrLazyObject"] = None
 ):
-    from .transport.utils import from_payment_app_id
-
     data = asdict(payment_data)
 
     if refund_data := data.get("refund_data"):

--- a/saleor/webhook/tests/test_tasks.py
+++ b/saleor/webhook/tests/test_tasks.py
@@ -16,8 +16,10 @@ from ...payment.models import TransactionEvent
 from ...payment.transaction_item_calculations import recalculate_transaction_amounts
 from ..event_types import WebhookEventSyncType
 from ..payloads import generate_transaction_action_request_payload
-from ..transport.synchronous.transport import handle_transaction_request_task
-from ..transport.utils import trigger_transaction_request
+from ..transport.synchronous.transport import (
+    handle_transaction_request_task,
+    trigger_transaction_request,
+)
 
 
 @pytest.fixture

--- a/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
@@ -10,7 +10,7 @@ from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....core import EventDeliveryStatus
 from .....core.models import EventDelivery
 from ....event_types import WebhookEventAsyncType
-from ...utils import get_webhooks_for_event
+from ....utils import get_webhooks_for_event
 from ..transport import (
     DeferredPayloadData,
     generate_deferred_payloads,


### PR DESCRIPTION
This PR fixes some of the circular imports in the webhook-related modules:
- Moved `trigger_transaction_request` to the "transport" module, as this function is effectively responsible for sync webhook delivery; before, it was placed in "utils," which is not correct.
- Moved import of the GraphQL `schema` to `anonymize_event_payload` for the observability module, which is consistent with other places that import the schema locally.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
