### PR TITLE
Remove reference cycle in Django DB

### DIFF
--- a/saleor/core/db/patch.py
+++ b/saleor/core/db/patch.py
@@ -1,0 +1,32 @@
+from django.db.backends.base.validation import BaseDatabaseValidation
+from django.db.backends.postgresql.client import DatabaseClient
+from django.db.backends.postgresql.creation import DatabaseCreation
+from django.db.backends.postgresql.features import DatabaseFeatures
+from django.db.backends.postgresql.introspection import DatabaseIntrospection
+from django.db.backends.postgresql.operations import DatabaseOperations
+from django.db.utils import DatabaseErrorWrapper
+
+
+def __del_connection__(self):
+    self.connection = None
+
+
+def __del_wrapper__(self):
+    self.wrapper = None
+
+
+def patch_db():
+    """Patch `__del__` in objects to avoid memory leaks.
+
+    Those changes will remove the circular references between database objects,
+    allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+    Issue: https://code.djangoproject.com/ticket/34865
+    """
+    DatabaseClient.__del__ = __del_connection__  # type: ignore[attr-defined]
+    DatabaseCreation.__del__ = __del_connection__  # type: ignore[attr-defined]
+    DatabaseFeatures.__del__ = __del_connection__  # type: ignore[attr-defined]
+    DatabaseIntrospection.__del__ = __del_connection__  # type: ignore[attr-defined]
+    DatabaseOperations.__del__ = __del_connection__  # type: ignore[attr-defined]
+    BaseDatabaseValidation.__del__ = __del_connection__  # type: ignore[attr-defined]
+
+    DatabaseErrorWrapper.__del__ = __del_wrapper__  # type: ignore[attr-defined]

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -28,6 +28,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
 from . import PatchedSubscriberExecutionContext, __version__
+from .core.db.patch import patch_db
 from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
@@ -1025,3 +1026,8 @@ patch_authlib()
 # Patch `Local` to remove all references that could result in reference cycles,
 # allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
 patch_local()
+
+# Patch `DatabaseClient`, `DatabaseCreation`, `DatabaseFeatures`, `DatabaseIntrospection`, `DatabaseOperations`,
+# `BaseDatabaseValidation` and `DatabaseErrorWrapper` to remove all references that could result in reference cycles,
+# allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+patch_db()


### PR DESCRIPTION
I want to merge this change because it allows memory to be freed immediately without needing a deep garbage collection cycle.
Fix for:  https://code.djangoproject.com/ticket/34865

Garbage before:
![garbage_before](https://github.com/user-attachments/assets/f4462be2-ce18-47ec-a687-d77fc23e770d)

Garbage after: 
![garbage_after](https://github.com/user-attachments/assets/b05d0d49-e515-4fc8-959e-459b3c029254)


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
