### PR TITLE
Prevent calling `excluded_shipping_methods_for_checkout` if shipping methods are empty

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /app
 RUN pip install poetry==2.0.1
 RUN poetry config virtualenvs.create false
 COPY poetry.lock pyproject.toml /app/
-RUN poetry install
+RUN poetry sync

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /app
 RUN pip install poetry==2.0.1
 RUN poetry config virtualenvs.create false
 COPY poetry.lock pyproject.toml /app/
-RUN poetry sync
+RUN poetry install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Fixed webhookTrigger payload type for events related to ProductVariant - #16956 by @delemeator
 - Truncate lenghty responses in `EventDeliveryAttempt` objects - #17044 by @wcislo-saleor
+- Webhooks `CHECKOUT_FILTER_SHIPPING_METHODS` & `ORDER_FILTER_SHIPPING_METHODS` are no longer executed when not needed (no available shipping methods, e.g. due to lack of shipping address) - #17328 by @lkostrowski
 
 ### Other changes
 - Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -626,11 +626,19 @@ def test_call_checkout_event_triggers_sync_webhook_when_needed(
     setup_checkout_webhooks,
     settings,
     django_capture_on_commit_callbacks,
+    address,
 ):
     # given
     plugins_manager = get_plugins_manager(allow_replica=False)
     checkout_with_items.price_expiration = timezone.now()
