### PR TITLE
Fix incorrect order for reordering collection products when sort_order is null

### DIFF
--- a/saleor/graphql/core/utils/reordering.py
+++ b/saleor/graphql/core/utils/reordering.py
@@ -41,10 +41,15 @@ class Reordering:
 
     @cached_property
     def ordered_node_map(self):
+        additional_sorters = [self.second_sort_field]
+        if self.second_sort_field != "id":
+            # add `id` to make sure that last sorting field is unique
+            additional_sorters.append("id")
+
         ordering_map = OrderedDict(
             self.qs.select_for_update()
             .values_list("pk", "sort_order")
-            .order_by(F("sort_order").asc(nulls_last=True), self.second_sort_field)
+            .order_by(F("sort_order").asc(nulls_last=True), *additional_sorters)
         )
         self.old_sort_map = ordering_map.copy()
         self.ordered_pks = list(ordering_map.keys())

--- a/saleor/graphql/product/mutations/collection/collection_reorder_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_reorder_products.py
@@ -99,6 +99,8 @@ class CollectionReorderProducts(BaseMutation):
             operations[m2m_info.pk] = move_info.sort_order
 
         with traced_atomic_transaction():
-            perform_reordering(m2m_related_field.all(), operations)
+            perform_reordering(
+                m2m_related_field.all(), operations, second_sort_field="product_id"
+            )
         context = ChannelContext(node=collection, channel_slug=None)
         return CollectionReorderProducts(collection=context)

--- a/saleor/graphql/product/tests/test_product_sorting.py
+++ b/saleor/graphql/product/tests/test_product_sorting.py
@@ -145,6 +145,59 @@ def test_sort_products_within_collection(
     assert products[2]["node"]["id"] == product
 
 
+def test_sort_products_within_collection_when_null_as_sort_order(
+    staff_api_client,
+    published_collection,
+    collection_with_products,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    collection_id = graphene.Node.to_global_id("Collection", published_collection.pk)
+
+    products = collection_with_products
+
+    collection = products[0].collections.first()
+
+    collection_products = collection.collectionproduct.all()
+    for c_p in collection_products:
+        c_p.sort_order = None
+    CollectionProduct.objects.bulk_update(collection_products, ["sort_order"])
+
+    collection_products = sorted(
+        collection.collectionproduct.all(), key=lambda c: c.product_id
+    )
+
+    collection_prod_1 = collection_products[0]
+    collection_prod_2 = collection_products[1]
+    collection_prod_3 = collection_products[2]
+
+    product = graphene.Node.to_global_id("Product", collection_prod_1.product_id)
+    second_product = graphene.Node.to_global_id("Product", collection_prod_2.product_id)
+    third_product = graphene.Node.to_global_id("Product", collection_prod_3.product_id)
+
+    variables = {
+        "collectionId": collection_id,
+        "moves": [{"productId": third_product, "sortOrder": -2}],
+    }
+
+    # when
+    content = get_graphql_content(
+        staff_api_client.post_graphql(COLLECTION_RESORT_QUERY, variables)
+    )["data"]["collectionReorderProducts"]
+
+    # then
+    assert not content["errors"]
+
+    assert content["collection"]["id"] == collection_id
+
+    products = content["collection"]["products"]["edges"]
+    assert products[0]["node"]["id"] == third_product
+    assert products[1]["node"]["id"] == product
+    assert products[2]["node"]["id"] == second_product
+
+
 GET_SORTED_PRODUCTS_QUERY = """
 query Products($sortBy: ProductOrder, $channel: String) {
     products(first: 10, sortBy: $sortBy, channel: $channel) {


### PR DESCRIPTION
I want to merge this change because it fixes the issue when calling `collectionReorderProducts` for products with `sort_order == Null`. By default `collection.products` are sorted by `sort_order, product_id`, but in case of reordering, the `id` of the many-to-many object was used (`CollectionProduct`). This caused that the first call to reorder objects, returned results in a different order than expected.


Internal task link: https://linear.app/saleor/issue/MERX-1423/fix-incorrect-sorting-for-reordering-products-in-collection-when-sort

Port of changes from: #17276 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
