### PR TITLE
Fix incorrect cursor returned when making a query with search input

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -1,13 +1,7 @@
 import json
 from collections.abc import Iterable
 from decimal import Decimal, InvalidOperation
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import graphene
 from django.conf import settings
@@ -80,10 +74,10 @@ def _prepare_filter_by_rank_expression(
     # making equal comparisons impossible. Instead we compare rank against small
     # range of values, constructed using epsilon.
     if sorting_direction == "gt":
-        return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__lt=id) | Q(
+        return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__gt=id) | Q(
             search_rank__gt=rank + EPSILON
         )
-    return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__gt=id) | Q(
+    return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__lt=id) | Q(
         search_rank__lt=rank - EPSILON
     )
 

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -158,7 +158,8 @@ def search_string_in_kwargs(kwargs: dict) -> bool:
 
 
 def sort_field_from_kwargs(kwargs: dict) -> Optional[list[str]]:
-    return kwargs.get("sort_by", {}).get("field") or None
+    sort_by = kwargs.get("sort_by", {}) or {}
+    return sort_by.get("field") or sort_by.get("attribute_id")
 
 
 def check_for_sorting_by_rank(info, kwargs: dict):


### PR DESCRIPTION
I want to merge this change because it fixes the issue when using `search` and `after`/`before` in the query. When items had similar search rank, the items returned when making a query with cursor could return duplicated results, results in different order or empty results.
For example, having 2 products with assigned attribute value  `NewAttr`, adding `search:"NewAttr"` to the query would return the results:
```
[
  {
    "cursor": "WyIwLjI0MzE3MDg0IiwgIjE1MyJd",
    "node": {
      "id": "UHJvZHVjdDoxNTM=",
      "name": "Bean Juice"
    }
  },
  {
    "cursor": "WyIwLjI0MzE3MDg0IiwgIjE1MiJd",
    "node": {
      "id": "UHJvZHVjdDoxNTI=",
      "name": "Apple Juice"
    }
  }
]
```
Then using a cursor from first object, with `first` should return the second object, but currently it returns empty list. In case of having more items to return, the returned objects can be duplicated or returned in different order than previously.

This PR fixes the issue, and the second item is returned correctly

Additionally the PR also fixes the case when input has provided `sortBy` by attribute (`sortBy: {attributeId:"QXR0cmlidXRlOjQw", direction: ASC}`). Previously it was overwritten by sort by search rank

Internal task link: https://linear.app/saleor/issue/MERX-1398/bug-pagination-breaks-with-search-for-attribute-value

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
