### PR TITLE
Add Makefile with common dev commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,25 +103,40 @@ You are ready to go 🎉.
 
 ### Common commands
 
+Saleor uses [Makefile](https://www.cs.colby.edu/maxwell/courses/tutorials/maketutor/) to store common development commands.
+
+List all development commands:
+
+```shell
+make
+```
+
 To start server:
 
 ```shell
-uvicorn saleor.asgi:application --reload
+make runserver
+```
+
+To run all tests (with database reuse):
+
+```shell
+make test
 ```
 
 To run database migrations:
 
 ```shell
-python manage.py migrate
+make migrate
 ```
 
 To populate database with example data and create the admin user:
 
 ```shell
-python manage.py populatedb --createsuperuser
+make populatedb
 ```
 
-*Note that `--createsuperuser` argument creates an admin account for `admin@example.com` with the password set to `admin`.*
+> [!NOTE]
+> `populatedb` populates database with example data and creates an admin account for `admin@example.com` with the password set to `admin`.*
 
 
 ## Managing dependencies
@@ -214,20 +229,6 @@ to ensure that our tests do not hit any external API without explicitly allowing
 The test file structure was introduced in the [tests file structure](./contributing#tests-file-structure).
 The main rule is not to overload test files. Smaller files are always preferable over big ones where lots of logic is tested, and it's hard to extend.
 In the case of testing the `API`, we would like to split all tests into `mutations` and `queries` sections and test every query and mutation in a separate file.
-
-### How to run tests?
-
-To run tests, enter `pytest` in your terminal.
-
-```bash
-pytest
-```
-
-We recommend using the `reuse-db` flag to speed up testing time.
-
-```bash
-pytest --reuse-db
-```
 
 ### How to run particular tests?
 
@@ -352,7 +353,7 @@ Use relative imports.
 ### Migrations
 
 Try to combine multiple migrations into one, but remember not to mix changes on the database with updating rows in migrations. In other words, operations that alter tables and use `RunPython` to run methods on existing data should be in separate files.
-Follow [zero-downtime policy](./developer/community/zero-downtime-migrations.mdx) when writing migrations.
+Follow [zero-downtime policy](https://docs.saleor.io/developer/community/zero-downtime-migrations) when writing migrations.
 
 ### Handling migrations between versions
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: runserver migrate populatedb test help
+.PHONY: runserver migrate populatedb test help build-schema release
 
 help: ## Display this help message
 	@echo "Saleor Development Commands:"

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,9 @@ populatedb: ## Populate database with example data and create superuser
 
 test: ## Run tests with database reuse
 	pytest --reuse-db
+
+build-schema: ## Build GraphQL schema
+	npm run build-schema
+
+release: ## Create a new release
+	npm run release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: runserver migrate populatedb test help
+
+help: ## Display this help message
+	@echo "Saleor Development Commands:"
+	@echo
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+runserver: ## Start the development server with auto-reload
+	uvicorn saleor.asgi:application --reload
+
+migrate: ## Run database migrations
+	python manage.py migrate
+
+populatedb: ## Populate database with example data and create superuser
+	python manage.py populatedb --createsuperuser
+
+test: ## Run tests with database reuse
+	pytest --reuse-db


### PR DESCRIPTION
I want to merge this change because this PR adds `Makefile` to store & easy reuse of common dev commands. You can read more on this [blog post](https://krzysztofzuraw.com/blog/2016/makefiles-in-python-projects/) 😄 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
