### PR TITLE
Fix incorrect order for reordering collection products when sort_order is null

### DIFF
--- a/saleor/graphql/product/mutations/collection/collection_reorder_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_reorder_products.py
@@ -99,6 +99,8 @@ class CollectionReorderProducts(BaseMutation):
             operations[m2m_info.pk] = move_info.sort_order
 
         with traced_atomic_transaction():
-            perform_reordering(m2m_related_field.all(), operations)
+            perform_reordering(
+                m2m_related_field.all(), operations, second_sort_field="product_id"
+            )
         context = ChannelContext(node=collection, channel_slug=None)
         return CollectionReorderProducts(collection=context)


### PR DESCRIPTION
I want to merge this change because it fixes the issue when calling `collectionReorderProducts` for products with `sort_order == Null`. By default `collection.products` are sorted by `sort_order, product_id`, but in case of reordering, the `id` of the many-to-many object was used (`CollectionProduct`). This caused that the first call to reorder objects, caused results in different order than expected.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
