### PR TITLE
Add source.service.name span tag

### DIFF
--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -2,6 +2,7 @@ import hashlib
 from unittest.mock import patch
 
 import graphene
+import pytest
 from opentracing.mocktracer import MockTracer
 
 
@@ -460,3 +461,54 @@ def test_tracing_have_app_data_app_as_requestor(
     # then
     assert span.tags["app.name"] == app.name
     assert span.tags["app.id"] == app.id
+
+
+@pytest.mark.parametrize(
+    ("header_source", "expected_result"),
+    [
+        ("saleor.dashboard", "saleor.dashboard"),
+        ("saleor.dashboard.plg", "saleor.dashboard.plg"),
+        ("saleor.plg", "saleor.plg"),
+        ("saleor.DASHBOARD", "saleor.dashboard"),
+        ("SALEOR.dashboard", "saleor.dashboard"),
+        ("saleor.dashboard.PLG", "saleor.dashboard.plg"),
+        ("saleor.plG", "saleor.plg"),
+        ("incorrect-value", "unknown_service"),
+    ],
+)
+@patch("saleor.graphql.views.opentracing.global_tracer")
+def test_tracing_have_source_service_name_set(
+    tracing_mock,
+    header_source,
+    expected_result,
+    app_api_client,
+    permission_manage_products,
+):
+    # given
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+    query = """
+        query test {
+          products(first:5) {
+            edges{
+              node{
+                id
+                name
+              }
+            }
+          }
+        }
+    """
+    app = app_api_client.app
+    app.permissions.add(permission_manage_products)
+
+    # when
+    app_api_client.post_graphql(query, headers={"source-service-name": header_source})
+
+    # then
+    spans = list(
+        filter(lambda s: s.tags.get("source.service.name"), tracer.finished_spans())
+    )
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.tags["source.service.name"] == expected_result

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -467,12 +467,12 @@ def test_tracing_have_app_data_app_as_requestor(
     ("header_source", "expected_result"),
     [
         ("saleor.dashboard", "saleor.dashboard"),
-        ("saleor.dashboard.plg", "saleor.dashboard.plg"),
-        ("saleor.plg", "saleor.plg"),
+        ("saleor.dashboard.playground", "saleor.dashboard.playground"),
+        ("saleor.playground", "saleor.playground"),
         ("saleor.DASHBOARD", "saleor.dashboard"),
         ("SALEOR.dashboard", "saleor.dashboard"),
-        ("saleor.dashboard.PLG", "saleor.dashboard.plg"),
-        ("saleor.plG", "saleor.plg"),
+        ("saleor.dashboard.Playground", "saleor.dashboard.playground"),
+        ("saleor.playgrounD", "saleor.playground"),
         ("incorrect-value", "unknown_service"),
     ],
 )

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -474,6 +474,7 @@ def test_tracing_have_app_data_app_as_requestor(
         ("saleor.dashboard.Playground", "saleor.dashboard.playground"),
         ("saleor.playgrounD", "saleor.playground"),
         ("incorrect-value", "unknown_service"),
+        (None, "unknown_service"),
     ],
 )
 @patch("saleor.graphql.views.opentracing.global_tracer")

--- a/saleor/graphql/tests/test_utils.py
+++ b/saleor/graphql/tests/test_utils.py
@@ -347,7 +347,7 @@ def test_check_if_query_contains_only_schema_with_introspection():
         ("saleor.dashboard.PLAYGROUND", "saleor.dashboard.playground"),
         ("saleor.PLAYGROUND", "saleor.playground"),
         ("incorrect-value", "unknown_service"),
-        (None, None),
+        (None, "unknown_service"),
     ],
 )
 def test_get_source_service_name_value(header_source, expected_result):

--- a/saleor/graphql/tests/test_utils.py
+++ b/saleor/graphql/tests/test_utils.py
@@ -344,8 +344,8 @@ def test_check_if_query_contains_only_schema_with_introspection():
     [
         ("saleor.DASHBOARD", "saleor.dashboard"),
         ("SALEOR.dashboard", "saleor.dashboard"),
-        ("saleor.dashboard.PLG", "saleor.dashboard.plg"),
-        ("saleor.plG", "saleor.plg"),
+        ("saleor.dashboard.PLAYGROUND", "saleor.dashboard.playground"),
+        ("saleor.PLAYGROUND", "saleor.playground"),
         ("incorrect-value", "unknown_service"),
         (None, None),
     ],

--- a/saleor/graphql/tests/test_utils.py
+++ b/saleor/graphql/tests/test_utils.py
@@ -6,7 +6,12 @@ from graphql import GraphQLError
 from graphql.utils import schema_printer
 
 from ..api import backend, schema
-from ..utils import ALLOWED_ERRORS, INTERNAL_ERROR_MESSAGE, format_error
+from ..utils import (
+    ALLOWED_ERRORS,
+    INTERNAL_ERROR_MESSAGE,
+    format_error,
+    get_source_service_name_value,
+)
 from ..utils.validators import check_if_query_contains_only_schema
 from .utils import get_graphql_content
 
@@ -332,3 +337,22 @@ def test_check_if_query_contains_only_schema_with_introspection():
 
     # then
     assert result is True
