### PR TITLE
Do not raise an error in case of updating shipping address for checkout without shipping required

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -220,7 +220,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             error_msg = "This pick up point is not applicable."
 
         delivery_method_is_valid = clean_delivery_method(
-            checkout_info=checkout_info, lines=lines, method=delivery_method
+            checkout_info=checkout_info, method=delivery_method
         )
         if not delivery_method_is_valid:
             raise ValidationError(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -15,7 +15,6 @@ from ....checkout.fetch import (
 from ....checkout.utils import (
     change_shipping_address_in_checkout,
     invalidate_checkout,
-    is_shipping_required,
 )
 from ....core.tracing import traced_atomic_transaction
 from ....graphql.account.mixins import AddressMetadataMixin
@@ -35,7 +34,6 @@ from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
 from .utils import (
     ERROR_CC_ADDRESS_CHANGE_FORBIDDEN,
-    ERROR_DOES_NOT_SHIP,
     check_lines_quantity,
     get_checkout,
     update_checkout_shipping_method_if_invalid,
@@ -146,15 +144,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             checkout,
         )
 
-        if use_legacy_error_flow_for_checkout and not is_shipping_required(lines):
-            raise ValidationError(
-                {
-                    "shipping_address": ValidationError(
-                        ERROR_DOES_NOT_SHIP,
-                        code=CheckoutErrorCode.SHIPPING_NOT_REQUIRED.value,
-                    )
-                }
-            )
         # prevent from changing the shipping address when click and collect is used.
         if checkout.collection_point_id:
             raise ValidationError(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -160,7 +160,6 @@ class CheckoutShippingMethodUpdate(BaseMutation):
     ) -> None:
         delivery_method_is_valid = clean_delivery_method(
             checkout_info=checkout_info,
-            lines=lines,
             method=delivery_method,
         )
         if not delivery_method_is_valid or not delivery_method:

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -66,7 +66,6 @@ class CheckoutLineData:
 
 def clean_delivery_method(
     checkout_info: "CheckoutInfo",
-    lines: Iterable[CheckoutLineInfo],
     method: Optional[
         Union[
             shipping_interface.ShippingMethodData,
@@ -78,11 +77,6 @@ def clean_delivery_method(
     if not method:
         # no shipping method was provided, it is valid
         return True
-
-    if not is_shipping_required(lines):
-        raise ValidationError(
-            ERROR_DOES_NOT_SHIP, code=CheckoutErrorCode.SHIPPING_NOT_REQUIRED.value
-        )
 
     if not checkout_info.shipping_address and isinstance(
         method, shipping_interface.ShippingMethodData
@@ -123,7 +117,6 @@ def update_checkout_shipping_method_if_invalid(
 
     is_valid = clean_delivery_method(
         checkout_info=checkout_info,
-        lines=lines,
         method=checkout_info.delivery_method_info.delivery_method,
     )
 

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
@@ -63,7 +63,6 @@ def test_checkout_shipping_method_update_by_id(
 
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),
@@ -104,7 +103,6 @@ def test_checkout_shipping_method_update_by_token(
 
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),
@@ -199,7 +197,6 @@ def test_checkout_shipping_method_update_by_id_no_checkout_metadata(
 
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -118,7 +118,7 @@ def test_checkout_delivery_method_update(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
     if is_valid_delivery_method:
@@ -243,7 +243,7 @@ def test_checkout_delivery_method_update_no_checkout_metadata(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
     if is_valid_delivery_method:
@@ -605,7 +605,7 @@ def test_checkout_delivery_method_update_valid_method_not_all_shipping_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -660,7 +660,7 @@ def test_checkout_delivery_method_update_valid_method_not_all_shipping_data_for_
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
     assert checkout.shipping_address == delivery_method.address
@@ -720,7 +720,7 @@ def test_checkout_delivery_method_update_invalid_method_not_all_shipping_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -788,7 +788,7 @@ def test_checkout_delivery_method_update_invalid_with_not_valid_address_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -853,7 +853,7 @@ def test_checkout_delivery_method_update_valid_with_not_valid_address_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -913,7 +913,7 @@ def test_checkout_delivery_method_update_valid_with_not_valid_address_data_for_c
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -43,6 +43,9 @@ MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
                     id
                     name
                 }
+                shippingAddress {
+                    postalCode
+                }
             }
             errors {
                 field
@@ -995,17 +998,12 @@ def test_checkout_update_shipping_address_with_digital(
     content = get_graphql_content(response)
     data = content["data"]["checkoutShippingAddressUpdate"]
 
-    assert data["errors"] == [
-        {
-            "field": "shippingAddress",
-            "message": "This checkout doesn't need shipping",
-            "code": CheckoutErrorCode.SHIPPING_NOT_REQUIRED.name,
-        }
-    ]
+    assert not data["errors"]
+    assert data["checkout"]["shippingAddress"]
 
-    # Ensure the address was unchanged
+    # Ensure the address was set
     checkout.refresh_from_db(fields=["shipping_address"])
-    assert checkout.shipping_address is None
+    assert checkout.shipping_address
 
 
 def test_checkout_shipping_address_update_with_not_applicable_voucher(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -77,7 +77,6 @@ def test_checkout_shipping_method_update(
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -1733,7 +1733,6 @@ def test_order_from_checkout_with_digital(
 ):
     """Ensure it is possible to complete a digital checkout without shipping."""
 
-    order_count = Order.objects.count()
     checkout = checkout_with_digital_item
     variables = {"id": graphene.Node.to_global_id("Checkout", checkout.pk)}
 
@@ -1750,10 +1749,46 @@ def test_order_from_checkout_with_digital(
     content = get_graphql_content(response)["data"]["orderCreateFromCheckout"]
     assert not content["errors"]
 
+    order = Order.objects.first()
     # Ensure the order was actually created
-    assert (
-        Order.objects.count() == order_count + 1
-    ), "The order should have been created"
+    assert order, "The order should have been created"
+
+    assert not order.shipping_address
+    assert order.billing_address
+
+
+def test_order_from_checkout_with_digital_and_shipping_address(
+    app_api_client,
+    permission_handle_checkouts,
+    checkout_with_digital_item,
+    address,
+):
+    """Ensure it is possible to complete a digital checkout without shipping."""
+
+    checkout = checkout_with_digital_item
+    variables = {"id": graphene.Node.to_global_id("Checkout", checkout.pk)}
+
+    # Set a billing address
+    checkout.billing_address = address
+    checkout.shipping_address = address
+    checkout.save(update_fields=["billing_address", "shipping_address"])
+
+    # Send the creation request
+    response = app_api_client.post_graphql(
+        MUTATION_ORDER_CREATE_FROM_CHECKOUT,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
+    content = get_graphql_content(response)["data"]["orderCreateFromCheckout"]
+    assert not content["errors"]
+
+    order = Order.objects.first()
+    # Ensure the order was actually created
+    assert order, "The order should have been created"
+
+    # FIXME: fix together with ext-1684
+    assert not order.shipping_address
+    assert order.billing_address
 
 
 @pytest.mark.integration

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -70,7 +70,7 @@ def test_clean_delivery_method_after_shipping_address_changes_stay_the_same(
     delivery_method = convert_to_shipping_method_data(
         shipping_method, shipping_method.channel_listings.first()
     )
-    is_valid_method = clean_delivery_method(checkout_info, lines, delivery_method)
+    is_valid_method = clean_delivery_method(checkout_info, delivery_method)
     assert is_valid_method is True
 
 
@@ -83,7 +83,7 @@ def test_clean_delivery_method_with_preorder_is_valid_for_enabled_warehouse(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    is_valid_method = clean_delivery_method(checkout_info, lines, warehouses_for_cc[1])
+    is_valid_method = clean_delivery_method(checkout_info, warehouses_for_cc[1])
 
     assert is_valid_method is True
 
@@ -98,7 +98,7 @@ def test_clean_delivery_method_does_nothing_if_no_shipping_method(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    is_valid_method = clean_delivery_method(checkout_info, lines, None)
+    is_valid_method = clean_delivery_method(checkout_info, None)
     assert is_valid_method is True
 
 


### PR DESCRIPTION
Allow setting checkout shipping address for checkout without shipping required.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
