### PR TITLE
Block `orderCreateFromCheckout` mutation when tax error occur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix `products` sorting when using `sortBy: {field: COLLECTION}` - #17189 by @korycins
 - Fix checkout funds releasing task - #17198 by @IKarbowiak
 - Fixed 'healthcheck' middleware (`/health/` endpoint) not forwarding incoming traffic whenever the protocol wasn't HTTP (such as WebSocket or Lifespan) - #17248 by @NyanKiyoshi
+- Prevent creating an order over the `orderCreateFromCheckout` mutation when the tax app returns an error response - #17258 by @zedzior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,4 +53,3 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix `products` sorting when using `sortBy: {field: COLLECTION}` - #17189 by @korycins
 - Fix checkout funds releasing task - #17198 by @IKarbowiak
 - Fixed 'healthcheck' middleware (`/health/` endpoint) not forwarding incoming traffic whenever the protocol wasn't HTTP (such as WebSocket or Lifespan) - #17248 by @NyanKiyoshi
-- Prevent creating an order over the `orderCreateFromCheckout` mutation when the tax app returns an error response - #17258 by @zedzior

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -127,6 +127,7 @@ def calculate_checkout_total_with_gift_cards(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: dict | None = None,
+    force_update: bool = False,
 ) -> "TaxedMoney":
     if pregenerated_subscription_payloads is None:
         pregenerated_subscription_payloads = {}
@@ -137,6 +138,7 @@ def calculate_checkout_total_with_gift_cards(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        force_update=force_update,
     ) - checkout_info.checkout.get_total_gift_cards_balance(database_connection_name)
 
     return max(total, zero_taxed_money(total.currency))
