### PR TITLE
Allow clearing the voucher code in case the voucher or voucher code is missing or inactive

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -864,6 +864,10 @@ def remove_promo_code_from_checkout_or_error(
         remove_voucher_code_from_checkout_or_error(checkout_info, promo_code)
     elif promo_code_is_gift_card(promo_code):
         remove_gift_card_code_from_checkout_or_error(checkout_info.checkout, promo_code)
+    # clear the voucher code in case the code does not exists anymore but it's still
+    # assigned to the checkout
+    elif promo_code == checkout_info.checkout.voucher_code:
+        remove_voucher_from_checkout(checkout_info.checkout)
     else:
         raise ValidationError(
             "Promo code does not exists.",
@@ -879,6 +883,11 @@ def remove_voucher_code_from_checkout_or_error(
     if checkout_info.voucher and voucher_code in checkout_info.voucher.promo_codes:
         remove_voucher_from_checkout(checkout_info.checkout)
         checkout_info.voucher = None
+    elif (
+        not checkout_info.voucher
+        and checkout_info.checkout.voucher_code == voucher_code
+    ):
+        remove_voucher_from_checkout(checkout_info.checkout)
     else:
         raise ValidationError(
             "Cannot remove a voucher not attached to this checkout.",

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -867,7 +867,7 @@ def remove_promo_code_from_checkout_or_error(
     # clear the voucher code in case the code does not exists anymore but it's still
     # assigned to the checkout
     elif promo_code == checkout_info.checkout.voucher_code:
-        remove_voucher_from_checkout(checkout_info.checkout)
+        remove_voucher_code_from_checkout_or_error(checkout_info, promo_code)
     else:
         raise ValidationError(
             "Promo code does not exists.",

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -190,13 +190,15 @@ def test_checkout_remove_voucher_code_voucher_not_exists_anymore(
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
     # then
-    assert data["errors"][0]["field"] == "promoCode"
-    assert data["errors"][0]["code"] == CheckoutErrorCode.NOT_FOUND.name
-    assert data["errors"][0]["message"] == "Promo code does not exists."
-
+    assert not data["errors"]
+    assert data["checkout"]["token"] == str(checkout_with_voucher.token)
+    assert data["checkout"]["voucherCode"] is None
     checkout_with_voucher.refresh_from_db()
-    assert checkout_with_voucher.last_change == previous_checkout_last_change
-    checkout_updated_webhook_mock.assert_not_called()
+    assert checkout_with_voucher.voucher_code is None
+    assert checkout_with_voucher.last_change != previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_called_once_with(
+        checkout_with_voucher, webhooks=set()
+    )
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_updated")
@@ -247,15 +249,15 @@ def test_checkout_remove_voucher_code_with_inactive_channel(
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
     # then
-    assert data["errors"][0]["field"] == "promoCode"
-    assert data["errors"][0]["code"] == CheckoutErrorCode.INVALID.name
-    assert data["errors"][0]["message"] == (
-        "Cannot remove a voucher not attached to this checkout."
-    )
-
+    assert not data["errors"]
+    assert data["checkout"]["token"] == str(checkout_with_voucher.token)
+    assert data["checkout"]["voucherCode"] is None
     checkout_with_voucher.refresh_from_db()
-    assert checkout_with_voucher.last_change == previous_checkout_last_change
-    checkout_updated_webhook_mock.assert_not_called()
+    assert checkout_with_voucher.voucher_code is None
+    assert checkout_with_voucher.last_change != previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_called_once_with(
+        checkout_with_voucher, webhooks=set()
+    )
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_updated")
@@ -844,3 +846,66 @@ def test_checkout_remove_triggers_webhooks(
         ]
     )
     assert wrapped_call_checkout_info_event.called
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_voucher_code_voucher_inactive(
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher
+):
+    # given
+    assert checkout_with_voucher.voucher_code is not None
+    previous_checkout_last_change = checkout_with_voucher.last_change
+    voucher_code = checkout_with_voucher.voucher_code
+    voucher = VoucherCode.objects.get(code=voucher_code).voucher
+    voucher.start_date = timezone.now() - timedelta(days=3)
+    voucher.end_date = timezone.now() - timedelta(days=1)
+    voucher.save(update_fields=["start_date", "end_date"])
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_voucher),
+        "promoCode": voucher_code,
+    }
+
+    # when
+    data = _mutate_checkout_remove_promo_code(api_client, variables)
+
+    # then
+    checkout_with_voucher.refresh_from_db()
+    assert not data["errors"]
+    assert data["checkout"]["token"] == str(checkout_with_voucher.token)
+    assert data["checkout"]["voucherCode"] is None
+    assert checkout_with_voucher.voucher_code is None
+    assert checkout_with_voucher.last_change != previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_called_once_with(
+        checkout_with_voucher, webhooks=set()
+    )
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_checkout_remove_voucher_code_voucher_code_deleted(
+    checkout_updated_webhook_mock, api_client, checkout_with_voucher
+):
+    # given
+    assert checkout_with_voucher.voucher_code is not None
+    previous_checkout_last_change = checkout_with_voucher.last_change
+    voucher_code = checkout_with_voucher.voucher_code
+    VoucherCode.objects.get(code=voucher_code).delete()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_voucher),
+        "promoCode": voucher_code,
+    }
+
+    # when
+    data = _mutate_checkout_remove_promo_code(api_client, variables)
+
+    # then
+    checkout_with_voucher.refresh_from_db()
+    assert not data["errors"]
+    assert data["checkout"]["token"] == str(checkout_with_voucher.token)
+    assert data["checkout"]["voucherCode"] is None
+    assert checkout_with_voucher.voucher_code is None
+    assert checkout_with_voucher.last_change != previous_checkout_last_change
+    checkout_updated_webhook_mock.assert_called_once_with(
+        checkout_with_voucher, webhooks=set()
+    )


### PR DESCRIPTION
Allow clearing the voucher code assigned to `checkout` in case the voucher is not active anymore, voucher or voucher code is deleted.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: Not needed, bug fixing

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [ ] ~~Database migrations are either absent or optimized for zero downtime~~
- [x] The changes are covered by test cases
- [ ] ~~All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)~~
- [ ] ~~All migrations have proper dependencies~~
- [ ] ~~All indexes are added concurrently in migrations~~
- [ ] ~~All RunSql and RunPython migrations have revert option defined~~
