### PR TITLE
Release 3.20.67

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.66",
+  "version": "3.20.67",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.66",
+      "version": "3.20.67",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.66",
+  "version": "3.20.67",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.66"
+version = "3.20.67"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.66"
+__version__ = "3.20.67"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Block `orderCreateFromCheckout` mutation when tax error occur (#17260) (6b610ac081)
* Fix undiscounted price taxation inside an order calculations when the Avatax plugin is used (#17253) (#17272) (6feb53e7d1)
* Fix missing currency in voucher discount objects (#17264) (dbb3292e37)
* Fix test http client (#17262) (#17270) (0209db2a53)
* Fix checkout funds releasing task (#17233) (a61aaf94a7)
* Fix duplicated checkout tests (#17256) (60aa042751)
* Fix incorrect tax rate returned by Avatax plugin (#17252) (79aacff978)
