### PR TITLE
Do not return external shipping methods with different currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added support for the AWS_S3_URL_PROTOCOL environment variable - #17305 by @p-febis
 - Fixed pycurl dependency and required system libraries to fix Celery worker issues when using SQS by @mariobrgomes
 - Added [`alg`](https://datatracker.ietf.org/doc/html/rfc7517#section-4.4) key to JWKS available at `/.well-known/jwks.json` - #17363 by @lkostrowski
+- Fix the issue of returning external shipping methods in a currency different from the checkout currency. - #17350 by @korycins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,5 +63,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added support for the AWS_S3_URL_PROTOCOL environment variable - #17305 by @p-febis
 - Fixed pycurl dependency and required system libraries to fix Celery worker issues when using SQS by @mariobrgomes
 - Added [`alg`](https://datatracker.ietf.org/doc/html/rfc7517#section-4.4) key to JWKS available at `/.well-known/jwks.json` - #17363 by @lkostrowski
-- Fix the issue of returning external shipping methods in a currency different from the checkout currency. - #17350 by @korycins
 - `checkout.shippingMethods` and `checkout.availableShippingMethods` will no longer return external shipping methods if their currency differs from the checkout's currency - #17350 by @korycins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed pycurl dependency and required system libraries to fix Celery worker issues when using SQS by @mariobrgomes
 - Added [`alg`](https://datatracker.ietf.org/doc/html/rfc7517#section-4.4) key to JWKS available at `/.well-known/jwks.json` - #17363 by @lkostrowski
 - Fix the issue of returning external shipping methods in a currency different from the checkout currency. - #17350 by @korycins
+- `checkout.shippingMethods` and `checkout.availableShippingMethods` will no longer return external shipping methods if their currency differs from the checkout's currency - #17350 by @korycins

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -158,16 +158,6 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )
 
-        if delivery_method and delivery_method.price.currency != checkout.currency:
-            raise ValidationError(
-                {
-                    "delivery_method_id": ValidationError(
-                        "Cannot choose shipping method with different currency than the checkout.",
-                        code=CheckoutErrorCode.DELIVERY_METHOD_NOT_APPLICABLE.value,
-                    )
-                }
-            )
-
         cls._update_delivery_method(
             manager,
             checkout_info,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -419,11 +419,8 @@ def test_checkout_delivery_method_update_external_shipping_invalid_currency(
     errors = data["errors"]
     assert len(errors) == 1
     assert errors[0]["field"] == "deliveryMethodId"
-    assert errors[0]["code"] == CheckoutErrorCode.DELIVERY_METHOD_NOT_APPLICABLE.name
-    assert (
-        errors[0]["message"]
-        == "Cannot choose shipping method with different currency than the checkout."
-    )
+    assert errors[0]["code"] == CheckoutErrorCode.NOT_FOUND.name
+    assert errors[0]["message"] == f"Couldn't resolve to a node: ${method_id}"
 
 
 @patch(

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2583,7 +2583,12 @@ class PluginsManager(PaymentInterface):
                 # https://github.com/python/mypy/issues/9975
                 getattr(plugin, "get_shipping_methods_for_checkout")(checkout, None)
             )
-        return shipping_methods
+        return list(
+            filter(
+                lambda method: method.price.currency == checkout.currency,
+                shipping_methods,
+            )
+        )
 
     def get_shipping_method(
         self,

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -14,6 +14,7 @@ from ...payment.interface import (
     TransactionSessionData,
     TransactionSessionResult,
 )
+from ...shipping.interface import ShippingMethodData
 from ..base_plugin import BasePlugin, ConfigurationTypeField, ExternalAccessTokens
 
 if TYPE_CHECKING:
@@ -365,6 +366,24 @@ class PluginSample(BasePlugin):
 
     def payment_method_process_tokenization(self, request_data, previous_value):
         return previous_value
+
+    def get_shipping_methods_for_checkout(
+        self, checkout: "Checkout", previous_value: Any
+    ) -> list["ShippingMethodData"]:
+        different_currency = "EUR"
+        assert checkout.currency != different_currency
+        return [
+            ShippingMethodData(
+                id="123",
+                price=Money(Decimal(10), currency=different_currency),
+                name="EUR shipping",
+            ),
+            ShippingMethodData(
+                id="123",
+                price=Money(Decimal(10), currency=checkout.currency),
+                name="Defualt shipping",
+            ),
+        ]
 
 
 class ChannelPluginSample(PluginSample):

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -381,7 +381,7 @@ class PluginSample(BasePlugin):
             ShippingMethodData(
                 id="123",
                 price=Money(Decimal(10), currency=checkout.currency),
-                name="Defualt shipping",
+                name="Default shipping",
             ),
         ]
 

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1630,6 +1630,25 @@ def test_run_plugin_method_until_first_success_for_active_plugins_only(
     assert mock_run_method.call_count == calls
 
 
+def test_manager_skips_external_shipping_with_different_currency_than_checkout_currency(
+    checkout_with_item,
+):
+    # given
+    plugins = ["saleor.plugins.tests.sample_plugins.PluginSample"]
+
+    # when
+    shipping_methods = PluginsManager(
+        plugins=plugins
+    ).list_shipping_methods_for_checkout(
+        checkout=checkout_with_item,
+        channel_slug=checkout_with_item.channel.slug,
+    )
+
+    # then
+    assert len(shipping_methods) == 1
+    assert shipping_methods[0].price.currency == checkout_with_item.currency
+
+
 @mock.patch(
     "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_plugins"
 )


### PR DESCRIPTION
I want to merge this change because it filters external shipping methods to return only those with the same currency as checkout's currency. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1473

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined
