### PR TITLE
Add a logic to force the order price refresh with the latest channel listing prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,4 +53,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix `products` sorting when using `sortBy: {field: COLLECTION}` - #17189 by @korycins
 - Fix checkout funds releasing task - #17198 by @IKarbowiak
 - Fixed 'healthcheck' middleware (`/health/` endpoint) not forwarding incoming traffic whenever the protocol wasn't HTTP (such as WebSocket or Lifespan) - #17248 by @NyanKiyoshi
-- Use denormalized discount prices during order update - #17160 by @zedzior
+- Use denormalized prices during order update - #17160 by @zedzior

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -338,7 +338,7 @@ def fetch_checkout_lines(
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ) -> tuple[list[CheckoutLineInfo], list[int]]:
     """Fetch checkout lines as CheckoutLineInfo objects."""
-    from ..discount.utils.voucher import apply_voucher_to_line
+    from ..discount.utils.voucher import attach_voucher_to_line_info
     from .utils import get_voucher_for_checkout
 
     select_related_fields = ["variant__product__product_type__tax_class"]
@@ -437,7 +437,7 @@ def fetch_checkout_lines(
             return lines_info, unavailable_variant_pks
         if voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order:
             voucher_info = fetch_voucher_info(voucher, checkout.voucher_code)
-            apply_voucher_to_line(voucher_info, lines_info)
+            attach_voucher_to_line_info(voucher_info, lines_info)
     return lines_info, unavailable_variant_pks
 
 

--- a/saleor/discount/tests/test_utils/test_refresh_order_prices_and_discounts.py
+++ b/saleor/discount/tests/test_utils/test_refresh_order_prices_and_discounts.py
@@ -1,0 +1,101 @@
+from decimal import Decimal
+
+import graphene
+import pytest
+
+from ....order import OrderStatus
+from ....order.fetch import fetch_draft_order_lines_info
+from ....product.models import Product
+from ....product.utils.variant_prices import update_discounted_prices_for_promotion
+from ....product.utils.variants import fetch_variants_for_promotion_rules
+from ... import RewardValueType
+from ...models import Promotion, PromotionRule
+from ...utils.order import refresh_order_base_prices_and_discounts
+
+
+@pytest.fixture
+def order_with_lines(order_with_lines):
+    order_with_lines.status = OrderStatus.DRAFT
+    return order_with_lines
+
+
+def test_refresh_order_base_prices(order_with_lines):
+    # given
+    order = order_with_lines
+    line_1, line_2 = order.lines.all()
+    variant_1 = line_1.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+    channel_listing = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing.price_amount
+    assert initial_variant_1_price == channel_listing.discounted_price_amount
+
+    new_variant_1_price = initial_variant_1_price + Decimal(1)
+    channel_listing.price_amount = new_variant_1_price
+    channel_listing.discounted_price_amount = new_variant_1_price
+    channel_listing.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
+    assert line_1.base_unit_price_amount == new_variant_1_price
+    assert line_2.undiscounted_base_unit_price_amount == initial_variant_2_price
+    assert line_2.base_unit_price_amount == initial_variant_2_price
+
+
+def test_refresh_order_base_prices_catalogue_discount_update(
+    order_with_lines_and_catalogue_promotion,
+):
+    # given
+    order = order_with_lines_and_catalogue_promotion
+    promotion = Promotion.objects.get()
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rule = promotion.rules.get()
+    initial_reward_value = rule.reward_value
+    initial_reward_value_type = rule.reward_value_type
+
+    line_1, line_2 = order.lines.all()
+    discount = line_1.discounts.first()
+    assert initial_reward_value == discount.value
+    assert initial_reward_value_type == discount.value_type == RewardValueType.FIXED
+
+    # update catalogue promotion
+    new_reward_value = Decimal(50)
+    new_reward_value_type = RewardValueType.PERCENTAGE
+    rule.reward_value = new_reward_value
+    rule.reward_value_type = new_reward_value_type
+    rule.save(update_fields=["reward_value", "reward_value_type"])
+    fetch_variants_for_promotion_rules(PromotionRule.objects.all())
+    update_discounted_prices_for_promotion(Product.objects.all())
+
+    undiscounted_line_1_price = line_1.undiscounted_base_unit_price_amount
+    undiscounted_line_2_price = line_2.undiscounted_base_unit_price_amount
+    expected_line_1_price = undiscounted_line_1_price * new_reward_value / 100
+    expected_unit_discount = undiscounted_line_1_price - expected_line_1_price
+    expected_discount_amount = expected_unit_discount * line_1.quantity
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == undiscounted_line_1_price
+    assert line_1.base_unit_price_amount == expected_line_1_price
+    assert line_2.undiscounted_base_unit_price_amount == undiscounted_line_2_price
+    assert line_2.base_unit_price_amount == undiscounted_line_2_price
+    assert line_1.unit_discount_amount == expected_unit_discount
+    assert line_1.unit_discount_reason == f"Promotion: {promotion_id}"
+    assert line_2.unit_discount_amount == Decimal(0)
+
+    discount.refresh_from_db()
+    assert discount.value == new_reward_value
+    assert discount.value_type == new_reward_value_type
+    assert discount.amount.amount == expected_discount_amount

--- a/saleor/discount/tests/test_utils/test_refresh_order_prices_and_discounts.py
+++ b/saleor/discount/tests/test_utils/test_refresh_order_prices_and_discounts.py
@@ -6,7 +6,6 @@ import pytest
 from ....core.prices import quantize_price
 from ....core.taxes import zero_money
 from ....order import OrderStatus
-from ....order.fetch import fetch_draft_order_lines_info
 from ....product.models import Product
 from ....product.utils.variant_prices import update_discounted_prices_for_promotion
 from ....product.utils.variants import fetch_variants_for_promotion_rules
@@ -49,13 +48,11 @@ def test_refresh_order_base_prices(order_with_lines):
     channel_listing_2.discounted_price_amount = new_variant_2_price
     channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
-
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info)
+    refresh_order_base_prices_and_discounts(order)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
     assert line_1.base_unit_price_amount == new_variant_1_price
     assert line_2.undiscounted_base_unit_price_amount == new_variant_2_price
@@ -89,14 +86,13 @@ def test_refresh_order_base_prices_single_line(order_with_lines):
     channel_listing_2.discounted_price_amount = new_variant_2_price
     channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
     line_ids_to_refresh = [line_1.id]
 
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+    refresh_order_base_prices_and_discounts(order, line_ids_to_refresh)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
     assert line_1.base_unit_price_amount == new_variant_1_price
     assert line_2.undiscounted_base_unit_price_amount == initial_variant_2_price
@@ -194,13 +190,11 @@ def test_refresh_order_base_prices_catalogue_discount(
     expected_unit_discount_2 = undiscounted_unit_price_2 - expected_unit_price_2
     expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
-
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info)
+    refresh_order_base_prices_and_discounts(order)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == undiscounted_unit_price_1
     assert line_1.base_unit_price_amount == expected_unit_price_1
     assert line_1.unit_discount_amount == expected_unit_discount_1
@@ -313,14 +307,13 @@ def test_refresh_order_base_prices_catalogue_discount_single_line(
     expected_unit_discount_2 = initial_reward_value_2
     expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
     line_ids_to_refresh = [line_1.id]
 
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+    refresh_order_base_prices_and_discounts(order, line_ids_to_refresh)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == undiscounted_unit_price_1
     assert line_1.base_unit_price_amount == expected_unit_price_1
     assert line_1.unit_discount_amount == expected_unit_discount_1
@@ -413,13 +406,11 @@ def test_refresh_order_base_prices_manual_line_discount(order_with_lines):
     expected_unit_discount_2 = new_variant_2_price - expected_unit_price_2
     expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
-
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info)
+    refresh_order_base_prices_and_discounts(order)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
     assert line_1.base_unit_price_amount == expected_unit_price_1
     assert line_1.unit_discount_amount == expected_unit_discount_1
