### PR TITLE
Do not take into account negative stock available quantity

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -1506,14 +1506,14 @@ def test_checkout_create_when_one_stock_exceeded(
 
     # make first stock exceeded
     stock = variant.stocks.first()
-    stock.quantity = -1
+    stock.quantity = -100
     stock.save()
 
     response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
     content = get_graphql_content(response)
     data = content["data"]["checkoutCreate"]
     assert data["errors"][0]["message"] == (
-        "Could not add items SKU_A. Only 2 remaining in stock."
+        "Could not add items SKU_A. Only 3 remaining in stock."
     )
     assert data["errors"][0]["field"] == "quantity"
 

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -1,12 +1,7 @@
 import sys
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import (
-    TYPE_CHECKING,
-    Optional,
-    TypedDict,
-    Union,
-)
+from typing import TYPE_CHECKING, Optional, TypedDict, Union
 from uuid import UUID
 
 from django.contrib.sites.models import Site
@@ -357,9 +352,12 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
                 # shipping zones supporting given country.
                 quantity = 0
                 for warehouse_id in used_warehouse_ids:
-                    quantity += available_quantity_by_warehouse_id_and_variant_id[
-                        warehouse_id
-                    ][variant_id]
+                    quantity += max(
+                        available_quantity_by_warehouse_id_and_variant_id[warehouse_id][
+                            variant_id
+                        ],
+                        0,
+                    )
                 quantity_map[variant_id] = quantity
             else:
                 # When country code is unknown, return the highest known quantity.

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -1,12 +1,6 @@
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    NamedTuple,
-    NoReturn,
-    Optional,
-)
+from typing import TYPE_CHECKING, Any, NamedTuple, NoReturn, Optional
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -295,7 +289,7 @@ def check_stock_quantity_bulk(
             quantity += variants_quantities.get(variant.pk, 0)
 
         stocks = variant_stocks.get(variant.pk, [])
-        available_quantity = sum([stock.available_quantity for stock in stocks])
+        available_quantity = sum([max(stock.available_quantity, 0) for stock in stocks])
         available_quantity = max(
             available_quantity - variant_reservations[variant.pk], 0
         )
@@ -545,7 +539,7 @@ def is_product_in_stock(
 
 
 def get_reserved_stock_quantity(
-    stocks: StockQuerySet, lines: Optional[list["CheckoutLine"]] = None
+    stocks: Iterable[Stock], lines: Optional[list["CheckoutLine"]] = None
 ) -> int:
     result = (
         Reservation.objects.filter(


### PR DESCRIPTION
I want to merge this change because it changes the way how we calculate available quantity. 

> [!WARNING]  
>  Potential breaking change in case of relying on negative stocks and the current relation between available quantity in different warehouses.

Negative stock means, assigned stock to the variant, where `stock.quantity - stock.allocations` returns negative value.
![image](https://github.com/user-attachments/assets/b93423ca-221b-40df-9f79-cef5fbd2e060)
☝️  returns `available-quantity` equal `-5` ( 1 - 6) for `Americas`

Negative stock can also happen when order is fulfilled with overstock flag:
![image](https://github.com/user-attachments/assets/b056bcd1-15c9-4ab2-be1f-465e6af58c40)
☝️  returns `available-quantity` equal `-3` ( -3 - 0)

---

In current flow, negative stock can impact on variant's quantity available in different warehouses. 👇 

![image](https://github.com/user-attachments/assets/e35b7ff4-c607-4c49-89d0-6164c5e28936)

`Americas` has 5 allocations and 1 quantity in stock. It results in `-4` available quanity.  `Default` warehouse has `3` quantity available. Saleor will return `InsufficentStock` error when calling checkout mutations as we make a sum of all `availableQuantities` for all warehouses in given channel. As `-4 + 3` results in negative value (`-1`), Saleor treats it as there is not enough stock for creating the checkout.

---

With this changes, we convert negetive available quantity values into `0`. Based on above example:
`Americas` has 5 allocations and 1 quantity in stock. It results in `0` available quantity. `Default` warehouse has `3` available quantity.  The  checkout mutations will not raise an exception, when adding to the checkout quanityt equal or lower than 3.  As `Americas` warehouse will not have an impact on `Default` warehouse, the `Default`'s stock will be available for sell. 




<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
