### PR TITLE
Move source-service-name from HTTP to GraphQL span

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -180,11 +180,6 @@ class GraphQLView(View):
             span.set_tag("http.useragent", request.headers.get("user-agent", ""))
             span.set_tag("span.type", "web")
 
-            source_service_name = get_source_service_name_value(
-                request.headers.get("source-service-name")
-            )
-            span.set_tag("source.service.name", source_service_name)
-
             main_ip_header = settings.REAL_IP_ENVIRON[0]
             additional_ip_headers = settings.REAL_IP_ENVIRON[1:]
 
@@ -292,6 +287,10 @@ class GraphQLView(View):
             span.set_tag("graphql.query", raw_query_string)
             span.set_tag("graphql.query_identifier", _query_identifier)
             span.set_tag("graphql.query_fingerprint", query_fingerprint(document))
+            source_service_name = get_source_service_name_value(
+                request.headers.get("source-service-name")
+            )
+            span.set_tag("source.service.name", source_service_name)
             try:
                 query_contains_schema = check_if_query_contains_only_schema(document)
             except GraphQLError as e:


### PR DESCRIPTION
I want to merge this change because moving source-service-name from HTTP to GraphQL span.

In https://github.com/saleor/saleor/pull/17250 we add the source of the query. To build query distribution per source dashboards in DataDog we need to have this information in the same span as information about query.

Port: #17315 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
