### PR TITLE
[Prevent sync webhooks in checkout bulk queries] Add SyncWebhookControlContext

### DIFF
--- a/saleor/graphql/account/tests/queries/test_me.py
+++ b/saleor/graphql/account/tests/queries/test_me.py
@@ -1,7 +1,10 @@
 from unittest import mock
 
 import graphene
+from django.utils import timezone
 
+from .....checkout.calculations import _fetch_checkout_prices_if_expired
+from .....checkout.fetch import fetch_checkout_lines
 from .....order.models import FulfillmentStatus
 from .....payment.interface import (
     ListStoredPaymentMethodsRequestData,
@@ -101,6 +104,123 @@ def test_me_query_checkout(user_api_client, checkout):
     assert data["checkout"]["token"] == str(checkout.token)
     assert data["checkouts"]["edges"][0]["node"]["id"] == graphene.Node.to_global_id(
         "Checkout", checkout.pk
+    )
+
+
+ME_WITH_CHECKOTUS_QUERY = """
+    query Me {
+        me {
+            id
+            email
+            checkouts(first: 10) {
+                edges {
+                    node {
+                        id
+                        totalPrice {
+                            currency
+                            gross {
+                                amount
+                            }
+                        }
+                    }
+                }
+                totalCount
+            }
+        }
+    }
+"""
+
+
+@mock.patch(
+    "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
+    wraps=_fetch_checkout_prices_if_expired,
+)
+@mock.patch("saleor.checkout.calculations._calculate_and_add_tax")
+def test_me_query_checkouts_do_not_trigger_sync_tax_webhooks(
+    mocked_calculate_and_add_tax,
+    mocked_fetch_checkout_prices_if_expired,
+    user_api_client,
+    checkout_with_item,
+    tax_configuration_tax_app,
+):
+    # given
+    user = user_api_client.user
+    checkout_with_item.user = user
+    checkout_with_item.price_expiration = timezone.now()
+    checkout_with_item.save()
+
+    # when
+    response = user_api_client.post_graphql(ME_WITH_CHECKOTUS_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["me"]
+    assert data["checkouts"]["edges"][0]["node"]["id"] == graphene.Node.to_global_id(
+        "Checkout", checkout_with_item.pk
+    )
+
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+
+    mocked_calculate_and_add_tax.assert_not_called()
+    mocked_fetch_checkout_prices_if_expired.assert_called_once_with(
+        checkout_info=mock.ANY,
+        allow_sync_webhooks=False,
+        address=None,
+        database_connection_name=mock.ANY,
+        force_update=False,
+        lines=lines,
+        manager=mock.ANY,
+        pregenerated_subscription_payloads=mock.ANY,
+    )
+
+
+@mock.patch(
+    "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
+    wraps=_fetch_checkout_prices_if_expired,
+)
+@mock.patch("saleor.checkout.calculations.update_checkout_prices_with_flat_rates")
+def test_me_query_checkouts_calculate_flat_taxes(
+    mocked_update_order_prices_with_flat_rates,
+    mocked_fetch_checkout_prices_if_expired,
+    user_api_client,
+    checkout_with_item,
+    tax_configuration_flat_rates,
+):
+    # given
+    user = user_api_client.user
+    checkout_with_item.user = user
+    checkout_with_item.price_expiration = timezone.now()
+    checkout_with_item.save()
+
+    # when
+    response = user_api_client.post_graphql(ME_WITH_CHECKOTUS_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["me"]
+    assert data["checkouts"]["edges"][0]["node"]["id"] == graphene.Node.to_global_id(
+        "Checkout", checkout_with_item.pk
+    )
+
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+
+    mocked_update_order_prices_with_flat_rates.assert_called_once_with(
+        checkout_with_item,
+        mock.ANY,
+        lines,
+        tax_configuration_flat_rates.prices_entered_with_tax,
+        None,
+        database_connection_name=mock.ANY,
+    )
+    mocked_fetch_checkout_prices_if_expired.assert_called_once_with(
+        checkout_info=mock.ANY,
+        allow_sync_webhooks=False,
+        address=None,
+        database_connection_name=mock.ANY,
+        force_update=False,
+        lines=lines,
+        manager=mock.ANY,
+        pregenerated_subscription_payloads=mock.ANY,
     )
 
 

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -11,6 +11,7 @@ from ....checkout.fetch import (
 from ....checkout.utils import add_promo_code_to_checkout, invalidate_checkout
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -128,4 +129,4 @@ class CheckoutAddPromoCode(BaseMutation):
             lines=lines,
         )
 
-        return CheckoutAddPromoCode(checkout=checkout)
+        return CheckoutAddPromoCode(checkout=SyncWebhookControlContext(node=checkout))

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -8,6 +8,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import AddressInput
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.scalars import UUID
@@ -113,4 +114,6 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             checkout_info=checkout_info,
             lines=lines,
         )
-        return CheckoutBillingAddressUpdate(checkout=checkout)
+        return CheckoutBillingAddressUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -17,6 +17,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_FIELD
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import LanguageCodeEnum
@@ -403,5 +404,6 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             event_name=WebhookEventAsyncType.CHECKOUT_CREATED,
             checkout=checkout,
         )
-        response.created = True
-        return response
+        return CheckoutCreate(
+            checkout=SyncWebhookControlContext(node=checkout), created=True
+        )

--- a/saleor/graphql/checkout/mutations/checkout_create_from_order.py
+++ b/saleor/graphql/checkout/mutations/checkout_create_from_order.py
@@ -13,6 +13,7 @@ from ....product.models import ProductVariant
 from ....warehouse.availability import check_stock_and_preorder_quantity_bulk
 from ....warehouse.reservations import get_reservation_length, is_reservation_enabled
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.types import BaseObjectType, Error, common
@@ -418,5 +419,6 @@ class CheckoutCreateFromOrder(BaseMutation):
             )
         apply_gift_reward_if_applicable_on_checkout_creation(checkout)
         return CheckoutCreateFromOrder(
-            checkout=checkout, unavailable_variants=variant_errors
+            checkout=SyncWebhookControlContext(node=checkout),
+            unavailable_variants=variant_errors,
         )

