### PR TITLE
Remove reference cycle in gzip

### DIFF
--- a/saleor/asgi/gzip_compression.py
+++ b/saleor/asgi/gzip_compression.py
@@ -140,6 +140,8 @@ def gzip_compression(
                         await send(message)
 
                 await app(scope, receive, send_compressed)
+                gzip_file.close()
+                gzip_buffer.close()
                 return
         await app(scope, receive, send)
 

--- a/saleor/patch_gzip.py
+++ b/saleor/patch_gzip.py
@@ -1,0 +1,16 @@
+from gzip import _WriteBufferStream  # type: ignore[attr-defined]
+
+
+def __del_tmp__(self):
+    del self.gzip_file
+
+
+def patch_gzip():
+    """Patch `__del__` in `_WriteBufferStream` from `gzip` to avoid memory leaks.
+
+    Those changes will remove the circular references in `GzipFile`,  allowing memory to be freed immediately,
+    without the need of a deep garbage collection cycle.
+    Cycle: `GzipFile._buffer` -> `BufferedWriter._raw` -> `_WriteBufferStream.gzip_file` -> `GzipFile`.
+    Issue: https://github.com/python/cpython/issues/129640
+    """
+    _WriteBufferStream.__del__ = __del_tmp__

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -33,6 +33,7 @@ from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
 from .graphql.promise import patch_promise
+from .patch_gzip import patch_gzip
 from .patch_local import patch_local
 from .plugins.openid_connect.patch import patch_authlib
 
@@ -1031,3 +1032,7 @@ patch_local()
 # `BaseDatabaseValidation` and `DatabaseErrorWrapper` to remove all references that could result in reference cycles,
 # allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
 patch_db()
+
+# Patch `_WriteBufferStream` from `gizip` to remove all references that could result in reference cycles,
+# allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+patch_gzip()


### PR DESCRIPTION
I want to merge this change because it allows memory to be freed immediately without needing a deep garbage collection cycle.
Fix for: https://github.com/python/cpython/issues/129640

Garbage before:
![garbage_before](https://github.com/user-attachments/assets/53f43dec-43bd-4ff3-bd94-0a48ccf5860b)

Garbage after is empty:
![garbage_after](https://github.com/user-attachments/assets/ed7b5776-b77f-4643-b5bd-7414f077dbf0)


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
