### PR TITLE
Add pregenerated payload for PAYMENT_GATEWAY_INITIALIZE_SESSION

### DIFF
--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -21,8 +21,14 @@ from ...core.utils import build_absolute_uri
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...csv.notifications import get_default_export_payload
 from ...graphql.core.context import SaleorContext
-from ...graphql.webhook.subscription_payload import initialize_request
-from ...graphql.webhook.utils import get_pregenerated_subscription_payload
+from ...graphql.webhook.subscription_payload import (
+    generate_payload_promise_from_subscription,
+    initialize_request,
+)
+from ...graphql.webhook.utils import (
+    get_pregenerated_subscription_payload,
+    get_subscription_query_hash,
+)
 from ...payment import PaymentError, TransactionKind
 from ...payment.interface import (
     GatewayResponse,
@@ -2859,13 +2865,18 @@ class WebhookPlugin(BasePlugin):
         amount: Decimal,
         source_object: Union["Order", "Checkout"],
         request: SaleorContext,
+        pregenerated_subscription_payloads: Optional[dict] = None,
     ):
+        if pregenerated_subscription_payloads is None:
+            pregenerated_subscription_payloads = {}
+
         if not webhook.app.identifier:
             logger.debug(
                 "Skipping app with id %s as identifier is not provided.",
                 webhook.app.pk,
             )
             return
+
         if webhook.app.identifier in response_gateway:
             logger.debug(
                 "Skipping next call for %s as app has been already processed.",
@@ -2883,6 +2894,10 @@ class WebhookPlugin(BasePlugin):
         )
         payload = {"id": source_object_id, "data": gateway_data, "amount": amount}
         subscribable_object = (source_object, gateway_data, amount)
+
+        pregenerated_subscription_payload = get_pregenerated_subscription_payload(
+            webhook, pregenerated_subscription_payloads
+        )
         response_data = trigger_webhook_sync(
             event_type=WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION,
             payload=json.dumps(payload, cls=CustomJsonEncoder),
@@ -2891,6 +2906,7 @@ class WebhookPlugin(BasePlugin):
             subscribable_object=subscribable_object,
             request=request,
             requestor=self.requestor,
+            pregenerated_subscription_payload=pregenerated_subscription_payload,
         )
         error_msg = None
         if response_data is None:
@@ -2910,6 +2926,8 @@ class WebhookPlugin(BasePlugin):
     ) -> list[PaymentGatewayData]:
         if not self.active:
             return previous_value
+
+        event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
         response_gateway: dict[str, PaymentGatewayData] = {}
         apps_identifiers = None
 
@@ -2918,16 +2936,52 @@ class WebhookPlugin(BasePlugin):
             gateways = {gateway.app_identifier: gateway for gateway in payment_gateways}
             apps_identifiers = list(gateways.keys())
 
-        webhooks = get_webhooks_for_event(
-            WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION,
-            apps_identifier=apps_identifiers,
+        webhooks = get_webhooks_for_event(event_type, apps_identifier=apps_identifiers)
+        request = initialize_request(
+            self.requestor, sync_event=True, event_type=event_type
         )
 
-        request = initialize_request(
-            self.requestor,
-            sync_event=True,
-            event_type=WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION,
+        pregenerated_subscription_payloads: dict[int, dict[str, dict[str, Any]]] = (
+            defaultdict(lambda: defaultdict(dict))
         )
+
+        app_ids = {webhook.app_id for webhook in webhooks}
+        apps_map = App.objects.filter(id__in=app_ids).in_bulk()
+
+        promises = []
+        for webhook in webhooks:
+            if not webhook.subscription_query:
+                continue
+
+            query_hash = get_subscription_query_hash(webhook.subscription_query)
+            app_id = webhook.app_id
+            app = apps_map[app_id]
+
+            gateway = gateways.get(webhook.app.identifier)
+            gateway_data = None
+            if gateway:
+                gateway_data = gateway.data
+
+            subscribable_object = (source_object, gateway_data, amount)
+
+            promise_payload = generate_payload_promise_from_subscription(
+                event_type=event_type,
+                subscribable_object=subscribable_object,
+                subscription_query=webhook.subscription_query,
+                request=request,
+                app=app,
+            )
+            promises.append(promise_payload)
+
+            def store_payload(
+                payload,
+                app_id=app_id,
+                query_hash=query_hash,
+            ):
+                if payload:
+                    pregenerated_subscription_payloads[app_id][query_hash] = payload
+
+            promise_payload.then(store_payload)
 
         for webhook in webhooks:
             self._payment_gateway_initialize_session_for_single_webhook(
@@ -2937,6 +2991,7 @@ class WebhookPlugin(BasePlugin):
                 amount=amount,
                 source_object=source_object,
                 request=request,
+                pregenerated_subscription_payloads=pregenerated_subscription_payloads,
             )
         return list(response_gateway.values())
 


### PR DESCRIPTION
Add pre-generated payload for `PAYMENT_GATEWAY_INITIALIZE_SESSION` sync webhook.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
