### PR TITLE
Allow providing saving address strategy in checkout mutations

### DIFF
--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -33,6 +33,7 @@ class CheckoutErrorCode(Enum):
     NON_EDITABLE_GIFT_LINE = "non_editable_gift_line"
     NON_REMOVABLE_GIFT_LINE = "non_removable_gift_line"
     SHIPPING_CHANGE_FORBIDDEN = "shipping_change_forbidden"
+    MISSING_ADDRESS_DATA = "missing_address_data"
 
 
 class OrderCreateFromCheckoutErrorCode(Enum):

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1821,12 +1821,13 @@ def test_change_address_in_checkout(checkout, address):
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
+    store_address_in_user_addresses = False
 
     shipping_updated_fields = change_shipping_address_in_checkout(
         checkout_info,
         address,
+        store_address_in_user_addresses,
         lines,
-        manager,
         checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(checkout, address)
@@ -1836,12 +1837,14 @@ def test_change_address_in_checkout(checkout, address):
     assert checkout.shipping_address == address
     assert checkout.billing_address == address
     assert checkout_info.shipping_address == address
+    assert checkout.save_shipping_address == store_address_in_user_addresses
 
 
 def test_change_address_in_checkout_to_none(checkout, address):
     checkout.shipping_address = address
     checkout.billing_address = address.get_copy()
     checkout.save()
+    store_address_in_user_addresses = False
 
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
@@ -1849,8 +1852,8 @@ def test_change_address_in_checkout_to_none(checkout, address):
     shipping_updated_fields = change_shipping_address_in_checkout(
         checkout_info,
         None,
+        store_address_in_user_addresses,
         lines,
-        manager,
         checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(checkout, None)
@@ -1860,6 +1863,7 @@ def test_change_address_in_checkout_to_none(checkout, address):
     assert checkout.shipping_address is None
     assert checkout.billing_address is None
     assert checkout_info.shipping_address is None
+    assert checkout.save_shipping_address == store_address_in_user_addresses
 
 
 def test_change_address_in_checkout_to_same(checkout, address):
@@ -1868,6 +1872,7 @@ def test_change_address_in_checkout_to_same(checkout, address):
     checkout.save(update_fields=["shipping_address", "billing_address"])
     shipping_address_id = checkout.shipping_address.id
     billing_address_id = checkout.billing_address.id
+    store_address_in_user_addresses = True
 
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
@@ -1875,8 +1880,8 @@ def test_change_address_in_checkout_to_same(checkout, address):
     shipping_updated_fields = change_shipping_address_in_checkout(
         checkout_info,
         address,
+        store_address_in_user_addresses,
         lines,
-        manager,
         checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(checkout, address)
@@ -1886,6 +1891,7 @@ def test_change_address_in_checkout_to_same(checkout, address):
     assert checkout.shipping_address.id == shipping_address_id
     assert checkout.billing_address.id == billing_address_id
     assert checkout_info.shipping_address == address
+    assert checkout.save_shipping_address == store_address_in_user_addresses
 
 
 def test_change_address_in_checkout_to_other(checkout, address):
@@ -1894,6 +1900,7 @@ def test_change_address_in_checkout_to_other(checkout, address):
     checkout.billing_address = address.get_copy()
     checkout.save(update_fields=["shipping_address", "billing_address"])
     other_address = Address.objects.create(country=Country("DE"))
+    store_address_in_user_addresses = True
 
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
@@ -1901,8 +1908,8 @@ def test_change_address_in_checkout_to_other(checkout, address):
     shipping_updated_fields = change_shipping_address_in_checkout(
         checkout_info,
         other_address,
+        store_address_in_user_addresses,
         lines,
-        manager,
         checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(checkout, other_address)
@@ -1913,6 +1920,7 @@ def test_change_address_in_checkout_to_other(checkout, address):
     assert checkout.billing_address == other_address
     assert not Address.objects.filter(id=address_id).exists()
     assert checkout_info.shipping_address == other_address
+    assert checkout.save_shipping_address == store_address_in_user_addresses
 
 
 def test_change_address_in_checkout_from_user_address_to_other(
@@ -1924,6 +1932,7 @@ def test_change_address_in_checkout_from_user_address_to_other(
     checkout.billing_address = address.get_copy()
     checkout.save(update_fields=["shipping_address", "billing_address"])
     other_address = Address.objects.create(country=Country("DE"))
+    store_address_in_user_addresses = True
 
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
@@ -1931,8 +1940,8 @@ def test_change_address_in_checkout_from_user_address_to_other(
     shipping_updated_fields = change_shipping_address_in_checkout(
         checkout_info,
         other_address,
+        store_address_in_user_addresses,
         lines,
-        manager,
         checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(checkout, other_address)
@@ -1950,6 +1959,7 @@ def test_change_address_in_checkout_invalidates_shipping_methods(
 ):
     # given
     checkout = checkout_with_items
+    store_address_in_user_addresses = True
 
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
@@ -1967,8 +1977,8 @@ def test_change_address_in_checkout_invalidates_shipping_methods(
     shipping_updated_fields = change_shipping_address_in_checkout(
         checkout_info,
         address,
+        store_address_in_user_addresses,
         lines,
-        manager,
         checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(checkout, address)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -466,7 +466,9 @@ def _check_new_checkout_address(checkout, address, address_type):
     return has_address_changed, remove_old_address
 
 
-def change_billing_address_in_checkout(checkout, address) -> list[str]:
+def change_billing_address_in_checkout(
+    checkout: "Checkout", address: "Address", store_in_user_addresses: bool
+) -> list[str]:
     """Save billing address in checkout if changed.
 
     Remove previously saved address if not connected to any user.
@@ -479,9 +481,12 @@ def change_billing_address_in_checkout(checkout, address) -> list[str]:
     updated_fields = []
     if changed:
         if remove:
-            checkout.billing_address.delete()
+            checkout.billing_address.delete()  # type: ignore[union-attr]
         checkout.billing_address = address
         updated_fields = ["billing_address", "last_change"]
+    if checkout.save_billing_address != store_in_user_addresses:
+        checkout.save_billing_address = store_in_user_addresses
+        updated_fields.append("save_billing_address")
     return updated_fields
 
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -488,8 +488,8 @@ def change_billing_address_in_checkout(checkout, address) -> list[str]:
 def change_shipping_address_in_checkout(
     checkout_info: "CheckoutInfo",
     address: "Address",
+    store_in_user_addresses: bool,
     lines: list["CheckoutLineInfo"],
-    manager: "PluginsManager",
     shipping_channel_listings: Iterable["ShippingMethodChannelListing"],
 ):
     """Save shipping address in checkout if changed.
@@ -516,6 +516,9 @@ def change_shipping_address_in_checkout(
             shipping_channel_listings=shipping_channel_listings,
         )
         updated_fields = ["shipping_address", "last_change"]
+    if checkout.save_shipping_address != store_in_user_addresses:
+        checkout.save_shipping_address = store_in_user_addresses
+        updated_fields.append("save_shipping_address")
     return updated_fields
 
 

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -159,7 +159,7 @@ class I18nMixin:
         format_check=True,
         required_check=True,
         enable_normalization=True,
-    ):
+    ) -> Address:
         if address_data.get("country") is None:
             params = {"address_type": address_type} if address_type else {}
             raise ValidationError(

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -8,7 +8,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import AddressInput
 from ...core import ResolveInfo
-from ...core.descriptions import DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
@@ -48,7 +48,8 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
                 "Indicates whether the billing address should be saved "
                 "to the user’s address book upon checkout completion. "
                 "If not provided, the default behavior is to save the address."
-            ),
+            )
+            + ADDED_IN_321,
         )
         validation_rules = CheckoutAddressValidationRules(
             required=False,

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -45,7 +45,9 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             required=False,
             default_value=True,
             description=(
-                "If true, the address will be saved in the user's address book."
+                "Indicates whether the billing address should be saved "
+                "to the user’s address book upon checkout completion."
+                "If not provided, the default behavior is to save the address."
             ),
         )
         validation_rules = CheckoutAddressValidationRules(

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -41,6 +41,13 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         billing_address = AddressInput(
             required=True, description="The billing address of the checkout."
         )
+        save_address = graphene.Boolean(
+            required=False,
+            default_value=True,
+            description=(
+                "If true, the address will be saved in the user's address book."
+            ),
+        )
         validation_rules = CheckoutAddressValidationRules(
             required=False,
             description=(
@@ -68,6 +75,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         /,
         *,
         billing_address,
+        save_address,
         validation_rules=None,
         checkout_id=None,
         token=None,
@@ -91,7 +99,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         with traced_atomic_transaction():
             billing_address.save()
             change_address_updated_fields = change_billing_address_in_checkout(
-                checkout, billing_address
+                checkout, billing_address, save_address
             )
             lines, _ = fetch_checkout_lines(checkout)
             checkout_info = fetch_checkout_info(checkout, lines, manager)

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -46,7 +46,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             default_value=True,
             description=(
                 "Indicates whether the billing address should be saved "
-                "to the user’s address book upon checkout completion."
+                "to the user’s address book upon checkout completion. "
                 "If not provided, the default behavior is to save the address."
             ),
         )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -141,7 +141,8 @@ class CheckoutCreateInput(BaseInputObjectType):
         description=(
             "Indicates whether the shipping address should be saved "
             "to the user’s address book upon checkout completion."
-            "Can only be set when a shipping address is provided."
+            "Can only be set when a shipping address is provided. If not specified "
+            "along with the address, the default behavior is to save the address."
         )
     )
     shipping_address = AddressInput(
@@ -156,7 +157,8 @@ class CheckoutCreateInput(BaseInputObjectType):
         description=(
             "Indicates whether the billing address should be saved "
             "to the user’s address book upon checkout completion. "
-            "Can only be set when a billing address is provided."
+            "Can only be set when a billing address is provided.  If not specified "
+            "along with the address, the default behavior is to save the address."
         )
     )
     billing_address = AddressInput(

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -157,7 +157,7 @@ class CheckoutCreateInput(BaseInputObjectType):
         description=(
             "Indicates whether the billing address should be saved "
             "to the user’s address book upon checkout completion. "
-            "Can only be set when a billing address is provided.  If not specified "
+            "Can only be set when a billing address is provided. If not specified "
             "along with the address, the default behavior is to save the address."
         )
     )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -18,7 +18,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel
 from ...core import ResolveInfo
-from ...core.descriptions import DEPRECATED_IN_3X_FIELD
+from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_FIELD
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelMutation
@@ -144,6 +144,7 @@ class CheckoutCreateInput(BaseInputObjectType):
             "Can only be set when a shipping address is provided. If not specified "
             "along with the address, the default behavior is to save the address."
         )
+        + ADDED_IN_321
     )
     shipping_address = AddressInput(
         description=(
@@ -160,6 +161,7 @@ class CheckoutCreateInput(BaseInputObjectType):
             "Can only be set when a billing address is provided. If not specified "
             "along with the address, the default behavior is to save the address."
         )
+        + ADDED_IN_321
     )
     billing_address = AddressInput(
         description=(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -21,7 +21,7 @@ from ....warehouse.reservations import is_reservation_enabled
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
-from ...core.descriptions import DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -71,7 +71,8 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
                 "Indicates whether the shipping address should be saved "
                 "to the user’s address book upon checkout completion. "
                 "If not provided, the default behavior is to save the address."
-            ),
+            )
+            + ADDED_IN_321,
         )
         validation_rules = CheckoutAddressValidationRules(
             required=False,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -64,6 +64,13 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             required=True,
             description="The mailing address to where the checkout will be shipped.",
         )
+        save_address = graphene.Boolean(
+            required=False,
+            default_value=True,
+            description=(
+                "If true, the address will be saved in the user's address book."
+            ),
+        )
         validation_rules = CheckoutAddressValidationRules(
             required=False,
             description=(
@@ -119,6 +126,7 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
         info,
         /,
         shipping_address,
+        save_address,
         validation_rules=None,
         checkout_id=None,
         token=None,
@@ -191,8 +199,8 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             shipping_address_updated_fields = change_shipping_address_in_checkout(
                 checkout_info,
                 shipping_address_instance,
+                save_address,
                 lines,
-                manager,
                 shipping_channel_listings,
             )
         invalidate_prices_updated_fields = invalidate_checkout(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -69,7 +69,7 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             default_value=True,
             description=(
                 "Indicates whether the shipping address should be saved "
-                "to the user’s address book upon checkout completion."
+                "to the user’s address book upon checkout completion. "
                 "If not provided, the default behavior is to save the address."
             ),
         )

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -68,7 +68,9 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             required=False,
             default_value=True,
             description=(
-                "If true, the address will be saved in the user's address book."
+                "Indicates whether the shipping address should be saved "
+                "to the user’s address book upon checkout completion."
+                "If not provided, the default behavior is to save the address."
             ),
         )
         validation_rules = CheckoutAddressValidationRules(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -11,12 +11,14 @@ from .....product.models import ProductChannelListing, ProductVariantChannelList
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
+from .test_utils import validate_address_data
 
 MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
     mutation checkoutBillingAddressUpdate(
             $checkoutId: ID,
             $id: ID,
             $billingAddress: AddressInput!
+            $saveAddress: Boolean
             $validationRules: CheckoutAddressValidationRules
         ) {
         checkoutBillingAddressUpdate(
@@ -24,6 +26,7 @@ MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
                 checkoutId: $checkoutId,
                 billingAddress: $billingAddress
                 validationRules: $validationRules
+                saveAddress: $saveAddress
         ){
             checkout {
                 token,
@@ -58,19 +61,7 @@ def test_checkout_billing_address_update_by_id(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.billing_address is not None
-    assert checkout.billing_address.first_name == billing_address["firstName"]
-    assert checkout.billing_address.last_name == billing_address["lastName"]
-    assert (
-        checkout.billing_address.street_address_1 == billing_address["streetAddress1"]
-    )
-    assert (
-        checkout.billing_address.street_address_2 == billing_address["streetAddress2"]
-    )
-    assert checkout.billing_address.postal_code == billing_address["postalCode"]
-    assert checkout.billing_address.country == billing_address["country"]
-    assert checkout.billing_address.city == billing_address["city"].upper()
-    assert checkout.billing_address.validation_skipped is False
+    validate_address_data(checkout.billing_address, billing_address)
 
 
 @pytest.mark.parametrize(
@@ -110,19 +101,7 @@ def test_checkout_billing_address_update_when_line_without_listing(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.billing_address is not None
-    assert checkout.billing_address.first_name == billing_address["firstName"]
-    assert checkout.billing_address.last_name == billing_address["lastName"]
-    assert (
-        checkout.billing_address.street_address_1 == billing_address["streetAddress1"]
-    )
-    assert (
-        checkout.billing_address.street_address_2 == billing_address["streetAddress2"]
-    )
-    assert checkout.billing_address.postal_code == billing_address["postalCode"]
-    assert checkout.billing_address.country == billing_address["country"]
-    assert checkout.billing_address.city == billing_address["city"].upper()
-    assert checkout.billing_address.validation_skipped is False
+    validate_address_data(checkout.billing_address, billing_address)
 
 
 def test_checkout_billing_address_update_by_id_without_required_fields(
@@ -184,20 +163,7 @@ def test_checkout_billing_address_update_by_id_without_street_address_2(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.billing_address is not None
-    assert checkout.billing_address.first_name == billing_address["firstName"]
-    assert checkout.billing_address.last_name == billing_address["lastName"]
-    assert (
-        checkout.billing_address.street_address_1 == billing_address["streetAddress1"]
-    )
-    assert (
-        checkout.billing_address.street_address_2
-        == billing_address["streetAddress2"]
-        == ""
-    )
-    assert checkout.billing_address.postal_code == billing_address["postalCode"]
-    assert checkout.billing_address.country == billing_address["country"]
-    assert checkout.billing_address.city == billing_address["city"].upper()
+    validate_address_data(checkout.billing_address, billing_address)
 
 
 @mock.patch(
@@ -242,19 +208,7 @@ def test_checkout_billing_address_update(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.billing_address.metadata == {"public": "public_value"}
-    assert checkout.billing_address is not None
-    assert checkout.billing_address.first_name == billing_address["firstName"]
-    assert checkout.billing_address.last_name == billing_address["lastName"]
-    assert (
-        checkout.billing_address.street_address_1 == billing_address["streetAddress1"]
-    )
-    assert (
-        checkout.billing_address.street_address_2 == billing_address["streetAddress2"]
-    )
-    assert checkout.billing_address.postal_code == billing_address["postalCode"]
-    assert checkout.billing_address.country == billing_address["country"]
-    assert checkout.billing_address.city == billing_address["city"].upper()
+    validate_address_data(checkout.billing_address, billing_address)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout.call_count == 1
 
@@ -784,3 +738,113 @@ def test_checkout_billing_address_triggers_webhooks(
 
     tax_delivery = tax_delivery_call.args[0]
     assert tax_delivery.webhook_id == tax_webhook.id
+
+
+def test_checkout_billing_address_update_reset_the_save_address_flag_to_default_value(
+    checkout_with_items,
+    user_api_client,
+    graphql_address_data,
+    address,
+):
+    checkout = checkout_with_items
+    # given checkout billing and billing address set both save billing flags different
+    # than default value - set to False
+    checkout.billing_address = address
+    checkout.billing_address = address
+    checkout.save_billing_address = False
+    checkout.save_shipping_address = False
+    checkout.save(
+        update_fields=[
+            "billing_address",
+            "billing_address",
+            "save_billing_address",
+            "save_shipping_address",
+        ]
+    )
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": graphql_address_data,
+    }
+
+    # when the checkout billing address is updated without providing saveAddress flag
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then the checkout billing address is updated, and `save_billing_address` is
+    # reset to the default True value; the `save_billing_address` is not changed
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+
+    checkout.refresh_from_db()
+    validate_address_data(checkout.billing_address, graphql_address_data)
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is False
+
+
+def test_checkout_billing_address_update_with_save_address_to_false(
+    checkout_with_items,
+    user_api_client,
+    graphql_address_data,
+):
+    # given checkout with default saving address values
+    checkout = checkout_with_items
+
+    save_address = False
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": graphql_address_data,
+        "saveAddress": save_address,
+    }
+
+    # when update billing address with saveAddress flag set to False
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then the address should be saved and the save_billing_address should be False
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    validate_address_data(checkout.billing_address, graphql_address_data)
+    assert checkout.save_billing_address is save_address
+    assert checkout.save_shipping_address is True
+
+
+def test_checkout_billing_address_update_change_save_address_option_to_true(
+    checkout_with_items,
+    user_api_client,
+    graphql_address_data,
+):
+    # given checkout with save addresses settings to False
+    checkout = checkout_with_items
+    checkout.save_billing_address = False
+    checkout.save_shipping_address = False
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": graphql_address_data,
+        "saveAddress": True,
+    }
+
+    # when the billing address is updated with saveAddress flag set to True
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then the address should be saved and the save_billing_address should be True
+    # the save_billing_address should not be changed
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    validate_address_data(checkout.billing_address, graphql_address_data)
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -11,7 +11,7 @@ from .....product.models import ProductChannelListing, ProductVariantChannelList
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
-from .test_utils import validate_address_data
+from .test_utils import assert_address_data
 
 MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
     mutation checkoutBillingAddressUpdate(
@@ -61,7 +61,7 @@ def test_checkout_billing_address_update_by_id(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.billing_address, billing_address)
+    assert_address_data(checkout.billing_address, billing_address)
     assert checkout.save_billing_address is True
 
 
@@ -102,7 +102,7 @@ def test_checkout_billing_address_update_when_line_without_listing(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.billing_address, billing_address)
+    assert_address_data(checkout.billing_address, billing_address)
     assert checkout.save_billing_address is True
 
 
@@ -165,7 +165,7 @@ def test_checkout_billing_address_update_by_id_without_street_address_2(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.billing_address, billing_address)
+    assert_address_data(checkout.billing_address, billing_address)
     assert checkout.save_billing_address is True
 
 
@@ -211,7 +211,7 @@ def test_checkout_billing_address_update(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.billing_address, billing_address)
+    assert_address_data(checkout.billing_address, billing_address)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout.call_count == 1
     assert checkout.save_billing_address is True
@@ -784,7 +784,7 @@ def test_checkout_billing_address_update_reset_the_save_address_flag_to_default_
     assert not data["errors"]
 
     checkout.refresh_from_db()
-    validate_address_data(checkout.billing_address, graphql_address_data)
+    assert_address_data(checkout.billing_address, graphql_address_data)
     assert checkout.save_billing_address is True
     assert checkout.save_shipping_address is False
 
@@ -815,7 +815,7 @@ def test_checkout_billing_address_update_with_save_address_to_false(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.billing_address, graphql_address_data)
+    assert_address_data(checkout.billing_address, graphql_address_data)
     assert checkout.save_billing_address is save_address
     assert checkout.save_shipping_address is True
 
@@ -849,6 +849,6 @@ def test_checkout_billing_address_update_change_save_address_option_to_true(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.billing_address, graphql_address_data)
+    assert_address_data(checkout.billing_address, graphql_address_data)
     assert checkout.save_billing_address is True
     assert checkout.save_shipping_address is False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -62,6 +62,7 @@ def test_checkout_billing_address_update_by_id(
     assert not data["errors"]
     checkout.refresh_from_db()
     validate_address_data(checkout.billing_address, billing_address)
+    assert checkout.save_billing_address is True
 
 
 @pytest.mark.parametrize(
@@ -102,6 +103,7 @@ def test_checkout_billing_address_update_when_line_without_listing(
     assert not data["errors"]
     checkout.refresh_from_db()
     validate_address_data(checkout.billing_address, billing_address)
+    assert checkout.save_billing_address is True
 
 
 def test_checkout_billing_address_update_by_id_without_required_fields(
@@ -164,6 +166,7 @@ def test_checkout_billing_address_update_by_id_without_street_address_2(
     assert not data["errors"]
     checkout.refresh_from_db()
     validate_address_data(checkout.billing_address, billing_address)
+    assert checkout.save_billing_address is True
 
 
 @mock.patch(
@@ -211,6 +214,7 @@ def test_checkout_billing_address_update(
     validate_address_data(checkout.billing_address, billing_address)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout.call_count == 1
+    assert checkout.save_billing_address is True
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -592,7 +592,10 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
     checkout_line = new_checkout.lines.first()
     assert checkout_line.variant == variant
     assert checkout_line.quantity == 1
+    assert new_checkout.billing_address is not None
     assert new_checkout.shipping_address is not None
+    assert new_checkout.save_shipping_address is True
+    assert new_checkout.save_billing_address is True
     assert (
         new_checkout.shipping_address.first_name == shipping_address_data["firstName"]
     )
@@ -2791,3 +2794,119 @@ def test_checkout_create_triggers_webhooks(
     assert WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES in sync_deliveries
     tax_delivery = sync_deliveries[WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES]
     assert tax_delivery.webhook_id == tax_webhook.id
+
+
+@pytest.mark.parametrize(
+    ("save_shipping_address", "save_billing_address"),
+    [(True, True), (True, False), (False, True), (False, False)],
+)
+def test_checkout_create_with_save_addresses_setting_provided(
+    save_shipping_address,
+    save_billing_address,
+    api_client,
+    stock,
+    graphql_address_data,
+    channel_USD,
+):
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    # given input with provided shipping, billing addresses with save settings
+    shipping_address_data = graphql_address_data.copy()
+    billing_address_data = graphql_address_data.copy()
+
+    variables = {
+        "checkoutInput": {
+            "channel": channel_USD.slug,
+            "lines": [{"quantity": 1, "variantId": variant_id}],
+            "shippingAddress": shipping_address_data,
+            "billingAddress": billing_address_data,
+            "saveShippingAddress": save_shipping_address,
+            "saveBillingAddress": save_billing_address,
+        }
+    }
+    assert not Checkout.objects.exists()
+
+    # when checkout create is called with provided variables
+    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+
+    # then the addresses with save settings are set
+    content = get_graphql_content(response)["data"]["checkoutCreate"]
+    assert not content["errors"]
+    new_checkout = Checkout.objects.first()
+    assert new_checkout is not None
+    checkout_data = content["checkout"]
+    assert checkout_data["token"] == str(new_checkout.token)
+    assert new_checkout.billing_address is not None
+    assert new_checkout.shipping_address is not None
+    assert new_checkout.save_billing_address == save_billing_address
+    assert new_checkout.save_shipping_address == save_shipping_address
+    assert not Reservation.objects.exists()
+
+    assert new_checkout.billing_address.validation_skipped is False
+    assert new_checkout.shipping_address.validation_skipped is False
+
+
+@pytest.mark.parametrize("save_shipping_address", [True, False])
+def test_checkout_create_no_shipping_address_providing_save_address_raising_error(
+    save_shipping_address, api_client, graphql_address_data, channel_USD, stock
+):
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    # given input with save shipping address and shipping method not provided
+    billing_address_data = graphql_address_data.copy()
+
+    variables = {
+        "checkoutInput": {
+            "channel": channel_USD.slug,
+            "lines": [{"quantity": 1, "variantId": variant_id}],
+            "billingAddress": billing_address_data,
+            "saveShippingAddress": save_shipping_address,
+        }
+    }
+    assert not Checkout.objects.exists()
+
+    # when checkout create is called with provided variables
+    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+
+    # then the error is raised
+    data = get_graphql_content(response)["data"]["checkoutCreate"]
+    assert not data["checkout"]
+    errors = data["errors"]
+    assert len(errors) == 1
+
+    error = errors[0]
+    assert error["field"] == "saveShippingAddress"
+    assert error["code"] == CheckoutErrorCode.MISSING_ADDRESS_DATA.name
+
+
+@pytest.mark.parametrize("save_billing_address", [True, False])
+def test_checkout_create_no_billing_address_providing_save_address_raising_error(
+    save_billing_address, api_client, graphql_address_data, channel_USD, stock
+):
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    # given input with save shipping address and shipping method not provided
+    shipping_address_data = graphql_address_data.copy()
+
+    variables = {
+        "checkoutInput": {
+            "channel": channel_USD.slug,
+            "lines": [{"quantity": 1, "variantId": variant_id}],
+            "shippingAddress": shipping_address_data,
+            "saveBillingAddress": save_billing_address,
+        }
+    }
+    assert not Checkout.objects.exists()
+
+    # when checkout create is called with provided variables
+    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+
+    # then the error is raised
+    data = get_graphql_content(response)["data"]["checkoutCreate"]
+    assert not data["checkout"]
+    errors = data["errors"]
+    assert len(errors) == 1
+
+    error = errors[0]
+    assert error["field"] == "saveBillingAddress"
+    assert error["code"] == CheckoutErrorCode.MISSING_ADDRESS_DATA.name

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -24,6 +24,7 @@ from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ...mutations.utils import update_checkout_shipping_method_if_invalid
+from .test_utils import validate_address_data
 
 MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
     mutation checkoutShippingAddressUpdate(
@@ -94,23 +95,6 @@ MUTATION_CHECKOUT_SHIPPING_ADDRESS_WITH_METADATA_UPDATE = """
 """
 
 
-def validate_address_data(checkout, address_data):
-    if metadata := address_data.get("metadata"):
-        assert checkout.shipping_address.metadata == {
-            data["key"]: data["value"] for data in metadata
-        }
-
-    assert checkout.shipping_address is not None
-    assert checkout.shipping_address.first_name == address_data["firstName"]
-    assert checkout.shipping_address.last_name == address_data["lastName"]
-    assert checkout.shipping_address.street_address_1 == address_data["streetAddress1"]
-    assert checkout.shipping_address.street_address_2 == address_data["streetAddress2"]
-    assert checkout.shipping_address.postal_code == address_data["postalCode"]
-    assert checkout.shipping_address.country == address_data["country"]
-    assert checkout.shipping_address.city == address_data["city"].upper()
-    assert checkout.shipping_address.validation_skipped is False
-
-
 @mock.patch(
     "saleor.graphql.checkout.mutations.checkout_shipping_address_update."
     "update_checkout_shipping_method_if_invalid",
@@ -145,7 +129,7 @@ def test_checkout_shipping_address_with_metadata_update(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout, shipping_address)
+    validate_address_data(checkout.shipping_address, shipping_address)
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -207,7 +191,7 @@ def test_checkout_shipping_address_when_variant_without_listing(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout, shipping_address)
+    validate_address_data(checkout.shipping_address, shipping_address)
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -255,7 +239,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout, shipping_address)
+    validate_address_data(checkout.shipping_address, shipping_address)
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -984,7 +968,7 @@ def test_checkout_update_shipping_address_with_digital(
     # Ensure the address was set
     checkout.refresh_from_db(fields=["shipping_address"])
     assert checkout.shipping_address
-    validate_address_data(checkout, graphql_address_data)
+    validate_address_data(checkout.shipping_address, graphql_address_data)
 
 
 def test_checkout_shipping_address_update_with_not_applicable_voucher(
@@ -1268,12 +1252,12 @@ def test_checkout_shipping_address_update_reset_the_save_address_flag_to_default
     assert not data["errors"]
 
     checkout.refresh_from_db()
-    validate_address_data(checkout, graphql_address_data)
+    validate_address_data(checkout.shipping_address, graphql_address_data)
     assert checkout.save_shipping_address is True
     assert checkout.save_billing_address is False
 
 
-def test_checkout_shipping_address_update_with_save_address(
+def test_checkout_shipping_address_update_with_save_address_to_false(
     checkout_with_items,
     user_api_client,
     graphql_address_data,
@@ -1299,12 +1283,12 @@ def test_checkout_shipping_address_update_with_save_address(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout, graphql_address_data)
+    validate_address_data(checkout.shipping_address, graphql_address_data)
     assert checkout.save_shipping_address is save_address
     assert checkout.save_billing_address is True
 
 
-def test_checkout_shipping_address_update_change_save_address_option(
+def test_checkout_shipping_address_update_change_save_address_option_to_true(
     checkout_with_items,
     user_api_client,
     graphql_address_data,
@@ -1333,6 +1317,6 @@ def test_checkout_shipping_address_update_change_save_address_option(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout, graphql_address_data)
+    validate_address_data(checkout.shipping_address, graphql_address_data)
     assert checkout.save_shipping_address is True
     assert checkout.save_billing_address is False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -136,6 +136,7 @@ def test_checkout_shipping_address_with_metadata_update(
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout.call_count == 1
+    assert checkout.save_shipping_address is True
 
 
 @pytest.mark.parametrize(
@@ -198,6 +199,7 @@ def test_checkout_shipping_address_when_variant_without_listing(
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout.call_count == 1
+    assert checkout.save_shipping_address is True
 
 
 @mock.patch(
@@ -246,6 +248,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.country == shipping_address["country"]
     assert checkout.last_change != previous_last_change
+    assert checkout.save_shipping_address is True
 
 
 @mock.patch(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -24,7 +24,7 @@ from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ...mutations.utils import update_checkout_shipping_method_if_invalid
-from .test_utils import validate_address_data
+from .test_utils import assert_address_data
 
 MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
     mutation checkoutShippingAddressUpdate(
@@ -129,7 +129,7 @@ def test_checkout_shipping_address_with_metadata_update(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.shipping_address, shipping_address)
+    assert_address_data(checkout.shipping_address, shipping_address)
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -192,7 +192,7 @@ def test_checkout_shipping_address_when_variant_without_listing(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.shipping_address, shipping_address)
+    assert_address_data(checkout.shipping_address, shipping_address)
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -241,7 +241,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.shipping_address, shipping_address)
+    assert_address_data(checkout.shipping_address, shipping_address)
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -971,7 +971,7 @@ def test_checkout_update_shipping_address_with_digital(
     # Ensure the address was set
     checkout.refresh_from_db(fields=["shipping_address"])
     assert checkout.shipping_address
-    validate_address_data(checkout.shipping_address, graphql_address_data)
+    assert_address_data(checkout.shipping_address, graphql_address_data)
 
 
 def test_checkout_shipping_address_update_with_not_applicable_voucher(
@@ -1255,7 +1255,7 @@ def test_checkout_shipping_address_update_reset_the_save_address_flag_to_default
     assert not data["errors"]
 
     checkout.refresh_from_db()
-    validate_address_data(checkout.shipping_address, graphql_address_data)
+    assert_address_data(checkout.shipping_address, graphql_address_data)
     assert checkout.save_shipping_address is True
     assert checkout.save_billing_address is False
 
@@ -1286,7 +1286,7 @@ def test_checkout_shipping_address_update_with_save_address_to_false(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.shipping_address, graphql_address_data)
+    assert_address_data(checkout.shipping_address, graphql_address_data)
     assert checkout.save_shipping_address is save_address
     assert checkout.save_billing_address is True
 
@@ -1320,6 +1320,6 @@ def test_checkout_shipping_address_update_change_save_address_option_to_true(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    validate_address_data(checkout.shipping_address, graphql_address_data)
+    assert_address_data(checkout.shipping_address, graphql_address_data)
     assert checkout.save_shipping_address is True
     assert checkout.save_billing_address is False

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -181,3 +181,18 @@ def test_group_on_update_when_one_line_and_mixed_parameters_provided(
     assert expected == group_lines_input_data_on_update(
         lines_data, existing_checkout_lines
     )
+
+
+def validate_address_data(address, address_data, validation_skipped=False):
+    if metadata := address_data.get("metadata"):
+        assert address.metadata == {data["key"]: data["value"] for data in metadata}
+
+    assert address is not None
+    assert address.first_name == address_data["firstName"]
+    assert address.last_name == address_data["lastName"]
+    assert address.street_address_1 == address_data["streetAddress1"]
+    assert address.street_address_2 == address_data["streetAddress2"]
+    assert address.postal_code == address_data["postalCode"]
+    assert address.country == address_data["country"]
+    assert address.city == address_data["city"].upper()
+    assert address.validation_skipped == validation_skipped

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -183,7 +183,7 @@ def test_group_on_update_when_one_line_and_mixed_parameters_provided(
     )
 
 
-def validate_address_data(address, address_data, validation_skipped=False):
+def assert_address_data(address, address_data, validation_skipped=False):
     if metadata := address_data.get("metadata"):
         assert address.metadata == {data["key"]: data["value"] for data in metadata}
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17206,7 +17206,9 @@ type Mutation {
     """The checkout's ID."""
     id: ID
 
-    """If true, the address will be saved in the user's address book."""
+    """
+    Indicates whether the billing address should be saved to the user’s address book upon checkout completion.If not provided, the default behavior is to save the address.
+    """
     saveAddress: Boolean = true
 
     """
@@ -17574,7 +17576,9 @@ type Mutation {
     """The checkout's ID."""
     id: ID
 
-    """If true, the address will be saved in the user's address book."""
+    """
+    Indicates whether the shipping address should be saved to the user’s address book upon checkout completion.If not provided, the default behavior is to save the address.
+    """
     saveAddress: Boolean = true
 
     """The mailing address to where the checkout will be shipped."""
@@ -26834,7 +26838,7 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   email: String
 
   """
-  Indicates whether the shipping address should be saved to the user’s address book upon checkout completion.Can only be set when a shipping address is provided.
+  Indicates whether the shipping address should be saved to the user’s address book upon checkout completion.Can only be set when a shipping address is provided. If not specified along with the address, the default behavior is to save the address.
   """
   saveShippingAddress: Boolean
 
@@ -26844,7 +26848,7 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   shippingAddress: AddressInput
 
   """
-  Indicates whether the billing address should be saved to the user’s address book upon checkout completion. Can only be set when a billing address is provided.
+  Indicates whether the billing address should be saved to the user’s address book upon checkout completion. Can only be set when a billing address is provided.  If not specified along with the address, the default behavior is to save the address.
   """
   saveBillingAddress: Boolean
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17571,6 +17571,9 @@ type Mutation {
     """The checkout's ID."""
     id: ID
 
+    """If true, the address will be saved in the user's address book."""
+    saveAddress: Boolean = true
+
     """The mailing address to where the checkout will be shipped."""
     shippingAddress: AddressInput!
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26734,6 +26734,7 @@ enum CheckoutErrorCode @doc(category: "Checkout") {
   NON_EDITABLE_GIFT_LINE
   NON_REMOVABLE_GIFT_LINE
   SHIPPING_CHANGE_FORBIDDEN
+  MISSING_ADDRESS_DATA
 }
 
 """
@@ -26827,9 +26828,19 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   email: String
 
   """
+  Indicates whether the shipping address should be saved to the user’s address book upon checkout completion.Can only be set when a shipping address is provided.
+  """
+  saveShippingAddress: Boolean
+
+  """
   The mailing address to where the checkout will be shipped. Note: the address will be ignored if the checkout doesn't contain shippable items. `skipValidation` requires HANDLE_CHECKOUTS and AUTHENTICATED_APP permissions.
   """
   shippingAddress: AddressInput
+
+  """
+  Indicates whether the billing address should be saved to the user’s address book upon checkout completion. Can only be set when a billing address is provided.
+  """
+  saveBillingAddress: Boolean
 
   """
   Billing address of the customer. `skipValidation` requires HANDLE_CHECKOUTS and AUTHENTICATED_APP permissions.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17206,6 +17206,9 @@ type Mutation {
     """The checkout's ID."""
     id: ID
 
+    """If true, the address will be saved in the user's address book."""
+    saveAddress: Boolean = true
+
     """
     Checkout token.
     

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17207,7 +17207,7 @@ type Mutation {
     id: ID
 
     """
-    Indicates whether the billing address should be saved to the user’s address book upon checkout completion.If not provided, the default behavior is to save the address.
+    Indicates whether the billing address should be saved to the user’s address book upon checkout completion. If not provided, the default behavior is to save the address.
     """
     saveAddress: Boolean = true
 
@@ -17577,7 +17577,7 @@ type Mutation {
     id: ID
 
     """
-    Indicates whether the shipping address should be saved to the user’s address book upon checkout completion.If not provided, the default behavior is to save the address.
+    Indicates whether the shipping address should be saved to the user’s address book upon checkout completion. If not provided, the default behavior is to save the address.
     """
     saveAddress: Boolean = true
 
@@ -26848,7 +26848,7 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   shippingAddress: AddressInput
 
   """
-  Indicates whether the billing address should be saved to the user’s address book upon checkout completion. Can only be set when a billing address is provided.  If not specified along with the address, the default behavior is to save the address.
+  Indicates whether the billing address should be saved to the user’s address book upon checkout completion. Can only be set when a billing address is provided. If not specified along with the address, the default behavior is to save the address.
   """
   saveBillingAddress: Boolean
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17208,6 +17208,8 @@ type Mutation {
 
     """
     Indicates whether the billing address should be saved to the user’s address book upon checkout completion. If not provided, the default behavior is to save the address.
+    
+    Added in Saleor 3.21.
     """
     saveAddress: Boolean = true
 
@@ -17578,6 +17580,8 @@ type Mutation {
 
     """
     Indicates whether the shipping address should be saved to the user’s address book upon checkout completion. If not provided, the default behavior is to save the address.
+    
+    Added in Saleor 3.21.
     """
     saveAddress: Boolean = true
 
@@ -26839,6 +26843,8 @@ input CheckoutCreateInput @doc(category: "Checkout") {
 
   """
   Indicates whether the shipping address should be saved to the user’s address book upon checkout completion.Can only be set when a shipping address is provided. If not specified along with the address, the default behavior is to save the address.
+  
+  Added in Saleor 3.21.
   """
   saveShippingAddress: Boolean
 
@@ -26849,6 +26855,8 @@ input CheckoutCreateInput @doc(category: "Checkout") {
 
   """
   Indicates whether the billing address should be saved to the user’s address book upon checkout completion. Can only be set when a billing address is provided. If not specified along with the address, the default behavior is to save the address.
+  
+  Added in Saleor 3.21.
   """
   saveBillingAddress: Boolean
 


### PR DESCRIPTION
Allow providing saving address option in the following checkout mutations:
- `CheckoutCreate`
- `CheckoutShippingAdddressUpdate`
- `CheckoutBillingAddressUpdate` 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
