### PR TITLE
Add tests when app do not return taxes

### DIFF
--- a/saleor/tests/e2e/checkout/taxes/test_checkout_complete_return_tax_error.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_complete_return_tax_error.py
@@ -1,0 +1,136 @@
+import pytest
+
+from ...apps.utils import add_app
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils import prepare_default_shop
+from ...taxes.utils import get_tax_configurations, update_tax_configuration
+from ...utils import assign_permissions
+from ...webhooks.utils import create_webhook
+from ..utils import (
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+    raw_checkout_complete,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_calculate_return_tax_error_when_app_not_respond_CORE_2013(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_apps,
+    permission_handle_taxes,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_apps,
+        permission_handle_taxes,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    app_input = {"name": "tax_app", "permissions": ["HANDLE_TAXES"]}
+    app_data = add_app(e2e_staff_api_client, app_input)
+    app_id = app_data["app"]["id"]
+
+    target_url = "http://localhost:8777"
+    webhook_input = {
+        "app": app_id,
+        "syncEvents": ["CHECKOUT_CALCULATE_TAXES"],
+        "asyncEvents": [],
+        "isActive": True,
+        "name": "dynamic taxes",
+        "targetUrl": target_url,
+        "query": "fragment TaxBaseLine on TaxableObjectLine {\n  sourceLine {\n    __typename\n    ... on CheckoutLine {\n      id\n      checkoutVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n    ... on OrderLine {\n      id\n      orderVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n  }\n  quantity\n  unitPrice {\n    amount\n  }\n  totalPrice {\n    amount\n  }\n  chargeTaxes\n}\n\nfragment TaxBase on TaxableObject {\n  pricesEnteredWithTax\n  currency\n  channel {\n    slug\n  }\n  shippingPrice {\n    amount\n  }\n  lines {\n    ...TaxBaseLine\n  }\n  discounts {\n    name\n    amount {\n      amount\n      currency\n    }\n  }\n  sourceObject {\n    __typename\n    ... on Checkout {\n      id\n    }\n    ... on Order {\n      id\n    }\n  }\n}\n\nfragment CalculateTaxesEvent on Event {\n  ... on CalculateTaxes {\n    taxBase {\n      ...TaxBase\n    }\n  }\n}\n\nsubscription CalculateTaxes {\n  event {\n    ...CalculateTaxesEvent\n  }\n}\n",
+        "customHeaders": "{}",
+    }
+    create_webhook(e2e_staff_api_client, webhook_input)
+
+    tax_configs = get_tax_configurations(e2e_staff_api_client)
+    assert len(tax_configs) == 1
+    tax_config_id = tax_configs[0]["node"]["id"]
+
+    update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        tax_calculation_strategy="TAX_APP",
+        display_gross_prices=True,
+        prices_entered_with_tax=False,
+        tax_app_id=app_id,
+    )
+
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=30,
+    )
+    product_variant_price = float(product_variant_price)
+
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_data["totalPrice"]["gross"]["amount"] == product_variant_price
+    assert checkout_data["totalPrice"]["net"]["amount"] == product_variant_price
+    # Tax is not calculated, app do not respond
+    assert checkout_data["totalPrice"]["tax"]["amount"] == 0
+
+    # Step 2 - Set DeliveryMethod for checkout
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    shipping_price = 10
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert checkout_data["shippingPrice"]["net"]["amount"] == shipping_price
+    # Tax is not calculated, app do not respond
+    assert checkout_data["shippingPrice"]["tax"]["amount"] == 0
+    calculated_total_net = product_variant_price + shipping_price
+    assert checkout_data["totalPrice"]["net"]["amount"] == calculated_total_net
+
+    # Step 3 - Create payment for checkout
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        calculated_total_net,
+    )
+
+    # Step 4 - Complete checkout
+    order_data = raw_checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["errors"] is not None
+    assert order_data["errors"][0]["code"] == "TAX_ERROR"
+    assert order_data["errors"][0]["message"] == "Configured Tax App didn't responded."