+
+
+@pytest.mark.parametrize(
+    ("header_source", "expected_result"),
+    [
+        ("saleor.DASHBOARD", "saleor.dashboard"),
+        ("SALEOR.dashboard", "saleor.dashboard"),
+        ("saleor.dashboard.PLG", "saleor.dashboard.plg"),
+        ("saleor.plG", "saleor.plg"),
+        ("incorrect-value", "unknown_service"),
+        (None, None),
+    ],
+)
+def test_get_source_service_name_value(header_source, expected_result):
+    # when
+    result = get_source_service_name_value(header_source)
+
+    # then
+    assert result == expected_result

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -315,8 +315,9 @@ def format_error(error, handled_exceptions, query=None):
 
 
 def get_source_service_name_value(header_source: str | None) -> str | None:
+    default_value = "unknown_service"
     if not header_source:
-        return None
+        return default_value
     if header_source.lower() in AVAILABLE_SOURCE_SERVICE_NAMES_FOR_SPAN_TAG:
         return header_source.lower()
-    return "unknown_service"
+    return default_value

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -17,10 +17,7 @@ from jwt import InvalidTokenError
 
 from ...account.models import User
 from ...app.models import App
-from ...core.exceptions import (
-    CircularSubscriptionSyncEvent,
-    PermissionDenied,
-)
+from ...core.exceptions import CircularSubscriptionSyncEvent, PermissionDenied
 from ..core.enums import PermissionEnum
 from ..core.types import TYPES_WITH_DOUBLE_ID_AVAILABLE, Permission
 from ..core.utils import from_global_id_or_error
@@ -50,6 +47,12 @@ ALLOWED_ERRORS = [
     ValidationError,
     QueryCostError,
 ]
+
+AVAILABLE_SOURCE_SERVICE_NAMES_FOR_SPAN_TAG = {
+    "saleor.dashboard",
+    "saleor.dashboard.plg",
+    "saleor.plg",
+}
 
 INTERNAL_ERROR_MESSAGE = "Internal Server Error"
 
@@ -309,3 +312,11 @@ def format_error(error, handled_exceptions, query=None):
                 lines.extend(line.rstrip().splitlines())
         result["extensions"]["exception"]["stacktrace"] = lines
     return result
+
+
+def get_source_service_name_value(header_source: str | None) -> str | None:
+    if not header_source:
+        return None
+    if header_source.lower() in AVAILABLE_SOURCE_SERVICE_NAMES_FOR_SPAN_TAG:
+        return header_source.lower()
+    return "unknown_service"

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -50,8 +50,8 @@ ALLOWED_ERRORS = [
 
 AVAILABLE_SOURCE_SERVICE_NAMES_FOR_SPAN_TAG = {
     "saleor.dashboard",
-    "saleor.dashboard.plg",
-    "saleor.plg",
+    "saleor.dashboard.playground",
+    "saleor.playground",
 }
 
 INTERNAL_ERROR_MESSAGE = "Internal Server Error"

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -186,10 +186,10 @@ class GraphQLView(View):
             span.set_tag("http.useragent", request.headers.get("user-agent", ""))
             span.set_tag("span.type", "web")
 
-            if source_service_name := get_source_service_name_value(
+            source_service_name = get_source_service_name_value(
                 request.headers.get("source-service-name")
-            ):
-                span.set_tag("source.service.name", source_service_name)
+            )
+            span.set_tag("source.service.name", source_service_name)
 
             main_ip_header = settings.REAL_IP_ENVIRON[0]
             additional_ip_headers = settings.REAL_IP_ENVIRON[1:]

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -28,7 +28,12 @@ from .api import API_PATH, schema
 from .context import clear_context, get_context_value
 from .core.validators.query_cost import validate_query_cost
 from .query_cost_map import COST_MAP
-from .utils import format_error, query_fingerprint, query_identifier
+from .utils import (
+    format_error,
+    get_source_service_name_value,
+    query_fingerprint,
+    query_identifier,
+)
 from .utils.validators import check_if_query_contains_only_schema
 
 INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
@@ -180,6 +185,11 @@ class GraphQLView(View):
             )
             span.set_tag("http.useragent", request.headers.get("user-agent", ""))
             span.set_tag("span.type", "web")
+
+            if source_service_name := get_source_service_name_value(
+                request.headers.get("source-service-name")
+            ):
+                span.set_tag("source.service.name", source_service_name)
 
             main_ip_header = settings.REAL_IP_ENVIRON[0]
             additional_ip_headers = settings.REAL_IP_ENVIRON[1:]


### PR DESCRIPTION
I want to merge this change because it adds the request header & span tag for tracing the source of the request. 
The name of the header is `source-service-name`. The span tag is `source.service.name`. 
The flow accepts the following values:
- `saleor.dashbaord` - for tracking dashboard traffic
- `saleor.dashboard.playground` -  for tracking dashboard playground usage traffic
- `saleor.playground` - core api playground

Providing different values will result in `unknown_service` value.

Internal task: https://linear.app/saleor/issue/MERX-1309/attach-source-of-traffic-to-the-span

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
