### PR TITLE
Remove reference cycle in Asgiref Local

### DIFF
--- a/saleor/patch_local.py
+++ b/saleor/patch_local.py
@@ -1,0 +1,53 @@
+import asyncio
+import contextlib
+
+from asgiref.local import Local, _CVar
+
+
+@contextlib.contextmanager
+def _Local_lock_storage(self):
+    # Thread safe access to storage
+    if self._thread_critical:
+        is_async = True
+        try:
+            # this is a test for are we in a async or sync
+            # thread - will raise RuntimeError if there is
+            # no current loop
+            asyncio.get_running_loop()
+        except RuntimeError:
+            is_async = False
+        if not is_async:
+            # We are in a sync thread, the storage is
+            # just the plain thread local (i.e, "global within
+            # this thread" - it doesn't matter where you are
+            # in a call stack you see the same storage)
+            yield self._storage
+        else:
+            # We are in an async thread - storage is still
+            # local to this thread, but additionally should
+            # behave like a context var (is only visible with
+            # the same async call stack)
+
+            # Ensure context exists in the current thread
+            if not hasattr(self._storage, "cvar"):
+                self._storage.cvar = _CVar()
+
+            # self._storage is a thread local, so the members
+            # can't be accessed in another thread (we don't
+            # need any locks)
+            yield self._storage.cvar
+    else:
+        # Lock for thread_critical=False as other threads
+        # can access the exact same storage object
+        with self._thread_lock:
+            yield self._storage
+
+
+def patch_local():
+    """Patch `_lock_storage in `Local` to avoid memory leaks.
+
+    Those changes will remove the circular references inside `Local` class,
+    allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+    Issue: https://github.com/django/asgiref/issues/487
+    """
+    Local._lock_storage = _Local_lock_storage  # type: ignore[method-assign]

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -32,6 +32,7 @@ from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
 from .graphql.promise import patch_promise
+from .patch_local import patch_local
 from .plugins.openid_connect.patch import patch_authlib
 
 django_stubs_ext.monkeypatch()
@@ -1020,3 +1021,7 @@ patch_promise()
 # Patch `OAuth2Session` and `TokenAuth` to remove all references that could result in reference cycles,
 # allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
 patch_authlib()
+
+# Patch `Local` to remove all references that could result in reference cycles,
+# allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+patch_local()


### PR DESCRIPTION
I want to merge this change because it allows memory to be freed immediately without needing a deep garbage collection cycle.
Fix for: https://github.com/django/asgiref/issues/487

Garbage before: 
![garbage_before](https://github.com/user-attachments/assets/dc8a7138-91a6-4a51-ae1a-0ba7fe56b0e2)
Garbage after is empty:
![garbage_after](https://github.com/user-attachments/assets/fbe69b0b-bf14-4276-b2b4-2e68ae3ab727)



<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
