### PR TITLE
Add pre-generated payload for transaction sync webhooks

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -2792,7 +2792,6 @@ def test_for_checkout_with_shipping_app(
     mocked_send_webhook_request_sync,
     app_api_client,
     checkout_with_prices,
-    plugins_manager,
     permission_manage_payments,
     shipping_app_with_subscription,
     webhook_app,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -1,3 +1,4 @@
+import datetime
 from decimal import Decimal
 from unittest import mock
 
@@ -25,7 +26,6 @@ from .....payment.interface import (
 )
 from .....payment.models import Payment, TransactionItem
 from .....webhook.event_types import WebhookEventSyncType
-from .....webhook.models import Webhook
 from ....channel.enums import TransactionFlowStrategyEnum
 from ....core.enums import TransactionInitializeErrorCode
 from ....core.utils import to_global_id_or_none
@@ -2794,47 +2794,12 @@ def test_for_checkout_with_shipping_app(
     checkout_with_prices,
     permission_manage_payments,
     shipping_app_with_subscription,
-    webhook_app,
+    transaction_initialize_session_app,
+    transaction_session_response,
     caplog,
 ):
     # given
-    mocked_send_webhook_request_sync.return_value = {}
-
-    webhook_app.identifier = "app.identifier"
-    webhook_app.save(update_fields=["identifier"])
-    webhook_app.permissions.add(permission_manage_payments)
-    webhook_transaction_initialize = Webhook.objects.create(
-        name="Webhook",
-        app=webhook_app,
-        target_url="http://www.example.com",
-        subscription_query="""
-            subscription TransactionInitializeSession {
-                event {
-                    ... on TransactionInitializeSession {
-                    transaction {
-                        id
-                    }
-                    sourceObject {
-                        ... on Checkout {
-                            totalPrice {
-                                gross {
-                                    amount
-                                    currency
-                                }
-                            }
-                            shippingMethods {
-                                id
-                                name
-                            }
-                        }
-                    }
-                    }
-                }
-            }
-        """,
-    )
-    event_type = WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION
-    webhook_transaction_initialize.events.create(event_type=event_type)
+    mocked_send_webhook_request_sync.return_value = transaction_session_response
 
     shipping_webhook = shipping_app_with_subscription.webhooks.first()
     shipping_webhook.subscription_query = """
@@ -2857,7 +2822,10 @@ def test_for_checkout_with_shipping_app(
         "action": TransactionFlowStrategyEnum.AUTHORIZATION.name,
         "amount": Decimal("10.00"),
         "id": to_global_id_or_none(checkout),
-        "paymentGateway": {"id": webhook_app.identifier, "data": None},
+        "paymentGateway": {
+            "id": transaction_initialize_session_app.identifier,
+            "data": None,
+        },
     }
 
     # when
@@ -2879,6 +2847,119 @@ def test_for_checkout_with_shipping_app(
     }
     assert len(event_types) == 2
     assert WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT in event_types
+    assert WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION in event_types
+
+    for call in mocked_send_webhook_request_sync.mock_calls:
+        delivery = call.args[0]
+        assert delivery.payload.get_payload()
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@override_settings(
+    PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"],
+    CHECKOUT_PRICES_TTL=datetime.timedelta(0),
+)
+def test_for_checkout_with_tax_app(
+    mocked_send_webhook_request_sync,
+    app_api_client,
+    checkout_with_prices,
+    permission_manage_payments,
+    transaction_initialize_session_app,
+    tax_app,
+    transaction_session_response,
+    caplog,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = transaction_session_response
+
+    checkout = checkout_with_prices
+    variables = {
+        "action": TransactionFlowStrategyEnum.AUTHORIZATION.name,
+        "amount": Decimal("10.00"),
+        "id": to_global_id_or_none(checkout),
+        "paymentGateway": {
+            "id": transaction_initialize_session_app.identifier,
+            "data": None,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_INITIALIZE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionInitialize"]["errors"]
+
+    assert "No payload was generated with subscription for event" not in "".join(
+        caplog.messages
+    )
+
+    # gather called event types
+    event_types = {
+        call.args[0].event_type for call in mocked_send_webhook_request_sync.mock_calls
+    }
+    assert len(event_types) == 2
+    assert WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES in event_types
+    assert WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION in event_types
+
+    for call in mocked_send_webhook_request_sync.mock_calls:
+        delivery = call.args[0]
+        assert delivery.payload.get_payload()
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_for_order_with_tax_app(
+    mocked_send_webhook_request_sync,
+    app_api_client,
+    permission_manage_payments,
+    draft_order,
+    tax_app,
+    transaction_initialize_session_app,
+    transaction_session_response,
+    caplog,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = transaction_session_response
+
+    order = draft_order
+    order.should_refresh_prices = True
+    order.save(update_fields=["should_refresh_prices"])
+
+    variables = {
+        "action": TransactionFlowStrategyEnum.AUTHORIZATION.name,
+        "amount": Decimal("10.00"),
+        "id": to_global_id_or_none(draft_order),
+        "paymentGateway": {
+            "id": transaction_initialize_session_app.identifier,
+            "data": None,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_INITIALIZE,
+        variables,
+        permissions=[permission_manage_payments],
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["transactionInitialize"]["errors"]
+
+    assert "No payload was generated with subscription for event" not in "".join(
+        caplog.messages
+    )
+
+    # gather called event types
+    event_types = {
+        call.args[0].event_type for call in mocked_send_webhook_request_sync.mock_calls
+    }
+    assert len(event_types) == 2
+    assert WebhookEventSyncType.ORDER_CALCULATE_TAXES in event_types
     assert WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION in event_types
 
     for call in mocked_send_webhook_request_sync.mock_calls:

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3023,6 +3023,35 @@ class WebhookPlugin(BasePlugin):
             transaction_session_data.payment_gateway_data,
         )
 
+        pregenerated_subscription_payloads: dict[int, dict[str, dict[str, Any]]] = (
+            defaultdict(lambda: defaultdict(dict))
+        )
+        if webhook.subscription_query:
+            query_hash = get_subscription_query_hash(webhook.subscription_query)
+            app = webhook.app
+
+            request = initialize_request(
+                self.requestor, sync_event=True, event_type=webhook_event
+            )
+
+            promise_payload = generate_payload_promise_from_subscription(
+                event_type=webhook_event,
+                subscribable_object=transaction_session_data,
+                subscription_query=webhook.subscription_query,
+                request=request,
+                app=app,
+            )
+
+            def store_payload(
+                payload,
+                app_id=app.pk,
+                query_hash=query_hash,
+            ):
+                if payload:
+                    pregenerated_subscription_payloads[app_id][query_hash] = payload
+
+            promise_payload.then(store_payload)
+
         response_data = trigger_webhook_sync(
             event_type=webhook_event,
             payload=payload,
@@ -3030,6 +3059,7 @@ class WebhookPlugin(BasePlugin):
             allow_replica=False,
             subscribable_object=transaction_session_data,
             requestor=self.requestor,
+            pregenerated_subscription_payload=pregenerated_subscription_payloads,
         )
         error_msg = None
         if response_data is None:


### PR DESCRIPTION
Add pre-generated payloads for sync webhooks:
- `TRANSACTION_INITIALIZE_SESSION`
- `TRANSACTION_PROCESS_SESSION`


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
