### PR TITLE
Release 3.20.68

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.67",
+  "version": "3.20.68",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.67",
+      "version": "3.20.68",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.67",
+  "version": "3.20.68",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.67"
+version = "3.20.68"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.67"
+__version__ = "3.20.68"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.20.68 (ecf1d94e85)
* Add Source-Service-Name to the CORS handler (#17303) (bb1d9f332b)
* Remove reference cycle in Asgiref Local (#17293) (731373810f)
* Remove reference cycles in authlib (#17292) (3ba052df92)
* Remove reference cycles in Promise (#17291) (39f77fa6b2)
* Fix test-migrations-compatibility workflow (#17288) (0bd66d5d06)
* Add source.service.name span tag (#17279) (b6be045049)
