### PR TITLE
[Prevent sync webhooks in checkout bulk queries] - Add allow-sync-webhooks

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -52,6 +52,7 @@ def checkout_shipping_price(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    allow_sync_webhooks: bool = True,
 ) -> "TaxedMoney":
     """Return checkout shipping price.
 
@@ -67,6 +68,7 @@ def checkout_shipping_price(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     return quantize_price(checkout_info.checkout.shipping_price, currency)
 
@@ -78,6 +80,7 @@ def checkout_shipping_tax_rate(
     lines: list["CheckoutLineInfo"],
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ) -> Decimal:
     """Return checkout shipping tax rate.
 
@@ -89,6 +92,7 @@ def checkout_shipping_tax_rate(
         lines=lines,
         address=address,
         database_connection_name=database_connection_name,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     return checkout_info.checkout.shipping_tax_rate
 
@@ -101,6 +105,7 @@ def checkout_subtotal(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    allow_sync_webhooks: bool = True,
 ) -> "TaxedMoney":
     """Return the total cost of all the checkout lines, taxes included.
 
@@ -116,6 +121,7 @@ def checkout_subtotal(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     return quantize_price(checkout_info.checkout.subtotal, currency)
 
@@ -127,6 +133,7 @@ def calculate_checkout_total_with_gift_cards(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    allow_sync_webhooks: bool = True,
 ) -> "TaxedMoney":
     if pregenerated_subscription_payloads is None:
         pregenerated_subscription_payloads = {}
@@ -137,6 +144,7 @@ def calculate_checkout_total_with_gift_cards(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        allow_sync_webhooks=allow_sync_webhooks,
     ) - checkout_info.checkout.get_total_gift_cards_balance(database_connection_name)
 
     return max(total, zero_taxed_money(total.currency))
@@ -150,6 +158,7 @@ def checkout_total(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    allow_sync_webhooks: bool = True,
 ) -> "TaxedMoney":
     """Return the total cost of the checkout.
 
@@ -168,6 +177,7 @@ def checkout_total(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     return quantize_price(checkout_info.checkout.total, currency)
 
@@ -180,6 +190,7 @@ def checkout_line_total(
     checkout_line_info: "CheckoutLineInfo",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    allow_sync_webhooks: bool = True,
 ) -> TaxedMoney:
     """Return the total price of provided line, taxes included.
 
@@ -196,6 +207,7 @@ def checkout_line_total(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     checkout_line = find_checkout_line_info(lines, checkout_line_info.line.id).line
     return quantize_price(checkout_line.total_price, currency)
@@ -209,6 +221,7 @@ def checkout_line_unit_price(
     checkout_line_info: "CheckoutLineInfo",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    allow_sync_webhooks: bool = True,
 ) -> TaxedMoney:
     """Return the unit price of provided line, taxes included.
 
@@ -225,6 +238,7 @@ def checkout_line_unit_price(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     checkout_line = find_checkout_line_info(lines, checkout_line_info.line.id).line
     unit_price = checkout_line.total_price / checkout_line.quantity
@@ -238,6 +252,7 @@ def checkout_line_tax_rate(
     lines: list["CheckoutLineInfo"],
     checkout_line_info: "CheckoutLineInfo",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ) -> Decimal:
     """Return the tax rate of provided line.
 
@@ -250,6 +265,7 @@ def checkout_line_tax_rate(
         lines=lines,
         address=address,
         database_connection_name=database_connection_name,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     checkout_line_info = find_checkout_line_info(lines, checkout_line_info.line.id)
     return checkout_line_info.line.tax_rate
@@ -298,6 +314,7 @@ def _fetch_checkout_prices_if_expired(
     checkout_info: "CheckoutInfo",
     manager: "PluginsManager",
     lines: list["CheckoutLineInfo"],
+    allow_sync_webhooks: bool,
     address: Optional["Address"] = None,
     force_update: bool = False,
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
@@ -325,6 +342,13 @@ def _fetch_checkout_prices_if_expired(
     tax_calculation_strategy = get_tax_calculation_strategy_for_checkout(
         checkout_info, lines, database_connection_name=database_connection_name
     )
+
+    if (
+        tax_calculation_strategy == TaxCalculationStrategy.TAX_APP
+        and not allow_sync_webhooks
+    ):
+        return checkout_info, lines
+
     prices_entered_with_tax = tax_configuration.prices_entered_with_tax
     charge_taxes = get_charge_taxes_for_checkout(
         checkout_info, lines, database_connection_name=database_connection_name
@@ -702,6 +726,7 @@ def fetch_checkout_data(
     force_status_update: bool = False,
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    allow_sync_webhooks: bool = True,
 ):
     """Fetch checkout data.
 
@@ -719,6 +744,7 @@ def fetch_checkout_data(
         force_update=force_update,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        allow_sync_webhooks=allow_sync_webhooks,
     )
     current_total_gross = checkout_info.checkout.total.gross
     if current_total_gross != previous_total_gross or force_status_update:

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -11,12 +11,7 @@ from prices import Money, TaxedMoney
 
 from ...checkout.utils import add_promo_code_to_checkout, set_external_shipping_id
 from ...core.prices import quantize_price
-from ...core.taxes import (
-    TaxData,
-    TaxDataErrorMessage,
-    TaxLineData,
-    zero_taxed_money,
-)
+from ...core.taxes import TaxData, TaxDataErrorMessage, TaxLineData, zero_taxed_money
 from ...graphql.core.utils import to_global_id_or_none
 from ...plugins import PLUGIN_IDENTIFIER_PREFIX
 from ...plugins.avatax.plugin import AvataxPlugin
@@ -179,7 +174,7 @@ def test_fetch_checkout_data_plugins(
     )
 
     # when
-    fetch_checkout_data(**fetch_kwargs)
+    fetch_checkout_data(**fetch_kwargs, allow_sync_webhooks=True)
 
     # then
     checkout_with_items.refresh_from_db()
@@ -194,6 +189,68 @@ def test_fetch_checkout_data_plugins(
     assert checkout_with_items.total == subtotal + shipping_price
 
 
+@freeze_time("2020-12-12 12:00:00")
+@patch("saleor.checkout.calculations._apply_tax_data")
+def test_fetch_checkout_data_plugins_allow_sync_webhooks_set_to_false(
+    _mocked_from_app,
+    plugins_manager,
+    fetch_kwargs,
+    checkout_with_items,
+):
+    # given
+    checkout_with_items.price_expiration = timezone.now()
+    checkout_with_items.save(update_fields=["price_expiration"])
+
+    currency = checkout_with_items.currency
+    plugins_manager.get_taxes_for_checkout = Mock(return_value=None)
+
+    previous_subtotal = checkout_with_items.subtotal
+    previous_shipping_price = checkout_with_items.shipping_price
+    previous_shipping_tax_rate = checkout_with_items.shipping_tax_rate
+    previous_total = checkout_with_items.total
+
+    plugins_manager.calculate_checkout_line_total = Mock(
+        return_value=zero_taxed_money(currency)
+    )
+    plugins_manager.get_checkout_line_tax_rate = Mock(return_value=Decimal("0.23"))
+
+    plugins_manager.calculate_checkout_shipping = Mock(
+        return_value=zero_taxed_money(currency)
+    )
+
+    plugins_manager.get_checkout_shipping_tax_rate = Mock(return_value=Decimal("0.23"))
+    plugins_manager.calculate_checkout_subtotal = Mock(
+        return_value=zero_taxed_money(currency)
+    )
+    plugins_manager.calculate_checkout_total = Mock(
+        return_value=zero_taxed_money(currency)
+    )
+
+    checkout_info = fetch_kwargs["checkout_info"]
+    assert (
+        checkout_info.tax_configuration.tax_calculation_strategy
+        == TaxCalculationStrategy.TAX_APP
+    )
+
+    # when
+    fetch_checkout_data(**fetch_kwargs, allow_sync_webhooks=False)
+
+    # then
+    assert checkout_with_items.subtotal == previous_subtotal
+    assert checkout_with_items.shipping_price == previous_shipping_price
+    assert checkout_with_items.shipping_tax_rate == previous_shipping_tax_rate
+    assert checkout_with_items.total == previous_total
+
+    plugins_manager.calculate_checkout_line_total.assert_not_called()
+    plugins_manager.get_checkout_line_tax_rate.assert_not_called()
+    plugins_manager.calculate_checkout_shipping.assert_not_called()
+    plugins_manager.get_checkout_shipping_tax_rate.assert_not_called()
+    plugins_manager.get_checkout_shipping_tax_rate.assert_not_called()
+    plugins_manager.calculate_checkout_subtotal.assert_not_called()
+    plugins_manager.calculate_checkout_total.assert_not_called()
+
+
+@pytest.mark.parametrize("allow_sync_webhooks", [True, False])
 @patch(
     "saleor.checkout.calculations.update_checkout_prices_with_flat_rates",
     wraps=update_checkout_prices_with_flat_rates,
@@ -201,6 +258,7 @@ def test_fetch_checkout_data_plugins(
 @pytest.mark.parametrize("prices_entered_with_tax", [True, False])
 def test_fetch_checkout_data_flat_rates(
     mocked_update_checkout_prices_with_flat_rates,
+    allow_sync_webhooks,
     checkout_with_items_and_shipping,
     fetch_kwargs,
     prices_entered_with_tax,
@@ -224,7 +282,7 @@ def test_fetch_checkout_data_flat_rates(
     )
 
     # when
-    fetch_checkout_data(**fetch_kwargs)
+    fetch_checkout_data(**fetch_kwargs, allow_sync_webhooks=allow_sync_webhooks)
     checkout.refresh_from_db()
     line = checkout.lines.first()
 
@@ -581,7 +639,6 @@ def test_fetch_checkout_data_calls_tax_app(
     mock_get_taxes,
     mock_calculate_checkout_total,
     mock_validate_tax_data,
-    fetch_kwargs,
     checkout_with_items,
 ):
     # given
@@ -602,6 +659,7 @@ def test_fetch_checkout_data_calls_tax_app(
         "manager": manager,
         "lines": lines_info,
         "address": checkout.shipping_address or checkout.billing_address,
+        "allow_sync_webhooks": True,
     }
 
     # when
@@ -611,6 +669,65 @@ def test_fetch_checkout_data_calls_tax_app(
     mock_get_taxes.assert_called_once()
     mock_apply_tax_data.assert_called_once()
     mock_calculate_checkout_total.assert_not_called()
+
+
+@freeze_time()
+@patch("saleor.checkout.calculations.validate_tax_data")
+@patch("saleor.plugins.manager.PluginsManager.calculate_checkout_total")
+@patch("saleor.plugins.manager.PluginsManager.get_taxes_for_checkout")
+@patch("saleor.checkout.calculations._apply_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.tests.sample_plugins.PluginSample"])
+def test_fetch_checkout_data_calls_tax_app_when_allow_sync_webhooks_set_to_false(
+    mock_apply_tax_data,
+    mock_get_taxes,
+    mock_calculate_checkout_total,
+    mock_validate_tax_data,
+    checkout_with_items,
+):
+    # given
+    mock_validate_tax_data.return_value = False
+
+    checkout = checkout_with_items
+    checkout.price_expiration = timezone.now()
+    checkout.save()
+
+    previous_subtotal = checkout_with_items.subtotal
+    previous_shipping_price = checkout_with_items.shipping_price
+    previous_shipping_tax_rate = checkout_with_items.shipping_tax_rate
+    previous_total = checkout_with_items.total
+
+    checkout.channel.tax_configuration.tax_app_id = "test.app"
+    checkout.channel.tax_configuration.save()
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines_info, _ = fetch_checkout_lines(checkout)
+
+    checkout_info = fetch_checkout_info(checkout, lines_info, manager)
+    fetch_kwargs = {
+        "checkout_info": checkout_info,
+        "manager": manager,
+        "lines": lines_info,
+        "address": checkout.shipping_address or checkout.billing_address,
+        "allow_sync_webhooks": False,
+    }
+    assert (
+        checkout_info.tax_configuration.tax_calculation_strategy
+        == TaxCalculationStrategy.TAX_APP
+    )
+
+    # when
+    fetch_checkout_data(**fetch_kwargs)
+
+    # then
+    assert checkout_with_items.subtotal == previous_subtotal
+    assert checkout_with_items.shipping_price == previous_shipping_price
+    assert checkout_with_items.shipping_tax_rate == previous_shipping_tax_rate
+    assert checkout_with_items.total == previous_total
+
+    mock_apply_tax_data.assert_not_called()
+    mock_get_taxes.assert_not_called()
+    mock_calculate_checkout_total.assert_not_called()
+    mock_validate_tax_data.assert_not_called()
 
 
 @freeze_time()


### PR DESCRIPTION
I want to merge this change because it adds a flag to control if the sync webhook for taxes should be called or not.

Covers: https://linear.app/saleor/issue/MERX-1388/add-allow-sync-webhooks-to-fetch-checkout-data-function

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
