### PR TITLE
Fix checkout order line creation in case of empty `ProductTranslation`

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -447,9 +447,13 @@ def _create_lines_for_order(
         quantities.append(line_info.line.quantity)
         products.append(line_info.product)
 
-    products_translation = ProductTranslation.objects.filter(
-        product__in=products, language_code=translation_language_code
-    ).values("product_id", "name")
+    products_translation = (
+        ProductTranslation.objects.filter(
+            product__in=products, language_code=translation_language_code
+        )
+        .exclude(name__isnull=True)
+        .values("product_id", "name")
+    )
     product_translations = {
         product_translation["product_id"]: product_translation.get("name")
         for product_translation in products_translation

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -4590,3 +4590,103 @@ def test_checkout_complete_log_unknown_discount_reason(
     assert not order_line.unit_discount_reason
     assert "Unknown discount reason" in caplog.text
     assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
+
+
+@patch("saleor.order.calculations._recalculate_with_plugins")
+@patch("saleor.plugins.manager.PluginsManager.order_confirmed")
+def test_checkout_complete_empty_product_translation(
+    order_confirmed_mock,
+    recalculate_with_plugins_mock,
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    address,
+    shipping_method,
+    transaction_events_generator,
+    transaction_item_generator,
+    caplog,
+):
+    # given
+    checkout = prepare_checkout_for_test(
+        checkout_with_gift_card,
+        address,
+        address,
+        shipping_method,
+        transaction_item_generator,
+        transaction_events_generator,
+    )
+
+    checkout_line = checkout.lines.first()
+    checkout_line_quantity = checkout_line.quantity
+    checkout_line_variant = checkout_line.variant
+    checkout_line_product = checkout_line_variant.product
+
+    checkout_line_product.translations.create(language_code="en")
+    checkout_line_variant.translations.create(language_code="en")
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    orders_count = Order.objects.count()
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+
+    order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.origin == OrderOrigin.CHECKOUT
+    assert not order.original
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
+    assert str(order.id) == order_token
+    assert order.redirect_url == redirect_url
+    assert order.total.gross == total.gross
+    assert order.subtotal.gross == get_subtotal(order.lines.all(), order.currency).gross
+    assert order.metadata == checkout.metadata_storage.metadata
+    assert order.private_metadata == checkout.metadata_storage.private_metadata
+    transaction = order.payment_transactions.first()
+    assert transaction
+    assert order.total_charged_amount == transaction.charged_value
+    assert order.total_authorized == zero_money(order.currency)
+
+    order_line = order.lines.first()
+
+    assert checkout_line_quantity == order_line.quantity
+    assert checkout_line_variant == order_line.variant
+    assert order_line.translated_product_name == ""
+    assert order_line.translated_variant_name == ""
+
+    assert order.shipping_address == address
+    assert order.shipping_method == checkout.shipping_method
+    assert order.search_vector
+
+    gift_card.refresh_from_db()
+    assert gift_card.current_balance == zero_money(gift_card.currency)
+    assert gift_card.last_used_on
+    assert GiftCardEvent.objects.filter(
+        gift_card=gift_card, type=GiftCardEvents.USED_IN_ORDER
+    )
+    assert not Checkout.objects.filter(pk=checkout.pk).exists(), (
+        "Checkout should have been deleted"
+    )
+    order_confirmed_mock.assert_called_once_with(order, webhooks=set())
+    recalculate_with_plugins_mock.assert_not_called()
+
+    assert not len(Reservation.objects.all())

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -2536,3 +2536,52 @@ def test_order_from_checkout_tax_error(
     assert data["errors"][0]["field"] is None
     assert not Order.objects.exists()
     assert "Tax app error for checkout" in caplog.text
+
+
+def test_order_from_checkout_with_transaction_empty_product_translation(
+    app_api_client,
+    site_settings,
+    checkout_with_item,
+    permission_handle_checkouts,
+    permission_manage_checkouts,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_variant = checkout_line.variant
+    checkout_line_product = checkout_line_variant.product
+    checkout_line_product.translations.create(language_code="en")
+    checkout_line_variant.translations.create(language_code="en")
+
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_ORDER_CREATE_FROM_CHECKOUT,
+        variables,
+        permissions=[permission_handle_checkouts, permission_manage_checkouts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderCreateFromCheckout"]
+    assert not data["errors"]
+
+    order = Order.objects.first()
+
+    assert order.status == OrderStatus.UNCONFIRMED
+    assert order.origin == OrderOrigin.CHECKOUT
+    assert not order.original
+
+    order_line = order.lines.first()
+    assert order_line.translated_product_name == ""
+    assert order_line.translated_variant_name == ""

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -308,6 +308,43 @@ def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
     assert existing_line.quantity_unfulfilled == quantity_unfulfilled_before + 1
 
 
+def test_add_variant_to_order_adds_line_empty_product_translation(
+    order_with_lines,
+    product,
+    anonymous_plugins,
+):
+    # given
+    order = order_with_lines
+    variant = product.variants.get()
+    product.translations.create(language_code="en")
+    lines_before = order.lines.count()
+    line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=1)
+
+    # when
+    add_variant_to_order(
+        order=order,
+        line_data=line_data,
+        user=None,
+        app=None,
+        manager=anonymous_plugins,
+    )
+
+    # then
+    line = order.lines.last()
+    assert order.lines.count() == lines_before + 1
+    assert line.product_sku == variant.sku
+    assert line.product_variant_id == variant.get_global_id()
+    assert line.quantity == 1
+    assert line.unit_price == TaxedMoney(net=Money(10, "USD"), gross=Money(10, "USD"))
+    assert line.variant_name == str(variant)
+    assert line.product_name == str(variant.product)
+    assert line.translated_product_name == ""
+    assert line.translated_variant_name == ""
+    assert not line.unit_discount_amount
+    assert not line.unit_discount_value
+    assert not line.unit_discount_reason
+
+
 def test_restock_fulfillment_lines(fulfilled_order, warehouse):
     fulfillment = fulfilled_order.fulfillments.first()
     line_1 = fulfillment.lines.first()

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -243,8 +243,8 @@ def create_order_line(
     product_name = str(product)
     variant_name = str(variant)
     language_code = order.language_code
-    translated_product_name = get_translation(product, language_code).name
-    translated_variant_name = get_translation(variant, language_code).name
+    translated_product_name = get_translation(product, language_code).name or ""
+    translated_variant_name = get_translation(variant, language_code).name or ""
     if translated_product_name == product_name:
         translated_product_name = ""
     if translated_variant_name == variant_name:

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -442,7 +442,7 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
 
     def display_product(self, translated: bool = False) -> str:
         if translated:
-            product = get_translation(self.product).name
+            product = get_translation(self.product).name or ""
             variant_display = get_translation(self).name
         else:
             variant_display = str(self)


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/17319

When a `ProductTranslation.name` is `None`, the checkout complete and order line creation is failing as the `product_name` on `OrderLine` cannot be `None`


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
