### PR TITLE
Fix undiscounted price taxation inside an order calculations when the Avatax plugin is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `productVariants` field to `Product` instead of `variants`. Mark `Product.variants` as deprecated - #16998 by @kadewu
 - Fix checkout `line.undiscountedTotalPrice` and `line.undiscountedUnitPrice` calculation. - #17193 by @IKarbowiak
   - Return the normalized price in case the checkout prices are not expired, otherwise fetch the price from variant channel listing.
+- Fix undiscounted price taxation inside an order calculations when the Avatax plugin is used - #17253 by @zedzior
 
 ### Webhooks
 

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -21,7 +21,7 @@ from ..payment.model_helpers import get_subtotal
 from ..plugins import PLUGIN_IDENTIFIER_PREFIX
 from ..plugins.manager import PluginsManager
 from ..tax import TaxCalculationStrategy
-from ..tax.calculations import get_taxed_undiscounted_price
+from ..tax.calculations import calculate_flat_rate_tax, get_taxed_undiscounted_price
 from ..tax.calculations.order import update_order_prices_with_flat_rates
 from ..tax.utils import (
     get_charge_taxes_for_order,
@@ -344,22 +344,21 @@ def _recalculate_with_plugins(
 
 
 def _get_undiscounted_price(
-    line_price: OrderTaxedPricesData,
-    line_base_price: Money,
+    price: OrderTaxedPricesData,
+    undiscounted_base_price: Money,
     tax_rate,
     prices_entered_with_tax,
-):
-    if (
-        tax_rate > 0
-        and line_price.undiscounted_price.net == line_price.undiscounted_price.gross
-    ):
-        get_taxed_undiscounted_price(
-            line_base_price,
-            line_price.undiscounted_price,
-            tax_rate,
-            prices_entered_with_tax,
+) -> TaxedMoney:
+    if tax_rate > 0 and price.undiscounted_price.net == price.undiscounted_price.gross:
+        return quantize_price(
+            calculate_flat_rate_tax(
+                money=undiscounted_base_price,
+                tax_rate=tax_rate * 100,
+                prices_entered_with_tax=prices_entered_with_tax,
+            ),
+            undiscounted_base_price.currency,
         )
-    return line_price.undiscounted_price
+    return price.undiscounted_price
 
 
 def _apply_tax_data(

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -21,7 +21,7 @@ from ..payment.model_helpers import get_subtotal
 from ..plugins import PLUGIN_IDENTIFIER_PREFIX
 from ..plugins.manager import PluginsManager
 from ..tax import TaxCalculationStrategy
-from ..tax.calculations import calculate_flat_rate_tax, get_taxed_undiscounted_price
+from ..tax.calculations import get_taxed_undiscounted_price
 from ..tax.calculations.order import update_order_prices_with_flat_rates
 from ..tax.utils import (
     get_charge_taxes_for_order,
@@ -344,21 +344,22 @@ def _recalculate_with_plugins(
 
 
 def _get_undiscounted_price(
-    price: OrderTaxedPricesData,
+    line_price: OrderTaxedPricesData,
     undiscounted_base_price: Money,
     tax_rate,
     prices_entered_with_tax,
 ) -> TaxedMoney:
-    if tax_rate > 0 and price.undiscounted_price.net == price.undiscounted_price.gross:
-        return quantize_price(
-            calculate_flat_rate_tax(
-                money=undiscounted_base_price,
-                tax_rate=tax_rate * 100,
-                prices_entered_with_tax=prices_entered_with_tax,
-            ),
-            undiscounted_base_price.currency,
+    if (
+        tax_rate > 0
+        and line_price.undiscounted_price.net == line_price.undiscounted_price.gross
+    ):
+        return get_taxed_undiscounted_price(
+            undiscounted_base_price,
+            line_price.price_with_discounts,
+            tax_rate,
+            prices_entered_with_tax,
         )
-    return price.undiscounted_price
+    return line_price.undiscounted_price
 
 
 def _apply_tax_data(

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -428,6 +428,206 @@ def test_recalculate_with_plugins_order_discounts_and_total_undiscounted_price_c
     assert order.shipping_tax_rate == shipping_tax_rate
 
 
+def test_recalculate_with_plugin_prices_entered_without_taxes(
+    order_with_lines, tax_configuration_avatax_plugin
+):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    lines = order.lines.all()
+    tax_rate = Decimal("1.23")
+
+    tc = tax_configuration_avatax_plugin
+    assert tc.prices_entered_with_tax is False
+
+    unit_prices = [
+        OrderTaxedPricesData(
+            # plugin don't calculate taxes for undiscounted prices
+            undiscounted_price=TaxedMoney(
+                net=line.undiscounted_base_unit_price,
+                gross=line.undiscounted_base_unit_price,
+            ),
+            price_with_discounts=TaxedMoney(
+                net=line.base_unit_price,
+                gross=line.base_unit_price * tax_rate,
+            ),
+        )
+        for line in lines
+    ]
+
+    total_line_prices = [
+        OrderTaxedPricesData(
+            # plugin don't calculate taxes for undiscounted prices
+            undiscounted_price=TaxedMoney(
+                net=line.undiscounted_base_unit_price * line.quantity,
+                gross=line.undiscounted_base_unit_price * line.quantity,
+            ),
+            price_with_discounts=TaxedMoney(
+                net=line.base_unit_price * line.quantity,
+                gross=line.base_unit_price * tax_rate * line.quantity,
+            ),
+        )
+        for line in lines
+    ]
+
+    shipping = TaxedMoney(
+        net=order.base_shipping_price,
+        gross=order.base_shipping_price * tax_rate,
+    )
+    subtotal = TaxedMoney(
+        net=Money(
+            sum(price.price_with_discounts.net.amount for price in total_line_prices),
+            currency,
+        ),
+        gross=Money(
+            sum(price.price_with_discounts.gross.amount for price in total_line_prices),
+            currency,
+        ),
+    )
+    total = shipping + subtotal
+
+    tax_rates = [Decimal("0.23") for _ in lines]
+    shipping_tax_rate = Decimal("0.23")
+
+    manager = Mock(
+        calculate_order_line_unit=Mock(side_effect=unit_prices),
+        calculate_order_line_total=Mock(side_effect=total_line_prices),
+        get_order_line_tax_rate=Mock(side_effect=tax_rates),
+        get_order_shipping_tax_rate=Mock(return_value=shipping_tax_rate),
+        calculate_order_shipping=Mock(return_value=shipping),
+        calculate_order_total=Mock(return_value=total),
+    )
+
+    # when
+    calculations._recalculate_with_plugins(manager, order, lines, False)
+
+    # then
+    assert order.total == total
+    assert order.shipping_price == shipping
+    assert order.shipping_tax_rate == shipping_tax_rate
+
+    for line_unit, line_total, tax_rate, line in zip(
+        unit_prices, total_line_prices, tax_rates, lines
+    ):
+        undiscounted_unit_gross = line_unit.undiscounted_price.net * (1 + tax_rate)
+        undiscounted_total_gross = line_total.undiscounted_price.net.amount * (
+            1 + tax_rate
+        )
+
+        assert line.unit_price == line_unit.price_with_discounts
+        assert line.undiscounted_unit_price.net == line_unit.undiscounted_price.net
+        assert line.undiscounted_unit_price.gross == undiscounted_unit_gross
+
+        assert line.total_price == line_total.price_with_discounts
+        assert line.undiscounted_total_price.net == line_total.undiscounted_price.net
+        assert line.undiscounted_total_price.gross.amount == undiscounted_total_gross
+        assert tax_rate == line.tax_rate
+
+
+def test_recalculate_with_plugin_prices_entered_with_taxes(
+    order_with_lines, tax_configuration_avatax_plugin
+):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    lines = order.lines.all()
+    tax_rate = Decimal("1.23")
+
+    tc = tax_configuration_avatax_plugin
+    tc.prices_entered_with_tax = True
+    tc.save(update_fields=["prices_entered_with_tax"])
+
+    unit_prices = [
+        OrderTaxedPricesData(
+            # plugin don't calculate taxes for undiscounted prices
+            undiscounted_price=TaxedMoney(
+                net=line.undiscounted_base_unit_price,
+                gross=line.undiscounted_base_unit_price,
+            ),
+            price_with_discounts=TaxedMoney(
+                net=quantize_price(line.base_unit_price / tax_rate, currency),
+                gross=line.base_unit_price,
+            ),
+        )
+        for line in lines
+    ]
+
+    total_line_prices = [
+        OrderTaxedPricesData(
+            # plugin don't calculate taxes for undiscounted prices
+            undiscounted_price=TaxedMoney(
+                net=line.undiscounted_base_unit_price * line.quantity,
+                gross=line.undiscounted_base_unit_price * line.quantity,
+            ),
+            price_with_discounts=TaxedMoney(
+                net=quantize_price(
+                    line.base_unit_price / tax_rate * line.quantity, currency
+                ),
+                gross=line.base_unit_price * line.quantity,
+            ),
+        )
+        for line in lines
+    ]
+
+    shipping = TaxedMoney(
+        net=quantize_price(order.base_shipping_price * tax_rate, currency),
+        gross=order.base_shipping_price,
+    )
+    subtotal = TaxedMoney(
+        net=Money(
+            sum(price.price_with_discounts.net.amount for price in total_line_prices),
+            currency,
+        ),
+        gross=Money(
+            sum(price.price_with_discounts.gross.amount for price in total_line_prices),
+            currency,
+        ),
+    )
+    total = shipping + subtotal
+
+    tax_rates = [Decimal("0.23") for _ in lines]
+    shipping_tax_rate = Decimal("0.23")
+
+    manager = Mock(
+        calculate_order_line_unit=Mock(side_effect=unit_prices),
+        calculate_order_line_total=Mock(side_effect=total_line_prices),
+        get_order_line_tax_rate=Mock(side_effect=tax_rates),
+        get_order_shipping_tax_rate=Mock(return_value=shipping_tax_rate),
+        calculate_order_shipping=Mock(return_value=shipping),
+        calculate_order_total=Mock(return_value=total),
+    )
+
+    # when
+    calculations._recalculate_with_plugins(manager, order, lines, True)
+
+    # then
+    assert order.total == total
+    assert order.shipping_price == shipping
+    assert order.shipping_tax_rate == shipping_tax_rate
+
+    for line_unit, line_total, tax_rate, line in zip(
+        unit_prices, total_line_prices, tax_rates, lines
+    ):
+        undiscounted_unit_net = quantize_price(
+            line_unit.undiscounted_price.net / (1 + tax_rate), currency
+        )
+        undiscounted_total_net = quantize_price(
+            line_total.undiscounted_price.net.amount * (1 + tax_rate), currency
+        )
+
+        assert line.unit_price == line_unit.price_with_discounts
+        assert line.undiscounted_unit_price.net == undiscounted_unit_net
+        assert line.undiscounted_unit_price.gross == line_unit.undiscounted_price.gross
+
+        assert line.total_price == line_total.price_with_discounts
+        assert line.undiscounted_total_price.net == undiscounted_total_net
+        assert (
+            line.undiscounted_total_price.gross.amount
+            == line_total.undiscounted_price.gross
+        )
+        assert tax_rate == line.tax_rate
+
+
 def test_recalculate_prices_total_shipping_price_changed(
     draft_order, order_lines, shipping_method_weight_based
 ):

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -612,7 +612,7 @@ def test_recalculate_with_plugin_prices_entered_with_taxes(
             line_unit.undiscounted_price.net / (1 + tax_rate), currency
         )
         undiscounted_total_net = quantize_price(
-            line_total.undiscounted_price.net.amount * (1 + tax_rate), currency
+            line_total.undiscounted_price.net / (1 + tax_rate), currency
         )
 
         assert line.unit_price == line_unit.price_with_discounts
@@ -622,8 +622,7 @@ def test_recalculate_with_plugin_prices_entered_with_taxes(
         assert line.total_price == line_total.price_with_discounts
         assert line.undiscounted_total_price.net == undiscounted_total_net
         assert (
-            line.undiscounted_total_price.gross.amount
-            == line_total.undiscounted_price.gross
+            line.undiscounted_total_price.gross == line_total.undiscounted_price.gross
         )
         assert tax_rate == line.tax_rate
 

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -507,7 +507,7 @@ def test_recalculate_with_plugin_prices_entered_without_taxes(
     assert order.shipping_tax_rate == shipping_tax_rate
 
     for line_unit, line_total, tax_rate, line in zip(
-        unit_prices, total_line_prices, tax_rates, lines
+        unit_prices, total_line_prices, tax_rates, lines, strict=False
     ):
         undiscounted_unit_gross = line_unit.undiscounted_price.net * (1 + tax_rate)
         undiscounted_total_gross = line_total.undiscounted_price.net.amount * (
@@ -606,7 +606,7 @@ def test_recalculate_with_plugin_prices_entered_with_taxes(
     assert order.shipping_tax_rate == shipping_tax_rate
 
     for line_unit, line_total, tax_rate, line in zip(
-        unit_prices, total_line_prices, tax_rates, lines
+        unit_prices, total_line_prices, tax_rates, lines, strict=False
     ):
         undiscounted_unit_net = quantize_price(
             line_unit.undiscounted_price.net / (1 + tax_rate), currency

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1660,3 +1660,14 @@ def tax_configuration_tax_app(channel_USD):
     tc.tax_app_id = "avatax.app"
     tc.save()
     return tc
+
+
+@pytest.fixture
+def tax_configuration_avatax_plugin(channel_USD):
+    tc = channel_USD.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.prices_entered_with_tax = False
+    tc.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tc.tax_app_id = "plugin:avatax"
+    tc.save()
+    return tc


### PR DESCRIPTION
I want to merge this change, because it fixes missing tax calculation for undiscounted prices when Avatax plugin is used and an order origins from draft order.

Internal issue: https://linear.app/saleor/issue/SHOPX-1775

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
