### PR TITLE
Remove reference cycle in Saleor context

### DIFF
--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -28,6 +28,7 @@ def get_context_value(request: HttpRequest) -> SaleorContext:
 
 def clear_context(context: SaleorContext):
     context.dataloaders.clear()
+    del context.user
 
 
 class RequestWithUser(HttpRequest):

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -91,7 +91,7 @@ class OrderConfirm(ModelMutation):
                 transaction.on_commit(
                     lambda: order_charged(
                         order_info,
-                        info.context.user,
+                        user,
                         app,
                         authorized_payment.total,
                         authorized_payment,


### PR DESCRIPTION
I want to merge this change because:
- allows memory to be freed immediately without needing a deep garbage collection cycle.
- Drop usage of SaleorContext in `transaction.on_commit`. 

Garbage before:
![garbage_before](https://github.com/user-attachments/assets/5480bb81-7c0b-4211-9ee6-51604acc219f)

Garbage after
![garbage_afterr](https://github.com/user-attachments/assets/8aeb96e3-16e6-4710-a874-1f39a6860e90)


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
