### PR TITLE
Fix undiscounted price taxation inside an order calculations when the Avatax plugin is used

### DIFF
--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -345,17 +345,17 @@ def _recalculate_with_plugins(
 
 def _get_undiscounted_price(
     line_price: OrderTaxedPricesData,
-    line_base_price: Money,
+    undiscounted_base_price: Money,
     tax_rate,
     prices_entered_with_tax,
-):
+) -> TaxedMoney:
     if (
         tax_rate > 0
         and line_price.undiscounted_price.net == line_price.undiscounted_price.gross
     ):
-        get_taxed_undiscounted_price(
-            line_base_price,
-            line_price.undiscounted_price,
+        return get_taxed_undiscounted_price(
+            undiscounted_base_price,
+            line_price.price_with_discounts,
             tax_rate,
             prices_entered_with_tax,
         )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -10165,6 +10165,17 @@ def tax_configuration_tax_app(channel_USD):
 
 
 @pytest.fixture
+def tax_configuration_avatax_plugin(channel_USD):
+    tc = channel_USD.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.prices_entered_with_tax = False
+    tc.tax_calculation_strategy = TaxCalculationStrategy.TAX_APP
+    tc.tax_app_id = "plugin:avatax"
+    tc.save()
+    return tc
+
+
+@pytest.fixture
 def order_with_lines_untaxed(order_with_lines):
     order = order_with_lines
     lines = order.lines.all()


### PR DESCRIPTION
I want to merge this change, because it fixes missing tax calculation for undiscounted prices when Avatax plugin is used and an order origins from draft order.

Internal issue: https://linear.app/saleor/issue/SHOPX-1775
Port: https://github.com/saleor/saleor/pull/17253

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
