### PR TITLE
Fix checkout funds releasing task

### DIFF
--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -146,7 +146,8 @@ class TransactionItem(ModelWithMetadata):
     app_identifier = models.CharField(blank=True, null=True, max_length=256)
 
     # If last release funds action failed the flag will be set to False
-    # Used to define if the checkout with transaction is refundable or not
+    # Used to define if the checkout with transaction is refundable or not.
+    # Set to False when automatic refund was triggered.
     last_refund_success = models.BooleanField(default=True)
 
     class Meta:

--- a/saleor/payment/tasks.py
+++ b/saleor/payment/tasks.py
@@ -2,13 +2,15 @@ import logging
 import uuid
 from datetime import datetime
 
+import graphene
 import pytz
 from django.conf import settings
-from django.db.models import OuterRef, Q, Subquery
+from django.db import transaction
+from django.db.models import Exists, OuterRef, Q
 
 from ..celeryconf import app
 from ..channel.models import Channel
-from ..checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
+from ..checkout import CheckoutAuthorizeStatus
 from ..checkout.models import Checkout
 from ..payment.models import TransactionEvent, TransactionItem
 from ..plugins.manager import get_plugins_manager
@@ -18,134 +20,172 @@ from .gateway import request_cancelation_action, request_refund_action
 logger = logging.getLogger(__name__)
 
 
-def checkouts_with_funds_to_release():
-    """Fetch checkouts that are ready release the funds.
+def transactions_to_release_funds():
+    """Fetch transactions for checkouts eligible for automatic refunds.
 
