### PR TITLE
Fix productVariantBulkUpdate not saved fields to DB (3.20)

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -685,8 +685,12 @@ class ProductVariantBulkUpdate(BaseMutation):
                 "metadata",
                 "private_metadata",
                 "external_reference",
+                "preorder_end_date",
+                "preorder_global_threshold",
+                "is_preorder",
             ],
         )
+
         if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
             warehouse_models.Stock.objects.bulk_create(stocks_to_create)
         else:

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -116,6 +116,10 @@ def test_product_variant_bulk_update(
         {
             "id": variant_id,
             "name": new_name,
+            "preorder": {
+                "endDate": "2022-12-12T12:12:12Z",
+                "globalThreshold": 10,
+            },
             "metadata": [{"key": metadata_key, "value": metadata_value}],
         }
     ]
@@ -145,6 +149,12 @@ def test_product_variant_bulk_update(
     assert product_variant_created_webhook_mock.call_count == data["count"]
     for rule in get_active_catalogue_promotion_rules():
         assert rule.variants_dirty
+
+    variant.refresh_from_db()
+
+    assert variant.preorder_end_date
+    assert variant.preorder_global_threshold
+    assert variant.is_preorder
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I want to merge this change because it is port of https://github.com/saleor/saleor/pull/17342 to `3.20`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
