### PR TITLE
Allow clearing the voucher code in case the voucher or voucher code is missing or inactive

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -764,6 +764,8 @@ def remove_promo_code_from_checkout(
         return remove_voucher_code_from_checkout(checkout_info, promo_code)
     elif promo_code_is_gift_card(promo_code):
         return remove_gift_card_code_from_checkout(checkout_info.checkout, promo_code)
+    elif promo_code == checkout_info.checkout.voucher_code:
+        return remove_voucher_code_from_checkout(checkout_info, promo_code)
     return False
 
 
@@ -775,7 +777,10 @@ def remove_voucher_code_from_checkout(
     Return information whether promo code was removed.
     """
     existing_voucher = checkout_info.voucher
-    if existing_voucher and existing_voucher.code == voucher_code:
+    if (existing_voucher and existing_voucher.code == voucher_code) or (
+        not checkout_info.voucher
+        and checkout_info.checkout.voucher_code == voucher_code
+    ):
         remove_voucher_from_checkout(checkout_info.checkout)
         checkout_info.voucher = None
         return True


### PR DESCRIPTION
Allow clearing the voucher code assigned to `checkout` in case the voucher is not active anymore, voucher or voucher code is deleted.

Port of https://github.com/saleor/saleor/pull/17219

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
