### PR TITLE
Always create checkout metadata for new checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,4 +55,3 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix `products` sorting when using `sortBy: {field: COLLECTION}` - #17189 by @korycins
 - Fix checkout funds releasing task - #17198 by @IKarbowiak
 - Fixed 'healthcheck' middleware (`/health/` endpoint) not forwarding incoming traffic whenever the protocol wasn't HTTP (such as WebSocket or Lifespan) - #17248 by @NyanKiyoshi
-- Always create checkout metadata for new checkouts - #17176 by @korycins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Truncate lenghty responses in `EventDeliveryAttempt` objects - #17044 by @wcislo-saleor
 
 ### Other changes
-
 - Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi
 - Fixed a potential crash when Checkout metadata is accessed with high concurrency - #16411 by @patrys
 - Add slugs to product/category/collection/page translations. Allow to query by translated slug - #16449 by @delemeator
@@ -56,3 +55,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix `products` sorting when using `sortBy: {field: COLLECTION}` - #17189 by @korycins
 - Fix checkout funds releasing task - #17198 by @IKarbowiak
 - Fixed 'healthcheck' middleware (`/health/` endpoint) not forwarding incoming traffic whenever the protocol wasn't HTTP (such as WebSocket or Lifespan) - #17248 by @NyanKiyoshi
