### PR TITLE
Move schema import to local function

### DIFF
--- a/saleor/webhook/observability/obfuscation.py
+++ b/saleor/webhook/observability/obfuscation.py
@@ -21,7 +21,6 @@ from graphql.validation import validate
 from graphql.validation.rules.base import ValidationRule
 from graphql.validation.validation import ValidationContext
 
-from ...graphql.api import schema
 from .sensitive_data import ALLOWED_HEADERS, SENSITIVE_HEADERS, SensitiveFieldsMap
 
 if TYPE_CHECKING:
@@ -201,6 +200,9 @@ def anonymize_event_payload(
 ) -> Any:
     if not subscription_query:
         return payload
+
+    from ...graphql.api import schema
+
     graphql_backend = get_default_backend()
     document = graphql_backend.document_from_string(schema, subscription_query)
     if _contain_sensitive_field(document, sensitive_fields):


### PR DESCRIPTION
Porting a change that was also done in `main` branch recently. Importing schema at the module level causes circular imports, but it also takes around 30 MiB of memory. When import is moved to a local function, the schema won't be imported when "observability" is not used.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
