### PR TITLE
Block `orderCreateFromCheckout` mutation when tax error occur

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -127,6 +127,7 @@ def calculate_checkout_total_with_gift_cards(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    force_update: bool = False,
 ) -> "TaxedMoney":
     if pregenerated_subscription_payloads is None:
         pregenerated_subscription_payloads = {}
@@ -137,6 +138,7 @@ def calculate_checkout_total_with_gift_cards(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        force_update=force_update,
     ) - checkout_info.checkout.get_total_gift_cards_balance(database_connection_name)
 
     return max(total, zero_taxed_money(total.currency))
@@ -150,6 +152,7 @@ def checkout_total(
     address: Optional["Address"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     pregenerated_subscription_payloads: Optional[dict] = None,
+    force_update: bool = False,
 ) -> "TaxedMoney":
     """Return the total cost of the checkout.
 
@@ -168,6 +171,7 @@ def checkout_total(
         address=address,
         database_connection_name=database_connection_name,
         pregenerated_subscription_payloads=pregenerated_subscription_payloads,
+        force_update=force_update,
     )
     return quantize_price(checkout_info.checkout.total, currency)
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1472,7 +1472,7 @@ def create_order_from_checkout(
                         "checkout_id": checkout_id,
                     },
                 )
-                raise TaxDataError("Configured Tax App didn't respond.")
+                raise TaxDataError("Configured Tax App returned invalid response.")
 
             if delete_checkout:
                 delete_checkouts([checkout_info.checkout.pk])
@@ -1535,7 +1535,7 @@ def complete_checkout(
     )
     if checkout_info.checkout.tax_error is not None:
         raise ValidationError(
-            "Configured Tax App didn't responded.",
+            "Configured Tax App returned invalid response.",
             code=CheckoutErrorCode.TAX_ERROR.value,
         )
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1469,7 +1469,7 @@ def create_order_from_checkout(
                     checkout_id,
                     extra={
                         "tax_error": checkout_info.checkout.tax_error,
-                        "checkoutId": checkout_id,
+                        "checkout_id": checkout_id,
                     },
                 )
                 raise TaxDataError("Configured Tax App didn't respond.")

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from uuid import UUID
 
+import graphene
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -21,7 +22,7 @@ from ..checkout import CheckoutAuthorizeStatus, calculations
 from ..checkout.error_codes import CheckoutErrorCode
 from ..core.exceptions import GiftCardNotApplicable, InsufficientStock
 from ..core.postgres import FlatConcatSearchVector
-from ..core.taxes import TaxError, zero_taxed_money
+from ..core.taxes import TaxDataError, TaxError, zero_taxed_money
 from ..core.tracing import traced_atomic_transaction
 from ..core.transactions import transaction_with_commit_on_errors
 from ..core.utils.url import validate_storefront_url
@@ -578,6 +579,7 @@ def _prepare_order_data(
             "subtotal": subtotal,
             "undiscounted_total": undiscounted_total,
             "shipping_tax_rate": shipping_tax_rate,
+            "tax_error": checkout.tax_error,
         }
     )
 
@@ -1223,6 +1225,7 @@ def _create_order_from_checkout(
     metadata_list: Optional[list] = None,
     private_metadata_list: Optional[list] = None,
     is_automatic_completion: bool = False,
+    force_update: bool = False,
 ):
     from ..order.utils import add_gift_cards_to_order
 
@@ -1240,6 +1243,7 @@ def _create_order_from_checkout(
         checkout_info=checkout_info,
         lines=checkout_lines_info,
         address=address,
+        force_update=force_update,
     )
 
     # voucher
@@ -1301,6 +1305,7 @@ def _create_order_from_checkout(
         redirect_url=checkout_info.checkout.redirect_url,
         should_refresh_prices=False,
         tax_exemption=checkout_info.checkout.tax_exemption,
+        tax_error=checkout_info.checkout.tax_error,
         **_process_shipping_data_for_order(
             checkout_info,
             undiscounted_base_shipping_price,
@@ -1435,6 +1440,7 @@ def create_order_from_checkout(
 
         # Fetching checkout info inside the transaction block with select_for_update
         # ensure that we are processing checkout on the current data.
+        force_update = checkout.tax_error is not None
         checkout_lines, _ = fetch_checkout_lines(checkout, voucher=voucher)
         checkout_info = fetch_checkout_info(
             checkout, checkout_lines, manager, voucher=voucher, voucher_code=code
@@ -1451,7 +1457,23 @@ def create_order_from_checkout(
                 metadata_list=metadata_list,
                 private_metadata_list=private_metadata_list,
                 is_automatic_completion=is_automatic_completion,
+                force_update=force_update,
             )
+
+            if checkout_info.checkout.tax_error is not None:
+                checkout_id = graphene.Node.to_global_id(
+                    "Checkout", checkout_info.checkout.pk
+                )
+                logger.warning(
+                    "Tax app error for checkout %s",
+                    checkout_id,
+                    extra={
+                        "tax_error": checkout_info.checkout.tax_error,
+                        "checkoutId": checkout_id,
+                    },
+                )
+                raise TaxDataError("Configured Tax App didn't respond.")
+
             if delete_checkout:
                 delete_checkouts([checkout_info.checkout.pk])
                 checkout_info.checkout.pk = None

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from unittest import mock
+from unittest.mock import patch
 
 import before_after
 import pytest
@@ -9,9 +10,16 @@ from prices import Money, TaxedMoney
 from ...checkout.models import Checkout, CheckoutLine
 from ...core.exceptions import InsufficientStock
 from ...core.prices import quantize_price
-from ...core.taxes import zero_money, zero_taxed_money
+from ...core.taxes import (
+    TaxDataError,
+    TaxDataErrorMessage,
+    zero_money,
+    zero_taxed_money,
+)
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCard, GiftCardEvent
+from ...graphql.core.utils import to_global_id_or_none
+from ...order.models import Order
 from ...plugins.manager import get_plugins_manager
 from ...product.models import ProductTranslation, ProductVariantTranslation
 from ...tests.utils import flush_post_commit_hooks
@@ -961,3 +969,34 @@ def test_create_order_product_on_promotion(
     assert (
         discount.amount_value == (order.undiscounted_total - order.total).gross.amount
     )
+
+
+@patch("saleor.checkout.calculations.validate_tax_data")
+def test_create_order_from_checkout_update_tax_error(
+    mock_validate_tax_data,
+    checkout_with_items_and_shipping,
+    customer_user,
+    app,
+    tax_configuration_tax_app,
+    caplog,
+):
+    # given
+    mock_validate_tax_data.side_effect = TaxDataError(TaxDataErrorMessage.EMPTY)
+
+    checkout = checkout_with_items_and_shipping
+    lines, _ = fetch_checkout_lines(checkout)
+
+    manager = get_plugins_manager(allow_replica=False)
+    checkout_info = fetch_checkout_info(checkout, lines, manager, [])
+
+    # when & then
+    with pytest.raises(TaxDataError):
+        create_order_from_checkout(
+            checkout_info=checkout_info,
+            manager=manager,
+            user=None,
+            app=app,
+        )
+    assert not Order.objects.exists()
+    assert "Tax app error for checkout" in caplog.text
+    assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -5,6 +5,7 @@ from ....checkout.checkout_cleaner import validate_checkout
 from ....checkout.complete_checkout import create_order_from_checkout
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....core.exceptions import GiftCardNotApplicable, InsufficientStock
+from ....core.taxes import TaxDataError
 from ....discount.models import NotApplicable
 from ....permission.enums import CheckoutPermissions
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
@@ -212,5 +213,10 @@ class OrderCreateFromCheckout(BaseMutation):
             raise error
         except GiftCardNotApplicable as e:
             raise ValidationError({"gift_cards": e})
+        except TaxDataError:
+            raise ValidationError(
+                "Configured Tax App didn't respond.",
+                code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
+            )
 
         return OrderCreateFromCheckout(order=order)

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -215,7 +215,7 @@ class OrderCreateFromCheckout(BaseMutation):
             raise ValidationError({"gift_cards": e})
         except TaxDataError:
             raise ValidationError(
-                "Configured Tax App didn't respond.",
+                "Configured Tax App returned invalid response.",
                 code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
             )
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -428,7 +428,9 @@ def test_checkout_complete_fails_with_invalid_tax_app(
     data = content["data"]["checkoutComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == CheckoutErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
     assert not EventDelivery.objects.exists()
 
     checkout.refresh_from_db()
@@ -540,7 +542,9 @@ def test_checkout_complete_calls_failing_plugin(
     data = content["data"]["checkoutComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == CheckoutErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
 
     checkout.refresh_from_db()
     assert checkout.price_expiration == timezone.now() + settings.CHECKOUT_PRICES_TTL

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -13,7 +13,13 @@ from .....checkout import calculations
 from .....checkout.error_codes import OrderCreateFromCheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout, CheckoutLine
-from .....core.taxes import TaxError, zero_money, zero_taxed_money
+from .....core.taxes import (
+    TaxDataError,
+    TaxDataErrorMessage,
+    TaxError,
+    zero_money,
+    zero_taxed_money,
+)
 from .....discount import DiscountType, DiscountValueType, RewardValueType
 from .....discount.models import CheckoutLineDiscount
 from .....giftcard import GiftCardEvents
@@ -2503,3 +2509,32 @@ def test_order_from_draft_create_0_total_value_from_giftcard(
     assert not Checkout.objects.filter(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
+
+
+@patch("saleor.checkout.calculations.validate_tax_data")
+def test_order_from_checkout_tax_error(
+    mock_validate_tax_data,
+    app_api_client,
+    permission_handle_checkouts,
+    checkout_with_items_and_shipping,
+    caplog,
+):
+    # given
+    mock_validate_tax_data.side_effect = TaxDataError(TaxDataErrorMessage.EMPTY)
+    checkout = checkout_with_items_and_shipping
+    variables = {"id": graphene.Node.to_global_id("Checkout", checkout.pk)}
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_ORDER_CREATE_FROM_CHECKOUT,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["orderCreateFromCheckout"]
+    assert data["errors"][0]["code"] == OrderCreateFromCheckoutErrorCode.TAX_ERROR.name
+    assert data["errors"][0]["field"] is None
+    assert not Order.objects.exists()
+    assert "Tax app error for checkout" in caplog.text

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -105,7 +105,7 @@ class DraftOrderComplete(BaseMutation):
         )
         if order.tax_error is not None:
             raise ValidationError(
-                "Configured Tax App didn't responded.",
+                "Configured Tax App returned invalid response.",
                 code=OrderErrorCode.TAX_ERROR.value,
             )
         cls.validate_order(order)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1103,7 +1103,9 @@ def test_draft_order_complete_fails_with_invalid_tax_app(
     data = content["data"]["draftOrderComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == OrderErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
     assert not EventDelivery.objects.exists()
 
     order.refresh_from_db()
@@ -1251,7 +1253,9 @@ def test_draft_order_complete_calls_failing_plugin(
     data = content["data"]["draftOrderComplete"]
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == OrderErrorCode.TAX_ERROR.name
-    assert data["errors"][0]["message"] == "Configured Tax App didn't responded."
+    assert (
+        data["errors"][0]["message"] == "Configured Tax App returned invalid response."
+    )
 
     order.refresh_from_db()
     assert not order.should_refresh_prices

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Optional, TypedDict
 from uuid import UUID
 
+import graphene
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import transaction
@@ -288,6 +289,15 @@ def order_created(
     automatic: bool = False,
 ):
     order = order_info.order
+
+    if order.tax_error is not None and not order.is_draft():
+        order_id = graphene.Node.to_global_id("Order", order.pk)
+        logger.error(
+            "Created non-draft order with tax_error for order: %s",
+            order_id,
+            extra={"tax_error": order.tax_error, "orderId": order_id},
+        )
+
     events.order_created_event(
         order=order, user=user, app=app, from_draft=from_draft, automatic=automatic
     )

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -295,7 +295,7 @@ def order_created(
         logger.error(
             "Created non-draft order with tax_error for order: %s",
             order_id,
-            extra={"tax_error": order.tax_error, "orderId": order_id},
+            extra={"tax_error": order.tax_error, "order_id": order_id},
         )
 
     events.order_created_event(

--- a/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
+++ b/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
@@ -130,4 +130,7 @@ def test_order_create_from_checkout_return_tax_error_when_app_not_respond_CORE_2
     )
     assert order_data["errors"] is not None
     assert order_data["errors"][0]["code"] == "TAX_ERROR"
-    assert order_data["errors"][0]["message"] == "Configured Tax App didn't respond."
+    assert (
+        order_data["errors"][0]["message"]
+        == "Configured Tax App returned invalid response."
+    )

--- a/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
+++ b/saleor/tests/e2e/checkout/taxes/test_order_create_from_checkout_return_tax_error.py
@@ -1,0 +1,133 @@
+import pytest
+
+from ...apps.utils import add_app
+from ...orders.utils import raw_order_create_from_checkout
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils import prepare_default_shop
+from ...taxes.utils import get_tax_configurations, update_tax_configuration
+from ...utils import assign_permissions
+from ...webhooks.utils import create_webhook
+from ..utils import (
+    checkout_create,
+    checkout_delivery_method_update,
+)
+
+
+@pytest.mark.e2e
+def test_order_create_from_checkout_return_tax_error_when_app_not_respond_CORE_2014(
+    e2e_app_api_client,
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_apps,
+    permission_handle_taxes,
+    permission_handle_checkouts,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_apps,
+        permission_handle_taxes,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    checkout_app_permissions = [permission_handle_checkouts]
+    assign_permissions(e2e_app_api_client, checkout_app_permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    app_input = {"name": "tax_app", "permissions": ["HANDLE_TAXES"]}
+    app_data = add_app(e2e_staff_api_client, app_input)
+    app_id = app_data["app"]["id"]
+
+    target_url = "http://localhost:8777"
+    webhook_input = {
+        "app": app_id,
+        "syncEvents": ["CHECKOUT_CALCULATE_TAXES"],
+        "asyncEvents": [],
+        "isActive": True,
+        "name": "dynamic taxes",
+        "targetUrl": target_url,
+        "query": "fragment TaxBaseLine on TaxableObjectLine {\n  sourceLine {\n    __typename\n    ... on CheckoutLine {\n      id\n      checkoutVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n    ... on OrderLine {\n      id\n      orderVariant: variant {\n        id\n        product {\n          taxClass {\n            id\n            name\n          }\n        }\n      }\n    }\n  }\n  quantity\n  unitPrice {\n    amount\n  }\n  totalPrice {\n    amount\n  }\n  chargeTaxes\n}\n\nfragment TaxBase on TaxableObject {\n  pricesEnteredWithTax\n  currency\n  channel {\n    slug\n  }\n  shippingPrice {\n    amount\n  }\n  lines {\n    ...TaxBaseLine\n  }\n  discounts {\n    name\n    amount {\n      amount\n      currency\n    }\n  }\n  sourceObject {\n    __typename\n    ... on Checkout {\n      id\n    }\n    ... on Order {\n      id\n    }\n  }\n}\n\nfragment CalculateTaxesEvent on Event {\n  ... on CalculateTaxes {\n    taxBase {\n      ...TaxBase\n    }\n  }\n}\n\nsubscription CalculateTaxes {\n  event {\n    ...CalculateTaxesEvent\n  }\n}\n",
+        "customHeaders": "{}",
+    }
+    create_webhook(e2e_staff_api_client, webhook_input)
+
+    tax_configs = get_tax_configurations(e2e_staff_api_client)
+    assert len(tax_configs) == 1
+    tax_config_id = tax_configs[0]["node"]["id"]
+
+    update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        tax_calculation_strategy="TAX_APP",
+        display_gross_prices=True,
+        prices_entered_with_tax=False,
+        tax_app_id=app_id,
+    )
+
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=30,
+    )
+    product_variant_price = float(product_variant_price)
+
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_data["totalPrice"]["gross"]["amount"] == product_variant_price
+    assert checkout_data["totalPrice"]["net"]["amount"] == product_variant_price
+    # Tax is not calculated, app do not respond
+    assert checkout_data["totalPrice"]["tax"]["amount"] == 0
+
+    # Step 2 - Set DeliveryMethod for checkout
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    shipping_price = 10
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingPrice"]["gross"]["amount"] == shipping_price
+    assert checkout_data["shippingPrice"]["net"]["amount"] == shipping_price
+    # Tax is not calculated, app do not respond
+    assert checkout_data["shippingPrice"]["tax"]["amount"] == 0
+    calculated_total_net = product_variant_price + shipping_price
+    assert checkout_data["totalPrice"]["net"]["amount"] == calculated_total_net
+
+    # Step 4 - Place order via orderCreateFromCheckout
+    order_data = raw_order_create_from_checkout(
+        e2e_app_api_client,
+        checkout_id,
+    )
+    assert order_data["errors"] is not None
+    assert order_data["errors"][0]["code"] == "TAX_ERROR"
+    assert order_data["errors"][0]["message"] == "Configured Tax App didn't respond."

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -4,7 +4,10 @@ from .draft_order_delete import draft_order_delete
 from .draft_order_update import draft_order_update
 from .order_by_checkout_id_query import order_by_checkout_id_query
 from .order_cancel import order_cancel
-from .order_create_from_checkout import order_create_from_checkout
+from .order_create_from_checkout import (
+    order_create_from_checkout,
+    raw_order_create_from_checkout,
+)
 from .order_discount_add import order_discount_add
 from .order_fulfill import order_fulfill
 from .order_fulfill_add_tracking import order_add_tracking
@@ -36,4 +39,5 @@ __all__ = [
     "order_fulfillment_cancel",
     "order_invoice_create",
     "order_update_shipping",
+    "raw_order_create_from_checkout",
 ]

--- a/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
+++ b/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
@@ -59,6 +59,20 @@ mutation orderCreateFromCheckout($id: ID!) {
 """
 
 
+def raw_order_create_from_checkout(api_client, id):
+    variables = {"id": id}
+
+    response = api_client.post_graphql(
+        ORDER_CREATE_FROM_CHECKOUT_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    raw_data = content["data"]["orderCreateFromCheckout"]
+
+    return raw_data
+
+
 def order_create_from_checkout(api_client, id):
     variables = {"id": id}
 

--- a/saleor/tests/e2e/taxes/utils/tax_configuration_update.py
+++ b/saleor/tests/e2e/taxes/utils/tax_configuration_update.py
@@ -42,10 +42,12 @@ def update_tax_configuration(
     prices_entered_with_tax=True,
     update_countries_configuration=[],
     remove_countries_configuration=[],
+    tax_app_id=None,
 ):
     variables = {
         "id": tax_config_id,
         "input": {
+            "taxAppId": tax_app_id,
             "chargeTaxes": charge_taxes,
             "taxCalculationStrategy": tax_calculation_strategy,
             "displayGrossPrices": display_gross_prices,


### PR DESCRIPTION
I want to merge this change because it prevents creating an order over the `orderCreateFromCheckout` mutation when the tax app returns an error response.

Internal issue: https://linear.app/saleor/issue/SHOPX-1712
Port: https://github.com/saleor/saleor/pull/17258

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
