### PR TITLE
Adjust order fulfillment

### DIFF
--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -1258,6 +1258,7 @@ def test_complete_checkout_0_total_with_transaction_for_mark_as_paid(
         )
 
     # then
+    order.refresh_from_db()
     assert order
     assert order.authorize_status == OrderAuthorizeStatus.FULL
     assert order.charge_status == OrderChargeStatus.FULL
@@ -2760,6 +2761,7 @@ def test_checkout_complete_with_voucher_0_total(
         )
 
     # then
+    order.refresh_from_db()
     assert order.status == OrderStatus.UNFULFILLED
     assert order.lines.count() == 1
     assert order.discounts.count() == 1

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -1035,6 +1035,7 @@ def test_create_order_with_voucher_0_total(
         )
 
     # then
+    order.refresh_from_db()
     assert order.status == OrderStatus.UNFULFILLED
     assert order.lines.count() == 1
     assert order.discounts.count() == 1

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -14,6 +14,7 @@ from ...core import TimePeriodType
 from ...core.exceptions import GiftCardNotApplicable
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...core.utils.promo_code import InvalidPromoCode
+from ...order import OrderEvents
 from ...order.models import OrderLine
 from ...plugins.manager import get_plugins_manager
 from ...site import GiftCardSettingsExpiryType
@@ -694,6 +695,11 @@ def test_fulfill_gift_card_lines(
         )
         assert card.fulfillment_line
         assert GiftCardEvent.objects.filter(gift_card=card, type=GiftCardEvents.BOUGHT)
+
+    event = order.events.filter(type=OrderEvents.FULFILLMENT_FULFILLED_ITEMS).first()
+    assert event
+    assert "auto" in event.parameters
+    assert event.parameters["auto"] is True
 
 
 def test_fulfill_gift_card_lines_lack_of_stock(

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -155,6 +155,7 @@ def fulfill_gift_card_lines(
         manager,
         settings,
         notify_customer=True,
+        auto=True,
     )
 
 

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -331,6 +331,10 @@ class CheckoutComplete(BaseMutation, I18nMixin):
             metadata_list=metadata,
         )
 
+        # Refresh the order status as it might be updated in post commit actions
+        if order:
+            order.refresh_from_db(fields=["status"])
+
         # If gateway returns information that additional steps are required we need
         # to inform the frontend and pass all required data
         return CheckoutComplete(

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -331,10 +331,6 @@ class CheckoutComplete(BaseMutation, I18nMixin):
             metadata_list=metadata,
         )
 
-        # Refresh the order status as it might be updated in post commit actions
-        if order:
-            order.refresh_from_db(fields=["status"])
-
         # If gateway returns information that additional steps are required we need
         # to inform the frontend and pass all required data
         return CheckoutComplete(

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -213,8 +213,4 @@ class OrderCreateFromCheckout(BaseMutation):
                 code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
             ) from e
 
-        # Refresh the order status as it might be updated in post commit actions
-        if order:
-            order.refresh_from_db(fields=["status"])
-
         return OrderCreateFromCheckout(order=order)

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -213,4 +213,8 @@ class OrderCreateFromCheckout(BaseMutation):
                 code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
             ) from e
 
+        # Refresh the order status as it might be updated in post commit actions
+        if order:
+            order.refresh_from_db(fields=["status"])
+
         return OrderCreateFromCheckout(order=order)

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_complete.py
@@ -74,6 +74,7 @@ def test_checkout_complete(
     address,
     shipping_method,
 ):
+    # given
     assert not gift_card.last_used_on
 
     checkout = checkout_with_gift_card
