### PR TITLE
Simplify attribute lookup queries

### DIFF
--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -490,24 +490,29 @@ class AttributeBulkUpdate(BaseMutation):
     def get_attributes(
         cls, attributes_data: list[AttributeBulkUpdateInput]
     ) -> list[models.Attribute]:
-        lookup = Q()
+        external_refs: set[str] = set()
+        attribute_ids: set[str] = set()
 
         for attribute_input in attributes_data:
-            external_ref = attribute_input.get("external_reference")
-            attribute_id = attribute_input.get("id")
+            external_ref = attribute_input.external_reference
+            attribute_id = attribute_input.id
 
             if not external_ref and not attribute_id:
                 continue
 
-            single_attr_lookup = Q()
-
             if attribute_id:
-                single_attr_lookup |= Q(
-                    pk=graphene.Node.from_global_id(attribute_id)[1]
-                )
+                attribute_ids.add(graphene.Node.from_global_id(attribute_id)[1])
             else:
-                single_attr_lookup |= Q(external_reference=external_ref)
-            lookup |= single_attr_lookup
+                external_refs.add(external_ref)
+
+        if attribute_ids and external_refs:
+            lookup = Q(pk__in=attribute_ids) | Q(external_reference__in=external_refs)
+        elif attribute_ids:
+            lookup = Q(pk__in=attribute_ids)
+        elif external_refs:
+            lookup = Q(external_reference__in=external_refs)
+        else:
+            return []
 
         attributes = models.Attribute.objects.filter(lookup).prefetch_related("values")
         return list(attributes)


### PR DESCRIPTION
Before, we created a big chain of `Q(id=a) | Q(id=b) | Q(id=c)`, this change replaces it with a simpler form of `Q(id__in={a, b, c})`, which also reduces the size of the resulting SQL query.

<details>
<summary>Before</summary>

```sql
SELECT ...
FROM "attribute_attribute"
WHERE (
  "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
  OR "attribute_attribute"."external_reference" = ?
)
ORDER BY ...
```

</details>

<details>
<summary>After</summary>

```sql
SELECT ...
FROM "attribute_attribute"
WHERE "attribute_attribute"."id" IN (?)
ORDER BY ...
```

</details>

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
