### PR TITLE
Fix checkout `line.undiscountedTotalPrice` and `line.undiscountedUnitPrice` calculations

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -255,6 +255,33 @@ def checkout_line_tax_rate(
     return checkout_line_info.line.tax_rate
 
 
+def checkout_line_undiscounted_unit_price(
+    *,
+    checkout_info: "CheckoutInfo",
+    checkout_line_info: "CheckoutLineInfo",
+):
+    # Fetch the undiscounted unit price from channel listings in case the prices
+    # are invalidated.
+    if checkout_info.checkout.price_expiration < timezone.now():
+        return base_calculations.calculate_undiscounted_base_line_unit_price(
+            checkout_line_info, checkout_info.channel
+        )
+    currency = checkout_info.checkout.currency
+    return quantize_price(checkout_line_info.line.undiscounted_unit_price, currency)
+
+
+def checkout_line_undiscounted_total_price(
+    *,
+    checkout_info: "CheckoutInfo",
+    checkout_line_info: "CheckoutLineInfo",
+):
+    undiscounted_unit_price = checkout_line_undiscounted_unit_price(
+        checkout_info=checkout_info, checkout_line_info=checkout_line_info
+    )
+    total_price = undiscounted_unit_price * checkout_line_info.line.quantity
+    return quantize_price(total_price, total_price.currency)
+
+
 def update_undiscounted_unit_price_for_lines(lines: Iterable["CheckoutLineInfo"]):
     """Update line undiscounted unit price amount.
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -6,10 +6,6 @@ from promise import Promise
 
 from ...account.models import User
 from ...checkout import calculations, models, problems
-from ...checkout.base_calculations import (
-    calculate_undiscounted_base_line_total_price,
-    calculate_undiscounted_base_line_unit_price,
-)
 from ...checkout.calculations import fetch_checkout_data
 from ...checkout.utils import get_valid_collection_points_for_checkout
 from ...core.db.connection import allow_writer_in_context
@@ -323,8 +319,9 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                 ) = data
                 for line_info in lines:
                     if line_info.line.pk == root.pk:
-                        return calculate_undiscounted_base_line_unit_price(
-                            line_info, checkout_info.channel
+                        return calculations.checkout_line_undiscounted_unit_price(
+                            checkout_info=checkout_info,
+                            checkout_line_info=line_info,
                         )
 
                 return None
@@ -406,8 +403,9 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                 ) = data
                 for line_info in lines:
                     if line_info.line.pk == root.pk:
-                        return calculate_undiscounted_base_line_total_price(
-                            line_info, checkout_info.channel
+                        return calculations.checkout_line_undiscounted_total_price(
+                            checkout_info=checkout_info,
+                            checkout_line_info=line_info,
                         )
                 return None
 


### PR DESCRIPTION
Ensure that `line.undiscountedTotalPrice` and `line.undiscountedUnitPrice` for checkout return the value that corresponds to other checkout line prices instead always returning it from channel listing.

Previous behaviour might be misleading in the following scenario:
1. The checkout with one line has been created
2. The variant price for this channel has been changed
3. The line total and unit price, order total and subtotal prices are unchanged. The `line.undiscountedTotalPrice` and `line.undiscountedUnitPrice` reflects the new variant price. Like below:
```
{
  "data": {
    "checkout": {
      "id": "Q2hlY2tvdXQ6YTkyNjljZDQtYTU1Zi00MTA2LTk5M2QtZDZmOWJhM2IxYzRj",
      "lines": [
        {
          "quantity": 1,
          "undiscountedTotalPrice": {
            "amount": 5
          },
          "undiscountedUnitPrice": {
            "amount": 5
          },
          "totalPrice": {
            "net": {
              "amount": 1.99
            }
          },
          "unitPrice": {
            "net": {
              "amount": 1.99
            }
          }
        }
      ],
      "totalPrice": {
        "gross": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "net": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "__typename": "TaxedMoney"
      },
      "subtotalPrice": {
        "gross": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "net": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "__typename": "TaxedMoney"
      }
    }
  }
}
```

After the changes the undercounted price will be fetched from checkout line:
```
{
  "data": {
    "checkout": {
      "id": "Q2hlY2tvdXQ6YTkyNjljZDQtYTU1Zi00MTA2LTk5M2QtZDZmOWJhM2IxYzRj",
      "lines": [
        {
          "quantity": 1,
          "undiscountedTotalPrice": {
            "amount": 1.99
          },
          "undiscountedUnitPrice": {
            "amount": 1.99
          },
          "totalPrice": {
            "net": {
              "amount": 1.99
            }
          },
          "unitPrice": {
            "net": {
              "amount": 1.99
            }
          }
        }
      ],
      "totalPrice": {
        "gross": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "net": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "__typename": "TaxedMoney"
      },
      "subtotalPrice": {
        "gross": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "net": {
          "amount": 1.99,
          "currency": "USD",
          "__typename": "Money"
        },
        "__typename": "TaxedMoney"
      }
    }
  }
}
```


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
