### PR TITLE
Remove c&c when assigning shipping method with CheckoutShippingMethodUpdate

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -213,13 +213,12 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
         delete_external_shipping_id(checkout=checkout)
         checkout.shipping_method = shipping_method
+        checkout.collection_point = None
         invalidate_prices_updated_fields = invalidate_checkout(
             checkout_info, lines, manager, save=False
         )
         checkout.save(
-            update_fields=[
-                "shipping_method",
-            ]
+            update_fields=["shipping_method", "collection_point"]
             + invalidate_prices_updated_fields
         )
         get_checkout_metadata(checkout).save()
@@ -254,13 +253,12 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
         set_external_shipping_id(checkout=checkout, app_shipping_id=delivery_method.id)
         checkout.shipping_method = None
+        checkout.collection_point = None
         invalidate_prices_updated_fields = invalidate_checkout(
             checkout_info, lines, manager, save=False
         )
         checkout.save(
-            update_fields=[
-                "shipping_method",
-            ]
+            update_fields=["shipping_method", "collection_point"]
             + invalidate_prices_updated_fields
         )
         get_checkout_metadata(checkout).save()

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -99,6 +99,39 @@ def test_checkout_shipping_method_update(
         assert checkout.last_change == previous_last_change
 
 
+def test_checkout_shipping_method_update_removes_c_and_c(
+    staff_api_client,
+    shipping_method,
+    checkout_with_item_and_shipping_method,
+    address,
+    warehouse_for_cc,
+):
+    # given
+    checkout = checkout_with_item_and_shipping_method
+    checkout.shipping_address = address
+    checkout.collection_point = warehouse_for_cc
+    checkout.save(update_fields=["shipping_address", "collection_point"])
+
+    query = MUTATION_UPDATE_SHIPPING_METHOD
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, {"id": to_global_id_or_none(checkout), "shippingMethodId": method_id}
+    )
+
+    # then
+    data = get_graphql_content(response)["data"]["checkoutShippingMethodUpdate"]
+
+    checkout.refresh_from_db()
+
+    errors = data["errors"]
+    assert not errors
+    assert data["checkout"]["token"] == str(checkout.token)
+    assert checkout.shipping_method == shipping_method
+    assert checkout.collection_point is None
+
+
 @mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 def test_checkout_shipping_method_update_external_shipping_method(
     mock_send_request,
@@ -139,6 +172,53 @@ def test_checkout_shipping_method_update_external_shipping_method(
 
     errors = data["errors"]
     assert not errors
+    assert data["checkout"]["token"] == str(checkout_with_item.token)
+    assert PRIVATE_META_APP_SHIPPING_ID in checkout.metadata_storage.private_metadata
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+def test_checkout_shipping_method_update_external_shipping_method_removes_c_and_c(
+    mock_send_request,
+    staff_api_client,
+    address,
+    checkout_with_item,
+    shipping_app,
+    channel_USD,
+    settings,
+    warehouse_for_cc,
+):
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    response_method_id = "abcd"
+    mock_json_response = [
+        {
+            "id": response_method_id,
+            "name": "Provider - Economy",
+            "amount": "10",
+            "currency": "USD",
+            "maximum_delivery_days": "7",
+        }
+    ]
+    mock_send_request.return_value = mock_json_response
+
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.collection_point = warehouse_for_cc
+    checkout.save(update_fields=["shipping_address", "collection_point"])
+
+    method_id = graphene.Node.to_global_id(
+        "app", f"{shipping_app.id}:{response_method_id}"
+    )
+
+    response = staff_api_client.post_graphql(
+        MUTATION_UPDATE_SHIPPING_METHOD,
+        {"id": to_global_id_or_none(checkout_with_item), "shippingMethodId": method_id},
+    )
+    data = get_graphql_content(response)["data"]["checkoutShippingMethodUpdate"]
+    checkout.refresh_from_db()
+
+    errors = data["errors"]
+    assert not errors
+    assert checkout.collection_point is None
     assert data["checkout"]["token"] == str(checkout_with_item.token)
     assert PRIVATE_META_APP_SHIPPING_ID in checkout.metadata_storage.private_metadata
 


### PR DESCRIPTION
I want to merge this change because it removes the assignment of collection_point, when assigning `CheckoutShippingMethodUpdate`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