-    Fetch checkouts with the funds where the last modification was more than defined
-    TTL ago. Exclude the checkouts with payment statuses which define that the
-    checkout doesn't have any processed funds.
+    The function retrieves checkouts that are automatically refundable and have exceeded the
+    predefined TTL. It then fetches related transactions that are authorized or charged,
+    ready for fund release.
     """
     expired_checkouts_time = (
         datetime.now(pytz.UTC) - settings.CHECKOUT_TTL_BEFORE_RELEASING_FUNDS
     )
 
-    return Checkout.objects.filter(
-        Q(
-            automatically_refundable=True,
-            last_change__lt=expired_checkouts_time,
-            last_transaction_modified_at__lt=expired_checkouts_time,
-        )
-        & (
-            ~Q(authorize_status=CheckoutAuthorizeStatus.NONE)
-            | ~Q(charge_status=CheckoutChargeStatus.NONE)
-        )
+    checkouts = Checkout.objects.using(
+        settings.DATABASE_CONNECTION_REPLICA_NAME
+    ).filter(
+        automatically_refundable=True,
+        last_change__lt=expired_checkouts_time,
+        last_transaction_modified_at__lt=expired_checkouts_time,
+        authorize_status__in=[
+            CheckoutAuthorizeStatus.PARTIAL,
+            CheckoutAuthorizeStatus.FULL,
+        ],
     )
+
+    # Fetch transactions for checkouts that are ready to release funds.
+    transactions = (
+        TransactionItem.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME).filter(
+            Q(
+                Exists(checkouts.filter(pk=OuterRef("checkout_id"))),
+                order_id=None,
+                last_refund_success=True,
+            )
+            & (Q(authorized_value__gt=0) | Q(charged_value__gt=0))
+        )
+    ).order_by("created_at")
+    return transactions
 
 
 @app.task
 def transaction_release_funds_for_checkout_task():
-    CHECKOUT_BATCH_SIZE = int(settings.CHECKOUT_BATCH_FOR_RELEASING_FUNDS)
     TRANSACTION_BATCH_SIZE = int(settings.TRANSACTION_BATCH_FOR_RELEASING_FUNDS)
 
-    # Fetch checkouts that are ready to release funds
-    checkouts = checkouts_with_funds_to_release().order_by("last_change")
-    checkouts_data = checkouts.values_list("pk", "channel_id")[:CHECKOUT_BATCH_SIZE]
-    checkout_pks = [pk for pk, _ in checkouts_data]
-    checkout_channel_ids = [channel_id for _, channel_id in checkouts_data]
-    channel_map = Channel.objects.filter(id__in=checkout_channel_ids).in_bulk()
-    if checkout_pks:
-        transaction_events = TransactionEvent.objects.filter(
-            transaction_id=OuterRef("pk"),
-        ).order_by("-created_at")
+    # Fetch transactions that are ready to release funds
+    transactions = transactions_to_release_funds().order_by("modified_at")
+    transactions_data = list(
+        transactions.values_list("pk", "checkout_id")[:TRANSACTION_BATCH_SIZE]
+    )
+    transaction_pks = [pk for pk, _checkout_id in transactions_data]
+    checkout_ids = [checkout_id for _, checkout_id in transactions_data]
 
-        checkout_subquery = Checkout.objects.filter(pk=OuterRef("checkout_id"))
-        # Fetch transactions for checkouts that are ready to release funds.
-        # Select_related app as, this will be used to trigger the proper webhook
-        # Annotate the last event for each transaction to exclude the transactions that
-        # were already processed
-        transactions = (
-            TransactionItem.objects.select_related("app")
-            .annotate(last_event_type=Subquery(transaction_events.values("type")[:1]))
-            .annotate(channel_id=Subquery(checkout_subquery.values("channel_id")[:1]))
-            .filter(
-                Q(checkout_id__in=checkout_pks, order_id=None)
-                & ~Q(
-                    last_event_type__in=[
-                        TransactionEventType.REFUND_REQUEST,
-                        TransactionEventType.CANCEL_REQUEST,
-                    ]
-                )
-            )[:TRANSACTION_BATCH_SIZE]
-        )
+    checkouts_data = Checkout.objects.filter(pk__in=checkout_ids).values_list(
+        "pk", "channel_id"
+    )
+    checkout_channel_ids = {channel_id for _, channel_id in checkouts_data}
+    channels_in_bulk = (
+        Channel.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+        .filter(id__in=checkout_channel_ids)
+        .in_bulk()
+    )
+    checkout_id_to_channel = {
+        checkout_id: channels_in_bulk[channel_id]
+        for checkout_id, channel_id in checkouts_data
+    }
+    if transaction_pks:
+        # Select_related app as, this will be used to trigger the proper webhook.
+        transactions = TransactionItem.objects.filter(
+            pk__in=transaction_pks,
+            order_id=None,  # type: ignore[misc]
+        ).select_related("app")
         transactions_with_cancel_request_events = []
         transactions_with_charge_request_events = []
 
-        for transaction in transactions:
+        for transaction_item in transactions:
             # If transaction is authorized we need to trigger the cancel event
-            if transaction.authorized_value:
+            if transaction_item.authorized_value:
                 event = TransactionEvent(
-                    amount_value=transaction.authorized_value,
-                    currency=transaction.currency,
+                    amount_value=transaction_item.authorized_value,
+                    currency=transaction_item.currency,
                     type=TransactionEventType.CANCEL_REQUEST,
-                    transaction_id=transaction.id,
+                    transaction_id=transaction_item.id,
                     idempotency_key=str(uuid.uuid4()),
                 )
-                transactions_with_cancel_request_events.append((transaction, event))
+                transactions_with_cancel_request_events.append(
+                    (transaction_item, event)
+                )
 
             # If transaction is charged we need to trigger the refund event
-            if transaction.charged_value:
+            if transaction_item.charged_value:
                 event = TransactionEvent(
-                    amount_value=transaction.charged_value,
-                    currency=transaction.currency,
+                    amount_value=transaction_item.charged_value,
+                    currency=transaction_item.currency,
                     type=TransactionEventType.REFUND_REQUEST,
-                    transaction_id=transaction.id,
+                    transaction_id=transaction_item.id,
                     idempotency_key=str(uuid.uuid4()),
                 )
-                transactions_with_charge_request_events.append((transaction, event))
+                transactions_with_charge_request_events.append(
+                    (transaction_item, event)
+                )
 
         if (
             transactions_with_charge_request_events
             or transactions_with_cancel_request_events
         ):
-            TransactionEvent.objects.bulk_create(
-                [event for _tr, event in transactions_with_cancel_request_events]
-                + [event for _tr, event in transactions_with_charge_request_events]
-            )
-            manager = get_plugins_manager(allow_replica=False)
-            for transaction, event in transactions_with_cancel_request_events:
-                channel_slug = channel_map[transaction.channel_id].slug
+            with transaction.atomic():
+                TransactionEvent.objects.bulk_create(
+                    [event for _tr, event in transactions_with_cancel_request_events]
+                    + [event for _tr, event in transactions_with_charge_request_events]
+                )
+                # Mark transactions as not refundable to avoid multiple automatic
+                # refund requests
+                transactions.update(last_refund_success=False)
+
+            manager = get_plugins_manager(allow_replica=True)
+            for transaction_item, event in transactions_with_cancel_request_events:
+                channel = checkout_id_to_channel[transaction_item.checkout_id]
+                logger.info(
+                    "Releasing funds for transaction %s - canceling",
+                    transaction_item.token,
+                    extra={
+                        "transactionId": graphene.Node.to_global_id(
+                            "TransactionItem", transaction_item.pk
+                        )
+                    },
+                )
                 try:
                     request_cancelation_action(
                         request_event=event,
                         cancel_value=event.amount_value,
                         action=TransactionAction.CANCEL,
-                        channel_slug=channel_slug,
+                        channel_slug=channel.slug,
                         user=None,
                         app=None,
-                        transaction=transaction,
+                        transaction=transaction_item,
                         manager=manager,
                     )
                 except PaymentError as e:
                     logger.warning(
                         "Unable to cancel transaction %s. %s",
-                        transaction.token,
+                        transaction_item.token,
                         str(e),
                     )
-            for transaction, event in transactions_with_charge_request_events:
-                channel_slug = channel_map[transaction.channel_id].slug
+            for transaction_item, event in transactions_with_charge_request_events:
+                channel = checkout_id_to_channel[transaction_item.checkout_id]
+                logger.info(
+                    "Releasing funds for transaction %s - refunding",
+                    transaction_item.token,
+                    extra={
+                        "transactionId": graphene.Node.to_global_id(
+                            "TransactionItem", transaction_item.pk
+                        )
+                    },
+                )
                 try:
                     request_refund_action(
                         request_event=event,
                         refund_value=event.amount_value,
-                        channel_slug=channel_slug,
+                        channel_slug=channel.slug,
                         user=None,
                         app=None,
-                        transaction=transaction,
+                        transaction=transaction_item,
                         manager=manager,
                     )
                 except PaymentError as e:
                     logger.warning(
                         "Unable to refund transaction %s. %s",
-                        transaction.token,
+                        transaction_item.token,
                         str(e),
                     )
+        else:
+            logger.warning("No transactions to release funds.")

--- a/saleor/payment/tests/test_tasks.py
+++ b/saleor/payment/tests/test_tasks.py
@@ -43,6 +43,8 @@ def test_transaction_release_funds_for_checkout_task_checkout_with_new_last_chan
     # then
     assert not mocked_refund_action.called
     assert not mocked_cancel_action.called
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is True
 
 
 @mock.patch("saleor.payment.tasks.request_cancelation_action")
@@ -74,6 +76,8 @@ def test_transaction_release_funds_for_checkout_task_checkout_not_refundable(
     # then
     assert not mocked_refund_action.called
     assert not mocked_cancel_action.called
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is True
 
 
 @mock.patch("saleor.payment.tasks.request_cancelation_action")
@@ -108,6 +112,8 @@ def test_transaction_release_funds_for_checkout_task_checkout_with_new_tr_modifi
     # then
     assert not mocked_refund_action.called
     assert not mocked_cancel_action.called
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is True
 
 
 @mock.patch("saleor.payment.tasks.request_cancelation_action")
@@ -141,6 +147,8 @@ def test_transaction_release_funds_for_checkout_task_checkout_with_none_status(
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert not mocked_refund_action.called
     assert not mocked_cancel_action.called
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is True
 
 
 @mock.patch("saleor.payment.tasks.request_cancelation_action")
@@ -250,6 +258,7 @@ def test_transaction_release_funds_for_checkout_task_refund_already_requested(
         transaction_item = transaction_item_generator(
             checkout_id=checkout.pk,
             charged_value=Decimal(100),
+            last_refund_success=False,
         )
         transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
         checkout.automatically_refundable = True
@@ -262,6 +271,8 @@ def test_transaction_release_funds_for_checkout_task_refund_already_requested(
     # then
     assert not mocked_refund_action.called
     assert not mocked_cancel_action.called
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is False
 
 
 @mock.patch("saleor.payment.tasks.request_cancelation_action")
@@ -282,6 +293,7 @@ def test_transaction_release_funds_for_checkout_task_cancel_already_requested(
         transaction_item = transaction_item_generator(
             checkout_id=checkout.pk,
             authorized_value=Decimal(100),
+            last_refund_success=False,
         )
         transaction_amounts_for_checkout_updated(transaction_item, plugins_manager)
         checkout.automatically_refundable = True
@@ -294,6 +306,8 @@ def test_transaction_release_funds_for_checkout_task_cancel_already_requested(
     # then
     assert not mocked_refund_action.called
     assert not mocked_cancel_action.called
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is False
 
 
 @mock.patch("saleor.payment.tasks.request_cancelation_action")
@@ -338,6 +352,8 @@ def test_transaction_release_funds_for_checkout_task_transaction_with_authorizat
         cancel_value=transaction_item.authorized_value,
         action=TransactionAction.CANCEL,
     )
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is False
 
 
 @mock.patch("saleor.payment.tasks.request_cancelation_action")
@@ -381,3 +397,5 @@ def test_transaction_release_funds_for_checkout_task_transaction_with_charge(
         request_event=request_event,
         refund_value=transaction_item.charged_value,
     )
+    transaction_item.refresh_from_db()
+    assert transaction_item.last_refund_success is False


### PR DESCRIPTION
Fix checkout funds releasing.
Missing `authorized_value` and `charged_value` in filters causes the task to clog, we were fetching still the same checkouts with transactions that cannot be released.

Port of https://github.com/saleor/saleor/pull/17198

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