--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -9,6 +9,7 @@ from ....permission.enums import AccountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import User
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -123,4 +124,4 @@ class CheckoutCustomerAttach(BaseMutation):
             checkout=checkout,
         )
 
-        return CheckoutCustomerAttach(checkout=checkout)
+        return CheckoutCustomerAttach(checkout=SyncWebhookControlContext(node=checkout))

--- a/saleor/graphql/checkout/mutations/checkout_customer_detach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_detach.py
@@ -6,6 +6,7 @@ from ....permission.auth_filters import AuthorizationFilters
 from ....permission.enums import AccountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -75,4 +76,4 @@ class CheckoutCustomerDetach(BaseMutation):
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )
-        return CheckoutCustomerDetach(checkout=checkout)
+        return CheckoutCustomerDetach(checkout=SyncWebhookControlContext(node=checkout))

--- a/saleor/graphql/checkout/mutations/checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_note_update.py
@@ -3,6 +3,7 @@ import graphene
 from ....checkout.actions import call_checkout_event
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -58,4 +59,6 @@ class CheckoutCustomerNoteUpdate(BaseMutation):
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )
-        return CheckoutCustomerNoteUpdate(checkout=checkout)
+        return CheckoutCustomerNoteUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -23,6 +23,7 @@ from ....warehouse import models as warehouse_models
 from ....webhook.const import APP_ID_PREFIX
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -124,7 +125,9 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             external_shipping_method=None,
             collection_point=None,
         )
-        return CheckoutDeliveryMethodUpdate(checkout=checkout)
+        return CheckoutDeliveryMethodUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )
 
     @classmethod
     def perform_on_external_shipping_method(
@@ -174,7 +177,9 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             external_shipping_method=delivery_method,
             collection_point=None,
         )
-        return CheckoutDeliveryMethodUpdate(checkout=checkout)
+        return CheckoutDeliveryMethodUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )
 
     @classmethod
     def perform_on_collection_point(
@@ -199,7 +204,9 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             external_shipping_method=None,
             collection_point=collection_point,
         )