@@ -508,14 +499,13 @@ def test_refresh_order_base_prices_manual_line_discount_single_line(order_with_l
     expected_unit_discount_2 = new_variant_2_price - expected_unit_price_2
     expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
     line_ids_to_refresh = [line_2.id]
 
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+    refresh_order_base_prices_and_discounts(order, line_ids_to_refresh)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == initial_variant_1_price
     assert line_1.base_unit_price_amount == expected_unit_price_1
     assert line_1.unit_discount_amount == expected_unit_discount_1
@@ -613,13 +603,11 @@ def test_refresh_order_base_prices_specific_product_voucher(order_with_lines, vo
     expected_unit_discount_2 = new_variant_2_price - expected_unit_price_2
     expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
-
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info)
+    refresh_order_base_prices_and_discounts(order)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
     assert line_1.base_unit_price_amount == expected_unit_price_1
     assert line_1.unit_discount_amount == expected_unit_discount_1
@@ -719,14 +707,13 @@ def test_refresh_order_base_prices_specific_product_voucher_single_line(
     expected_unit_discount_2 = initial_variant_2_price - expected_unit_price_2
     expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
     line_ids_to_refresh = [line_1.id]
 
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+    refresh_order_base_prices_and_discounts(order, line_ids_to_refresh)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
     assert line_1.base_unit_price_amount == expected_unit_price_1
     assert line_1.unit_discount_amount == expected_unit_discount_1
@@ -819,19 +806,15 @@ def test_refresh_order_base_prices_apply_once_per_order_voucher(
     expected_unit_discount_1 = 0
 
     # line 2 is now the cheapest and should have the price discounted by voucher
-    expected_discount_amount_2 = new_variant_2_price * (
-        1 - new_voucher_unit_discount / 100
-    )
+    expected_discount_amount_2 = new_variant_2_price * (new_voucher_unit_discount / 100)
     expected_unit_discount_2 = expected_discount_amount_2 / line_2.quantity
     expected_unit_price_2 = new_variant_2_price - expected_unit_discount_2
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
-
     # when
-    refresh_order_base_prices_and_discounts(order, lines_info)
+    refresh_order_base_prices_and_discounts(order)
 
     # then
-    line_1, line_2 = (line_info.line for line_info in lines_info)
+    line_1, line_2 = order.lines.all()
     assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
     assert line_1.base_unit_price_amount == new_variant_1_price
     assert line_1.unit_discount_amount == expected_unit_discount_1
@@ -848,3 +831,205 @@ def test_refresh_order_base_prices_apply_once_per_order_voucher(
     assert discount_2.amount.amount == expected_discount_amount_2
     assert discount_2.value == new_voucher_unit_discount
     assert discount_2.value_type == DiscountValueType.PERCENTAGE
+
+
+def test_refresh_order_base_prices_apply_once_per_order_voucher_single_line_new_cheapest(
+    order_with_lines, voucher
+):
+    # Requesting an update of the line 2, which price has changed and is now the cheapest, should apply the
+    # voucher discount to the new cheapest line 2 and delete the discount from line 1, even if we didn't request
+    # update for line 1
+
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+    variant_2 = line_2.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # prepare apply once per order voucher
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.type = VoucherType.ENTIRE_ORDER
+    voucher.apply_once_per_order = True
+    voucher.save(update_fields=["discount_value_type", "type", "apply_once_per_order"])
+
+    voucher_listing = voucher.channel_listings.get()
+    initial_voucher_unit_discount = Decimal(1)
+    voucher_listing.discount_value = initial_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    # apply voucher
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    create_or_update_voucher_discount_objects_for_order(order)
+
+    # line 1 is the cheapest so should have the discount applied
+    assert initial_variant_1_price < initial_variant_2_price
+    line_1.refresh_from_db()
+    discount_1 = line_1.discounts.get()
+    discount_amount_1 = initial_voucher_unit_discount
+    unit_discount_amount_1 = discount_amount_1 / line_1.quantity
+    assert quantize_price(line_1.base_unit_price_amount, currency) == quantize_price(
+        line_1.undiscounted_base_unit_price_amount - unit_discount_amount_1, currency
+    )
+    assert discount_1.value == initial_voucher_unit_discount
+    assert discount_1.amount_value == discount_amount_1
+
+    assert not line_2.discounts.exists()
+    assert line_2.base_unit_price_amount == line_2.undiscounted_base_unit_price_amount
+
+    # change variant 2 pricing to be lower than variant 1
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_1_price - Decimal(1)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change voucher reward value and type
+    new_voucher_unit_discount = Decimal(25)
+    voucher_listing.discount_value = new_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    # line 1 is not the cheapest anymore, so should not have discount applied
+    assert initial_variant_1_price > new_variant_2_price
+    expected_unit_discount_1 = 0
+
+    # line 2 is now the cheapest and should have the price discounted by voucher
+    expected_discount_amount_2 = new_variant_2_price * (new_voucher_unit_discount / 100)
+    expected_unit_discount_2 = expected_discount_amount_2 / line_2.quantity
+    expected_unit_price_2 = new_variant_2_price - expected_unit_discount_2
+
+    line_ids_to_refresh = [line_2.id]
+
+    # when
+    refresh_order_base_prices_and_discounts(order, line_ids_to_refresh)
+
+    # then
+    line_1, line_2 = order.lines.all()
+    assert line_1.undiscounted_base_unit_price_amount == initial_variant_1_price
+    assert line_1.base_unit_price_amount == initial_variant_1_price
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+
+    assert line_2.undiscounted_base_unit_price_amount == new_variant_2_price
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+
+    with pytest.raises(OrderLineDiscount.DoesNotExist):
+        discount_1.refresh_from_db()
+    assert not line_1.discounts.exists()
+
+    discount_2 = line_2.discounts.get()
+    assert discount_2.amount.amount == expected_discount_amount_2
+    assert discount_2.value == new_voucher_unit_discount
+    assert discount_2.value_type == DiscountValueType.PERCENTAGE
+
+
+def test_refresh_order_base_prices_apply_once_per_order_voucher_single_line_old_cheapest(
+    order_with_lines, voucher
+):
+    # Requesting an update of the line 1, which price has changed and is not the cheapest anymore, should apply the
+    # voucher discount to the new cheapest line 2, even if we didn't request to update prices for the line 2
+
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+    variant_1 = line_1.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # prepare apply once per order voucher
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.type = VoucherType.ENTIRE_ORDER
+    voucher.apply_once_per_order = True
+    voucher.save(update_fields=["discount_value_type", "type", "apply_once_per_order"])
+
+    voucher_listing = voucher.channel_listings.get()
+    initial_voucher_unit_discount = Decimal(1)
+    voucher_listing.discount_value = initial_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    # apply voucher
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    create_or_update_voucher_discount_objects_for_order(order)
+
+    # line 1 is the cheapest so should have the discount applied
+    assert initial_variant_1_price < initial_variant_2_price
+    line_1.refresh_from_db()
+    discount_1 = line_1.discounts.get()
+    discount_amount_1 = initial_voucher_unit_discount
+    unit_discount_amount_1 = discount_amount_1 / line_1.quantity
+    assert quantize_price(line_1.base_unit_price_amount, currency) == quantize_price(
+        line_1.undiscounted_base_unit_price_amount - unit_discount_amount_1, currency
+    )
+    assert discount_1.value == initial_voucher_unit_discount
+    assert discount_1.amount_value == discount_amount_1
+
+    assert not line_2.discounts.exists()
+    assert line_2.base_unit_price_amount == line_2.undiscounted_base_unit_price_amount
+
+    # change variant 1 pricing to be higher than variant 2
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
+    new_variant_1_price = initial_variant_2_price + Decimal(1)
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change voucher reward value and type
+    new_voucher_unit_discount = Decimal(25)
+    voucher_listing.discount_value = new_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    # line 1 is not the cheapest anymore, so should not have discount applied
+    assert new_variant_1_price > initial_variant_2_price
+    expected_unit_discount_1 = 0
+
+    # line 2 is now the cheapest and should have the price discounted by voucher, even there was no request to update
+    # this line
+    expected_discount_amount_2 = initial_variant_2_price * (
+        new_voucher_unit_discount / 100
+    )
+    expected_unit_discount_2 = expected_discount_amount_2 / line_2.quantity
+    expected_unit_price_2 = initial_variant_2_price - expected_unit_discount_2
+
+    line_ids_to_refresh = [line_1.id]
+
+    # when
+    refresh_order_base_prices_and_discounts(order, line_ids_to_refresh)
+
+    # then
+    line_1, line_2 = order.lines.all()
+    assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
+    assert line_1.base_unit_price_amount == new_variant_1_price
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+
+    assert line_2.undiscounted_base_unit_price_amount == initial_variant_2_price
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+
+    with pytest.raises(OrderLineDiscount.DoesNotExist):
+        discount_1.refresh_from_db()
+    assert not line_1.discounts.exists()
+
+    discount_2 = line_2.discounts.get()
+    assert discount_2.amount.amount == expected_discount_amount_2
+    assert discount_2.value == new_voucher_unit_discount
+    assert discount_2.value_type == DiscountValueType.PERCENTAGE
+
+
+def test_refresh_order_base_prices_order_without_lines(order):
+    """The function should not produce error for order without lines."""
+    assert not order.lines.exists()
+    refresh_order_base_prices_and_discounts(order)

--- a/saleor/discount/tests/test_utils/test_refresh_order_prices_and_discounts.py
+++ b/saleor/discount/tests/test_utils/test_refresh_order_prices_and_discounts.py
@@ -3,14 +3,17 @@ from decimal import Decimal
 import graphene
 import pytest
 
+from ....core.prices import quantize_price
+from ....core.taxes import zero_money
 from ....order import OrderStatus
 from ....order.fetch import fetch_draft_order_lines_info
 from ....product.models import Product
 from ....product.utils.variant_prices import update_discounted_prices_for_promotion
 from ....product.utils.variants import fetch_variants_for_promotion_rules
-from ... import RewardValueType
-from ...models import Promotion, PromotionRule
+from ... import DiscountType, DiscountValueType, RewardValueType, VoucherType
+from ...models import OrderLineDiscount, Promotion, PromotionRule
 from ...utils.order import refresh_order_base_prices_and_discounts
+from ...utils.voucher import create_or_update_voucher_discount_objects_for_order
 
 
 @pytest.fixture
@@ -23,18 +26,28 @@ def test_refresh_order_base_prices(order_with_lines):
     # given
     order = order_with_lines
     line_1, line_2 = order.lines.all()
-    variant_1 = line_1.variant
+    variant_1, variant_2 = line_1.variant, line_2.variant
 
     initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
     initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
-    channel_listing = variant_1.channel_listings.get()
-    assert initial_variant_1_price == channel_listing.price_amount
-    assert initial_variant_1_price == channel_listing.discounted_price_amount
 
+    # change variant 1 pricing
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
     new_variant_1_price = initial_variant_1_price + Decimal(1)
-    channel_listing.price_amount = new_variant_1_price
-    channel_listing.discounted_price_amount = new_variant_1_price
-    channel_listing.save(update_fields=["price_amount", "discounted_price_amount"])
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change variant 2 pricing
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_2_price - Decimal(2)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
 
     lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
 
@@ -45,40 +58,141 @@ def test_refresh_order_base_prices(order_with_lines):
     line_1, line_2 = (line_info.line for line_info in lines_info)
     assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
     assert line_1.base_unit_price_amount == new_variant_1_price
+    assert line_2.undiscounted_base_unit_price_amount == new_variant_2_price
+    assert line_2.base_unit_price_amount == new_variant_2_price
+
+
+def test_refresh_order_base_prices_single_line(order_with_lines):
+    # given
+    order = order_with_lines
+    line_1, line_2 = order.lines.all()
+    variant_1, variant_2 = line_1.variant, line_2.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # change variant 1 pricing
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
+    new_variant_1_price = initial_variant_1_price + Decimal(1)
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change variant 2 pricing
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_2_price - Decimal(2)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+    line_ids_to_refresh = [line_1.id]
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
+    assert line_1.base_unit_price_amount == new_variant_1_price
     assert line_2.undiscounted_base_unit_price_amount == initial_variant_2_price
     assert line_2.base_unit_price_amount == initial_variant_2_price
 
 
-def test_refresh_order_base_prices_catalogue_discount_update(
-    order_with_lines_and_catalogue_promotion,
+def test_refresh_order_base_prices_catalogue_discount(
+    order_with_lines_and_catalogue_promotion, plugins_manager
 ):
     # given
     order = order_with_lines_and_catalogue_promotion
+    channel = order.channel
+    currency = order.currency
     promotion = Promotion.objects.get()
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
-    rule = promotion.rules.get()
-    initial_reward_value = rule.reward_value
-    initial_reward_value_type = rule.reward_value_type
+    rule_1 = promotion.rules.get()
+    initial_reward_value_1 = rule_1.reward_value
+    initial_reward_value_type_1 = rule_1.reward_value_type
 
-    line_1, line_2 = order.lines.all()
-    discount = line_1.discounts.first()
-    assert initial_reward_value == discount.value
-    assert initial_reward_value_type == discount.value_type == RewardValueType.FIXED
+    lines = order.lines.all()
+    line_1, line_2 = lines
+    variant_2 = line_2.variant
+    undiscounted_subtotal = zero_money(currency)
+    for line in lines:
+        undiscounted_subtotal += line.undiscounted_base_unit_price * line.quantity
 
-    # update catalogue promotion
-    new_reward_value = Decimal(50)
-    new_reward_value_type = RewardValueType.PERCENTAGE
-    rule.reward_value = new_reward_value
-    rule.reward_value_type = new_reward_value_type
-    rule.save(update_fields=["reward_value", "reward_value_type"])
+    discount_1 = line_1.discounts.first()
+    assert discount_1.value == initial_reward_value_1
+    assert discount_1.value_type == initial_reward_value_type_1
+    assert discount_1.amount_value == initial_reward_value_1 * line_1.quantity
+
+    # prepare new catalog promotion rule for variant 2
+    initial_reward_value_2 = Decimal(5)
+    initial_reward_value_type_2 = DiscountValueType.FIXED
+    rule_2 = promotion.rules.create(
+        name="Rule 2",
+        catalogue_predicate={
+            "variantPredicate": {
+                "ids": [graphene.Node.to_global_id("ProductVariant", variant_2.id)]
+            }
+        },
+        reward_value_type=initial_reward_value_type_2,
+        reward_value=initial_reward_value_2,
+    )
+    rule_2.channels.add(channel)
+
+    listing_2 = variant_2.channel_listings.get(channel=channel)
+    listing_2.discounted_price_amount = listing_2.price_amount - initial_reward_value_2
+    listing_2.save(update_fields=["discounted_price_amount"])
+    listing_2.variantlistingpromotionrule.create(
+        promotion_rule=rule_2,
+        discount_amount=initial_reward_value_2,
+        currency=currency,
+    )
+
+    discount_2 = line_2.discounts.create(
+        type=DiscountType.PROMOTION,
+        value_type=RewardValueType.FIXED,
+        value=initial_reward_value_2,
+        amount_value=initial_reward_value_2 * line_2.quantity,
+        currency=currency,
+        promotion_rule=rule_2,
+        reason=f"Promotion: {promotion_id}",
+    )
+
+    line_2.base_unit_price_amount = (
+        line_2.undiscounted_base_unit_price_amount - initial_reward_value_2
+    )
+    line_2.save(update_fields=["base_unit_price_amount"])
+
+    # update promotion rules
+    new_reward_value_1 = Decimal(50)
+    new_reward_value_type_1 = RewardValueType.PERCENTAGE
+    rule_1.reward_value = new_reward_value_1
+    rule_1.reward_value_type = new_reward_value_type_1
+    rule_1.save(update_fields=["reward_value", "reward_value_type"])
+
+    new_reward_value_2 = Decimal(30)
+    new_reward_value_type_2 = RewardValueType.PERCENTAGE
+    rule_2.reward_value = new_reward_value_2
+    rule_2.reward_value_type = new_reward_value_type_2
+    rule_2.save(update_fields=["reward_value", "reward_value_type"])
+
     fetch_variants_for_promotion_rules(PromotionRule.objects.all())
     update_discounted_prices_for_promotion(Product.objects.all())
 
-    undiscounted_line_1_price = line_1.undiscounted_base_unit_price_amount
-    undiscounted_line_2_price = line_2.undiscounted_base_unit_price_amount
-    expected_line_1_price = undiscounted_line_1_price * new_reward_value / 100
-    expected_unit_discount = undiscounted_line_1_price - expected_line_1_price
-    expected_discount_amount = expected_unit_discount * line_1.quantity
+    # both lines should have price refreshed
+    undiscounted_unit_price_1 = line_1.undiscounted_base_unit_price_amount
+    expected_unit_price_1 = undiscounted_unit_price_1 * (1 - new_reward_value_1 / 100)
+    expected_unit_discount_1 = undiscounted_unit_price_1 - expected_unit_price_1
+    expected_discount_amount_1 = expected_unit_discount_1 * line_1.quantity
+
+    undiscounted_unit_price_2 = line_2.undiscounted_base_unit_price_amount
+    expected_unit_price_2 = undiscounted_unit_price_2 * (1 - new_reward_value_2 / 100)
+    expected_unit_discount_2 = undiscounted_unit_price_2 - expected_unit_price_2
+    expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
 
     lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
 
@@ -87,15 +201,650 @@ def test_refresh_order_base_prices_catalogue_discount_update(
 
     # then
     line_1, line_2 = (line_info.line for line_info in lines_info)
-    assert line_1.undiscounted_base_unit_price_amount == undiscounted_line_1_price
-    assert line_1.base_unit_price_amount == expected_line_1_price
-    assert line_2.undiscounted_base_unit_price_amount == undiscounted_line_2_price
-    assert line_2.base_unit_price_amount == undiscounted_line_2_price
-    assert line_1.unit_discount_amount == expected_unit_discount
+    assert line_1.undiscounted_base_unit_price_amount == undiscounted_unit_price_1
+    assert line_1.base_unit_price_amount == expected_unit_price_1
+    assert line_1.unit_discount_amount == expected_unit_discount_1
     assert line_1.unit_discount_reason == f"Promotion: {promotion_id}"
-    assert line_2.unit_discount_amount == Decimal(0)
 
-    discount.refresh_from_db()
-    assert discount.value == new_reward_value
-    assert discount.value_type == new_reward_value_type
-    assert discount.amount.amount == expected_discount_amount
+    assert line_2.undiscounted_base_unit_price_amount == undiscounted_unit_price_2
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+    assert line_2.unit_discount_reason == f"Promotion: {promotion_id}"
+
+    discount_1.refresh_from_db()
+    assert discount_1.value == new_reward_value_1
+    assert discount_1.value_type == new_reward_value_type_1
+    assert discount_1.amount.amount == expected_discount_amount_1
+
+    discount_2.refresh_from_db()
+    assert discount_2.value == new_reward_value_2
+    assert discount_2.value_type == new_reward_value_type_2
+    assert discount_2.amount.amount == expected_discount_amount_2
+
+
+def test_refresh_order_base_prices_catalogue_discount_single_line(
+    order_with_lines_and_catalogue_promotion, plugins_manager
+):
+    # given
+    order = order_with_lines_and_catalogue_promotion
+    channel = order.channel
+    currency = order.currency
+    promotion = Promotion.objects.get()
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rule_1 = promotion.rules.get()
+    initial_reward_value_1 = rule_1.reward_value
+    initial_reward_value_type_1 = rule_1.reward_value_type
+
+    lines = order.lines.all()
+    line_1, line_2 = lines
+    variant_2 = line_2.variant
+    undiscounted_subtotal = zero_money(currency)
+    for line in lines:
+        undiscounted_subtotal += line.undiscounted_base_unit_price * line.quantity
+
+    discount_1 = line_1.discounts.first()
+    assert discount_1.value == initial_reward_value_1
+    assert discount_1.value_type == initial_reward_value_type_1
+    assert discount_1.amount_value == initial_reward_value_1 * line_1.quantity
+
+    # prepare new catalog promotion rule for variant 2
+    initial_reward_value_2 = Decimal(5)
+    initial_reward_value_type_2 = DiscountValueType.FIXED
+    rule_2 = promotion.rules.create(
+        name="Rule 2",
+        catalogue_predicate={
+            "variantPredicate": {
+                "ids": [graphene.Node.to_global_id("ProductVariant", variant_2.id)]
+            }
+        },
+        reward_value_type=initial_reward_value_type_2,
+        reward_value=initial_reward_value_2,
+    )
+    rule_2.channels.add(channel)
+
+    listing_2 = variant_2.channel_listings.get(channel=channel)
+    listing_2.discounted_price_amount = listing_2.price_amount - initial_reward_value_2
+    listing_2.save(update_fields=["discounted_price_amount"])
+    listing_2.variantlistingpromotionrule.create(
+        promotion_rule=rule_2,
+        discount_amount=initial_reward_value_2,
+        currency=currency,
+    )
+
+    discount_2 = line_2.discounts.create(
+        type=DiscountType.PROMOTION,
+        value_type=RewardValueType.FIXED,
+        value=initial_reward_value_2,
+        amount_value=initial_reward_value_2 * line_2.quantity,
+        currency=currency,
+        promotion_rule=rule_2,
+        reason=f"Promotion: {promotion_id}",
+    )
+
+    line_2.base_unit_price_amount = (
+        line_2.undiscounted_base_unit_price_amount - initial_reward_value_2
+    )
+    line_2.save(update_fields=["base_unit_price_amount"])
+
+    # update promotion rules
+    new_reward_value_1 = Decimal(50)
+    new_reward_value_type_1 = RewardValueType.PERCENTAGE
+    rule_1.reward_value = new_reward_value_1
+    rule_1.reward_value_type = new_reward_value_type_1
+    rule_1.save(update_fields=["reward_value", "reward_value_type"])
+
+    new_reward_value_2 = Decimal(30)
+    new_reward_value_type_2 = RewardValueType.PERCENTAGE
+    rule_2.reward_value = new_reward_value_2
+    rule_2.reward_value_type = new_reward_value_type_2
+    rule_2.save(update_fields=["reward_value", "reward_value_type"])
+
+    fetch_variants_for_promotion_rules(PromotionRule.objects.all())
+    update_discounted_prices_for_promotion(Product.objects.all())
+
+    undiscounted_unit_price_1 = line_1.undiscounted_base_unit_price_amount
+    expected_unit_price_1 = undiscounted_unit_price_1 * (1 - new_reward_value_1 / 100)
+    expected_unit_discount_1 = undiscounted_unit_price_1 - expected_unit_price_1
+    expected_discount_amount_1 = expected_unit_discount_1 * line_1.quantity
+
+    # line 2 prices shouldn't be refreshed
+    undiscounted_unit_price_2 = line_2.undiscounted_base_unit_price_amount
+    expected_unit_price_2 = undiscounted_unit_price_2 - initial_reward_value_2
+    expected_unit_discount_2 = initial_reward_value_2
+    expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+    line_ids_to_refresh = [line_1.id]
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == undiscounted_unit_price_1
+    assert line_1.base_unit_price_amount == expected_unit_price_1
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+    assert line_1.unit_discount_reason == f"Promotion: {promotion_id}"
+
+    assert line_2.undiscounted_base_unit_price_amount == undiscounted_unit_price_2
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+    assert line_2.unit_discount_reason == f"Promotion: {promotion_id}"
+
+    discount_1.refresh_from_db()
+    assert discount_1.value == new_reward_value_1
+    assert discount_1.value_type == new_reward_value_type_1
+    assert discount_1.amount.amount == expected_discount_amount_1
+
+    discount_2.refresh_from_db()
+    assert discount_2.value == initial_reward_value_2
+    assert discount_2.value_type == initial_reward_value_type_2
+    assert discount_2.amount.amount == expected_discount_amount_2
+
+
+def test_refresh_order_base_prices_manual_line_discount(order_with_lines):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+    variant_1, variant_2 = line_1.variant, line_2.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # add manual discount to line 1
+    discount_1_reward_value = Decimal(20)
+    discount_1_unit_amount = discount_1_reward_value / 100 * initial_variant_1_price
+    discount_1_amount = discount_1_unit_amount * line_1.quantity
+    discount_1 = line_1.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.PERCENTAGE,
+        value=discount_1_reward_value,
+        amount_value=discount_1_amount,
+        currency=currency,
+        unique_type=DiscountType.MANUAL,
+    )
+    line_1.base_unit_price_amount = (
+        line_1.undiscounted_base_unit_price_amount - discount_1_unit_amount
+    )
+    line_1.save(update_fields=["base_unit_price_amount"])
+
+    # add manual discount to line 2
+    discount_2_reward_value = Decimal(10)
+    discount_2_unit_amount = discount_2_reward_value / 100 * initial_variant_2_price
+    discount_2_amount = discount_2_unit_amount * line_2.quantity
+    discount_2 = line_2.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.PERCENTAGE,
+        value=discount_2_reward_value,
+        amount_value=discount_2_amount,
+        currency=currency,
+        unique_type=DiscountType.MANUAL,
+    )
+    line_2.base_unit_price_amount = (
+        line_2.undiscounted_base_unit_price_amount - discount_2_unit_amount
+    )
+    line_2.save(update_fields=["base_unit_price_amount"])
+
+    # change variant 1 pricing
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
+    new_variant_1_price = initial_variant_1_price + Decimal(1)
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change variant 2 pricing
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_2_price - Decimal(2)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # both lines should have price refreshed
+    expected_unit_price_1 = new_variant_1_price * (1 - discount_1_reward_value / 100)
+    expected_unit_discount_1 = new_variant_1_price - expected_unit_price_1
+    expected_discount_amount_1 = expected_unit_discount_1 * line_1.quantity
+
+    expected_unit_price_2 = new_variant_2_price * (1 - discount_2_reward_value / 100)
+    expected_unit_discount_2 = new_variant_2_price - expected_unit_price_2
+    expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
+    assert line_1.base_unit_price_amount == expected_unit_price_1
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+
+    assert line_2.undiscounted_base_unit_price_amount == new_variant_2_price
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+
+    discount_1.refresh_from_db()
+    assert discount_1.amount.amount == expected_discount_amount_1
+
+    discount_2.refresh_from_db()
+    assert discount_2.amount.amount == expected_discount_amount_2
+
+
+def test_refresh_order_base_prices_manual_line_discount_single_line(order_with_lines):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+    variant_1, variant_2 = line_1.variant, line_2.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # add manual discount to line 1
+    discount_1_reward_value = Decimal(20)
+    discount_1_unit_amount = discount_1_reward_value / 100 * initial_variant_1_price
+    initial_discount_1_amount = discount_1_unit_amount * line_1.quantity
+    discount_1 = line_1.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.PERCENTAGE,
+        value=discount_1_reward_value,
+        amount_value=initial_discount_1_amount,
+        currency=currency,
+        unique_type=DiscountType.MANUAL,
+    )
+    line_1.base_unit_price_amount = (
+        line_1.undiscounted_base_unit_price_amount - discount_1_unit_amount
+    )
+    line_1.save(update_fields=["base_unit_price_amount"])
+
+    # add manual discount to line 2
+    discount_2_reward_value = Decimal(10)
+    discount_2_unit_amount = discount_2_reward_value / 100 * initial_variant_2_price
+    initial_discount_2_amount = discount_2_unit_amount * line_2.quantity
+    discount_2 = line_2.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.PERCENTAGE,
+        value=discount_2_reward_value,
+        amount_value=initial_discount_2_amount,
+        currency=currency,
+        unique_type=DiscountType.MANUAL,
+    )
+    line_2.base_unit_price_amount = (
+        line_2.undiscounted_base_unit_price_amount - discount_2_unit_amount
+    )
+    line_2.save(update_fields=["base_unit_price_amount"])
+
+    # change variant 1 pricing
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
+    new_variant_1_price = initial_variant_1_price + Decimal(1)
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change variant 2 pricing
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_2_price - Decimal(2)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # line 1 prices shouldn't be refreshed
+    expected_unit_price_1 = initial_variant_1_price * (
+        1 - discount_1_reward_value / 100
+    )
+    expected_unit_discount_1 = initial_variant_1_price - expected_unit_price_1
+    expected_discount_amount_1 = expected_unit_discount_1 * line_1.quantity
+
+    expected_unit_price_2 = new_variant_2_price * (1 - discount_2_reward_value / 100)
+    expected_unit_discount_2 = new_variant_2_price - expected_unit_price_2
+    expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+    line_ids_to_refresh = [line_2.id]
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == initial_variant_1_price
+    assert line_1.base_unit_price_amount == expected_unit_price_1
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+
+    assert line_2.undiscounted_base_unit_price_amount == new_variant_2_price
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+
+    discount_1.refresh_from_db()
+    assert (
+        discount_1.amount.amount
+        == expected_discount_amount_1
+        == initial_discount_1_amount
+    )
+
+    discount_2.refresh_from_db()
+    assert discount_2.amount.amount == expected_discount_amount_2
+
+
+def test_refresh_order_base_prices_specific_product_voucher(order_with_lines, voucher):
+    # given
+    order = order_with_lines
+    line_1, line_2 = order.lines.all()
+    variant_1, variant_2 = line_1.variant, line_2.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # prepare specific product voucher which cover both line variants
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.type = VoucherType.SPECIFIC_PRODUCT
+    voucher.save(update_fields=["discount_value_type", "type"])
+    voucher.variants.set([line_1.variant, line_2.variant])
+
+    voucher_listing = voucher.channel_listings.get()
+    initial_voucher_unit_discount = Decimal(1)
+    voucher_listing.discount_value = initial_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    # apply voucher
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    create_or_update_voucher_discount_objects_for_order(order)
+
+    line_1, line_2 = order.lines.all()
+    discount_1 = line_1.discounts.get()
+    discount_amount_1 = initial_voucher_unit_discount * line_1.quantity
+    assert (
+        line_1.base_unit_price_amount
+        == line_1.undiscounted_base_unit_price_amount - initial_voucher_unit_discount
+    )
+    assert discount_1.value == initial_voucher_unit_discount
+    assert discount_1.amount_value == discount_amount_1
+
+    discount_2 = line_2.discounts.get()
+    discount_amount_2 = initial_voucher_unit_discount * line_2.quantity
+    assert (
+        line_2.base_unit_price_amount
+        == line_2.undiscounted_base_unit_price_amount - initial_voucher_unit_discount
+    )
+    assert discount_2.value == initial_voucher_unit_discount
+    assert discount_2.amount_value == discount_amount_2
+
+    # change variant 1 pricing
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
+    new_variant_1_price = initial_variant_1_price + Decimal(2)
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change variant 2 pricing
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_2_price - Decimal(4)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change voucher reward value and type
+    new_voucher_unit_discount = Decimal(25)
+    voucher_listing.discount_value = new_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    # both lines should have price refreshed
+    expected_unit_price_1 = new_variant_1_price * (1 - new_voucher_unit_discount / 100)
+    expected_unit_discount_1 = new_variant_1_price - expected_unit_price_1
+    expected_discount_amount_1 = expected_unit_discount_1 * line_1.quantity
+
+    expected_unit_price_2 = new_variant_2_price * (1 - new_voucher_unit_discount / 100)
+    expected_unit_discount_2 = new_variant_2_price - expected_unit_price_2
+    expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
+    assert line_1.base_unit_price_amount == expected_unit_price_1
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+
+    assert line_2.undiscounted_base_unit_price_amount == new_variant_2_price
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+
+    discount_1.refresh_from_db()
+    assert discount_1.amount.amount == expected_discount_amount_1
+    assert discount_1.value == new_voucher_unit_discount
+    assert discount_1.value_type == DiscountValueType.PERCENTAGE
+
+    discount_2.refresh_from_db()
+    assert discount_2.amount.amount == expected_discount_amount_2
+    assert discount_2.value == new_voucher_unit_discount
+    assert discount_2.value_type == DiscountValueType.PERCENTAGE
+
+
+def test_refresh_order_base_prices_specific_product_voucher_single_line(
+    order_with_lines, voucher
+):
+    # given
+    order = order_with_lines
+    line_1, line_2 = order.lines.all()
+    variant_1, variant_2 = line_1.variant, line_2.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # prepare specific product voucher which cover both line variants
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.type = VoucherType.SPECIFIC_PRODUCT
+    voucher.save(update_fields=["discount_value_type", "type"])
+    voucher.variants.set([line_1.variant, line_2.variant])
+
+    voucher_listing = voucher.channel_listings.get()
+    initial_voucher_unit_discount = Decimal(1)
+    voucher_listing.discount_value = initial_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    # apply voucher
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    create_or_update_voucher_discount_objects_for_order(order)
+
+    line_1, line_2 = order.lines.all()
+    discount_1 = line_1.discounts.get()
+    discount_amount_1 = initial_voucher_unit_discount * line_1.quantity
+    assert (
+        line_1.base_unit_price_amount
+        == line_1.undiscounted_base_unit_price_amount - initial_voucher_unit_discount
+    )
+    assert discount_1.value == initial_voucher_unit_discount
+    assert discount_1.amount_value == discount_amount_1
+
+    discount_2 = line_2.discounts.get()
+    discount_amount_2 = initial_voucher_unit_discount * line_2.quantity
+    assert (
+        line_2.base_unit_price_amount
+        == line_2.undiscounted_base_unit_price_amount - initial_voucher_unit_discount
+    )
+    assert discount_2.value == initial_voucher_unit_discount
+    assert discount_2.amount_value == discount_amount_2
+
+    # change variant 1 pricing
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
+    new_variant_1_price = initial_variant_1_price + Decimal(2)
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change variant 2 pricing
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_2_price - Decimal(4)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change voucher reward value and type
+    new_voucher_unit_discount = Decimal(25)
+    voucher_listing.discount_value = new_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    expected_unit_price_1 = new_variant_1_price * (1 - new_voucher_unit_discount / 100)
+    expected_unit_discount_1 = new_variant_1_price - expected_unit_price_1
+    expected_discount_amount_1 = expected_unit_discount_1 * line_1.quantity
+
+    # line 2 prices shouldn't be refreshed
+    expected_unit_price_2 = initial_variant_2_price - initial_voucher_unit_discount
+    expected_unit_discount_2 = initial_variant_2_price - expected_unit_price_2
+    expected_discount_amount_2 = expected_unit_discount_2 * line_2.quantity
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+    line_ids_to_refresh = [line_1.id]
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info, line_ids_to_refresh)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
+    assert line_1.base_unit_price_amount == expected_unit_price_1
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+
+    assert line_2.undiscounted_base_unit_price_amount == initial_variant_2_price
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+
+    discount_1.refresh_from_db()
+    assert discount_1.amount.amount == expected_discount_amount_1
+    assert discount_1.value == new_voucher_unit_discount
+    assert discount_1.value_type == DiscountValueType.PERCENTAGE
+
+    discount_2.refresh_from_db()
+    assert discount_2.amount.amount == expected_discount_amount_2
+    assert discount_2.value == initial_voucher_unit_discount
+    assert discount_2.value_type == DiscountValueType.FIXED
+
+
+def test_refresh_order_base_prices_apply_once_per_order_voucher(
+    order_with_lines, voucher
+):
+    # given
+    order = order_with_lines
+    currency = order.currency
+    line_1, line_2 = order.lines.all()
+    variant_1, variant_2 = line_1.variant, line_2.variant
+
+    initial_variant_1_price = line_1.undiscounted_base_unit_price_amount
+    initial_variant_2_price = line_2.undiscounted_base_unit_price_amount
+
+    # prepare apply once per order voucher
+    voucher.discount_value_type = DiscountValueType.FIXED
+    voucher.type = VoucherType.ENTIRE_ORDER
+    voucher.apply_once_per_order = True
+    voucher.save(update_fields=["discount_value_type", "type", "apply_once_per_order"])
+
+    voucher_listing = voucher.channel_listings.get()
+    initial_voucher_unit_discount = Decimal(1)
+    voucher_listing.discount_value = initial_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+
+    # apply voucher
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    create_or_update_voucher_discount_objects_for_order(order)
+
+    # line 1 is the cheapest so should have the discount applied
+    assert initial_variant_1_price < initial_variant_2_price
+    line_1.refresh_from_db()
+    discount_1 = line_1.discounts.get()
+    discount_amount_1 = initial_voucher_unit_discount
+    unit_discount_amount_1 = discount_amount_1 / line_1.quantity
+    assert quantize_price(line_1.base_unit_price_amount, currency) == quantize_price(
+        line_1.undiscounted_base_unit_price_amount - unit_discount_amount_1, currency
+    )
+    assert discount_1.value == initial_voucher_unit_discount
+    assert discount_1.amount_value == discount_amount_1
+
+    assert not line_2.discounts.exists()
+    assert line_2.base_unit_price_amount == line_2.undiscounted_base_unit_price_amount
+
+    # change variant 1 pricing to be higher than variant 2
+    channel_listing_1 = variant_1.channel_listings.get()
+    assert initial_variant_1_price == channel_listing_1.price_amount
+    assert initial_variant_1_price == channel_listing_1.discounted_price_amount
+    new_variant_1_price = initial_variant_1_price + Decimal(6)
+    channel_listing_1.price_amount = new_variant_1_price
+    channel_listing_1.discounted_price_amount = new_variant_1_price
+    channel_listing_1.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change variant 2 pricing to be lower than variant 1
+    channel_listing_2 = variant_2.channel_listings.get()
+    assert initial_variant_2_price == channel_listing_2.price_amount
+    assert initial_variant_2_price == channel_listing_2.discounted_price_amount
+    new_variant_2_price = initial_variant_2_price - Decimal(8)
+    channel_listing_2.price_amount = new_variant_2_price
+    channel_listing_2.discounted_price_amount = new_variant_2_price
+    channel_listing_2.save(update_fields=["price_amount", "discounted_price_amount"])
+
+    # change voucher reward value and type
+    new_voucher_unit_discount = Decimal(25)
+    voucher_listing.discount_value = new_voucher_unit_discount
+    voucher_listing.save(update_fields=["discount_value"])
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save(update_fields=["discount_value_type"])
+
+    # line 1 is not the cheapest anymore, so should not have discount applied
+    assert new_variant_1_price > new_variant_2_price
+    expected_unit_discount_1 = 0
+
+    # line 2 is now the cheapest and should have the price discounted by voucher
+    expected_discount_amount_2 = new_variant_2_price * (
+        1 - new_voucher_unit_discount / 100
+    )
+    expected_unit_discount_2 = expected_discount_amount_2 / line_2.quantity
+    expected_unit_price_2 = new_variant_2_price - expected_unit_discount_2
+
+    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+
+    # when
+    refresh_order_base_prices_and_discounts(order, lines_info)
+
+    # then
+    line_1, line_2 = (line_info.line for line_info in lines_info)
+    assert line_1.undiscounted_base_unit_price_amount == new_variant_1_price
+    assert line_1.base_unit_price_amount == new_variant_1_price
+    assert line_1.unit_discount_amount == expected_unit_discount_1
+
+    assert line_2.undiscounted_base_unit_price_amount == new_variant_2_price
+    assert line_2.base_unit_price_amount == expected_unit_price_2
+    assert line_2.unit_discount_amount == expected_unit_discount_2
+
+    with pytest.raises(OrderLineDiscount.DoesNotExist):
+        discount_1.refresh_from_db()
+    assert not line_1.discounts.exists()
+
+    discount_2 = line_2.discounts.get()
+    assert discount_2.amount.amount == expected_discount_amount_2
+    assert discount_2.value == new_voucher_unit_discount
+    assert discount_2.value_type == DiscountValueType.PERCENTAGE

--- a/saleor/discount/utils/checkout.py
+++ b/saleor/discount/utils/checkout.py
@@ -16,11 +16,11 @@ from ..models import (
 )
 from .promotion import (
     _get_rule_discount_amount,
-    _is_discounted_line_by_catalogue_promotion,
     create_discount_objects_for_order_promotions,
     delete_gift_line,
     get_discount_name,
     get_discount_translated_name,
+    is_discounted_line_by_catalogue_promotion,
     prepare_promotion_discount_reason,
     update_promotion_discount,
 )
@@ -134,7 +134,7 @@ def prepare_checkout_line_discount_objects_for_catalogue_promotions(
             continue
 
         # check if the line price is discounted by catalogue promotion
-        discounted_line = _is_discounted_line_by_catalogue_promotion(
+        discounted_line = is_discounted_line_by_catalogue_promotion(
             line_info.channel_listing
         )
 

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -300,7 +300,9 @@ def refresh_order_base_prices_and_discounts(
     if order.status not in ORDER_EDITABLE_STATUS:
         return
 
-    lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
+    lines_info = fetch_draft_order_lines_info(
+        order, lines=None, fetch_actual_prices=True
+    )
     if not lines_info:
         return
 

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -11,6 +11,7 @@ from ...channel.models import Channel
 from ...core.db.connection import allow_writer
 from ...core.prices import quantize_price
 from ...core.taxes import zero_money
+from ...order import ORDER_EDITABLE_STATUS
 from ...order.base_calculations import base_order_subtotal
 from ...order.models import Order, OrderLine
 from .. import DiscountType
@@ -295,6 +296,9 @@ def refresh_order_base_prices_and_discounts(
         fetch_draft_order_lines_info,
         reattach_apply_once_per_order_voucher_info,
     )
+
+    if order.status not in ORDER_EDITABLE_STATUS:
+        return
 
     lines_info = fetch_draft_order_lines_info(order, lines=None, extend=True)
     if not lines_info:

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -157,7 +157,7 @@ def get_product_discount_on_promotion(
     raise NotApplicable("Promotion rule not applicable for this product")
 
 
-def _is_discounted_line_by_catalogue_promotion(
+def is_discounted_line_by_catalogue_promotion(
     variant_channel_listing: "ProductVariantChannelListing",
 ) -> bool:
     """Return True when the price is discounted by catalogue promotion."""

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 class VoucherDenormalizedInfo:
     discount_value: Decimal
     discount_value_type: str
-    voucher_type: VoucherType
+    voucher_type: str
     reason: str | None
     name: str | None
     apply_once_per_order: bool

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -181,7 +181,7 @@ def get_active_voucher_code(voucher, channel_slug):
     return voucher_code
 
 
-def apply_voucher_to_line(
+def attach_voucher_to_line_info(
     voucher_info: "VoucherInfo",
     lines_info: Sequence["LineInfo"],
 ):

--- a/saleor/graphql/checkout/dataloaders/checkout_infos.py
+++ b/saleor/graphql/checkout/dataloaders/checkout_infos.py
@@ -9,7 +9,7 @@ from ....checkout.fetch import (
 )
 from ....core.db.connection import allow_writer_in_context
 from ....discount import VoucherType
-from ....discount.utils.voucher import apply_voucher_to_line
+from ....discount.utils.voucher import attach_voucher_to_line_info
 from ...account.dataloaders import AddressByIdLoader, UserByUserIdLoader
 from ...channel.dataloaders import ChannelByIdLoader
 from ...core.dataloaders import DataLoader
@@ -342,7 +342,7 @@ class CheckoutLinesInfoByCheckoutTokenLoader(
                         voucher.type == VoucherType.SPECIFIC_PRODUCT
                         or voucher.apply_once_per_order
                     ):
-                        apply_voucher_to_line(
+                        attach_voucher_to_line_info(
                             voucher_info=voucher_info,
                             lines_info=lines_info_map[checkout.pk],
                         )

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -62,7 +62,6 @@ def fetch_order_prices_if_expired(
 
     # handle promotions
     lines_info: list[EditableOrderLineInfo] = fetch_draft_order_lines_info(order, lines)
-
     create_or_update_discount_objects_for_order(
         order, lines_info, database_connection_name
     )

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -62,6 +62,7 @@ def fetch_order_prices_if_expired(
 
     # handle promotions
     lines_info: list[EditableOrderLineInfo] = fetch_draft_order_lines_info(order, lines)
+
     create_or_update_discount_objects_for_order(
         order, lines_info, database_connection_name
     )

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -20,8 +20,8 @@ from ..discount.interface import (
 from ..discount.models import OrderLineDiscount
 from ..discount.utils.voucher import (
     VoucherDenormalizedInfo,
-    apply_voucher_to_line,
     get_the_cheapest_line,
+    attach_voucher_to_line_info,
 )
 from ..graphql.core.types import Money
 from ..payment.models import Payment
@@ -186,11 +186,12 @@ def fetch_draft_order_lines_info(
         voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order
     ):
         voucher_info = fetch_voucher_info(voucher, order.voucher_code)
-        apply_voucher_to_line(voucher_info, lines_info)
+        attach_voucher_to_line_info(voucher_info, lines_info)
         denormalized_voucher_info = _get_denormalized_voucher_info(lines_info, voucher)
         _apply_denormalized_voucher_to_line_info(
             lines_info, denormalized_voucher_info, order.voucher_code
         )
+
     return lines_info
 
 

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -20,8 +20,8 @@ from ..discount.interface import (
 from ..discount.models import OrderLineDiscount
 from ..discount.utils.voucher import (
     VoucherDenormalizedInfo,
-    get_the_cheapest_line,
     attach_voucher_to_line_info,
+    get_the_cheapest_line,
 )
 from ..graphql.core.types import Money
 from ..payment.models import Payment
@@ -187,8 +187,10 @@ def fetch_draft_order_lines_info(
     ):
         voucher_info = fetch_voucher_info(voucher, order.voucher_code)
         attach_voucher_to_line_info(voucher_info, lines_info)
-        denormalized_voucher_info = _get_denormalized_voucher_info(lines_info, voucher)
-        _apply_denormalized_voucher_to_line_info(
+        denormalized_voucher_info = _fetch_denormalized_voucher_info(
+            lines_info, voucher
+        )
+        _attach_denormalized_voucher_to_line_info(
             lines_info, denormalized_voucher_info, order.voucher_code
         )
 
@@ -206,7 +208,7 @@ def _get_variant_listing(
     return None
 
 
-def _get_denormalized_voucher_info(lines_info: list[EditableOrderLineInfo], voucher):
+def _fetch_denormalized_voucher_info(lines_info: list[EditableOrderLineInfo], voucher):
     voucher_discounts = [
         discount
         for line_info in lines_info
@@ -230,7 +232,7 @@ def _get_denormalized_voucher_info(lines_info: list[EditableOrderLineInfo], vouc
     )
 
 
-def _apply_denormalized_voucher_to_line_info(
+def _attach_denormalized_voucher_to_line_info(
     lines_info: list[EditableOrderLineInfo],
     denormalized_voucher_info: VoucherDenormalizedInfo | None,
     voucher_code: str | None,

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -118,19 +118,20 @@ class EditableOrderLineInfo(LineInfo):
 def fetch_draft_order_lines_info(
     order: "Order",
     lines: Iterable["OrderLine"] | None = None,
-    extend: bool = False,
+    fetch_actual_prices: bool = False,
 ) -> list[EditableOrderLineInfo]:
     """Fetch the necessary order lines info in order to recalculate its prices.
 
-    `extend` argument determines if the function should additionally retrieve the latest
-    variant channel listing prices
+    `fetch_actual_prices` argument determines if the function should additionally
+    retrieve the latest variant channel listing prices
     """
     prefetch_related_fields = [
         "discounts__promotion_rule__promotion",
         "variant__product__collections",
         "variant__product__product_type",
     ]
-    if extend:
+    if fetch_actual_prices:
+        # TODO zedzior: optimize the prefetch to get channel relevant data only
         prefetch_related_fields.extend(
             [
                 "variant__channel_listings__variantlistingpromotionrule__promotion_rule__promotion__translations",
@@ -159,7 +160,7 @@ def fetch_draft_order_lines_info(
 
         variant_channel_listing = None
         rules_info = []
-        if extend:
+        if fetch_actual_prices:
             variant_channel_listing = _get_variant_listing(variant, channel.id)
             if variant_channel_listing:
                 rules_info = (

--- a/saleor/order/fetch.py
+++ b/saleor/order/fetch.py
@@ -186,7 +186,8 @@ def fetch_draft_order_lines_info(
                 rules_info=rules_info,
             )
         )
-        attach_voucher_info(lines_info, order)
+
+    attach_voucher_info(lines_info, order)
 
     return lines_info
 

--- a/saleor/order/tests/test_fetch.py
+++ b/saleor/order/tests/test_fetch.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 import pytest
 
+from ...product.models import ProductVariantChannelListing
 from ..fetch import EditableOrderLineInfo, fetch_draft_order_lines_info
 
 
@@ -52,6 +53,73 @@ def test_fetch_draft_order_lines_info(
     assert line_info_2.discounts == [catalogue_discount]
     assert line_info_2.channel == channel
     assert line_info_2.voucher is None
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_fetch_draft_order_lines_info_extended(
+    draft_order_and_promotions, django_assert_num_queries, count_queries
+):
+    # given
+    order, rule_catalogue, rule_total, rule_gift = draft_order_and_promotions
+    channel = order.channel
+    lines = order.lines.all()
+    line_1 = [line for line in lines if line.quantity == 3][0]
+    line_2 = [line for line in lines if line.quantity == 2][0]
+
+    manual_discount = line_1.discounts.create(
+        value=Decimal(1),
+        amount_value=Decimal(1),
+        currency=channel.currency_code,
+        name="Manual line discount",
+    )
+    rule_translation = "Rule translation"
+    rule_catalogue.translations.create(
+        language_code=order.language_code, name=rule_translation
+    )
+    promotion_translation = "Promotion"
+    rule_catalogue.promotion.translations.create(
+        language_code=order.language_code, name=promotion_translation
+    )
+
+    # when
+    with django_assert_num_queries(14):
+        lines_info = fetch_draft_order_lines_info(order, extend=True)
+
+    # then
+    line_info_1 = [line_info for line_info in lines_info if line_info.line == line_1][0]
+    line_info_2 = [line_info for line_info in lines_info if line_info.line == line_2][0]
+
+    variant_1 = line_1.variant
+    assert line_info_1.variant == variant_1
+    assert (
+        line_info_1.channel_listing
+        == ProductVariantChannelListing.objects.filter(
+            channel=channel, variant=variant_1
+        ).first()
+    )
+    assert line_info_1.discounts == [manual_discount]
+    assert line_info_1.channel == channel
+    assert line_info_1.voucher is None
+    assert line_info_1.rules_info == []
+
+    variant_2 = line_2.variant
+    assert line_info_2.variant == variant_2
+    assert (
+        line_info_2.channel_listing
+        == ProductVariantChannelListing.objects.filter(
+            channel=channel, variant=variant_2
+        ).first()
+    )
+    assert len(line_info_2.discounts) == 1
+    assert line_info_2.channel == channel
+    assert line_info_2.voucher is None
+    rule_info_2 = line_info_2.rules_info[0]
+    assert rule_info_2.rule == rule_catalogue
+    assert rule_info_2.variant_listing_promotion_rule
+    assert rule_info_2.promotion == rule_catalogue.promotion
+    assert rule_info_2.promotion_translation.name == promotion_translation
+    assert rule_info_2.rule_translation.name == rule_translation
 
 
 def test_editable_order_line_info_variant_discounted_price(

--- a/saleor/order/tests/test_fetch.py
+++ b/saleor/order/tests/test_fetch.py
@@ -84,7 +84,7 @@ def test_fetch_draft_order_lines_info_extended(
 
     # when
     with django_assert_num_queries(14):
-        lines_info = fetch_draft_order_lines_info(order, extend=True)
+        lines_info = fetch_draft_order_lines_info(order, fetch_actual_prices=True)
 
     # then
     line_info_1 = [line_info for line_info in lines_info if line_info.line == line_1][0]

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -819,6 +819,7 @@ def create_order_discount_for_order(
     current_total: TaxedMoney = order.undiscounted_total
     currency = order.currency
 
+    # TODO zedzior: why gross price is taken?
     gross_total = apply_discount_to_value(
         value, value_type, currency, current_total.gross
     )


### PR DESCRIPTION
Part of: https://github.com/saleor/saleor/pull/17160
Issue: https://linear.app/saleor/issue/SCL-704/add-a-logic-to-force-the-order-price-refresh-with-the-latest-channel

This PR adds a logic, which allows to update the order prices (all the lines or particular lines), based on the latest conditions including update of a discount objects. By latest conditions, I mean latest channel listing prices, catalog promotion and voucher details.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
