### PR TITLE
Fix product sorting over collection order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop tax data line number validation for Avatax plugin - #16917 by @zedzior
 - Fix decreasing voucher code usage after changing `includeDraftOrderInVoucherUsage` to false - #17028 by @zedzior
 - Fix undiscounted price taxation when prices are entered with taxes - #16992 by @zedzior
+- Fix `products` sorting when using `sortBy: {field: COLLECTION}` - #17189 by @korycins


### PR DESCRIPTION
I want to merge this change because it solves the issue of invalid cursor and incorrect sorting when using sortBy collection:
query like this:
```graphql
{
  collection(id: "Q29sbGVjdGlvbjo0", channel: "default-channel") {
    products(first: 10, sortBy: {direction: ASC, field: COLLECTION}) {
      edges {
        node {
          id
          name
        }
      }
      pageInfo {
        endCursor
        hasNextPage
        hasPreviousPage
      }
    }
  }
}
```
Should return 10 first items with sort order, starting from lower to higher.  The returned `...Cursor`s should contain the list of two items `[sort_order, product_pk]`.  Right now, the cursor is incorrect as it returns `null` instead of `sort_order`. For example: `W251bGwsICIxMTMiXQ==` -> `[null, "113"]`.

This PR solves the problem.


Internal task link: https://linear.app/saleor/issue/MERX-1361/pagination-and-fetching-products-in-collection-does-not-return-proper

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