-        return CheckoutDeliveryMethodUpdate(checkout=checkout)
+        return CheckoutDeliveryMethodUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )
 
     @staticmethod
     def _check_delivery_method(

--- a/saleor/graphql/checkout/mutations/checkout_email_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_email_update.py
@@ -5,6 +5,7 @@ from ....checkout.actions import call_checkout_event
 from ....checkout.error_codes import CheckoutErrorCode
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -85,4 +86,4 @@ class CheckoutEmailUpdate(BaseMutation):
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )
-        return CheckoutEmailUpdate(checkout=checkout)
+        return CheckoutEmailUpdate(checkout=SyncWebhookControlContext(node=checkout))

--- a/saleor/graphql/checkout/mutations/checkout_language_code_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_language_code_update.py
@@ -4,6 +4,7 @@ from saleor.checkout.actions import call_checkout_event
 from saleor.webhook.event_types import WebhookEventAsyncType
 
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import LanguageCodeEnum
@@ -72,4 +73,6 @@ class CheckoutLanguageCodeUpdate(BaseMutation):
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,
             checkout=checkout,
         )
-        return CheckoutLanguageCodeUpdate(checkout=checkout)
+        return CheckoutLanguageCodeUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )

--- a/saleor/graphql/checkout/mutations/checkout_line_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_line_delete.py
@@ -6,6 +6,7 @@ from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import invalidate_checkout
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -89,4 +90,4 @@ class CheckoutLineDelete(BaseMutation):
             lines=lines,
         )
 
-        return CheckoutLineDelete(checkout=checkout)
+        return CheckoutLineDelete(checkout=SyncWebhookControlContext(node=checkout))

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -12,6 +12,7 @@ from ....warehouse.reservations import get_reservation_length, is_reservation_en
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -236,7 +237,7 @@ class CheckoutLinesAdd(BaseMutation):
             lines=lines,
         )
 
-        return CheckoutLinesAdd(checkout=checkout)
+        return CheckoutLinesAdd(checkout=SyncWebhookControlContext(node=checkout))
 
     @classmethod
     def _get_variants_from_lines_input(cls, lines: list[dict]) -> list[ProductVariant]:

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -7,6 +7,7 @@ from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import invalidate_checkout
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -108,4 +109,4 @@ class CheckoutLinesDelete(BaseMutation):
             lines=lines,
         )
 
-        return CheckoutLinesDelete(checkout=checkout)
+        return CheckoutLinesDelete(checkout=SyncWebhookControlContext(node=checkout))

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -13,6 +13,7 @@ from ....checkout.utils import (
 )
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -114,7 +115,9 @@ class CheckoutRemovePromoCode(BaseMutation):
             lines=lines,
         )
 
-        return CheckoutRemovePromoCode(checkout=checkout)
+        return CheckoutRemovePromoCode(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )
 
     @staticmethod
     def clean_promo_code_id(promo_code_id: str | None):

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -22,6 +22,7 @@ from ....warehouse.reservations import is_reservation_enabled
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -221,4 +222,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             lines=lines,
         )
 
-        return CheckoutShippingAddressUpdate(checkout=checkout)
+        return CheckoutShippingAddressUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -17,6 +17,7 @@ from ....shipping.utils import convert_to_shipping_method_data
 from ....webhook.const import APP_ID_PREFIX
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
@@ -228,7 +229,9 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             checkout_info=checkout_info,
             lines=lines,
         )
-        return CheckoutShippingMethodUpdate(checkout=checkout)
+        return CheckoutShippingMethodUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )
 
     @classmethod
     def perform_on_external_shipping_method(
@@ -269,7 +272,9 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             lines=lines,
         )
 
-        return CheckoutShippingMethodUpdate(checkout=checkout)
+        return CheckoutShippingMethodUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )
 
     @classmethod
     def remove_shipping_method(cls, checkout, checkout_info, lines, manager):
@@ -292,4 +297,6 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             checkout_info=checkout_info,
             lines=lines,
         )