--- a/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
+++ b/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
@@ -1,0 +1,136 @@
+import pytest
+
+from ...apps.utils import add_app
+
+# from ...orders.utils import raw_order_create_from_checkout
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils import prepare_default_shop
+from ...taxes.utils import get_tax_configurations, update_tax_configuration
+from ...utils import assign_permissions
+from ...webhooks.utils import create_webhook
+from ..utils import (
+    checkout_create,
+    checkout_delivery_method_update,
+)
+
+
+@pytest.mark.e2e
+def test_order_create_from_checkout_return_tax_error_when_app_not_respond_CORE_2014(
+    e2e_app_api_client,
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_apps,
+    permission_handle_taxes,
+    permission_handle_checkouts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_apps,
+        permission_handle_taxes,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    checkout_app_permissions = [permission_handle_checkouts]
+    assign_permissions(e2e_app_api_client, checkout_app_permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    app_input = {"name": "tax_app", "permissions": ["HANDLE_TAXES"]}
+    app_data = add_app(e2e_staff_api_client, app_input)
+    app_id = app_data["app"]["id"]
+
+    target_url = "http://localhost:8777"
+    webhook_input = {
+        "app": app_id,
+        "syncEvents": ["CHECKOUT_CALCULATE_TAXES"],
+        "asyncEvents": [],
+        "isActive": True,
+        "name": "dynamic taxes",
+        "targetUrl": target_url,
+        "query": "fragment TaxBaseLine on TaxableObjectLine {\n  sourceLine {\n    __typename\n    ... on CheckoutLine {\n      id\n      checkoutVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n    ... on OrderLine {\n      id\n      orderVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n  }\n  quantity\n  unitPrice {\n    amount\n  }\n  totalPrice {\n    amount\n  }\n  chargeTaxes\n}\n\nfragment TaxBase on TaxableObject {\n  pricesEnteredWithTax\n  currency\n  channel {\n    slug\n  }\n  shippingPrice {\n    amount\n  }\n  lines {\n    ...TaxBaseLine\n  }\n  discounts {\n    name\n    amount {\n      amount\n      currency\n    }\n  }\n  sourceObject {\n    __typename\n    ... on Checkout {\n      id\n    }\n    ... on Order {\n      id\n    }\n  }\n}\n\nfragment CalculateTaxesEvent on Event {\n  ... on CalculateTaxes {\n    taxBase {\n      ...TaxBase\n    }\n  }\n}\n\nsubscription CalculateTaxes {\n  event {\n    ...CalculateTaxesEvent\n  }\n}\n",
+        "customHeaders": "{}",
+    }
+    create_webhook(e2e_staff_api_client, webhook_input)
+
+    tax_configs = get_tax_configurations(e2e_staff_api_client)
+    assert len(tax_configs) == 1
+    tax_config_id = tax_configs[0]["node"]["id"]
+
+    update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        tax_calculation_strategy="TAX_APP",
+        display_gross_prices=True,
+        prices_entered_with_tax=False,
+        tax_app_id=app_id,
+    )
+
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=30,
+    )
+    product_variant_price = float(product_variant_price)
+
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_data["totalPrice"]["gross"]["amount"] == product_variant_price
+    assert checkout_data["totalPrice"]["net"]["amount"] == product_variant_price
+    # Tax is not calculated, app do not respond
+    assert checkout_data["totalPrice"]["tax"]["amount"] == 0
+
+    # Step 2 - Set DeliveryMethod for checkout
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    shipping_price = 10
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert checkout_data["shippingPrice"]["net"]["amount"] == shipping_price
+    # Tax is not calculated, app do not respond
+    assert checkout_data["shippingPrice"]["tax"]["amount"] == 0
+    calculated_total_net = product_variant_price + shipping_price
+    assert checkout_data["totalPrice"]["net"]["amount"] == calculated_total_net
+
+    # BUG: https://linear.app/saleor/issue/SHOPX-1712/
+    # uncomment this step when the bug is fixed
+    # # Step 4 - Place order via orderCreateFromCheckout
+    # order_data = raw_order_create_from_checkout(
+    #     e2e_app_api_client,
+    #     checkout_id,
+    # )
+    # assert order_data["errors"] is not None
+    # assert order_data["errors"][0]["code"] == "TAX_ERROR"
+    # assert order_data["errors"][0]["message"] == "Configured Tax App didn't responded."