-    checkout_with_items.save(update_fields=["price_expiration"])
+
+    # Set address - so SHIPPING_LIST_METHODS_FOR_CHECKOUT is executed too
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
+    checkout_with_items.save(
+        update_fields=["price_expiration", "billing_address", "shipping_address"]
+    )
 
     mocked_send_webhook_request_sync.return_value = []
     (
@@ -713,11 +721,19 @@ def test_call_checkout_event_skips_tax_webhook_when_not_expired(
     setup_checkout_webhooks,
     settings,
     django_capture_on_commit_callbacks,
+    address,
 ):
     # given
     plugins_manager = get_plugins_manager(allow_replica=False)
+
+    # Ensure shipping & billing is set, so shipping webhooks are actually emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
     checkout_with_items.price_expiration = timezone.now() + datetime.timedelta(hours=1)
-    checkout_with_items.save(update_fields=["price_expiration"])
+    checkout_with_items.save(
+        update_fields=["price_expiration", "shipping_address", "billing_address"]
+    )
 
     mocked_send_webhook_request_sync.return_value = []
     (
@@ -938,11 +954,19 @@ def test_call_checkout_info_event_triggers_sync_webhook_when_needed(
     setup_checkout_webhooks,
     settings,
     django_capture_on_commit_callbacks,
+    address,
 ):
     # given
     plugins_manager = get_plugins_manager(allow_replica=False)
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
     checkout_with_items.price_expiration = timezone.now()
-    checkout_with_items.save(update_fields=["price_expiration"])
+    checkout_with_items.save(
+        update_fields=["price_expiration", "billing_address", "shipping_address"]
+    )
 
     mocked_send_webhook_request_sync.return_value = []
     (
@@ -1036,11 +1060,19 @@ def test_call_checkout_info_event_skips_tax_webhook_when_not_expired(
     setup_checkout_webhooks,
     settings,
     django_capture_on_commit_callbacks,
+    address,
 ):
     # given
     plugins_manager = get_plugins_manager(allow_replica=False)
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
     checkout_with_items.price_expiration = timezone.now() + datetime.timedelta(hours=1)
-    checkout_with_items.save(update_fields=["price_expiration"])
+    checkout_with_items.save(
+        update_fields=["price_expiration", "billing_address", "shipping_address"]
+    )
 
     mocked_send_webhook_request_sync.return_value = []
     (
@@ -1249,11 +1281,19 @@ def test_transaction_amounts_for_checkout_fully_paid_triggers_sync_webhook(
     checkout_with_items,
     transaction_item_generator,
     django_capture_on_commit_callbacks,
+    address,
 ):
     # given
     plugins_manager = get_plugins_manager(allow_replica=False)
     checkout_with_items.price_expiration = timezone.now() - datetime.timedelta(hours=10)
-    checkout_with_items.save(update_fields=["price_expiration"])
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
+    checkout_with_items.save(
+        update_fields=["price_expiration", "billing_address", "shipping_address"]
+    )
 
     mocked_send_webhook_request_sync.return_value = []
     (
@@ -1382,11 +1422,19 @@ def test_call_checkout_events_triggers_sync_webhook_when_needed(
     setup_checkout_webhooks,
     settings,
     django_capture_on_commit_callbacks,
+    address,
 ):
     # given
     plugins_manager = get_plugins_manager(allow_replica=False)
     checkout_with_items.price_expiration = timezone.now()
-    checkout_with_items.save(update_fields=["price_expiration"])
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
+    checkout_with_items.save(
+        update_fields=["price_expiration", "shipping_address", "billing_address"]
+    )
 
     mocked_send_webhook_request_sync.return_value = []
     (
@@ -1477,11 +1525,19 @@ def test_call_checkout_events_skips_tax_webhook_when_not_expired(
     setup_checkout_webhooks,
     settings,
     django_capture_on_commit_callbacks,
+    address,
 ):
     # given
     plugins_manager = get_plugins_manager(allow_replica=False)
     checkout_with_items.price_expiration = timezone.now() + datetime.timedelta(hours=1)
-    checkout_with_items.save(update_fields=["price_expiration"])
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
+    checkout_with_items.save(
+        update_fields=["price_expiration", "billing_address", "shipping_address"]
+    )
 
     mocked_send_webhook_request_sync.return_value = []
     (

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1361,6 +1361,7 @@ def test_checkout_add_voucher_triggers_webhooks(
     api_client,
     checkout_with_item,
     voucher,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -1375,6 +1376,12 @@ def test_checkout_add_voucher_triggers_webhooks(
         "id": to_global_id_or_none(checkout_with_item),
         "promoCode": voucher.code,
     }
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_item.shipping_address = address
+    checkout_with_item.billing_address = address
+
+    checkout_with_item.save()
 
     # when
     response = api_client.post_graphql(MUTATION_CHECKOUT_ADD_PROMO_CODE, variables)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -716,6 +716,7 @@ def test_checkout_billing_address_triggers_webhooks(
     user_api_client,
     checkout_with_item,
     graphql_address_data,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -727,6 +728,12 @@ def test_checkout_billing_address_triggers_webhooks(
     ) = setup_checkout_webhooks(WebhookEventAsyncType.CHECKOUT_UPDATED)
 
     checkout = checkout_with_item
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
+    checkout.save()
 
     query = MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE
     billing_address = graphql_address_data

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -305,6 +305,7 @@ def test_checkout_customer_triggers_webhooks(
     checkout_with_item,
     customer_user2,
     permission_impersonate_user,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -317,6 +318,11 @@ def test_checkout_customer_triggers_webhooks(
 
     checkout = checkout_with_item
     checkout.email = "old@email.com"
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
     checkout.save()
 
     query = MUTATION_CHECKOUT_CUSTOMER_ATTACH

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -176,6 +176,7 @@ def test_checkout_customer_detach_triggers_webhooks(
     user_api_client,
     checkout_with_item,
     customer_user,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -188,7 +189,12 @@ def test_checkout_customer_detach_triggers_webhooks(
 
     checkout = checkout_with_item
     checkout.user = customer_user
-    checkout.save(update_fields=["user"])
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
+    checkout.save(update_fields=["user", "shipping_address", "billing_address"])
 
     variables = {"id": to_global_id_or_none(checkout)}
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
@@ -136,6 +136,7 @@ def test_checkout_customer_note_update_triggers_webhooks(
     settings,
     user_api_client,
     checkout_with_item,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -145,6 +146,12 @@ def test_checkout_customer_note_update_triggers_webhooks(
         shipping_filter_webhook,
         checkout_updated_webhook,
     ) = setup_checkout_webhooks(WebhookEventAsyncType.CHECKOUT_UPDATED)
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_item.shipping_address = address
+    checkout_with_item.billing_address = address
+
+    checkout_with_item.save()
 
     customer_note = "New customer note value"
     variables = {

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -143,6 +143,7 @@ def test_checkout_email_update_triggers_webhooks(
     settings,
     user_api_client,
     checkout_with_item,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -155,7 +156,12 @@ def test_checkout_email_update_triggers_webhooks(
 
     checkout = checkout_with_item
     checkout.email = None
-    checkout.save(update_fields=["email"])
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
+    checkout.save(update_fields=["email", "billing_address", "shipping_address"])
 
     email = "test@example.com"
     variables = {"id": to_global_id_or_none(checkout), "email": email}

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -131,6 +131,7 @@ def test_checkout_update_language_code_triggers_webhooks(
     settings,
     user_api_client,
     checkout_with_gift_card,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -143,6 +144,13 @@ def test_checkout_update_language_code_triggers_webhooks(
 
     language_code = "PL"
     checkout = checkout_with_gift_card
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
+    checkout.save()
+
     variables = {"id": to_global_id_or_none(checkout), "languageCode": language_code}
 
     # when

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -348,6 +348,7 @@ def test_checkout_line_delete_triggers_webhooks(
     api_client,
     checkout_with_items,
     product_with_single_variant,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -366,6 +367,12 @@ def test_checkout_line_delete_triggers_webhooks(
     add_variant_to_checkout(checkout_info, variant, 1)
 
     line = checkout_info.checkout.lines.last()
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
+    checkout_with_items.save()
 
     variables = {
         "id": to_global_id_or_none(checkout_with_items),

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1910,6 +1910,7 @@ def test_checkout_lines_add_triggers_webhooks(
     user_api_client,
     checkout_with_item,
     stock,
+    address,
 ):
     # given
     mocked_send_webhook_using_scheme_method.return_value = WebhookResponse(content="")
@@ -1924,6 +1925,12 @@ def test_checkout_lines_add_triggers_webhooks(
     variant = stock.product_variant
 
     checkout = checkout_with_item
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
+    checkout.save()
 
     lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -352,6 +352,7 @@ def test_checkout_lines_delete_triggers_webhooks(
     settings,
     api_client,
     checkout_with_items,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -369,6 +370,12 @@ def test_checkout_lines_delete_triggers_webhooks(
         "id": to_global_id_or_none(checkout_with_items),
         "linesIds": [first_line_id],
     }
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
+    checkout_with_items.save()
 
     # when
     response = api_client.post_graphql(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1516,6 +1516,7 @@ def test_checkout_lines_update_triggers_webhooks(
     api_client,
     checkout_with_items,
     product_with_single_variant,
+    address,
 ):
     # given
     mocked_send_webhook_using_scheme_method.return_value = WebhookResponse(content="")
@@ -1533,6 +1534,12 @@ def test_checkout_lines_update_triggers_webhooks(
         checkout_with_items, [], get_plugins_manager(allow_replica=False)
     )
     add_variant_to_checkout(checkout_info, variant, 1)
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_items.shipping_address = address
+    checkout_with_items.billing_address = address
+
+    checkout_with_items.save()
 
     variables = {
         "id": to_global_id_or_none(checkout_with_items),

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -803,6 +803,7 @@ def test_checkout_remove_triggers_webhooks(
     settings,
     api_client,
     checkout_with_voucher,
+    address,
 ):
     # given
     mocked_send_webhook_using_scheme_method.return_value = WebhookResponse(content="")
@@ -813,6 +814,12 @@ def test_checkout_remove_triggers_webhooks(
         shipping_filter_webhook,
         checkout_updated_webhook,
     ) = setup_checkout_webhooks(WebhookEventAsyncType.CHECKOUT_UPDATED)
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout_with_voucher.shipping_address = address
+    checkout_with_voucher.billing_address = address
+
+    checkout_with_voucher.save()
 
     variables = {
         "id": to_global_id_or_none(checkout_with_voucher),

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -20,7 +20,11 @@ from ....checkout.checkout_cleaner import (
 )
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
-from ....checkout.utils import add_variant_to_checkout, add_voucher_to_checkout
+from ....checkout.utils import (
+    PRIVATE_META_APP_SHIPPING_ID,
+    add_variant_to_checkout,
+    add_voucher_to_checkout,
+)
 from ....core.db.connection import allow_writer
 from ....core.prices import quantize_price
 from ....discount import DiscountValueType, VoucherType
@@ -528,9 +532,9 @@ def test_checkout_available_shipping_methods(
 GET_CHECKOUT_SHIPPING_METHODS_QUERY = """
 query getCheckout($id: ID) {
     checkout(id: $id) {
-			shippingMethods{
-        id
-      }
+		shippingMethods{
+            id
+        }
     }
 }
 """
@@ -549,6 +553,9 @@ def test_query_checkout_empty_address_with_shipping_method_without_exclude_webho
     # given checkout without address
     # and checkout in channel with available shipping methods
 
+    checkout_with_item.metadata_storage.private_metadata = {
+        PRIVATE_META_APP_SHIPPING_ID: "TEST_METHOD"
+    }
     checkout_with_item.shipping_address = None
     checkout_with_item.billing_address = None
 
@@ -577,6 +584,9 @@ def test_query_checkout_with_address_with_shipping_method_without_exclude_webhoo
     # GIVEN checkout with address
     # AND checkout in channel with available shipping methods
 
+    checkout_with_item.metadata_storage.private_metadata = {
+        PRIVATE_META_APP_SHIPPING_ID: "TEST_METHOD"
+    }
     checkout_with_item.shipping_address = address
     checkout_with_item.billing_address = address
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -524,6 +524,58 @@ def test_checkout_available_shipping_methods(
     assert data[field][0]["translation"]["name"] == translated_name
 
 
+GET_CHECKOUT_SHIPPING_METHODS_QUERY = """
+query getCheckout($id: ID) {
+    checkout(id: $id) {
+			shippingMethods{
+        id
+      }
+    }
+}
+"""
+
+
+@mock.patch(
+    "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
+)
+def test_query_checkout_empty_address_with_shipping_method_without_exclude_webhook(
+    mock__run_method_on_plugins, api_client, checkout_with_item, shipping_method
+):
+    # given checkout without address
+    # and checkout in channel with available shipping methods
+
+    checkout_with_item.shipping_address = None
+    checkout_with_item.billing_address = None
+
+    # when query is invoked
+    variables = {"id": to_global_id_or_none(checkout_with_item)}
+    api_client.post_graphql(GET_CHECKOUT_SHIPPING_METHODS_QUERY, variables)
+
+    # then webhook plugin is not executing excluded_shipping_methods_for_checkout
+
+    mock__run_method_on_plugins.assert_not_called()
+
+
+@mock.patch(
+    "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
+)
+def test_query_checkout_with_address_with_shipping_method_without_exclude_webhook(
+    mock__run_method_on_plugins, api_client, checkout_with_item, shipping_method
+):
+    # GIVEN checkout with address
+    # AND checkout in channel with available shipping methods
+
+    # TODO Add addresses
+
+    # when query is invoked
+    variables = {"id": to_global_id_or_none(checkout_with_item)}
+    api_client.post_graphql(GET_CHECKOUT_SHIPPING_METHODS_QUERY, variables)
+
+    # then webhook plugin is not executing excluded_shipping_methods_for_checkout
+
+    mock__run_method_on_plugins.assert_called_once()
+
+
 @pytest.mark.parametrize("minimum_order_weight_value", [0, 2, None])
 def test_checkout_available_shipping_methods_with_weight_based_shipping_method(
     api_client,

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -380,6 +380,7 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
     settings,
     api_client,
     checkout,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -392,7 +393,14 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
 
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     checkout.price_expiration = timezone.now() - datetime.timedelta(hours=10)
-    checkout.save(update_fields=["price_expiration"])
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
+    checkout.save(
+        update_fields=["price_expiration", "billing_address", "shipping_address"]
+    )
     # when
     response = execute_update_public_metadata_for_item(
         api_client, None, checkout_id, "Checkout"
@@ -460,6 +468,7 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     settings,
     api_client,
     checkout,
+    address,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -473,7 +482,14 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     checkout.price_expiration = timezone.now() - datetime.timedelta(hours=10)
-    checkout.save(update_fields=["price_expiration"])
+
+    # Ensure shipping is set so shipping webhooks are emitted
+    checkout.shipping_address = address
+    checkout.billing_address = address
+
+    checkout.save(
+        update_fields=["price_expiration", "shipping_address", "billing_address"]
+    )
 
     # when
     response = execute_update_public_metadata_for_item(

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -379,10 +379,15 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
     setup_checkout_webhooks,
     settings,
     api_client,
-    checkout,
+    checkout_with_item,
     address,
+    shipping_method,
 ):
     # given
+
+    # Include item so shipping webhooks are emitted
+    checkout = checkout_with_item
+
     mocked_send_webhook_request_sync.return_value = []
     (
         tax_webhook,
@@ -467,10 +472,15 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     setup_checkout_webhooks,
     settings,
     api_client,
-    checkout,
+    checkout_with_item,
     address,
+    shipping_method,
 ):
     # given
+
+    # Include item so shipping is also triggered
+    checkout = checkout_with_item
+
     mocked_send_webhook_request_sync.return_value = []
     (
         tax_webhook,
@@ -479,7 +489,6 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
         checkout_metadata_updated_webhook,
     ) = setup_checkout_webhooks(WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED)
 
-    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     checkout.price_expiration = timezone.now() - datetime.timedelta(hours=10)
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2880,11 +2880,15 @@ class PluginsManager(PaymentInterface):
         available_shipping_methods: list["ShippingMethodData"],
         pregenerated_subscription_payloads: dict | None = None,
     ) -> list[ExcludedShippingMethod]:
+        default_value: list[ExcludedShippingMethod] = []
+
+        if not available_shipping_methods:
+            return default_value
         if pregenerated_subscription_payloads is None:
             pregenerated_subscription_payloads = {}
         return self.__run_method_on_plugins(
             "excluded_shipping_methods_for_checkout",
-            [],
+            default_value,
             checkout,
             available_shipping_methods,
             pregenerated_subscription_payloads=pregenerated_subscription_payloads,

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2865,9 +2865,14 @@ class PluginsManager(PaymentInterface):
         order: "Order",
         available_shipping_methods: list["ShippingMethodData"],
     ) -> list[ExcludedShippingMethod]:
+        default_value: list[ExcludedShippingMethod] = []
+
+        if not available_shipping_methods:
+            return default_value
+
         return self.__run_method_on_plugins(
             "excluded_shipping_methods_for_order",
-            [],
+            default_value,
             order,
             available_shipping_methods,
             channel_slug=order.channel.slug,

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -34,6 +34,7 @@ from ...payment.interface import (
     TransactionSessionResult,
 )
 from ...product.models import Product
+from ...shipping.interface import ShippingMethodData
 from ..base_plugin import ExternalAccessTokens
 from ..manager import PluginsManager, get_plugins_manager
 from ..models import PluginConfiguration
@@ -1627,3 +1628,62 @@ def test_run_plugin_method_until_first_success_for_active_plugins_only(
     # then
     assert result is None
     assert mock_run_method.call_count == calls
+
+
+@mock.patch(
+    "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
+)
+def test_excluded_shipping_methods_for_checkout_run_webhook_on_existing_shipping_methods(
+    mock__run_method_on_plugins, channel_USD, checkout
+):
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+    ]
+
+    manager = PluginsManager(plugins=plugins)
+
+    # given shipping methods contain at least 1 method
+
+    shipping_method = ShippingMethodData(
+        id="123",
+        price=Money(Decimal("10.59"), "USD"),
+    )
+
+    non_empty_shipping_methods = [shipping_method]
+
+    # when manager executes for shipping methods exclusion
+
+    manager.excluded_shipping_methods_for_checkout(
+        checkout, channel_USD, non_empty_shipping_methods
+    )
+
+    # then webhook should be emitted
+
+    mock__run_method_on_plugins.assert_called_once()
+
+
+@mock.patch(
+    "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
+)
+def test_excluded_shipping_methods_for_checkout_dont_run_webhook_on_missing_shipping_methods(
+    mock__run_method_on_plugins, channel_USD, checkout
+):
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+    ]
+
+    manager = PluginsManager(plugins=plugins)
+
+    # given shipping methods are empty
+
+    non_empty_shipping_methods = []
+
+    # when manager executes for shipping methods exclusion
+
+    manager.excluded_shipping_methods_for_checkout(
+        checkout, channel_USD, non_empty_shipping_methods
+    )
+
+    # then webhook should not be emitted
+
+    mock__run_method_on_plugins.assert_not_called()

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1676,17 +1676,18 @@ def test_excluded_shipping_methods_for_checkout_dont_run_webhook_on_missing_ship
 
     # given shipping methods are empty
 
-    non_empty_shipping_methods = []
+    empty_shipping_methods = []
 
     # when manager executes for shipping methods exclusion
 
     manager.excluded_shipping_methods_for_checkout(
-        checkout, channel_USD, non_empty_shipping_methods
+        checkout, channel_USD, empty_shipping_methods
     )
 
     # then webhook should not be emitted
 
     mock__run_method_on_plugins.assert_not_called()
+
 
 @mock.patch(
     "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
@@ -1711,13 +1712,12 @@ def test_excluded_shipping_methods_for_order_run_webhook_on_existing_shipping_me
 
     # when manager executes for shipping methods exclusion
 
-    manager.excluded_shipping_methods_for_order(
-        draft_order, non_empty_shipping_methods
-    )
+    manager.excluded_shipping_methods_for_order(draft_order, non_empty_shipping_methods)
 
     # then webhook should be emitted
 
     mock__run_method_on_plugins.assert_called_once()
+
 
 @mock.patch(
     "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
@@ -1737,9 +1737,7 @@ def test_excluded_shipping_methods_for_order_dont_run_webhook_on_missing_shippin
 
     # when manager executes for shipping methods exclusion
 
-    manager.excluded_shipping_methods_for_order(
-        draft_order, non_empty_shipping_methods
-    )
+    manager.excluded_shipping_methods_for_order(draft_order, non_empty_shipping_methods)
 
     # then webhook should not be emitted
 

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1687,3 +1687,60 @@ def test_excluded_shipping_methods_for_checkout_dont_run_webhook_on_missing_ship
     # then webhook should not be emitted
 
     mock__run_method_on_plugins.assert_not_called()
+
+@mock.patch(
+    "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
+)
+def test_excluded_shipping_methods_for_order_run_webhook_on_existing_shipping_methods(
+    mock__run_method_on_plugins, draft_order
+):
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+    ]
+
+    manager = PluginsManager(plugins=plugins)
+
+    # given shipping methods contain at least 1 method
+
+    shipping_method = ShippingMethodData(
+        id="123",
+        price=Money(Decimal("10.59"), "USD"),
+    )
+
+    non_empty_shipping_methods = [shipping_method]
+
+    # when manager executes for shipping methods exclusion
+
+    manager.excluded_shipping_methods_for_order(
+        draft_order, non_empty_shipping_methods
+    )
+
+    # then webhook should be emitted
+
+    mock__run_method_on_plugins.assert_called_once()
+
+@mock.patch(
+    "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
+)
+def test_excluded_shipping_methods_for_order_dont_run_webhook_on_missing_shipping_methods(
+    mock__run_method_on_plugins, draft_order
+):
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+    ]
+
+    manager = PluginsManager(plugins=plugins)
+
+    # given shipping methods are empty
+
+    non_empty_shipping_methods = []
+
+    # when manager executes for shipping methods exclusion
+
+    manager.excluded_shipping_methods_for_order(
+        draft_order, non_empty_shipping_methods
+    )
+
+    # then webhook should not be emitted
+
+    mock__run_method_on_plugins.assert_not_called()

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1733,11 +1733,11 @@ def test_excluded_shipping_methods_for_order_dont_run_webhook_on_missing_shippin
 
     # given shipping methods are empty
 
-    non_empty_shipping_methods = []
+    empty_shipping_methods = []
 
     # when manager executes for shipping methods exclusion
 
-    manager.excluded_shipping_methods_for_order(draft_order, non_empty_shipping_methods)
+    manager.excluded_shipping_methods_for_order(draft_order, empty_shipping_methods)
 
     # then webhook should not be emitted
 


### PR DESCRIPTION
This PR effectively prevents `CHECKOUT_FILTER_SHIPPING_METHODS` to be emitted if shipping methods list is empty.

Business-wise - if e.g. address is not set, shipping methods available to chose (and filter) are empty. 
Previously, the sync webhook was emitted anyway - now it won't

- [x] Finish test for `query checkout` to verify if empty address leads to empty methods 
- [x] Add the same behavior for draftOrder (`ORDER_FILTER_SHIPPING_METHODS`)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