-        return CheckoutShippingMethodUpdate(checkout=checkout)
+        return CheckoutShippingMethodUpdate(
+            checkout=SyncWebhookControlContext(node=checkout)
+        )

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -6,11 +6,12 @@ from ...permission.enums import (
     PaymentPermissions,
 )
 from ..core import ResolveInfo
-from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import (
-    DEPRECATED_IN_3X_FIELD,
-    DEPRECATED_IN_3X_INPUT,
+from ..core.connection import (
+    create_connection_slice,
+    create_connection_slice_for_sync_webhook_control_context,
+    filter_connection_queryset,
 )
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD, DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_CHECKOUT
 from ..core.fields import BaseField, ConnectionField, FilterConnectionField
 from ..core.scalars import UUID
@@ -99,7 +100,9 @@ class CheckoutQueries(graphene.ObjectType):
         qs = filter_connection_queryset(
             qs, kwargs, allow_replica=info.context.allow_replica
         )
-        return create_connection_slice(qs, info, kwargs, CheckoutCountableConnection)
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, CheckoutCountableConnection, allow_sync_webhooks=False
+        )
 
     @staticmethod
     def resolve_checkout_lines(_root, info: ResolveInfo, **kwargs):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -13,6 +13,7 @@ from measurement.measures import Weight
 from prices import Money
 
 from ....checkout import base_calculations, calculations