--- a/saleor/tests/e2e/orders/taxes/test_draft_order_complete_return_tax_error.py
+++ b/saleor/tests/e2e/orders/taxes/test_draft_order_complete_return_tax_error.py
@@ -1,0 +1,132 @@
+import pytest
+
+from ... import DEFAULT_ADDRESS
+from ...apps.utils import add_app
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_default_shop
+from ...taxes.utils import get_tax_configurations, update_tax_configuration
+from ...utils import assign_permissions
+from ...webhooks.utils import create_webhook
+from ..utils import (
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+    raw_draft_order_complete,
+)
+
+
+@pytest.mark.e2e
+def test_draft_order_complte_return_tax_error_when_app_not_respond_CORE_2015(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_apps,
+    permission_handle_taxes,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_apps,
+        permission_handle_taxes,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+    shipping_price = 10
+
+    app_input = {"name": "tax_app", "permissions": ["HANDLE_TAXES"]}
+    app_data = add_app(e2e_staff_api_client, app_input)
+    app_id = app_data["app"]["id"]
+
+    target_url = "http://localhost:8777"
+    webhook_input = {
+        "app": app_id,
+        "syncEvents": ["CHECKOUT_CALCULATE_TAXES"],
+        "asyncEvents": [],
+        "isActive": True,
+        "name": "dynamic taxes",
+        "targetUrl": target_url,
+        "query": "fragment TaxBaseLine on TaxableObjectLine {\n  sourceLine {\n    __typename\n    ... on CheckoutLine {\n      id\n      checkoutVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n    ... on OrderLine {\n      id\n      orderVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n  }\n  quantity\n  unitPrice {\n    amount\n  }\n  totalPrice {\n    amount\n  }\n  chargeTaxes\n}\n\nfragment TaxBase on TaxableObject {\n  pricesEnteredWithTax\n  currency\n  channel {\n    slug\n  }\n  shippingPrice {\n    amount\n  }\n  lines {\n    ...TaxBaseLine\n  }\n  discounts {\n    name\n    amount {\n      amount\n      currency\n    }\n  }\n  sourceObject {\n    __typename\n    ... on Checkout {\n      id\n    }\n    ... on Order {\n      id\n    }\n  }\n}\n\nfragment CalculateTaxesEvent on Event {\n  ... on CalculateTaxes {\n    taxBase {\n      ...TaxBase\n    }\n  }\n}\n\nsubscription CalculateTaxes {\n  event {\n    ...CalculateTaxesEvent\n  }\n}\n",
+        "customHeaders": "{}",
+    }
+    create_webhook(e2e_staff_api_client, webhook_input)
+
+    tax_configs = get_tax_configurations(e2e_staff_api_client)
+    assert len(tax_configs) == 1
+    tax_config_id = tax_configs[0]["node"]["id"]
+
+    update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        tax_calculation_strategy="TAX_APP",
+        display_gross_prices=True,
+        prices_entered_with_tax=False,
+        tax_app_id=app_id,
+    )
+
+    (_product_id, product_variant_id, product_variant_price) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=200,
+    )
+    product_variant_price = float(product_variant_price)
+
+    # Step 1 - Create a draft order
+    input = {
+        "channelId": channel_id,
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        input,
+    )
+    order_id = data["order"]["id"]
+
+    # Step 2 - Add lines to the order
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_data = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_data = order_data["order"]
+    assert order_data["total"]["gross"]["amount"] == product_variant_price
+    assert order_data["total"]["net"]["amount"] == product_variant_price
+    # Tax is not calculated, app do not respond
+    assert order_data["total"]["tax"]["amount"] == 0
+
+    # Step 3 - Add a shipping method
+    input = {"shippingMethod": shipping_method_id}
+    order_data = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_data = order_data["order"]
+    assert order_data["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert order_data["shippingPrice"]["net"]["amount"] == shipping_price
+    # Tax is not calculated, app do not respond
+    assert order_data["shippingPrice"]["tax"]["amount"] == 0
+    calculated_total_net = product_variant_price + shipping_price
+    assert order_data["total"]["net"]["amount"] == calculated_total_net
+    assert order_data["total"]["gross"]["amount"] == calculated_total_net
+    # Tax is not calculated, app do not respond
+    assert order_data["total"]["tax"]["amount"] == 0
+
+    # Step 4 - Complete the draft order
+    order = raw_draft_order_complete(
+        e2e_staff_api_client,
+        order_id,
+    )
+    assert order["errors"] is not None
+    assert order["errors"][0]["code"] == "TAX_ERROR"
+    assert order["errors"][0]["message"] == "Configured Tax App didn't responded."

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -5,7 +5,10 @@ from .draft_order_delete import draft_order_delete
 from .draft_order_update import draft_order_update
 from .order_by_checkout_id_query import order_by_checkout_id_query
 from .order_cancel import order_cancel
-from .order_create_from_checkout import order_create_from_checkout
+from .order_create_from_checkout import (
+    order_create_from_checkout,
+    raw_order_create_from_checkout,
+)
 from .order_discount_add import order_discount_add
 from .order_fulfill import order_fulfill
 from .order_fulfill_add_tracking import order_add_tracking
@@ -42,4 +45,5 @@ __all__ = [
     "draft_order_bulk_delete",
     "order_line_update",
     "order_line_delete",
+    "raw_order_create_from_checkout",
 ]

--- a/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
+++ b/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
@@ -59,7 +59,7 @@ mutation orderCreateFromCheckout($id: ID!) {
 """
 
 
-def order_create_from_checkout(api_client, id):
+def raw_order_create_from_checkout(api_client, id):
     variables = {"id": id}
 
     response = api_client.post_graphql(
@@ -68,7 +68,13 @@ def order_create_from_checkout(api_client, id):
     )
     content = get_graphql_content(response)
 
-    data = content["data"]["orderCreateFromCheckout"]
+    raw_data = content["data"]["orderCreateFromCheckout"]
+
+    return raw_data
+
+
+def order_create_from_checkout(api_client, id):
+    data = raw_order_create_from_checkout(api_client, id)
 
     order_id = data["order"]["id"]
     errors = data["errors"]

--- a/saleor/tests/e2e/taxes/utils/query_tax_configurations.py
+++ b/saleor/tests/e2e/taxes/utils/query_tax_configurations.py
@@ -26,7 +26,7 @@ def get_tax_configurations(
     staff_api_client,
     first=10,
 ):
-    variables = {"first": 10}
+    variables = {"first": first}
 
     response = staff_api_client.post_graphql(TAX_CONFIGURATIONS_QUERY, variables)
     content = get_graphql_content(response)

--- a/saleor/tests/e2e/taxes/utils/tax_configuration_update.py
+++ b/saleor/tests/e2e/taxes/utils/tax_configuration_update.py
@@ -42,6 +42,7 @@ def update_tax_configuration(
     prices_entered_with_tax=True,
     update_countries_configuration=None,
     remove_countries_configuration=None,
+    tax_app_id=None,
 ):
     if remove_countries_configuration is None:
         remove_countries_configuration = []
@@ -50,6 +51,7 @@ def update_tax_configuration(
     variables = {
         "id": tax_config_id,
         "input": {
+            "taxAppId": tax_app_id,
             "chargeTaxes": charge_taxes,
             "taxCalculationStrategy": tax_calculation_strategy,
             "displayGrossPrices": display_gross_prices,


### PR DESCRIPTION
I want to merge this change because it covers cases when taxes are set to TAX APP but the tax app does not respond with payload.

[Should return tax error for checkoutComplete
](https://saleor.testmo.net/repositories/5?group_id=589&case_id=26522)[Should return tax error for orderCreateFromCheckout
](https://saleor.testmo.net/repositories/5?group_id=589&case_id=26523)[Should return tax error for draftOrder
](https://saleor.testmo.net/repositories/5?group_id=589&case_id=26524)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
