### PR TITLE
Do not raise an error in case of updating shipping address for checkout without shipping required

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -216,7 +216,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             error_msg = "This pick up point is not applicable."
 
         delivery_method_is_valid = clean_delivery_method(
-            checkout_info=checkout_info, lines=lines, method=delivery_method
+            checkout_info=checkout_info, method=delivery_method
         )
         if not delivery_method_is_valid:
             raise ValidationError(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -14,7 +14,6 @@ from ....checkout.fetch import (
 from ....checkout.utils import (
     change_shipping_address_in_checkout,
     invalidate_checkout,
-    is_shipping_required,
 )
 from ....core.tracing import traced_atomic_transaction
 from ....graphql.account.mixins import AddressMetadataMixin
@@ -34,7 +33,6 @@ from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
 from .utils import (
     ERROR_CC_ADDRESS_CHANGE_FORBIDDEN,
-    ERROR_DOES_NOT_SHIP,
     check_lines_quantity,
     get_checkout,
     update_checkout_shipping_method_if_invalid,
@@ -144,15 +142,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             checkout,
         )
 
-        if use_legacy_error_flow_for_checkout and not is_shipping_required(lines):
-            raise ValidationError(
-                {
-                    "shipping_address": ValidationError(
-                        ERROR_DOES_NOT_SHIP,
-                        code=CheckoutErrorCode.SHIPPING_NOT_REQUIRED.value,
-                    )
-                }
-            )
         # prevent from changing the shipping address when click and collect is used.
         if checkout.collection_point_id:
             raise ValidationError(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -157,7 +157,6 @@ class CheckoutShippingMethodUpdate(BaseMutation):
     ) -> None:
         delivery_method_is_valid = clean_delivery_method(
             checkout_info=checkout_info,
-            lines=lines,
             method=delivery_method,
         )
         if not delivery_method_is_valid or not delivery_method:

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -65,18 +65,12 @@ class CheckoutLineData:
 
 def clean_delivery_method(
     checkout_info: "CheckoutInfo",
-    lines: list[CheckoutLineInfo],
     method: shipping_interface.ShippingMethodData | warehouse_models.Warehouse | None,
 ) -> bool:
     """Check if current shipping method is valid."""
     if not method:
         # no shipping method was provided, it is valid
         return True
-
-    if not is_shipping_required(lines):
-        raise ValidationError(
-            ERROR_DOES_NOT_SHIP, code=CheckoutErrorCode.SHIPPING_NOT_REQUIRED.value
-        )
 
     if not checkout_info.shipping_address and isinstance(
         method, shipping_interface.ShippingMethodData
@@ -117,7 +111,6 @@ def update_checkout_shipping_method_if_invalid(
 
     is_valid = clean_delivery_method(
         checkout_info=checkout_info,
-        lines=lines,
         method=checkout_info.delivery_method_info.delivery_method,
     )
 

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
@@ -63,7 +63,6 @@ def test_checkout_shipping_method_update_by_id(
 
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),
@@ -104,7 +103,6 @@ def test_checkout_shipping_method_update_by_token(
 
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),
@@ -199,7 +197,6 @@ def test_checkout_shipping_method_update_by_id_no_checkout_metadata(
 
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -3373,7 +3373,6 @@ def test_checkout_complete_with_digital(
 ):
     """Ensure it is possible to complete a digital checkout without shipping."""
 
-    order_count = Order.objects.count()
     checkout = checkout_with_digital_item
     variables = {
         "id": to_global_id_or_none(checkout),
@@ -3405,10 +3404,58 @@ def test_checkout_complete_with_digital(
     content = get_graphql_content(response)["data"]["checkoutComplete"]
     assert not content["errors"]
 
+    order = Order.objects.first()
     # Ensure the order was actually created
-    assert Order.objects.count() == order_count + 1, (
-        "The order should have been created"
+    assert order, "The order should have been created"
+
+    assert not order.shipping_address
+    assert order.billing_address
+
+
+def test_checkout_complete_with_digital_and_shipping_address(
+    api_client, checkout_with_digital_item, address, payment_dummy
+):
+    """Ensure it is possible to complete a digital checkout without shipping."""
+
+    checkout = checkout_with_digital_item
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    # Set a billing address
+    checkout.billing_address = address
+    checkout.shipping_address = address
+    checkout.save(update_fields=["billing_address", "shipping_address"])
+
+    # Create a dummy payment to charge
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+    total = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    # Send the creation request
+    response = api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+    content = get_graphql_content(response)["data"]["checkoutComplete"]
+    assert not content["errors"]
+
+    order = Order.objects.first()
+    # Ensure the order was actually created
+    assert order, "The order should have been created"
+
+    # FIXME: fix together with ext-1684
+    assert not order.shipping_address
+    assert order.billing_address
 
 
 @pytest.mark.integration

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -104,10 +104,12 @@ def prepare_checkout_for_test(
     transaction_item_generator,
     transaction_events_generator,
     voucher=None,
+    user=None,
 ):
     checkout.shipping_address = shipping_address
     checkout.shipping_method = shipping_method
     checkout.billing_address = billing_address
+    checkout.user = user
     checkout.save()
 
     manager = get_plugins_manager(allow_replica=False)
@@ -3466,6 +3468,7 @@ def test_checkout_complete_with_digital(
     address,
     transaction_events_generator,
     transaction_item_generator,
+    customer_user,
 ):
     # given
     checkout = prepare_checkout_for_test(
@@ -3475,6 +3478,7 @@ def test_checkout_complete_with_digital(
         None,
         transaction_item_generator,
         transaction_events_generator,
+        user=customer_user,
     )
 
     variables = {
@@ -3489,8 +3493,51 @@ def test_checkout_complete_with_digital(
     content = get_graphql_content(response)["data"]["checkoutComplete"]
     assert not content["errors"]
 
+    order = Order.objects.first()
     # Ensure the order was actually created
-    assert Order.objects.count() == 1, "The order should have been created"
+    assert order, "The order should have been created"
+
+    # FIXME: fix together with ext-1684
+    assert not order.shipping_address
+    assert order.billing_address
+
+
+def test_checkout_complete_with_digital_no_shipping_address_set(
+    api_client,
+    checkout_with_digital_item,
+    address,
+    transaction_events_generator,
+    transaction_item_generator,
+    customer_user,
+):
+    # given
+    checkout = prepare_checkout_for_test(
+        checkout_with_digital_item,
+        None,
+        address,
+        None,
+        transaction_item_generator,
+        transaction_events_generator,
+        user=customer_user,
+    )
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    # when
+    response = api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)["data"]["checkoutComplete"]
+    assert not content["errors"]
+
+    order = Order.objects.first()
+    # Ensure the order was actually created
+    assert order, "The order should have been created"
+    assert not order.shipping_address
+    assert order.billing_address
 
 
 def test_complete_checkout_for_local_click_and_collect(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -118,7 +118,7 @@ def test_checkout_delivery_method_update(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
     if is_valid_delivery_method:
@@ -243,7 +243,7 @@ def test_checkout_delivery_method_update_no_checkout_metadata(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
     if is_valid_delivery_method:
@@ -665,7 +665,7 @@ def test_checkout_delivery_method_update_valid_method_not_all_shipping_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -720,7 +720,7 @@ def test_checkout_delivery_method_update_valid_method_not_all_shipping_data_for_
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
     assert checkout.shipping_address == delivery_method.address
@@ -780,7 +780,7 @@ def test_checkout_delivery_method_update_invalid_method_not_all_shipping_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -848,7 +848,7 @@ def test_checkout_delivery_method_update_invalid_with_not_valid_address_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -913,7 +913,7 @@ def test_checkout_delivery_method_update_valid_with_not_valid_address_data(
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 
@@ -973,7 +973,7 @@ def test_checkout_delivery_method_update_valid_with_not_valid_address_data_for_c
     checkout.refresh_from_db()
 
     mock_clean_delivery.assert_called_once_with(
-        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+        checkout_info=checkout_info, method=shipping_method_data
     )
     errors = data["errors"]
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -43,6 +43,9 @@ MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
                     id
                     name
                 }
+                shippingAddress {
+                    postalCode
+                }
             }
             errors {
                 field
@@ -995,17 +998,12 @@ def test_checkout_update_shipping_address_with_digital(
     content = get_graphql_content(response)
     data = content["data"]["checkoutShippingAddressUpdate"]
 
-    assert data["errors"] == [
-        {
-            "field": "shippingAddress",
-            "message": "This checkout doesn't need shipping",
-            "code": CheckoutErrorCode.SHIPPING_NOT_REQUIRED.name,
-        }
-    ]
+    assert not data["errors"]
+    assert data["checkout"]["shippingAddress"]
 
-    # Ensure the address was unchanged
+    # Ensure the address was set
     checkout.refresh_from_db(fields=["shipping_address"])
-    assert checkout.shipping_address is None
+    assert checkout.shipping_address
 
 
 def test_checkout_shipping_address_update_with_not_applicable_voucher(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -77,7 +77,6 @@ def test_checkout_shipping_method_update(
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mock_clean_shipping.assert_called_once_with(
         checkout_info=checkout_info,
-        lines=lines,
         method=convert_to_shipping_method_data(
             shipping_method, shipping_method.channel_listings.first()
         ),

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -70,7 +70,7 @@ def test_clean_delivery_method_after_shipping_address_changes_stay_the_same(
     delivery_method = convert_to_shipping_method_data(
         shipping_method, shipping_method.channel_listings.first()
     )
-    is_valid_method = clean_delivery_method(checkout_info, lines, delivery_method)
+    is_valid_method = clean_delivery_method(checkout_info, delivery_method)
     assert is_valid_method is True
 
 
@@ -83,7 +83,7 @@ def test_clean_delivery_method_with_preorder_is_valid_for_enabled_warehouse(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    is_valid_method = clean_delivery_method(checkout_info, lines, warehouses_for_cc[1])
+    is_valid_method = clean_delivery_method(checkout_info, warehouses_for_cc[1])
 
     assert is_valid_method is True
 
@@ -98,7 +98,7 @@ def test_clean_delivery_method_does_nothing_if_no_shipping_method(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    is_valid_method = clean_delivery_method(checkout_info, lines, None)
+    is_valid_method = clean_delivery_method(checkout_info, None)
     assert is_valid_method is True
 
 


### PR DESCRIPTION
Allow setting checkout shipping address for checkout without shipping required.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
