### PR TITLE
Reset the `save_shipping_address` during `CheckoutDeliveryMethodUpdate`

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -251,14 +251,16 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
         # Clear checkout shipping address if it was switched from C&C.
         if checkout.collection_point_id and not collection_point:
             checkout.shipping_address = None
-            checkout_fields_to_update += ["shipping_address"]
+            checkout.save_shipping_address = False
+            checkout_fields_to_update += ["shipping_address", "save_shipping_address"]
 
         checkout.shipping_method = shipping_method
         checkout.collection_point = collection_point
         if collection_point is not None:
             checkout.shipping_address = collection_point.address.get_copy()
+            checkout.save_shipping_address = False
             checkout_info.shipping_address = checkout.shipping_address
-            checkout_fields_to_update += ["shipping_address"]
+            checkout_fields_to_update += ["shipping_address", "save_shipping_address"]
         invalidate_prices_updated_fields = invalidate_checkout(
             checkout_info, lines, manager, save=False
         )


### PR DESCRIPTION
Ensure the `save_shipping_address` is reset to default in case the delivery method is updated to or from cc

Extend tests after merging: https://github.com/saleor/saleor/pull/17366

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
