### PR TITLE
Revert `sync` back to `install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip pip install poetry==2.0.1
 RUN poetry config virtualenvs.create false
 COPY poetry.lock pyproject.toml /app/
-RUN --mount=type=cache,mode=0755,target=/root/.cache/pypoetry poetry sync
+RUN --mount=type=cache,mode=0755,target=/root/.cache/pypoetry poetry install
 
 ### Final image
 FROM python:3.12-slim


### PR DESCRIPTION
`poetry` tries to uninstall itself and it fails, reverts https://github.com/saleor/saleor/pull/17307/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15, `--no-root` is handled in https://github.com/saleor/saleor/blob/main/pyproject.toml#L15.