### PR TITLE
Remove reference cycles in Promise

### DIFF
--- a/saleor/graphql/promise.py
+++ b/saleor/graphql/promise.py
@@ -1,0 +1,22 @@
+from promise import Promise
+
+
+def __del_promise__(self: Promise) -> None:
+    # Clean up references to break up any reference cycles
+    self._handlers = None  # type: ignore[assignment]
+    self._fulfillment_handler0 = None
+    self._rejection_handler0 = None
+    self._promise0 = None
+    self._future = None  # type: ignore[assignment]
+    self._event_instance = None  # type: ignore[attr-defined]
+    self._traceback = None
+
+
+def patch_promise():
+    """Patch Promise.__del__ to avoid memory leaks.
+
+    Promise.__del__ will remove all references that could result in reference cycles,
+    allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+    Issue: https://github.com/syrusakbary/promise/issues/106
+    """
+    Promise.__del__ = __del_promise__  # type: ignore[attr-defined]

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -31,6 +31,7 @@ from . import PatchedSubscriberExecutionContext, __version__
 from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
+from .graphql.promise import patch_promise
 
 django_stubs_ext.monkeypatch()
 
@@ -1009,3 +1010,8 @@ ENABLE_DEPRECATED_MANAGER_PERFORM_MUTATION = get_bool_from_env(
 # Disable Django warnings regarding too long cache keys being incompatible with
 # memcached to avoid leaking key values.
 warnings.filterwarnings("ignore", category=CacheKeyWarning)
+
+
+# Patch Promise to remove all references that could result in reference cycles, allowing memory to be freed
+# immediately, without the need of a deep garbage collection cycle.
+patch_promise()


### PR DESCRIPTION
I want to merge this change because it allows memory to be freed immediately without needing a deep garbage collection cycle.
Fix for: https://github.com/syrusakbary/promise/issues/106

Garbage before:
![garbage_before](https://github.com/user-attachments/assets/03eda007-a40f-4219-b764-17d09c72c2c5)
Garbage after:
![garbage_fixed](https://github.com/user-attachments/assets/7a184178-de66-4cf5-a40f-ef39c365e811)

⚠️ OpenID Connect cycle will be removed in separate PR. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
