### PR TITLE
Fix incorrect cursor returned when making a query with search input

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -1,13 +1,7 @@
 import json
 from collections.abc import Iterable
 from decimal import Decimal, InvalidOperation
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import graphene
 from django.conf import settings
@@ -80,10 +74,10 @@ def _prepare_filter_by_rank_expression(
     # making equal comparisons impossible. Instead we compare rank against small
     # range of values, constructed using epsilon.
     if sorting_direction == "gt":
-        return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__lt=id) | Q(
+        return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__gt=id) | Q(
             search_rank__gt=rank + EPSILON
         )
-    return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__gt=id) | Q(
+    return Q(search_rank__range=(rank - EPSILON, rank + EPSILON), id__lt=id) | Q(
         search_rank__lt=rank - EPSILON
     )
 

--- a/saleor/graphql/order/tests/queries/test_pagination.py
+++ b/saleor/graphql/order/tests/queries/test_pagination.py
@@ -678,3 +678,93 @@ def test_query_orders_pagination_with_sort(
         assert orders[order]["node"]["number"] == str(
             created_orders[order_number].number
         )
+
+
+@pytest.mark.parametrize(
+    ("sort_order", "reversed"),
+    [
+        (
+            "ASC",
+            False,
+        ),
+        ("DESC", True),
+    ],
+)
+def test_orders_with_filter_search_returns_correct_cursor(
+    sort_order,
+    reversed,
+    staff_api_client,
+    permission_group_manage_orders,
+    customer_user,
+    channel_USD,
+):
+    # given
+    search_query = "test@mirumee.com"
+    orders = Order.objects.bulk_create(
+        [
+            Order(
+                user=customer_user,
+                user_email=search_query,
+                status=OrderStatus.DRAFT,
+                channel=channel_USD,
+                should_refresh_prices=False,
+            ),
+            Order(
+                user_email=search_query,
+                status=OrderStatus.DRAFT,
+                channel=channel_USD,
+                should_refresh_prices=False,
+            ),
+            Order(
+                user_email=search_query,
+                status=OrderStatus.DRAFT,
+                channel=channel_USD,
+                should_refresh_prices=False,
+            ),
+        ]
+    )
+
+    for order in orders:
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
+    Order.objects.bulk_update(orders, ["search_vector"])
+
+    orders_sorted_by_id = sorted(orders, key=lambda order: order.id, reverse=reversed)
+
+    page_size = 1
+    variables = {
+        "first": page_size,
+        "after": None,
+        "filter": {"search": search_query},
+        "sortBy": {"field": "RANK", "direction": sort_order},
+    }
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_DRAFT_ORDERS_WITH_PAGINATION, variables
+    )
+    content = get_graphql_content(response)
+    orders = content["data"]["draftOrders"]["edges"]
+    assert len(orders) == 1
+    assert orders[0]["node"]["number"] == str(orders_sorted_by_id[0].number)
+
+    cursor = content["data"]["draftOrders"]["pageInfo"]["endCursor"]
+    variables = {
+        "first": 2,
+        "after": cursor,
+        "filter": {"search": search_query},
+        "sortBy": {"field": "RANK", "direction": sort_order},
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_DRAFT_ORDERS_WITH_PAGINATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["draftOrders"]["edges"]
+
+    assert len(orders) == 2
+    assert orders[0]["node"]["number"] == str(orders_sorted_by_id[1].number)
+    assert orders[1]["node"]["number"] == str(orders_sorted_by_id[2].number)

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -156,7 +156,8 @@ def search_string_in_kwargs(kwargs: dict) -> bool:
 
 
 def sort_field_from_kwargs(kwargs: dict) -> Optional[list[str]]:
-    return kwargs.get("sort_by", {}).get("field") or None
+    sort_by = kwargs.get("sort_by", {}) or {}
+    return sort_by.get("field") or sort_by.get("attribute_id")
 
 
 def check_for_sorting_by_rank(info, kwargs: dict):


### PR DESCRIPTION
I want to merge this change because it fixes the issue when using `search` and `after`/`before` in the query. When items had similar search rank, the items returned when making a query with cursor could return duplicated results, results in different order or empty results.
For example, having 2 products with assigned attribute value  `NewAttr`, adding `search:"NewAttr"` to the query would return the results:
```
[
  {
    "cursor": "WyIwLjI0MzE3MDg0IiwgIjE1MyJd",
    "node": {
      "id": "UHJvZHVjdDoxNTM=",
      "name": "Bean Juice"
    }
  },
  {
    "cursor": "WyIwLjI0MzE3MDg0IiwgIjE1MiJd",
    "node": {
      "id": "UHJvZHVjdDoxNTI=",
      "name": "Apple Juice"
    }
  }
]
```
Then using a cursor from first object, with `first` should return the second object, but currently it returns empty list. In case of having more items to return, the returned objects can be duplicated or returned in different order than previously.

This PR fixes the issue, and the second item is returned correctly

Additionally the PR also fixes the case when input has provided `sortBy` by attribute (`sortBy: {attributeId:"QXR0cmlidXRlOjQw", direction: ASC}`). Previously it was overwritten by sort by search rank

Internal task link: https://linear.app/saleor/issue/MERX-1398/bug-pagination-breaks-with-search-for-attribute-value

Port of changes from #17222 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
