### PR TITLE
Fix updating metadata in `transactionUpdate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable, unreleased changes to this project will be documented in this file.
   - `SetPassword` - #16243 by @kadewu
 - Require `MANAGE_ORDERS` for updating order and order line metadata - #17223 by @IKarbowiak
   - The `updateMetadata` for `Order` and `OrderLine` types requires the `MANAGE_ORDERS` permission
+- Fix updating `metadata` and `privateMetadata` in `transactionUpdate` - #17261 by @IKarbowiak
+  - The provided data in the input field are merged with the existing one (previously the existing data was overridden by the new one).
 
 ### GraphQL API
 

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -212,7 +212,11 @@ class TransactionUpdate(TransactionCreate):
         if transaction:
             cls.validate_transaction_input(instance, transaction)
             cls.assign_app_to_transaction_data_if_missing(instance, transaction, app)
-            cls.cleanup_metadata_data(transaction)
+            cls.cleanup_and_update_metadata_data(
+                instance,
+                transaction.pop("metadata", None),
+                transaction.pop("private_metadata", None),
+            )
             money_data = cls.get_money_data_from_input(transaction, instance.currency)
             cls.update_transaction(instance, transaction, money_data, user, app)
 


### PR DESCRIPTION
Fix updating metadata and private metadata by `transactionUpdate` mutation. Previously the provided data overrides the existing one, after the change, the data are merged instead.

Related task: https://github.com/saleor/saleor/issues/14082

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1441

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [ ] ~~Database migrations are either absent or optimized for zero downtime~~
- [x] The changes are covered by test cases
- [ ] ~~All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)~~
- [ ] ~~All migrations have proper dependencies~~
- [ ] ~~All indexes are added concurrently in migrations~~
- [ ] ~~All RunSql and RunPython migrations have revert option defined~~
