### PR TITLE
Remove reference cycles in Authlib

### DIFF
--- a/saleor/plugins/openid_connect/patch.py
+++ b/saleor/plugins/openid_connect/patch.py
@@ -1,0 +1,22 @@
+from authlib.integrations.requests_client import OAuth2Session
+from authlib.oauth2.auth import TokenAuth
+
+
+def __del_OAuth2Session__(self):
+    del self.session
+
+
+def __del_TokenAuth__(self):
+    del self.client
+    del self.hooks
+
+
+def patch_authlib():
+    """Patch `__del__` in `OAuth2Session` and `TokenAuth` to avoid memory leaks.
+
+    Those changes will remove the circular references between `OAuth2Session` and `TokenAuth`
+    allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+    Issue: https://github.com/lepture/authlib/issues/698
+    """
+    OAuth2Session.__del__ = __del_OAuth2Session__
+    TokenAuth.__del__ = __del_TokenAuth__

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -32,6 +32,7 @@ from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
 from .graphql.promise import patch_promise
+from .plugins.openid_connect.patch import patch_authlib
 
 django_stubs_ext.monkeypatch()
 
@@ -1015,3 +1016,7 @@ warnings.filterwarnings("ignore", category=CacheKeyWarning)
 # Patch Promise to remove all references that could result in reference cycles, allowing memory to be freed
 # immediately, without the need of a deep garbage collection cycle.
 patch_promise()
+
+# Patch `OAuth2Session` and `TokenAuth` to remove all references that could result in reference cycles,
+# allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+patch_authlib()


### PR DESCRIPTION
I want to merge this change because it allows memory to be freed immediately without needing a deep garbage collection cycle.
Fix for: https://github.com/lepture/authlib/issues/698

Garbage before:
![garbage_before](https://github.com/user-attachments/assets/f7848bfc-8d44-4173-beb8-85f7f3bc2e57)

Garbage after:
![garbage_after](https://github.com/user-attachments/assets/dce478d5-8598-4872-8db5-0b27284ef312)

⚠️ Promies cycles will be removed in #17291


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
