### PR TITLE
Release 3.20.69

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.68",
+  "version": "3.20.69",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.68",
+      "version": "3.20.69",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.68",
+  "version": "3.20.69",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.68"
+version = "3.20.69"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.68"
+__version__ = "3.20.69"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Fix checkout order line creation in case of empty `ProductTranslation` by @IKarbowiak in #17319
* Update test_create_transaction_event_message_limit_exceeded by @IKarbowiak in #17060
* Remove reference cycle in gzip by @fowczarek in #17318
* Adjust order fulfillment  by @IKarbowiak in #17300 
* Move source-service-name from http to GraphQL span by @fowczarek in #17316
* Remove reference cycle in Django DB by @fowczarek  in #17313
* Remove reference cycle in Saleor context by @fowczarek in #17309
* Fix incorrect order for reordering collection products when sort_order is null by @korycins  #17283
