### PR TITLE
Sync webhooks circuit breakers imrovements

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1012,6 +1012,9 @@ BREAKER_BOARD_COOLDOWN_SECONDS = int(
     os.environ.get("BREAKER_BOARD_COOLDOWN_SECONDS", 5 * 60)
 )
 BREAKER_BOARD_TTL_SECONDS = int(os.environ.get("BREAKER_BOARD_TTL_SECONDS", 10 * 60))
+# List of lowercase sync webhook events that should be monitored by the breaker board, for ex:
+# "checkout_calculate_taxes, shipping_list_methods_for_checkout".
+BREAKER_BOARD_SYNC_EVENTS = get_list(os.environ.get("BREAKER_BOARD_SYNC_EVENTS", ""))
 
 if ENABLE_BREAKER_BOARD is True and not BREAKER_BOARD_STORAGE_CLASS:
     raise ImproperlyConfigured(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1000,9 +1000,7 @@ warnings.filterwarnings("ignore", category=CacheKeyWarning)
 ENABLE_BREAKER_BOARD = get_bool_from_env("ENABLE_BREAKER_BOARD", False)
 # Storage class string for the breaker board, for example:
 # "saleor.webhook.circuit_breaker.storage.InMemoryStorage"
-BREAKER_BOARD_STORAGE_CLASS_STRING = os.environ.get(
-    "BREAKER_BOARD_STORAGE_CLASS_STRING"
-)
+BREAKER_BOARD_STORAGE_CLASS = os.environ.get("BREAKER_BOARD_STORAGE_CLASS")
 BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE = int(
     os.environ.get("BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE", 50)
 )
@@ -1015,7 +1013,7 @@ BREAKER_BOARD_COOLDOWN_SECONDS = int(
 )
 BREAKER_BOARD_TTL_SECONDS = int(os.environ.get("BREAKER_BOARD_TTL_SECONDS", 10 * 60))
 
-if ENABLE_BREAKER_BOARD is True and not BREAKER_BOARD_STORAGE_CLASS_STRING:
+if ENABLE_BREAKER_BOARD is True and not BREAKER_BOARD_STORAGE_CLASS:
     raise ImproperlyConfigured(
-        "BREAKER_BOARD_STORAGE_CLASS_STRING must be defined when ENABLE_BREAKER_BOARD is set to True"
+        "BREAKER_BOARD_STORAGE_CLASS must be defined when ENABLE_BREAKER_BOARD is set to True"
     )

--- a/saleor/webhook/circuit_breaker/breaker_board.py
+++ b/saleor/webhook/circuit_breaker/breaker_board.py
@@ -108,7 +108,7 @@ def initialize_breaker_board():
     if not settings.ENABLE_BREAKER_BOARD:
         return None
 
-    storage_class = import_string(settings.BREAKER_BOARD_STORAGE_CLASS_STRING)  # type: ignore[arg-type]
+    storage_class = import_string(settings.BREAKER_BOARD_STORAGE_CLASS)  # type: ignore[arg-type]
     return BreakerBoard(
         storage=storage_class(),
         failure_threshold=settings.BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE,

--- a/saleor/webhook/circuit_breaker/breaker_board.py
+++ b/saleor/webhook/circuit_breaker/breaker_board.py
@@ -3,6 +3,7 @@ import time
 from typing import TYPE_CHECKING
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
 from saleor.webhook.event_types import WebhookEventSyncType
@@ -32,19 +33,23 @@ class BreakerBoard:
         cooldown_seconds: int,
         ttl_seconds: int,
     ):
+        self.validate_sync_events()
         self.storage = storage
-
-        # TODO - make event types configurable
-        self.webhook_event_types = [
-            WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
-        ]
         self.failure_threshold = failure_threshold
         self.failure_min_count = failure_min_count
         self.cooldown_seconds = cooldown_seconds
         self.ttl_seconds = ttl_seconds
 
+    def validate_sync_events(self):
+        if settings.BREAKER_BOARD_SYNC_EVENTS == [""]:
+            raise ImproperlyConfigured("BREAKER_BOARD_SYNC_EVENTS cannot be empty.")
+        for event in settings.BREAKER_BOARD_SYNC_EVENTS:
+            if not WebhookEventSyncType.EVENT_MAP.get(event):
+                raise ImproperlyConfigured(
+                    f'Event "{event}" is not supported by circuit breaker.'
+                )
+
     def is_closed(self, app_id: int):
-        # TODO - cache last open to optimize?
         return self.storage.last_open(app_id) < (time.time() - self.cooldown_seconds)
 
     def register_error(self, app_id: int):
@@ -82,20 +87,18 @@ class BreakerBoard:
             event_type: str = args[0]
             webhook: Webhook = args[2]
 
-            if event_type not in self.webhook_event_types:
+            if event_type not in settings.BREAKER_BOARD_SYNC_EVENTS:
                 return func(*args, **kwargs)
 
-            # TODO - ensure webhook and app are preloaded
-            app = webhook.app
-
-            if not self.is_closed(app.id):
+            app_id = webhook.app.id
+            if not self.is_closed(app_id):
                 return None
 
             response = func(*args, **kwargs)
             if response is None:
-                self.register_error(app.id)
+                self.register_error(app_id)
             else:
-                self.register_success(app.id)
+                self.register_success(app_id)
 
             return response
 

--- a/saleor/webhook/tests/circuit_breaker/test_breaker_board.py
+++ b/saleor/webhook/tests/circuit_breaker/test_breaker_board.py
@@ -5,7 +5,10 @@ from saleor.webhook.circuit_breaker.storage import InMemoryStorage
 from saleor.webhook.event_types import WebhookEventSyncType
 
 
-def test_breaker_board_failure(app_with_webhook, failed_response_function_mock):
+def test_breaker_board_failure(
+    settings, app_with_webhook, failed_response_function_mock
+):
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     breaker_board = BreakerBoard(
         storage=InMemoryStorage(),
         failure_threshold=1,
@@ -15,10 +18,6 @@ def test_breaker_board_failure(app_with_webhook, failed_response_function_mock):
     )
     app, webhook = app_with_webhook
 
-    assert (
-        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
-        in breaker_board.webhook_event_types
-    )
     wrapped_function_mock = breaker_board(failed_response_function_mock)
 
     assert failed_response_function_mock.call_count == 0
@@ -36,8 +35,9 @@ def test_breaker_board_failure(app_with_webhook, failed_response_function_mock):
 
 
 def test_breaker_board_failure_ignored_webhook_event_type(
-    app_with_webhook, failed_response_function_mock
+    settings, app_with_webhook, failed_response_function_mock
 ):
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     breaker_board = BreakerBoard(
         storage=InMemoryStorage(),
         failure_threshold=1,
@@ -47,7 +47,6 @@ def test_breaker_board_failure_ignored_webhook_event_type(
     )
     app, webhook = app_with_webhook
 
-    assert WebhookEventSyncType.PAYMENT_CAPTURE not in breaker_board.webhook_event_types
     wrapped_function_mock = breaker_board(failed_response_function_mock)
 
     assert failed_response_function_mock.call_count == 0
@@ -60,7 +59,10 @@ def test_breaker_board_failure_ignored_webhook_event_type(
     assert breaker_board.storage.last_open(app.id) == 0
 
 
-def test_breaker_board_success(app_with_webhook, success_response_function_mock):
+def test_breaker_board_success(
+    settings, app_with_webhook, success_response_function_mock
+):
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     breaker_board = BreakerBoard(
         storage=InMemoryStorage(),
         failure_threshold=1,
@@ -70,10 +72,6 @@ def test_breaker_board_success(app_with_webhook, success_response_function_mock)
     )
     app, webhook = app_with_webhook
 
-    assert (
-        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
-        in breaker_board.webhook_event_types
-    )
     wrapped_function_mock = breaker_board(success_response_function_mock)
 
     assert success_response_function_mock.call_count == 0
@@ -104,10 +102,12 @@ def test_breaker_board_threshold(
     failed_attempts,
     threshold,
     tripped,
+    settings,
     app_with_webhook,
     failed_response_function_mock,
     success_response_function_mock,
 ):
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     breaker_board = BreakerBoard(
         storage=InMemoryStorage(),
         failure_threshold=threshold,
@@ -117,10 +117,6 @@ def test_breaker_board_threshold(
     )
     app, webhook = app_with_webhook
 
-    assert (
-        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
-        in breaker_board.webhook_event_types
-    )
     wrapped_function_mock_success = breaker_board(success_response_function_mock)
     wrapped_function_mock_failed = breaker_board(failed_response_function_mock)
 
@@ -138,9 +134,11 @@ def test_breaker_board_threshold(
 
 
 def test_breaker_board_clear_state_for_app(
+    settings,
     app_with_webhook,
     failed_response_function_mock,
 ):
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     breaker_board = BreakerBoard(
         storage=InMemoryStorage(),
         failure_threshold=3,

--- a/saleor/webhook/tests/circuit_breaker/test_breaker_board_decorator.py
+++ b/saleor/webhook/tests/circuit_breaker/test_breaker_board_decorator.py
@@ -29,7 +29,7 @@ def test_breaker_board(
     expected_data = {"some": "data"}
 
     settings.ENABLE_BREAKER_BOARD = enable_breaker_board
-    settings.BREAKER_BOARD_STORAGE_CLASS_STRING = storage_class_string
+    settings.BREAKER_BOARD_STORAGE_CLASS = storage_class_string
     _, webhook = app_with_webhook
 
     # Import alone is not sufficient, once module is imported the subsequent tests will
@@ -55,7 +55,7 @@ def test_breaker_board(
 
 def test_breaker_board_open(settings, app_with_webhook, caplog):
     settings.ENABLE_BREAKER_BOARD = True
-    settings.BREAKER_BOARD_STORAGE_CLASS_STRING = (
+    settings.BREAKER_BOARD_STORAGE_CLASS = (
         "saleor.webhook.circuit_breaker.storage.InMemoryStorage"
     )
     settings.BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE = 50
@@ -94,7 +94,7 @@ def test_breaker_board_open(settings, app_with_webhook, caplog):
 
 def test_breaker_board_closes(settings, app_with_webhook, caplog):
     settings.ENABLE_BREAKER_BOARD = True
-    settings.BREAKER_BOARD_STORAGE_CLASS_STRING = (
+    settings.BREAKER_BOARD_STORAGE_CLASS = (
         "saleor.webhook.circuit_breaker.storage.InMemoryStorage"
     )
     settings.BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE = 50

--- a/saleor/webhook/tests/circuit_breaker/test_breaker_board_decorator.py
+++ b/saleor/webhook/tests/circuit_breaker/test_breaker_board_decorator.py
@@ -29,6 +29,7 @@ def test_breaker_board(
     expected_data = {"some": "data"}
 
     settings.ENABLE_BREAKER_BOARD = enable_breaker_board
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     settings.BREAKER_BOARD_STORAGE_CLASS = storage_class_string
     _, webhook = app_with_webhook
 
@@ -55,6 +56,7 @@ def test_breaker_board(
 
 def test_breaker_board_open(settings, app_with_webhook, caplog):
     settings.ENABLE_BREAKER_BOARD = True
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     settings.BREAKER_BOARD_STORAGE_CLASS = (
         "saleor.webhook.circuit_breaker.storage.InMemoryStorage"
     )
@@ -94,6 +96,7 @@ def test_breaker_board_open(settings, app_with_webhook, caplog):
 
 def test_breaker_board_closes(settings, app_with_webhook, caplog):
     settings.ENABLE_BREAKER_BOARD = True
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["shipping_list_methods_for_checkout"]
     settings.BREAKER_BOARD_STORAGE_CLASS = (
         "saleor.webhook.circuit_breaker.storage.InMemoryStorage"
     )


### PR DESCRIPTION
I want to merge this change because it refactors BREAKER_BOARD_STORAGE_CLASS_STRING setting and makes the breaker events configurable.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