@@ -113,8 +114,11 @@ def test_checkout_complete(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     redirect_url = "https://www.example.com"
     variables = {"checkoutId": checkout_id, "redirectUrl": redirect_url}
+
+    # when
     response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
 
+    # then
     content = get_graphql_content(response)
     data = content["data"]["checkoutComplete"]
     assert not data["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -3895,6 +3895,7 @@ def test_checkout_complete_with_preorder_variant(
     address,
     shipping_method,
 ):
+    # given
     checkout = checkout_with_item_and_preorder_item
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
@@ -3926,8 +3927,11 @@ def test_checkout_complete_with_preorder_variant(
         "id": to_global_id_or_none(checkout),
         "redirectUrl": "https://www.example.com",
     }
+
+    # when
     response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
 
+    # then
     content = get_graphql_content(response)
     data = content["data"]["checkoutComplete"]
     assert not data["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -2717,6 +2717,7 @@ def test_checkout_complete_with_voucher_on_specific_product_and_gift_card(
     shipping_method,
     transaction_events_generator,
     transaction_item_generator,
+    django_capture_on_commit_callbacks,
 ):
     # given
     checkout_with_item_and_voucher_specific_products.gift_cards.add(gift_card)
@@ -2760,7 +2761,8 @@ def test_checkout_complete_with_voucher_on_specific_product_and_gift_card(
     }
 
     # when
-    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, patch
 
 import graphene
 import pytest
+from django.db import transaction
 from django.db.models.aggregates import Sum
 from django.utils import timezone
 from prices import TaxedMoney
@@ -51,6 +52,7 @@ MUTATION_CHECKOUT_COMPLETE = """
             ) {
             order {
                 id
+                status
                 token
                 original
                 origin
@@ -4739,3 +4741,48 @@ def test_checkout_complete_empty_product_translation(
     recalculate_with_plugins_mock.assert_not_called()
 
     assert not len(Reservation.objects.all())
+
+
+def test_complete_checkout_order_status_changed_after_creation(
+    checkout_with_item_total_0,
+    customer_user,
+    user_api_client,
+):
+    """Ensure order status is valid in the mutation response.
+    In case that order is created with `UNCONFIRMED` and then changed into `UNFULFILLED`
+    in post commit action, the returned order status should be upt-to-date.
+    """
+    # given
+    checkout = checkout_with_item_total_0
+
+    channel = checkout.channel
+    channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
+    channel.save(update_fields=["order_mark_as_paid_strategy"])
+
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.save()
+
+    update_checkout_payment_statuses(
+        checkout, zero_money(checkout.currency), checkout_has_lines=True
+    )
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    def immediate_on_commit(func):
+        func()
+
+    # when
+    with patch.object(transaction, "on_commit", side_effect=immediate_on_commit):
+        response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+
+    order = data["order"]
+    assert order
+    assert order["status"] == OrderStatus.UNFULFILLED.upper()

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -4749,6 +4749,7 @@ def test_complete_checkout_order_status_changed_after_creation(
     user_api_client,
 ):
     """Ensure order status is valid in the mutation response.
+
     In case that order is created with `UNCONFIRMED` and then changed into `UNFULFILLED`
     in post commit action, the returned order status should be upt-to-date.
     """

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -2633,6 +2633,7 @@ def test_order_from_checkout_order_status_changed_after_creation(
     permission_handle_checkouts,
 ):
     """Ensure order status is valid in the mutation response.
+
     In case that order is created with `UNCONFIRMED` and then changed into `UNFULFILLED`
     in post commit action, the returned order status should be upt-to-date.
     """

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -6,7 +6,7 @@ from django.db import transaction
 
 from ....account.models import User
 from ....core.tracing import traced_atomic_transaction
-from ....order import OrderStatus, models
+from ....order import models
 from ....order.actions import (
     WEBHOOK_EVENTS_FOR_ORDER_CHARGED,
     WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED,
@@ -15,7 +15,7 @@ from ....order.actions import (
 )
 from ....order.error_codes import OrderErrorCode
 from ....order.fetch import fetch_order_info
-from ....order.utils import update_order_display_gross_prices
+from ....order.utils import update_order_display_gross_prices, update_order_status
 from ....payment import gateway
 from ....permission.enums import OrderPermissions
 from ....webhook.utils import get_webhooks_for_multiple_events
@@ -72,9 +72,9 @@ class OrderConfirm(ModelMutation):
         user = cast(User, user)
         order = cls.get_instance(info, **data)
         cls.check_channel_permissions(info, [order.channel_id])
-        order.status = OrderStatus.UNFULFILLED
+        order = update_order_status(order)
         update_order_display_gross_prices(order)
-        order.save(update_fields=["status", "updated_at", "display_gross_prices"])
+        order.save(update_fields=["updated_at", "display_gross_prices"])
         order_info = fetch_order_info(order)
         payment = order_info.payment
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -72,7 +72,7 @@ class OrderConfirm(ModelMutation):
         user = cast(User, user)
         order = cls.get_instance(info, **data)
         cls.check_channel_permissions(info, [order.channel_id])
-        order = update_order_status(order)
+        update_order_status(order)
         update_order_display_gross_prices(order)
         order.save(update_fields=["updated_at", "display_gross_prices"])
         order_info = fetch_order_info(order)

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -286,9 +286,9 @@ class OrderFulfill(BaseMutation):
                 dict(lines_for_warehouses),
                 manager,
                 site.settings,
-                notify_customer,
+                notify_customer=notify_customer,
                 allow_stock_to_be_exceeded=allow_stock_to_be_exceeded,
-                approved=approved,
+                auto_approved=approved,
                 tracking_number=tracking_number,
             )
         except InsufficientStock as e:

--- a/saleor/graphql/order/tests/deprecated/test_order.py
+++ b/saleor/graphql/order/tests/deprecated/test_order.py
@@ -281,9 +281,9 @@ def test_order_fulfill_old_line_id(
         fulfillment_lines_for_warehouses,
         ANY,
         site_settings,
-        True,
+        notify_customer=True,
         allow_stock_to_be_exceeded=False,
-        approved=fulfillment_auto_approve,
+        auto_approved=fulfillment_auto_approve,
         tracking_number="",
     )
 

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -16,7 +16,7 @@ from .....order.actions import order_transaction_updated
 from .....order.events import transaction_event as order_transaction_event
 from .....order.fetch import fetch_order_info
 from .....order.search import update_order_search_vector
-from .....order.utils import updates_amounts_for_order
+from .....order.utils import update_order_status, updates_amounts_for_order
 from .....payment import TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionCreateErrorCode
@@ -321,8 +321,7 @@ class TransactionCreate(BaseMutation):
             order.channel.automatically_confirm_all_new_orders
             and order.status == OrderStatus.UNCONFIRMED
         ):
-            order.status = OrderStatus.UNFULFILLED
-            update_fields.append("status")
+            update_order_status(order)
 
         if update_search_vector:
             update_order_search_vector(order, save=False)

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -392,8 +392,7 @@ def handle_fully_paid_order(
         )
 
     if not order.is_draft() and order.channel.automatically_confirm_all_new_orders:
-        order = update_order_status(order)
-        order_info.order = order
+        update_order_status(order)
 
     call_order_events(
         manager,
@@ -553,7 +552,7 @@ def order_fulfilled(
     # transaction ensures webhooks are triggered only when order status and fulfillment
     # events are successfully created
     with traced_atomic_transaction():
-        order = update_order_status(order)
+        update_order_status(order)
         if gift_card_lines_info:
             gift_cards_create(
                 order,

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -11,6 +11,7 @@ from django.contrib.sites.models import Site
 from django.db import transaction
 
 from ..account.models import User
+from ..app.models import App
 from ..core.exceptions import AllocationError, InsufficientStock, InsufficientStockData
 from ..core.tracing import traced_atomic_transaction
 from ..core.transactions import transaction_with_commit_on_errors
@@ -379,7 +380,7 @@ def handle_fully_paid_order(
     if order_info.customer_email:
         send_payment_confirmation(order_info, manager)
         if utils.order_needs_automatic_fulfillment(order_info.lines_data):
-            automatically_fulfill_digital_lines(order_info, manager)
+            automatically_fulfill_digital_lines(order_info, manager, user, app)
 
     if site_settings is None:
         site_settings = Site.objects.get_current().settings
@@ -391,7 +392,8 @@ def handle_fully_paid_order(
         )
 
     if not order.is_draft() and order.channel.automatically_confirm_all_new_orders:
-        update_order_status(order)
+        order = update_order_status(order)
+        order_info.order = order
 
     call_order_events(
         manager,
@@ -537,6 +539,8 @@ def order_fulfilled(
     gift_card_lines_info: list[GiftCardLineData],
     site_settings: "SiteSettings",
     notify_customer=True,
+    auto=False,
+    manually_approved=False,
     webhook_event_map: dict[str, set["Webhook"]] | None = None,
 ):
     from ..giftcard.utils import gift_cards_create
@@ -549,26 +553,34 @@ def order_fulfilled(
     # transaction ensures webhooks are triggered only when order status and fulfillment
     # events are successfully created
     with traced_atomic_transaction():
-        update_order_status(order)
-        gift_cards_create(
-            order,
-            gift_card_lines_info,
-            site_settings,
-            user,
-            app,
-            manager,
-        )
+        order = update_order_status(order)
+        if gift_card_lines_info:
+            gift_cards_create(
+                order,
+                gift_card_lines_info,
+                site_settings,
+                user,
+                app,
+                manager,
+            )
         events.fulfillment_fulfilled_items_event(
-            order=order, user=user, app=app, fulfillment_lines=fulfillment_lines
+            order=order,
+            user=user,
+            app=app,
+            fulfillment_lines=fulfillment_lines,
+            auto=auto,
         )
         webhook_events = [WebhookEventAsyncType.ORDER_UPDATED]
         for fulfillment in fulfillments:
             call_event(manager.fulfillment_created, fulfillment, notify_customer)
 
-        if order.status == OrderStatus.FULFILLED:
+        order_fulfilled = order.status == OrderStatus.FULFILLED
+        if order_fulfilled:
             webhook_events.append(WebhookEventAsyncType.ORDER_FULFILLED)
+
+        if order_fulfilled or manually_approved:
             for fulfillment in fulfillments:
-                call_event(manager.fulfillment_approved, fulfillment)
+                call_event(manager.fulfillment_approved, fulfillment, notify_customer)
 
         call_order_events(
             manager,
@@ -578,8 +590,13 @@ def order_fulfilled(
         )
     if notify_customer:
         for fulfillment in fulfillments:
-            send_fulfillment_confirmation_to_customer(
-                order, fulfillment, user, app, manager
+            call_event(
+                send_fulfillment_confirmation_to_customer,
+                order,
+                fulfillment,
+                user,
+                app,
+                manager,
             )
 
 
@@ -835,28 +852,17 @@ def approve_fulfillment(
     notify_customer=True,
     allow_stock_to_be_exceeded: bool = False,
 ):
-    from ..giftcard.utils import gift_cards_create
-
     with traced_atomic_transaction():
         fulfillment.status = FulfillmentStatus.FULFILLED
         fulfillment.save()
         order = fulfillment.order
-        if notify_customer:
-            send_fulfillment_confirmation_to_customer(
-                fulfillment.order, fulfillment, user, app, manager
-            )
-        events.fulfillment_fulfilled_items_event(
-            order=order,
-            user=user,
-            app=app,
-            fulfillment_lines=list(fulfillment.lines.all()),
-        )
         lines_to_fulfill = []
         gift_card_lines_info = []
         insufficient_stocks = []
-        for fulfillment_line in fulfillment.lines.all().prefetch_related(
+        fulfillment_lines = fulfillment.lines.all().prefetch_related(
             "order_line__variant"
-        ):
+        )
+        for fulfillment_line in fulfillment_lines:
             order_line = fulfillment_line.order_line
             variant = fulfillment_line.order_line.variant
 
@@ -898,32 +904,17 @@ def approve_fulfillment(
 
         _decrease_stocks(lines_to_fulfill, manager, allow_stock_to_be_exceeded)
         order.refresh_from_db()
-        update_order_status(order)
-
-        webhook_event_map = get_webhooks_for_multiple_events(
-            WEBHOOK_EVENTS_FOR_ORDER_FULFILLED
-        )
-        webhook_events = [WebhookEventAsyncType.ORDER_UPDATED]
-        call_event(manager.fulfillment_approved, fulfillment, notify_customer)
-        if order.status == OrderStatus.FULFILLED:
-            webhook_events.append(WebhookEventAsyncType.ORDER_FULFILLED)
-
-        call_order_events(
+        order_fulfilled(
+            [fulfillment],
+            user,
+            app,
+            list(fulfillment_lines),
             manager,
-            webhook_events,
-            order,
-            webhook_event_map=webhook_event_map,
+            gift_card_lines_info,
+            settings,
+            notify_customer,
+            manually_approved=True,
         )
-
-        if gift_card_lines_info:
-            gift_cards_create(
-                order,
-                gift_card_lines_info,
-                settings,
-                user,
-                app,
-                manager,
-            )
 
     return fulfillment
 
@@ -1077,7 +1068,10 @@ def fulfill_order_lines(
 
 
 def automatically_fulfill_digital_lines(
-    order_info: "OrderInfo", manager: "PluginsManager"
+    order_info: "OrderInfo",
+    manager: "PluginsManager",
+    user: User | None = None,
+    app: App | None = None,
 ):
     """Fulfill all digital lines which have enabled automatic fulfillment setting.
 
@@ -1125,6 +1119,9 @@ def automatically_fulfill_digital_lines(
 
         FulfillmentLine.objects.bulk_create(fulfillments)
         fulfill_order_lines(lines_info, manager)
+        events.fulfillment_fulfilled_items_event(
+            order=order, user=user, app=app, fulfillment_lines=fulfillments, auto=True
+        )
 
         send_fulfillment_confirmation_to_customer(
             order, fulfillment, user=order.user, app=None, manager=manager
@@ -1258,8 +1255,10 @@ def create_fulfillments(
     fulfillment_lines_for_warehouses: dict[UUID, list[OrderFulfillmentLineInfo]],
     manager: "PluginsManager",
     site_settings: "SiteSettings",
+    *,
     notify_customer: bool = True,
-    approved: bool = True,
+    auto: bool = False,
+    auto_approved: bool = True,
     allow_stock_to_be_exceeded: bool = False,
     tracking_number: str = "",
 ) -> list[Fulfillment]:
@@ -1287,7 +1286,8 @@ def create_fulfillments(
         notify_customer (bool): If `True` system send email about
             fulfillments to customer.
         site_settings (SiteSettings): Site settings used for creating gift cards.
-        approved (Boolean): fulfillments will have status fulfilled if it's True,
+        auto (Boolean): define if the fulfillment is automatic
+        auto_approved (Boolean): fulfillments will have status fulfilled if it's True,
             otherwise waiting_for_approval.
         allow_stock_to_be_exceeded (bool): If `True` then stock quantity could exceed.
             Default value is set to `False`.
@@ -1307,7 +1307,7 @@ def create_fulfillments(
     gift_card_lines_info: list[GiftCardLineData] = []
     status = (
         FulfillmentStatus.FULFILLED
-        if approved
+        if auto_approved
         else FulfillmentStatus.WAITING_FOR_APPROVAL
     )
 
@@ -1340,7 +1340,7 @@ def create_fulfillments(
                     order.channel.slug,
                     gift_card_lines_info,
                     manager,
-                    decrease_stock=approved,
+                    decrease_stock=auto_approved,
                     allow_stock_to_be_exceeded=allow_stock_to_be_exceeded,
                 )
             )
@@ -1349,28 +1349,25 @@ def create_fulfillments(
 
         FulfillmentLine.objects.bulk_create(fulfillment_lines)
         order.refresh_from_db()
-        if approved:
-            transaction.on_commit(
-                lambda: order_fulfilled(
-                    fulfillments,
-                    user,
-                    app,
-                    fulfillment_lines,
-                    manager,
-                    gift_card_lines_info,
-                    site_settings,
-                    notify_customer,
-                )
+        if auto_approved:
+            order_fulfilled(
+                fulfillments,
+                user,
+                app,
+                fulfillment_lines,
+                manager,
+                gift_card_lines_info,
+                site_settings,
+                notify_customer,
+                auto,
             )
         else:
-            transaction.on_commit(
-                lambda: order_awaits_fulfillment_approval(
-                    fulfillments,
-                    user,
-                    app,
-                    fulfillment_lines,
-                    manager,
-                )
+            order_awaits_fulfillment_approval(
+                fulfillments,
+                user,
+                app,
+                fulfillment_lines,
+                manager,
             )
     return fulfillments
 

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -595,13 +595,17 @@ def fulfillment_fulfilled_items_event(
     user: User | None,
     app: App | None,
     fulfillment_lines: list[FulfillmentLine],
+    auto: bool = False,
 ) -> OrderEvent:
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_FULFILLED_ITEMS,
         user=user,
         app=app,
-        parameters={"fulfilled_items": [line.pk for line in fulfillment_lines]},
+        parameters={
+            "fulfilled_items": [line.pk for line in fulfillment_lines],
+            "auto": auto,
+        },
     )
 
 

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -385,6 +385,7 @@ def test_restock_fulfillment_lines(fulfilled_order, warehouse):
 
 
 def test_update_order_status_partially_fulfilled(fulfilled_order):
+    # given
     fulfillment = fulfilled_order.fulfillments.first()
     line = fulfillment.lines.first()
     order_line = line.order_line
@@ -392,8 +393,12 @@ def test_update_order_status_partially_fulfilled(fulfilled_order):
     order_line.quantity_fulfilled -= line.quantity
     order_line.save()
     line.delete()
+
+    # when
     update_order_status(fulfilled_order)
 
+    # then
+    fulfilled_order.refresh_from_db()
     assert fulfilled_order.status == OrderStatus.PARTIALLY_FULFILLED
 
 

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -398,7 +398,6 @@ def test_update_order_status_partially_fulfilled(fulfilled_order):
     update_order_status(fulfilled_order)
 
     # then
-    fulfilled_order.refresh_from_db()
     assert fulfilled_order.status == OrderStatus.PARTIALLY_FULFILLED
 
 
@@ -408,7 +407,6 @@ def test_update_order_status_unfulfilled(order_with_lines):
 
     update_order_status(order_with_lines)
 
-    order_with_lines.refresh_from_db()
     assert order_with_lines.status == OrderStatus.UNFULFILLED
 
 
@@ -428,7 +426,6 @@ def test_update_order_status_fulfilled(fulfilled_order):
 
     update_order_status(fulfilled_order)
 
-    fulfilled_order.refresh_from_db()
     assert fulfilled_order.status == OrderStatus.FULFILLED
 
 
@@ -439,7 +436,6 @@ def test_update_order_status_returned(fulfilled_order):
 
     update_order_status(fulfilled_order)
 
-    fulfilled_order.refresh_from_db()
     assert fulfilled_order.status == OrderStatus.RETURNED
 
 
@@ -472,7 +468,6 @@ def test_update_order_status_partially_returned(fulfilled_order):
 
     update_order_status(fulfilled_order)
 
-    fulfilled_order.refresh_from_db()
     assert fulfilled_order.status == OrderStatus.PARTIALLY_RETURNED
 
 
@@ -483,7 +478,6 @@ def test_update_order_status_waiting_for_approval(fulfilled_order):
 
     update_order_status(fulfilled_order)
 
-    fulfilled_order.refresh_from_db()
     assert fulfilled_order.status == OrderStatus.PARTIALLY_FULFILLED
 
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Optional, cast
 import graphene
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.db.models import QuerySet, Sum
 from django.template.defaultfilters import pluralize
 from django.utils import timezone
@@ -166,37 +167,43 @@ def _calculate_quantity_including_returns(order):
     return total_quantity, quantity_fulfilled, quantity_returned
 
 
-def update_order_status(order: Order):
+def update_order_status(order: Order) -> Order:
     """Update order status depending on fulfillments."""
-    (
-        total_quantity,
-        quantity_fulfilled,
-        quantity_returned,
-    ) = _calculate_quantity_including_returns(order)
+    # Add a transaction block to ensure that the order status won't be overridden by
+    # another process.
+    with transaction.atomic():
+        order = Order.objects.select_for_update().get(pk=order.pk)
+        (
+            total_quantity,
+            quantity_fulfilled,
+            quantity_returned,
+        ) = _calculate_quantity_including_returns(order)
 
-    # check if order contains any fulfillments that awaiting approval
-    awaiting_approval = order.fulfillments.filter(
-        status=FulfillmentStatus.WAITING_FOR_APPROVAL
-    ).exists()
+        # check if order contains any fulfillments that awaiting approval
+        awaiting_approval = order.fulfillments.filter(
+            status=FulfillmentStatus.WAITING_FOR_APPROVAL
+        ).exists()
 
-    # total_quantity == 0 means that all products have been replaced, we don't change
-    # the order status in that case
-    if total_quantity == 0:
-        status = order.status
-    elif quantity_fulfilled <= 0:
-        status = OrderStatus.UNFULFILLED
-    elif 0 < quantity_returned < total_quantity:
-        status = OrderStatus.PARTIALLY_RETURNED
-    elif quantity_returned == total_quantity:
-        status = OrderStatus.RETURNED
-    elif quantity_fulfilled < total_quantity or awaiting_approval:
-        status = OrderStatus.PARTIALLY_FULFILLED
-    else:
-        status = OrderStatus.FULFILLED
+        # total_quantity == 0 means that all products have been replaced, we don't change
+        # the order status in that case
+        if total_quantity == 0:
+            status = order.status
+        elif quantity_fulfilled <= 0:
+            status = OrderStatus.UNFULFILLED
+        elif 0 < quantity_returned < total_quantity:
+            status = OrderStatus.PARTIALLY_RETURNED
+        elif quantity_returned == total_quantity:
+            status = OrderStatus.RETURNED
+        elif quantity_fulfilled < total_quantity or awaiting_approval:
+            status = OrderStatus.PARTIALLY_FULFILLED
+        else:
+            status = OrderStatus.FULFILLED
 
-    if status != order.status:
-        order.status = status
-        order.save(update_fields=["status", "updated_at"])
+        if status != order.status:
+            order.status = status
+            order.save(update_fields=["status", "updated_at"])
+
+    return order
 
 
 @traced_atomic_transaction()


### PR DESCRIPTION
Solution:
- Call gift card creation and order status updates to the transaction where fulfillment in the same transaction where fulfillment lines are created - currently, there is a risk that fulfillment might be created, but if an error occurs while sending webhooks, the fulfillment event may not be recorded, and the order status might remain unchanged.
- Ensure that `update_order_status` is performed in transaction to ensure that the status is not overridden by another thread.
- Extend parameters of `FULFILLMENT_FULFILLED_ITEMS` order event with `auto` that is saying if the fulfillments was done automatically or not

Port of https://github.com/saleor/saleor/pull/17300

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