+from ....checkout.calculations import _fetch_checkout_prices_if_expired
 from ....checkout.checkout_cleaner import (
     clean_checkout_payment,
     clean_checkout_shipping,
@@ -3590,6 +3591,12 @@ CHECKOUTS_QUERY = """
             edges {
                 node {
                     token
+                    totalPrice {
+                        currency
+                        gross {
+                            amount
+                        }
+                    }
                 }
             }
         }
@@ -3652,6 +3659,97 @@ def test_query_checkouts(
     content = get_graphql_content(response)
     received_checkout = content["data"]["checkouts"]["edges"][0]["node"]
     assert str(checkout.token) == received_checkout["token"]
+
+
+@mock.patch(
+    "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
+    wraps=_fetch_checkout_prices_if_expired,
+)
+@mock.patch("saleor.checkout.calculations._calculate_and_add_tax")
+def test_query_checkouts_do_not_trigger_sync_tax_webhooks(
+    mocked_calculate_and_add_tax,
+    mocked_fetch_checkout_prices_if_expired,
+    checkout_with_item,
+    staff_api_client,
+    permission_manage_checkouts,
+    tax_configuration_tax_app,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.price_expiration = timezone.now()
+    checkout.save()
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHECKOUTS_QUERY, {}, permissions=[permission_manage_checkouts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["checkouts"]["edges"])
+
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+
+    mocked_calculate_and_add_tax.assert_not_called()
+    mocked_fetch_checkout_prices_if_expired.assert_called_once_with(
+        checkout_info=mock.ANY,
+        allow_sync_webhooks=False,
+        address=None,
+        database_connection_name=mock.ANY,
+        force_update=False,
+        lines=lines,
+        manager=mock.ANY,
+        pregenerated_subscription_payloads=mock.ANY,
+    )
+
+
+@mock.patch(
+    "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
+    wraps=_fetch_checkout_prices_if_expired,
+)
+@mock.patch("saleor.checkout.calculations.update_checkout_prices_with_flat_rates")
+def test_query_checkouts_calculate_flat_taxes(
+    mocked_update_order_prices_with_flat_rates,
+    mocked_fetch_checkout_prices_if_expired,
+    checkout_with_item,
+    staff_api_client,
+    permission_manage_checkouts,
+    tax_configuration_flat_rates,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.price_expiration = timezone.now()
+    checkout.save()
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHECKOUTS_QUERY, {}, permissions=[permission_manage_checkouts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["checkouts"]["edges"])
+
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+
+    mocked_update_order_prices_with_flat_rates.assert_called_once_with(
+        checkout_with_item,
+        mock.ANY,
+        lines,
+        tax_configuration_flat_rates.prices_entered_with_tax,
+        None,
+        database_connection_name=mock.ANY,
+    )
+    mocked_fetch_checkout_prices_if_expired.assert_called_once_with(
+        checkout_info=mock.ANY,
+        allow_sync_webhooks=False,
+        address=None,
+        database_connection_name=mock.ANY,
+        force_update=False,
+        lines=lines,
+        manager=mock.ANY,
+        pregenerated_subscription_payloads=mock.ANY,
+    )
 
 
 def test_query_with_channel(

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -20,6 +20,7 @@ from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core.enums import OrderDirection
 from ..core.types import BaseConnection, NonNullList
 from ..utils.sorting import sort_queryset_for_connection
+from .context import SyncWebhookControlContext
 
 if TYPE_CHECKING:
     from ..core import ResolveInfo
@@ -644,6 +645,22 @@ def _handle_or_filter_input(
             )
     queryset &= qs
     return queryset
+
+
+def create_connection_slice_for_sync_webhook_control_context(
+    iterable, info: "ResolveInfo", args, connection_type, allow_sync_webhooks
+):
+    edges_with_context = []
+    sliced_connection = create_connection_slice(iterable, info, args, connection_type)
+
+    for edge in sliced_connection.edges:
+        node = edge.node
+        edge.node = SyncWebhookControlContext(
+            node=node, allow_sync_webhooks=allow_sync_webhooks
+        )
+        edges_with_context.append(edge)
+    sliced_connection.edges = edges_with_context
+    return sliced_connection
 
 
 # TODO: needs optimization

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -1,5 +1,6 @@
 import datetime
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from django.conf import settings
 from django.http import HttpRequest
@@ -64,3 +65,12 @@ def setup_context_user(context: SaleorContext) -> None:
     ):
         context.user._setup()  # type: ignore[union-attr]
         context.user = context.user._wrapped  # type: ignore[union-attr]
+
+
+N = TypeVar("N")
+
+
+@dataclass
+class SyncWebhookControlContext(Generic[N]):
+    node: N
+    allow_sync_webhooks: bool = True

--- a/saleor/graphql/core/types/order_or_checkout.py
+++ b/saleor/graphql/core/types/order_or_checkout.py
@@ -4,6 +4,7 @@ from ....checkout.models import Checkout
 from ....order.models import Order
 from ...checkout import types as checkout_types
 from ...order import types as order_types
+from ..context import SyncWebhookControlContext
 
 # The file hasn't been attached to the __init__ file as it generates the circular
 # graphql import. Graphene for Union types requires already initialized types so
@@ -20,6 +21,9 @@ class OrderOrCheckoutBase(graphene.Union):
 
     @classmethod
     def resolve_type(cls, instance, info: graphene.ResolveInfo):
+        if isinstance(instance, SyncWebhookControlContext):
+            instance = instance.node
+
         if isinstance(instance, Checkout):
             return checkout_types.Checkout
         if isinstance(instance, Order):

--- a/saleor/graphql/core/types/sync_webhook_control.py
+++ b/saleor/graphql/core/types/sync_webhook_control.py
@@ -1,0 +1,26 @@
+from typing import TypeVar
+
+from django.db.models import Model
+from graphene.types.resolver import get_default_resolver
+
+from .. import ResolveInfo
+from ..context import SyncWebhookControlContext
+from .model import ModelObjectType
+
+T = TypeVar("T", bound=Model)
+
+
+class SyncWebhookControlContextType(ModelObjectType[T]):
+    class Meta:
+        abstract = True
+
+    @staticmethod
+    def resolver_with_context(
+        attname,
+        default_value,
+        root: SyncWebhookControlContext,
+        info: ResolveInfo,
+        **args,
+    ):
+        resolver = get_default_resolver()
+        return resolver(attname, default_value, root.node, info, **args)

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -41,6 +41,7 @@ from ...tax.dataloaders import (
 )
 from ...tax.enums import TaxableObjectDiscountTypeEnum
 from .. import ResolveInfo
+from ..context import SyncWebhookControlContext
 from .common import NonNullList
 from .money import Money as MoneyType
 from .order_or_checkout import OrderOrCheckoutBase
@@ -331,6 +332,8 @@ class TaxableObject(BaseObjectType):
 
     @staticmethod
     def resolve_source_object(root: Checkout | Order, _info: ResolveInfo):
+        if isinstance(root, Checkout):
+            return SyncWebhookControlContext(node=root)
         return root
 
     @staticmethod

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -6,6 +6,7 @@ from ...core.models import ModelWithMetadata
 from ...discount.models import Promotion
 from ..channel import ChannelContext
 from ..core import ResolveInfo
+from ..core.context import SyncWebhookControlContext
 from ..core.types import NonNullList
 from .resolvers import (
     check_private_metadata_privilege,
@@ -149,13 +150,14 @@ class ObjectWithMetadata(graphene.Interface):
 
     @classmethod
     def resolve_type(cls, instance: ModelWithMetadata, info: ResolveInfo):
-        if isinstance(instance, ChannelContext):
+        if isinstance(instance, (ChannelContext)):
             # Return instance for types that use ChannelContext
             instance = instance.node
-        if isinstance(instance, Checkout):
-            from ..checkout.types import Checkout as CheckoutType
+        if isinstance(instance, SyncWebhookControlContext):
+            if isinstance(instance.node, Checkout):
+                from ..checkout.types import Checkout as CheckoutType
 
-            return CheckoutType.resolve_type(instance, info)
+                return CheckoutType.resolve_type(instance, info)
         if isinstance(instance, Promotion) and instance.old_sale_id:
             # For old sales migrated into promotions
             from ..discount.types.sales import Sale as SaleType

--- a/saleor/graphql/payment/mutations/payment/checkout_payment_create.py
+++ b/saleor/graphql/payment/mutations/payment/checkout_payment_create.py
@@ -21,6 +21,7 @@ from ....account.i18n import I18nMixin
 from ....checkout.mutations.utils import get_checkout
 from ....checkout.types import Checkout
 from ....core import ResolveInfo
+from ....core.context import SyncWebhookControlContext
 from ....core.descriptions import DEPRECATED_IN_3X_INPUT
 from ....core.doc_category import DOC_CATEGORY_CHECKOUT, DOC_CATEGORY_PAYMENTS
 from ....core.mutations import BaseMutation
@@ -327,4 +328,6 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
                     metadata=metadata,
                 )
 
-        return CheckoutPaymentCreate(payment=payment, checkout=checkout)
+        return CheckoutPaymentCreate(
+            payment=payment, checkout=SyncWebhookControlContext(node=checkout)
+        )

--- a/saleor/graphql/tax/mutations/tax_exemption_manage.py
+++ b/saleor/graphql/tax/mutations/tax_exemption_manage.py
@@ -10,6 +10,7 @@ from ....order.models import Order
 from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.types import Error
 from ...core.types.taxes import TaxSourceObject
@@ -95,6 +96,7 @@ class TaxExemptionManage(BaseMutation):
         if isinstance(obj, Checkout):
             cls._invalidate_checkout(info, obj)
             obj.save(update_fields=["tax_exemption", "price_expiration", "last_change"])
+            obj = SyncWebhookControlContext(node=obj)
 
         if isinstance(obj, Order):
             cls.validate_order_status(obj)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1646,7 +1646,7 @@ def tax_configuration_flat_rates(channel_USD):
     tc.country_exceptions.all().delete()
     tc.prices_entered_with_tax = False
     tc.tax_calculation_strategy = TaxCalculationStrategy.FLAT_RATES
-    tc.tax_app_id = "avatax.app"
+    tc.tax_app_id = None
     tc.save()
     return tc
 


### PR DESCRIPTION
I want to merge this change because it adds usage of SyncWebhookControlContext for all places where checkout is used to generate the graphql response. (In the same way as ChannelContext works).

More details: https://github.com/saleor/saleor/pull/17268
Internal task: https://linear.app/saleor/issue/MERX-1389/use-contextwithsyncwebhookcontrol-for-checkout-type

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
