### PR TITLE
Fix csv exporter for products

### DIFF
--- a/saleor/csv/tests/export/test_export.py
+++ b/saleor/csv/tests/export/test_export.py
@@ -57,6 +57,7 @@ def test_export_products(
             ProductFieldEnum.NAME.value,
             ProductFieldEnum.VARIANT_ID.value,
             ProductFieldEnum.VARIANT_SKU.value,
+            ProductFieldEnum.CHARGE_TAXES.value,
         ],
         "warehouses": [],
         "attributes": [],
@@ -73,17 +74,20 @@ def test_export_products(
 
     # then
     create_file_with_headers_mock.assert_called_once_with(
-        ["id", "name", "variant id", "variant sku"], ",", file_type
+        ["id", "name", "variant id", "variant sku", "charge taxes"], ",", file_type
     )
     assert export_products_in_batches_mock.call_count == 1
     args, kwargs = export_products_in_batches_mock.call_args
     assert set(args[0].values_list("pk", flat=True)) == set(
         Product.objects.all().values_list("pk", flat=True)
     )
+    # charge taxes are deprecated, and do not return any value. In case of requesting
+    # them, the headers number needs to match to the size of the row
+    expected_charge_taxes = ""
     assert args[1:] == (
         export_info,
-        {"id", "name", "variants__id", "variants__sku"},
-        ["id", "name", "variants__id", "variants__sku"],
+        {"id", "name", "variants__id", "variants__sku", expected_charge_taxes},
+        ["id", "name", "variants__id", "variants__sku", expected_charge_taxes],
         ",",
         mock_file,
         file_type,

--- a/saleor/csv/utils/__init__.py
+++ b/saleor/csv/utils/__init__.py
@@ -8,6 +8,8 @@ class ProductExportFields:
             "description": "description_as_str",
             "category": "category__slug",
             "product type": "product_type__name",
+            # charge taxes are deprecated, and do not return any value. In case of
+            # requesting them, the headers number needs to match to the size of the row
             "charge taxes": "",  # deprecated; remove in Saleor 4.0
             "product weight": "product_weight",
             "variant id": "variants__id",
@@ -43,14 +45,14 @@ class ProductExportFields:
     }
 
     PRODUCT_CHANNEL_LISTING_FIELDS = {
-        "channel_pk": "channel_listings__channel__pk",
-        "slug": "channel_listings__channel__slug",
-        "product_currency_code": "channel_listings__currency",
-        "published": "channel_listings__is_published",
-        "publication_date": "channel_listings__published_at",
-        "published_at": "channel_listings__published_at",
-        "searchable": "channel_listings__visible_in_listings",
-        "available for purchase": "channel_listings__available_for_purchase_at",
+        "channel_pk": "channel_id",
+        "slug": "channel__slug",
+        "product_currency_code": "currency",
+        "published": "is_published",
+        "publication_date": "published_at",
+        "published_at": "published_at",
+        "searchable": "visible_in_listings",
+        "available for purchase": "available_for_purchase_at",
     }
 
     WAREHOUSE_FIELDS = {
@@ -60,30 +62,28 @@ class ProductExportFields:
     }
 
     VARIANT_ATTRIBUTE_FIELDS = {
-        "value_slug": "variants__attributes__values__slug",
-        "value_name": "variants__attributes__values__name",
-        "file_url": "variants__attributes__values__file_url",
-        "rich_text": "variants__attributes__values__rich_text",
-        "value": "variants__attributes__values__value",
-        "boolean": "variants__attributes__values__boolean",
-        "date_time": "variants__attributes__values__date_time",
-        "slug": "variants__attributes__assignment__attribute__slug",
-        "input_type": "variants__attributes__assignment__attribute__input_type",
-        "entity_type": "variants__attributes__assignment__attribute__entity_type",
-        "unit": "variants__attributes__assignment__attribute__unit",
-        "attribute_pk": "variants__attributes__assignment__attribute__pk",
-        "reference_page": "variants__attributes__values__reference_page",
-        "reference_product": "variants__attributes__values__reference_product",
-        "reference_variant": "variants__attributes__values__reference_variant",
+        "value_slug": "values__slug",
+        "value_name": "values__name",
+        "file_url": "values__file_url",
+        "rich_text": "values__rich_text",
+        "value": "values__value",
+        "boolean": "values__boolean",
+        "date_time": "values__date_time",
+        "slug": "assignment__attribute__slug",
+        "input_type": "assignment__attribute__input_type",
+        "entity_type": "assignment__attribute__entity_type",
+        "unit": "assignment__attribute__unit",
+        "attribute_pk": "assignment__attribute__pk",
+        "reference_page": "values__reference_page",
+        "reference_product": "values__reference_product",
+        "reference_variant": "values__reference_variant",
     }
 
     VARIANT_CHANNEL_LISTING_FIELDS = {
-        "channel_pk": "variants__channel_listings__channel__pk",
-        "slug": "variants__channel_listings__channel__slug",
-        "price_amount": "variants__channel_listings__price_amount",
-        "variant_currency_code": "variants__channel_listings__currency",
-        "variant_cost_price": "variants__channel_listings__cost_price_amount",
-        "variant_preorder_quantity_threshold": (
-            "variants__channel_listings__preorder_quantity_threshold"
-        ),
+        "channel_pk": "channel__pk",
+        "slug": "channel__slug",
+        "price_amount": "price_amount",
+        "variant_currency_code": "currency",
+        "variant_cost_price": "cost_price_amount",
+        "variant_preorder_quantity_threshold": "preorder_quantity_threshold",
     }

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from ..models import ExportFile
 
 
-BATCH_SIZE = 10000
+BATCH_SIZE = 1000
 
 
 def export_products(
@@ -214,7 +214,6 @@ def export_products_in_batches(
                 "category",
             )
         )
-
         export_data = get_products_data(
             product_batch, export_fields, attributes, warehouses, channels
         )

--- a/saleor/csv/utils/product_headers.py
+++ b/saleor/csv/utils/product_headers.py
@@ -52,8 +52,7 @@ def get_product_export_fields_and_headers(
 
     for field in fields:
         lookup_field = fields_mapping[field]
-        if lookup_field:
-            export_fields.append(lookup_field)
+        export_fields.append(lookup_field)
         file_headers.append(field)
 
     return export_fields, file_headers


### PR DESCRIPTION
I want to merge this change because it fixes:
- incorrect csv structure when deprecated charge-taxes is provided
- empty values for field: `<channel-name> (channel published at)`
- reduce the overfetching of data that would slow down the file generation

Additionally, PR also reduces the `BATCH_SIZE`, from `10k` to `1k`. `10k` was really high, as we also fetches additional objects like attributes, channel listings etc. In case of having a lot of channels or attributes, the amount of data loaded to memory could be really high.

The PR also improves the execution time for the task. From `9.421472834001179s` to `1.771742124998127s`
Memory consumption captured with memray: From `39.9 MiB` to  `14.1 MiB`
☝️ Above results are for 5k+ products, when fetching all possible product's fields, data for single channel and single product's attribute.

(skipping changelog as this will also be ported to 3.20)
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