@@ -150,6 +152,7 @@ def checkout_total(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: dict | None = None,
+    force_update: bool = False,
 ) -> "TaxedMoney":
     """Return the total cost of the checkout.
 
@@ -168,6 +171,7 @@ def checkout_total(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        force_update=force_update,
     )
     return quantize_price(checkout_info.checkout.total, currency)
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1477,7 +1477,7 @@ def create_order_from_checkout(
                         "checkout_id": checkout_id,
                     },
                 )
-                raise TaxDataError("Configured Tax App didn't respond.")
+                raise TaxDataError("Configured Tax App returned invalid response.")
 
             if delete_checkout:
                 delete_checkouts([checkout_info.checkout.pk])
@@ -1540,7 +1540,7 @@ def complete_checkout(
     )
     if checkout_info.checkout.tax_error is not None:
         raise ValidationError(
-            "Configured Tax App didn't responded.",
+            "Configured Tax App returned invalid response.",
             code=CheckoutErrorCode.TAX_ERROR.value,
         )
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1474,7 +1474,7 @@ def create_order_from_checkout(
                     checkout_id,
                     extra={
                         "tax_error": checkout_info.checkout.tax_error,
-                        "checkoutId": checkout_id,
+                        "checkout_id": checkout_id,
                     },
                 )
                 raise TaxDataError("Configured Tax App didn't respond.")

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional, cast
 from uuid import UUID
 
+import graphene
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -21,7 +22,7 @@ from ..checkout import CheckoutAuthorizeStatus, calculations
 from ..checkout.error_codes import CheckoutErrorCode
 from ..core.exceptions import GiftCardNotApplicable, InsufficientStock
 from ..core.postgres import FlatConcatSearchVector
-from ..core.taxes import TaxError, zero_taxed_money
+from ..core.taxes import TaxDataError, TaxError, zero_taxed_money
 from ..core.tracing import traced_atomic_transaction
 from ..core.transactions import transaction_with_commit_on_errors
 from ..core.utils.url import validate_storefront_url
@@ -579,6 +580,7 @@ def _prepare_order_data(
             "subtotal": subtotal,
             "undiscounted_total": undiscounted_total,
             "shipping_tax_rate": shipping_tax_rate,
+            "tax_error": checkout.tax_error,
         }
     )
 
@@ -1224,6 +1226,7 @@ def _create_order_from_checkout(
     metadata_list: list | None = None,
     private_metadata_list: list | None = None,
     is_automatic_completion: bool = False,
+    force_update: bool = False,
 ):
     from ..order.utils import add_gift_cards_to_order
 
@@ -1241,6 +1244,7 @@ def _create_order_from_checkout(
         checkout_info=checkout_info,
         lines=checkout_lines_info,
         address=address,
+        force_update=force_update,
     )
 
     # voucher
@@ -1306,6 +1310,7 @@ def _create_order_from_checkout(
         redirect_url=checkout_info.checkout.redirect_url,
         should_refresh_prices=False,
         tax_exemption=checkout_info.checkout.tax_exemption,
+        tax_error=checkout_info.checkout.tax_error,
         **_process_shipping_data_for_order(
             checkout_info,
             undiscounted_base_shipping_price,
@@ -1440,6 +1445,7 @@ def create_order_from_checkout(
 
         # Fetching checkout info inside the transaction block with select_for_update
         # ensure that we are processing checkout on the current data.
+        force_update = checkout.tax_error is not None
         checkout_lines, _ = fetch_checkout_lines(checkout, voucher=voucher)
         checkout_info = fetch_checkout_info(
             checkout, checkout_lines, manager, voucher=voucher, voucher_code=code
@@ -1456,7 +1462,23 @@ def create_order_from_checkout(
                 metadata_list=metadata_list,
                 private_metadata_list=private_metadata_list,
                 is_automatic_completion=is_automatic_completion,
+                force_update=force_update,
             )
+
+            if checkout_info.checkout.tax_error is not None:
+                checkout_id = graphene.Node.to_global_id(
+                    "Checkout", checkout_info.checkout.pk
+                )
+                logger.warning(
+                    "Tax app error for checkout %s",
+                    checkout_id,
+                    extra={
+                        "tax_error": checkout_info.checkout.tax_error,
+                        "checkoutId": checkout_id,
+                    },
+                )
+                raise TaxDataError("Configured Tax App didn't respond.")
+
             if delete_checkout:
                 delete_checkouts([checkout_info.checkout.pk])
                 checkout_info.checkout.pk = None

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -209,7 +209,7 @@ class OrderCreateFromCheckout(BaseMutation):
             raise ValidationError({"gift_cards": e}) from e
         except TaxDataError as e:
             raise ValidationError(
-                "Configured Tax App didn't respond.",
+                "Configured Tax App returned invalid response.",
                 code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
             ) from e
 

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -5,6 +5,7 @@ from ....checkout.checkout_cleaner import validate_checkout
 from ....checkout.complete_checkout import create_order_from_checkout
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....core.exceptions import GiftCardNotApplicable, InsufficientStock
+from ....core.taxes import TaxDataError
 from ....discount.models import NotApplicable
 from ....permission.enums import CheckoutPermissions
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
@@ -206,5 +207,10 @@ class OrderCreateFromCheckout(BaseMutation):
             raise error from e
         except GiftCardNotApplicable as e:
             raise ValidationError({"gift_cards": e}) from e
+        except TaxDataError as e:
+            raise ValidationError(
+                "Configured Tax App didn't respond.",
+                code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
+            ) from e
 
         return OrderCreateFromCheckout(order=order)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -428,7 +428,9 @@ def test_checkout_complete_fails_with_invalid_tax_app(
     data = content["data"]["checkoutComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == CheckoutErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
     assert not EventDelivery.objects.exists()
 
     checkout.refresh_from_db()
@@ -540,7 +542,9 @@ def test_checkout_complete_calls_failing_plugin(
     data = content["data"]["checkoutComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == CheckoutErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
 
     checkout.refresh_from_db()
     assert checkout.price_expiration == timezone.now() + settings.CHECKOUT_PRICES_TTL

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -105,7 +105,7 @@ class DraftOrderComplete(BaseMutation):
         )
         if order.tax_error is not None:
             raise ValidationError(
-                "Configured Tax App didn't responded.",
+                "Configured Tax App returned invalid response.",
                 code=OrderErrorCode.TAX_ERROR.value,
             )
         cls.validate_order(order)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1103,7 +1103,9 @@ def test_draft_order_complete_fails_with_invalid_tax_app(
     data = content["data"]["draftOrderComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == OrderErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
     assert not EventDelivery.objects.exists()
 
     order.refresh_from_db()
@@ -1251,7 +1253,9 @@ def test_draft_order_complete_calls_failing_plugin(
     data = content["data"]["draftOrderComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == OrderErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
 
     order.refresh_from_db()
     assert not order.should_refresh_prices

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -294,7 +294,7 @@ def order_created(
         logger.error(
             "Created non-draft order with tax_error for order: %s",
             order_id,
-            extra={"tax_error": order.tax_error, "orderId": order_id},
+            extra={"tax_error": order.tax_error, "order_id": order_id},
         )
 
     events.order_created_event(

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Optional, TypedDict
 from uuid import UUID
 
+import graphene
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import transaction
@@ -287,6 +288,15 @@ def order_created(
     automatic: bool = False,
 ):
     order = order_info.order
+
+    if order.tax_error is not None and not order.is_draft():
+        order_id = graphene.Node.to_global_id("Order", order.pk)
+        logger.error(
+            "Created non-draft order with tax_error for order: %s",
+            order_id,
+            extra={"tax_error": order.tax_error, "orderId": order_id},
+        )
+
     events.order_created_event(
         order=order, user=user, app=app, from_draft=from_draft, automatic=automatic
     )

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_complete_return_tax_error.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_complete_return_tax_error.py
@@ -133,4 +133,7 @@ def test_checkout_calculate_return_tax_error_when_app_not_respond_CORE_2013(
     )
     assert order_data["errors"] is not None
     assert order_data["errors"][0]["code"] == "TAX_ERROR"
-    assert order_data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        order_data["errors"][0]["message"]
+        == "Configured Tax App returned invalid response."
+    )

--- a/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
+++ b/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
@@ -130,4 +130,7 @@ def test_order_create_from_checkout_return_tax_error_when_app_not_respond_CORE_2
     )
     assert order_data["errors"] is not None
     assert order_data["errors"][0]["code"] == "TAX_ERROR"
-    assert order_data["errors"][0]["message"] == "Configured Tax App didn't respond."
+    assert (
+        order_data["errors"][0]["message"]
+        == "Configured Tax App returned invalid response."
+    )

--- a/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
+++ b/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
@@ -1,8 +1,7 @@
 import pytest
 
 from ...apps.utils import add_app
-
-# from ...orders.utils import raw_order_create_from_checkout
+from ...orders.utils import raw_order_create_from_checkout
 from ...product.utils.preparing_product import prepare_product
 from ...shop.utils import prepare_default_shop
 from ...taxes.utils import get_tax_configurations, update_tax_configuration
@@ -124,13 +123,11 @@ def test_order_create_from_checkout_return_tax_error_when_app_not_respond_CORE_2
     calculated_total_net = product_variant_price + shipping_price
     assert checkout_data["totalPrice"]["net"]["amount"] == calculated_total_net
 
-    # BUG: https://linear.app/saleor/issue/SHOPX-1712/
-    # uncomment this step when the bug is fixed
-    # # Step 4 - Place order via orderCreateFromCheckout
-    # order_data = raw_order_create_from_checkout(
-    #     e2e_app_api_client,
-    #     checkout_id,
-    # )
-    # assert order_data["errors"] is not None
-    # assert order_data["errors"][0]["code"] == "TAX_ERROR"
-    # assert order_data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    # Step 4 - Place order via orderCreateFromCheckout
+    order_data = raw_order_create_from_checkout(
+        e2e_app_api_client,
+        checkout_id,
+    )
+    assert order_data["errors"] is not None
+    assert order_data["errors"][0]["code"] == "TAX_ERROR"
+    assert order_data["errors"][0]["message"] == "Configured Tax App didn't respond."

--- a/saleor/tests/e2e/orders/taxes/test_draft_order_complete_return_tax_error.py
+++ b/saleor/tests/e2e/orders/taxes/test_draft_order_complete_return_tax_error.py
@@ -129,4 +129,6 @@ def test_draft_order_complte_return_tax_error_when_app_not_respond_CORE_2015(
     )
     assert order["errors"] is not None
     assert order["errors"][0]["code"] == "TAX_ERROR"
-    assert order["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        order["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )


### PR DESCRIPTION
I want to merge this change because it prevents creating an order over the `orderCreateFromCheckout` mutation when the tax app returns an error response.

Internal issue: https://linear.app/saleor/issue/SHOPX-1712

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