+- Always create checkout metadata for new checkouts - #17176 by @korycins

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -706,19 +706,21 @@ def _create_order(
 
     # assign checkout payments to the order
     checkout.payments.update(order=order)
-    checkout_metadata = get_checkout_metadata(checkout)
 
     # store current tax configuration
     update_order_display_gross_prices(order)
 
+    checkout_metadata = get_checkout_metadata(checkout)
     # copy metadata from the checkout into the new order
-    order.metadata = checkout_metadata.metadata
+    if checkout_metadata:
+        order.metadata = checkout_metadata.metadata
+        order.private_metadata = checkout_metadata.private_metadata
+
     if metadata_list:
         order.store_value_in_metadata({data.key: data.value for data in metadata_list})
 
     order.redirect_url = checkout.redirect_url
 
-    order.private_metadata = checkout_metadata.private_metadata
     if private_metadata_list:
         order.store_value_in_private_metadata(
             {data.key: data.value for data in private_metadata_list}

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -39,7 +39,7 @@ from ..fetch import (
     fetch_checkout_info,
     fetch_checkout_lines,
 )
-from ..models import Checkout, CheckoutLine
+from ..models import Checkout, CheckoutLine, CheckoutMetadata
 from ..utils import (
     PRIVATE_META_APP_SHIPPING_ID,
     add_voucher_to_checkout,
@@ -357,6 +357,52 @@ def test_clear_delivery_method(checkout, shipping_method):
     checkout.refresh_from_db()
     assert not checkout.shipping_method
     assert isinstance(checkout_info.delivery_method_info, DeliveryMethodBase)
+
+
+@patch.object(CheckoutMetadata, "save")
+def test_clear_delivery_method_do_not_update_metadata_when_no_external_shipping(
+    mocked_metadata_save, checkout, shipping_method
+):
+    # given
+    checkout.shipping_method = shipping_method
+    checkout.save()
+    manager = get_plugins_manager(allow_replica=False)
+    checkout_info = fetch_checkout_info(checkout, [], manager)
+
+    # when
+    clear_delivery_method(checkout_info)
+
+    # then
+    checkout.refresh_from_db()
+    assert not mocked_metadata_save.called
+    assert not checkout.shipping_method
+    assert isinstance(checkout_info.delivery_method_info, DeliveryMethodBase)
+
+
+@patch.object(CheckoutMetadata, "save")
+def test_clear_delivery_method_update_metadata_when_external_shipping(
+    mocked_metadata_save, checkout, shipping_method
+):
+    # given
+    checkout.shipping_method = shipping_method
+    checkout.metadata_storage.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: "ID"}
+    checkout.metadata_storage.save()
+    checkout.save()
+    manager = get_plugins_manager(allow_replica=False)
+    checkout_info = fetch_checkout_info(checkout, [], manager)
+
+    # when
+    clear_delivery_method(checkout_info)
+
+    # then
+    checkout.refresh_from_db()
+    checkout.metadata_storage.refresh_from_db()
+    assert mocked_metadata_save.called
+    assert not checkout.shipping_method
+    assert isinstance(checkout_info.delivery_method_info, DeliveryMethodBase)
+    assert (
+        PRIVATE_META_APP_SHIPPING_ID not in checkout.metadata_storage.private_metadata
+    )
 
 
 def test_last_change_update(checkout):
@@ -2187,19 +2233,62 @@ def test_checkout_without_delivery_method_creates_empty_delivery_method(
     assert not delivery_method_info.is_method_in_valid_methods(checkout_info)
 
 
-def test_manage_external_shipping_id(checkout):
+def test_set_external_shipping_id(checkout):
+    # given
     app_shipping_id = "abcd"
     initial_private_metadata = {"test": 123}
     checkout.metadata_storage.private_metadata = initial_private_metadata
     checkout.metadata_storage.save()
 
+    # when
     set_external_shipping_id(checkout, app_shipping_id)
+
+    # then
     assert PRIVATE_META_APP_SHIPPING_ID in checkout.metadata_storage.private_metadata
 
+
+def test_get_external_shipping_id(checkout):
+    # given
+    app_shipping_id = "abcd"
+    initial_private_metadata = {"test": 123}
+    checkout.metadata_storage.private_metadata = initial_private_metadata
+    checkout.metadata_storage.save()
+    set_external_shipping_id(checkout, app_shipping_id)
+
+    # when
     shipping_id = get_external_shipping_id(checkout)
+
+    # then
     assert shipping_id == app_shipping_id
 
-    delete_external_shipping_id(checkout)
+
+def test_delete_external_shipping_id(checkout):
+    # given
+    app_shipping_id = "abcd"
+    initial_private_metadata = {"test": 123}
+    checkout.metadata_storage.private_metadata = initial_private_metadata
+    checkout.metadata_storage.save()
+    set_external_shipping_id(checkout, app_shipping_id)
+
+    # when
+    deleted = delete_external_shipping_id(checkout)
+
+    # then
+    assert deleted
+    assert checkout.metadata_storage.private_metadata == initial_private_metadata
+
+
+def test_delete_external_shipping_id_when_external_shipping_missing(checkout):
+    # given
+    initial_private_metadata = {"test": 123}
+    checkout.metadata_storage.private_metadata = initial_private_metadata
+    checkout.metadata_storage.save()
+
+    # when
+    deleted = delete_external_shipping_id(checkout)
+
+    # then
+    assert not deleted
     assert checkout.metadata_storage.private_metadata == initial_private_metadata
 
 

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -48,7 +48,7 @@ from ..utils import (
     change_billing_address_in_checkout,
     change_shipping_address_in_checkout,
     clear_delivery_method,
-    delete_external_shipping_id,
+    delete_external_shipping_id_if_present,
     get_checkout_metadata,
     get_external_shipping_id,
     get_voucher_discount_for_checkout,
@@ -2271,10 +2271,9 @@ def test_delete_external_shipping_id(checkout):
     set_external_shipping_id(checkout, app_shipping_id)
 
     # when
-    deleted = delete_external_shipping_id(checkout)
+    delete_external_shipping_id_if_present(checkout)
 
     # then
-    assert deleted
     assert checkout.metadata_storage.private_metadata == initial_private_metadata
 
 
@@ -2285,10 +2284,9 @@ def test_delete_external_shipping_id_when_external_shipping_missing(checkout):
     checkout.metadata_storage.save()
 
     # when
-    deleted = delete_external_shipping_id(checkout)
+    delete_external_shipping_id_if_present(checkout)
 
     # then
-    assert not deleted
     assert checkout.metadata_storage.private_metadata == initial_private_metadata
 
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import graphene
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import prefetch_related_objects
 from django.utils import timezone
 from prices import Money
@@ -1012,7 +1012,6 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
         shipping_channel_listings=checkout_info.shipping_channel_listings,
     )
 
-    delete_external_shipping_id(checkout=checkout)
     checkout.save(
         update_fields=[
             "shipping_method",
@@ -1020,7 +1019,8 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
             "last_change",
         ]
     )
-    get_checkout_metadata(checkout).save()
+    if delete_external_shipping_id(checkout=checkout):
+        checkout.metadata_storage.save()
 
 
 def is_fully_paid(
@@ -1099,19 +1099,32 @@ def set_external_shipping_id(checkout: Checkout, app_shipping_id: str):
 
 
 def get_external_shipping_id(container: Union["Checkout", "Order"]):
-    metadata_object: ModelWithMetadata
+    metadata_object: ModelWithMetadata | None
     if isinstance(container, Checkout):
         metadata_object = get_checkout_metadata(container)
     else:
         metadata_object = container
+    if not metadata_object:
+        return None
     return metadata_object.get_value_from_private_metadata(PRIVATE_META_APP_SHIPPING_ID)
 
 
-def delete_external_shipping_id(checkout: Checkout, save: bool = False):
+def delete_external_shipping_id(checkout: Checkout, save: bool = False) -> bool:
     metadata = get_or_create_checkout_metadata(checkout)
-    metadata.delete_value_from_private_metadata(PRIVATE_META_APP_SHIPPING_ID)
-    if save:
+    field_deleted = metadata.delete_value_from_private_metadata(
+        PRIVATE_META_APP_SHIPPING_ID
+    )
+    if save and field_deleted:
         metadata.save(update_fields=["private_metadata"])
+    return field_deleted
+
+
+@allow_writer()
+def create_checkout_metadata(checkout: "Checkout"):
+    try:
+        return CheckoutMetadata.objects.create(checkout=checkout)
+    except IntegrityError:
+        return checkout.metadata_storage
 
 
 @allow_writer()
@@ -1123,11 +1136,11 @@ def get_or_create_checkout_metadata(checkout: "Checkout") -> CheckoutMetadata:
 
 
 @allow_writer()
-def get_checkout_metadata(checkout: "Checkout"):
+def get_checkout_metadata(checkout: "Checkout") -> CheckoutMetadata | None:
     if hasattr(checkout, "metadata_storage"):
         # TODO: load metadata_storage with dataloader and pass as an argument
         return checkout.metadata_storage
-    return CheckoutMetadata(checkout=checkout)
+    return None
 
 
 def calculate_checkout_weight(lines: list["CheckoutLineInfo"]) -> "Weight":

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import graphene
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError, transaction
+from django.db import transaction
 from django.db.models import prefetch_related_objects
 from django.utils import timezone
 from prices import Money
@@ -1121,10 +1121,7 @@ def delete_external_shipping_id(checkout: Checkout, save: bool = False) -> bool:
 
 @allow_writer()
 def create_checkout_metadata(checkout: "Checkout"):
-    try:
-        return CheckoutMetadata.objects.create(checkout=checkout)
-    except IntegrityError:
-        return checkout.metadata_storage
+    return CheckoutMetadata.objects.create(checkout=checkout)
 
 
 @allow_writer()

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1110,7 +1110,11 @@ def get_external_shipping_id(container: Union["Checkout", "Order"]):
 
 
 def delete_external_shipping_id(checkout: Checkout, save: bool = False) -> bool:
-    metadata = get_or_create_checkout_metadata(checkout)
+    metadata = get_checkout_metadata(checkout)
+    if not metadata:
+        field_deleted = False
+        return field_deleted
+
     field_deleted = metadata.delete_value_from_private_metadata(
         PRIVATE_META_APP_SHIPPING_ID
     )

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1019,8 +1019,7 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
             "last_change",
         ]
     )
-    if delete_external_shipping_id(checkout=checkout):
-        checkout.metadata_storage.save()
+    delete_external_shipping_id_if_present(checkout=checkout)
 
 
 def is_fully_paid(
@@ -1096,6 +1095,7 @@ def set_external_shipping_id(checkout: Checkout, app_shipping_id: str):
     metadata.store_value_in_private_metadata(
         {PRIVATE_META_APP_SHIPPING_ID: app_shipping_id}
     )
+    metadata.save()
 
 
 def get_external_shipping_id(container: Union["Checkout", "Order"]):
@@ -1109,18 +1109,17 @@ def get_external_shipping_id(container: Union["Checkout", "Order"]):
     return metadata_object.get_value_from_private_metadata(PRIVATE_META_APP_SHIPPING_ID)
 
 
-def delete_external_shipping_id(checkout: Checkout, save: bool = False) -> bool:
+def delete_external_shipping_id_if_present(checkout: Checkout):
+    """Delete external shipping key if present in metadata."""
     metadata = get_checkout_metadata(checkout)
     if not metadata:
-        field_deleted = False
-        return field_deleted
+        return
 
     field_deleted = metadata.delete_value_from_private_metadata(
         PRIVATE_META_APP_SHIPPING_ID
     )
-    if save and field_deleted:
+    if field_deleted:
         metadata.save(update_fields=["private_metadata"])
-    return field_deleted
 
 
 @allow_writer()

--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -101,9 +101,11 @@ class ModelWithMetadata(models.Model):
     def clear_private_metadata(self):
         self.private_metadata = {}
 
-    def delete_value_from_private_metadata(self, key: str):
+    def delete_value_from_private_metadata(self, key: str) -> bool:
         if key in self.private_metadata:
             del self.private_metadata[key]
+            return True
+        return False
 
     def get_value_from_metadata(self, key: str, default: Any = None) -> Any:
         return self.metadata.get(key, default)

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from ....checkout import AddressType, models
 from ....checkout.actions import call_checkout_event
 from ....checkout.error_codes import CheckoutErrorCode
-from ....checkout.utils import add_variants_to_checkout
+from ....checkout.utils import add_variants_to_checkout, create_checkout_metadata
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.country import get_active_country
 from ....product import models as product_models
@@ -375,6 +375,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
                 instance.billing_address = billing_address.get_copy()
 
             instance.save()
+            create_checkout_metadata(instance)
 
     @classmethod
     def get_instance(cls, info: ResolveInfo, **data):

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -11,7 +11,6 @@ from ....checkout.fetch import (
 )
 from ....checkout.utils import (
     delete_external_shipping_id,
-    get_or_create_checkout_metadata,
     invalidate_checkout,
     is_shipping_required,
     set_external_shipping_id,
@@ -242,12 +241,17 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
     ) -> None:
         checkout_fields_to_update = ["shipping_method", "collection_point"]
         checkout = checkout_info.checkout
+        metadata_to_save = True
         if external_shipping_method:
             set_external_shipping_id(
                 checkout=checkout, app_shipping_id=external_shipping_method.id
             )
         else:
-            delete_external_shipping_id(checkout=checkout)
+            if not delete_external_shipping_id(checkout=checkout):
+                metadata_to_save = False
+
+        if metadata_to_save:
+            checkout.metadata_storage.save()
 
         # Clear checkout shipping address if it was switched from C&C.
         if checkout.collection_point_id and not collection_point:
@@ -266,7 +270,6 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
         checkout.save(
             update_fields=checkout_fields_to_update + invalidate_prices_updated_fields
         )
-        get_or_create_checkout_metadata(checkout).save()
         call_checkout_info_event(
             manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -10,7 +10,7 @@ from ....checkout.fetch import (
     fetch_checkout_lines,
 )
 from ....checkout.utils import (
-    delete_external_shipping_id,
+    delete_external_shipping_id_if_present,
     invalidate_checkout,
     is_shipping_required,
     set_external_shipping_id,
@@ -241,17 +241,12 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
     ) -> None:
         checkout_fields_to_update = ["shipping_method", "collection_point"]
         checkout = checkout_info.checkout
-        metadata_to_save = True
         if external_shipping_method:
             set_external_shipping_id(
                 checkout=checkout, app_shipping_id=external_shipping_method.id
             )
         else:
-            if not delete_external_shipping_id(checkout=checkout):
-                metadata_to_save = False
-
-        if metadata_to_save:
-            checkout.metadata_storage.save()
+            delete_external_shipping_id_if_present(checkout=checkout)
 
         # Clear checkout shipping address if it was switched from C&C.
         if checkout.collection_point_id and not collection_point:

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -5,7 +5,7 @@ from ....checkout.actions import call_checkout_info_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import (
-    delete_external_shipping_id,
+    delete_external_shipping_id_if_present,
     invalidate_checkout,
     is_shipping_required,
     set_external_shipping_id,
@@ -218,8 +218,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        if delete_external_shipping_id(checkout=checkout):
-            checkout.metadata_storage.save()
+        delete_external_shipping_id_if_present(checkout=checkout)
 
         call_checkout_info_event(
             manager,
@@ -260,7 +259,6 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        checkout.metadata_storage.save()
         call_checkout_info_event(
             manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
@@ -282,8 +280,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        if delete_external_shipping_id(checkout=checkout):
-            checkout.metadata_storage.save()
+        delete_external_shipping_id_if_present(checkout=checkout)
 
         call_checkout_info_event(
             manager,

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -19,7 +19,7 @@ from ....checkout.fetch import CheckoutInfo, CheckoutLineInfo
 from ....checkout.utils import (
     calculate_checkout_quantity,
     clear_delivery_method,
-    delete_external_shipping_id,
+    delete_external_shipping_id_if_present,
     get_external_shipping_id,
     is_shipping_required,
 )
@@ -103,7 +103,7 @@ def update_checkout_external_shipping_method_if_invalid(
     checkout_info: "CheckoutInfo", lines: list[CheckoutLineInfo]
 ):
     if not _is_external_shipping_valid(checkout_info):
-        delete_external_shipping_id(checkout_info.checkout, save=True)
+        delete_external_shipping_id_if_present(checkout_info.checkout)
 
 
 def update_checkout_shipping_method_if_invalid(

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -417,7 +417,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(82):
+    with django_assert_num_queries(83):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -435,7 +435,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(82):
+    with django_assert_num_queries(83):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -567,7 +567,7 @@ def test_create_checkout_with_order_promotion(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(87):
+    with django_assert_num_queries(88):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -7,11 +7,6 @@ from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
 
 
-# `instance = get_checkout_metadata(instance)` is calling the
-# `get_checkout_metadata` function to retrieve the metadata associated with a
-# checkout instance. This function is defined in the `.../checkout/utils.py` file
-# and takes a `Checkout` instance as an argument. It returns a dictionary
-# containing the metadata associated with the checkout.
 def get_valid_metadata_instance(instance) -> ModelWithMetadata:
     if isinstance(instance, Checkout):
         instance = get_or_create_checkout_metadata(instance)

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -357,7 +357,12 @@ def request_data_for_gateway_config(
         country_code = country.code
     else:
         country_code = Country(settings.DEFAULT_COUNTRY).code
-    channel = get_checkout_metadata(checkout).get_value_from_metadata("channel", "web")
+    checkout_metadata = get_checkout_metadata(checkout)
+    if checkout_metadata:
+        channel = checkout_metadata.get_value_from_metadata("channel", "web")
+    else:
+        channel = "web"
+
     return {
         "merchantAccount": merchant_account,
         "countryCode": country_code,

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -269,7 +269,10 @@ def create_payment_information(
         checkout_token = str(checkout.token)
         from ..checkout.utils import get_checkout_metadata
 
-        checkout_metadata = get_checkout_metadata(checkout).metadata
+        checkout_metadata = None
+        checkout_metadata_storage = get_checkout_metadata(checkout)
+        if checkout_metadata_storage:
+            checkout_metadata = checkout_metadata_storage.metadata
     elif order := payment.order:
         billing = order.billing_address
         shipping = order.shipping_address
@@ -988,9 +991,11 @@ def parse_transaction_action_data(
         TransactionRequestResponse(
             psp_reference=psp_reference,
             available_actions=available_actions,
-            event=TransactionRequestEventResponse(**parsed_event_data)
-            if parsed_event_data
-            else None,
+            event=(
+                TransactionRequestEventResponse(**parsed_event_data)
+                if parsed_event_data
+                else None
+            ),
         ),
         None,
     )
@@ -1555,9 +1560,9 @@ def get_transaction_item_params(
 ):
     return {
         "name": name,
-        "checkout_id": source_object.pk
-        if isinstance(source_object, Checkout)
-        else None,
+        "checkout_id": (
+            source_object.pk if isinstance(source_object, Checkout) else None
+        ),
         "order_id": source_object.pk if isinstance(source_object, Order) else None,
         "currency": source_object.currency,
         "app": app,
@@ -1633,9 +1638,11 @@ def handle_transaction_initialize_session(
             amount_value=amount,
             defaults={
                 "include_in_calculations": False,
-                "type": TransactionEventType.CHARGE_REQUEST
-                if action == TransactionFlowStrategy.CHARGE
-                else TransactionEventType.AUTHORIZATION_REQUEST,
+                "type": (
+                    TransactionEventType.CHARGE_REQUEST
+                    if action == TransactionFlowStrategy.CHARGE
+                    else TransactionEventType.AUTHORIZATION_REQUEST
+                ),
                 "currency": transaction_item.currency,
                 "amount_value": amount,
                 "idempotency_key": idempotency_key,


### PR DESCRIPTION
I want to merge this change because it adds logic, to always create the checkout's metadata object when creating the checkout.
Additionally, I've drop some UPDATE queries, where there is no need to make an update on CheckoutMetadata.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
