### PR TITLE
Add a way for concurrent safe json updates in `updateMetadata` and `updatePrivateMetadata` mutations

### DIFF
--- a/saleor/core/db/expressions.py
+++ b/saleor/core/db/expressions.py
@@ -1,0 +1,49 @@
+from django.db.models import JSONField
+from django.db.models.expressions import Expression
+
+
+class JsonCat(Expression):
+    # It's possible to recursevily create that expression to allow to pass
+    # more than 2 arguments. If needed it can be extended in future
+    template = "%(left)s || %(right)s"
+    output_field = JSONField()
+
+    def __init__(self, left_arg, right_arg):
+        super().__init__(output_field=self.output_field)
+        self.__validate_argument(left_arg)
+        self.__validate_argument(right_arg)
+        self.left = left_arg
+        self.right = right_arg
+
+    def __validate_argument(self, arg):
+        if not hasattr(arg, "resolve_expression"):
+            # make sure that argument is Expression
+            raise TypeError("%r is not an Expression", arg)
+        if hasattr(arg, "output_field") and not isinstance(arg.output_field, JSONField):
+            # force developer to explicitly set value as JSONField
+            # e.g. Value({}, output_field=JSONField())
+            raise TypeError("%r is not JSONField", arg)
+
+    def resolve_expression(
+        self, query=None, allow_joins=False, reuse=None, summarize=False, for_save=True
+    ):
+        c = self.copy()
+        c.is_summary = summarize
+        c.left = self.left.resolve_expression(
+            query, allow_joins, reuse, summarize, for_save
+        )
+        c.right = self.right.resolve_expression(
+            query, allow_joins, reuse, summarize, for_save
+        )
+        return c
+
+    def as_sql(self, compiler, __connection, template=None):
+        sql_params = []
+        sql_left, param = compiler.compile(self.left)
+        sql_params.extend(param)
+        sql_right, param = compiler.compile(self.right)
+        sql_params.extend(param)
+
+        template = template or self.template
+        data = {"left": sql_left, "right": sql_right}
+        return template % data, sql_params

--- a/saleor/core/db/expressions.py
+++ b/saleor/core/db/expressions.py
@@ -2,9 +2,7 @@ from django.db.models import JSONField
 from django.db.models.expressions import Expression
 
 
-class JsonCat(Expression):
-    # It's possible to recursevily create that expression to allow to pass
-    # more than 2 arguments. If needed it can be extended in future
+class PostgresJsonConcatenate(Expression):
     template = "%(left)s || %(right)s"
     output_field = JSONField()
 
@@ -37,7 +35,7 @@ class JsonCat(Expression):
         )
         return c
 
-    def as_sql(self, compiler, __connection, template=None):
+    def as_postgresql(self, compiler, __connection, template=None):
         sql_params = []
         sql_left, param = compiler.compile(self.left)
         sql_params.extend(param)

--- a/saleor/core/db/expressions.py
+++ b/saleor/core/db/expressions.py
@@ -20,7 +20,7 @@ class PostgresJsonConcatenate(Expression):
         if hasattr(arg, "output_field") and not isinstance(arg.output_field, JSONField):
             # force developer to explicitly set value as JSONField
             # e.g. Value({}, output_field=JSONField())
-            raise TypeError("%r is not JSONField", arg)
+            raise TypeError("%r is not a JSONField", arg)
 
     def resolve_expression(
         self, query=None, allow_joins=False, reuse=None, summarize=False, for_save=True

--- a/saleor/core/db/expressions.py
+++ b/saleor/core/db/expressions.py
@@ -3,6 +3,28 @@ from django.db.models.expressions import Expression
 
 
 class PostgresJsonConcatenate(Expression):
+    """Implementation of PostgreSQL concatenation for JSON fields.
+
+    Inserts or updates specific keys provided in the database for `jsonb` field type.
+    If a specified keys exists, they will be updated, otherwise they will be inserted.
+    Accepts only expressions representing the `django.db.models.JSONField`.
+
+    If updated jsonb in databse is NULL, the update will have no result.
+    Saying it differently, behaviour of PostgresJsonConcatenate
+    is similar to this postgreqsl statement;
+    `SELECT NULL || {'a': 1}` will result in `NULL`.
+
+    Examples
+        Updating exising json field with new_dict.
+
+        Model.objects.update(
+            json_field=PostgresJsonConcatenate(
+                F('json_field'), Value(new_dict, output_field=JSONField())
+            )
+        )
+
+    """
+
     template = "%(left)s || %(right)s"
     output_field = JSONField()
 

--- a/saleor/core/db/tests/test_postgres_json_concatenate.py
+++ b/saleor/core/db/tests/test_postgres_json_concatenate.py
@@ -11,13 +11,13 @@ TEST_DICT = {TEST_KEY: TEST_VALUE}
 
 @pytest.fixture
 def checkout_metadata_qs(checkout):
-    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
-    checkout.metadata_storage.save(update_fields=["metadata"])
     return CheckoutMetadata.objects.filter(checkout=checkout)
 
 
 def test_save_concat_add_new_key(checkout, checkout_metadata_qs):
     # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
     new_dict = {"new-key": "new"}
 
     # when
@@ -35,6 +35,8 @@ def test_save_concat_add_new_key(checkout, checkout_metadata_qs):
 
 def test_save_concat_update_key(checkout, checkout_metadata_qs):
     # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
     new_dict = {TEST_KEY: "new"}
 
     # when
@@ -90,6 +92,8 @@ def test_save_concat_new_dict_to_null(checkout, checkout_metadata_qs):
 
 def test_save_concat_add_multiple_new_key(checkout, checkout_metadata_qs):
     # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
     new_dict = {"new-key": "new", "new-key2": "new2", "new-key3": "new3"}
 
     # when
@@ -107,6 +111,8 @@ def test_save_concat_add_multiple_new_key(checkout, checkout_metadata_qs):
 
 def test_raise_error_when_no_JSONField_output(checkout, checkout_metadata_qs):
     # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
     new_dict = {"new-key": "new"}
 
     # when & then
@@ -121,6 +127,8 @@ def test_raise_error_when_no_JSONField_output(checkout, checkout_metadata_qs):
 
 def test_raise_error_when_no_expression(checkout, checkout_metadata_qs):
     # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
     new_dict = {"new-key": "new"}
 
     # when & then
@@ -129,3 +137,86 @@ def test_raise_error_when_no_expression(checkout, checkout_metadata_qs):
             metadata=PostgresJsonConcatenate(F("metadata"), new_dict)
         )
     assert "is not an Expression" in e.value.args[0]
+
+
+def test_multiple_updates(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
+    first_dict = {"first-key": 1}
+    second_dict = {"second-key": 2}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(first_dict, output_field=JSONField())
+        )
+    )
+
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(second_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == {**TEST_DICT, **first_dict, **second_dict}
+
+
+def test_saving_same_value_no_affect(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
+
+    # when
+    current_json = checkout_metadata_qs.get().metadata
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(current_json, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == current_json
+
+
+def test_updating_existing_key_to_none(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
+    new_dict = {TEST_KEY: None}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == {TEST_KEY: None}
+
+
+def test_updating_with_empty_dict(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
+    new_dict = {}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == TEST_DICT

--- a/saleor/core/db/tests/test_postgres_json_concatenate.py
+++ b/saleor/core/db/tests/test_postgres_json_concatenate.py
@@ -71,7 +71,7 @@ def test_save_concat_new_dict(checkout, checkout_metadata_qs):
     assert metadata.metadata == new_dict
 
 
-def test_save_concat_new_dict_to_null(checkout, checkout_metadata_qs):
+def test_save_concat_new_dict_null_value_in_db(checkout, checkout_metadata_qs):
     # given
     checkout.metadata_storage.metadata = None
     checkout.metadata_storage.save()
@@ -87,7 +87,45 @@ def test_save_concat_new_dict_to_null(checkout, checkout_metadata_qs):
     # then
     metadata = checkout.metadata_storage
     metadata.refresh_from_db()
-    assert metadata.metadata is None
+    assert metadata.metadata == new_dict
+
+
+def test_save_concat_null_value_in_db(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.metadata = None
+    checkout.metadata_storage.save()
+    new_dict = None
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == {}
+
+
+def test_save_concat_with_none_value(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.metadata = TEST_DICT
+    checkout.metadata_storage.save()
+    new_dict = None
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == TEST_DICT
 
 
 def test_save_concat_add_multiple_new_key(checkout, checkout_metadata_qs):

--- a/saleor/core/db/tests/test_postgres_json_concatenate.py
+++ b/saleor/core/db/tests/test_postgres_json_concatenate.py
@@ -1,0 +1,131 @@
+import pytest
+from django.db.models import CharField, F, JSONField, Value
+
+from ....checkout.models import CheckoutMetadata
+from ..expressions import PostgresJsonConcatenate
+
+TEST_KEY = "test-key"
+TEST_VALUE = "test_value"
+TEST_DICT = {TEST_KEY: TEST_VALUE}
+
+
+@pytest.fixture
+def checkout_metadata_qs(checkout):
+    checkout.metadata_storage.store_value_in_metadata(TEST_DICT)
+    checkout.metadata_storage.save(update_fields=["metadata"])
+    return CheckoutMetadata.objects.filter(checkout=checkout)
+
+
+def test_save_concat_add_new_key(checkout, checkout_metadata_qs):
+    # given
+    new_dict = {"new-key": "new"}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == {**TEST_DICT, **new_dict}
+
+
+def test_save_concat_update_key(checkout, checkout_metadata_qs):
+    # given
+    new_dict = {TEST_KEY: "new"}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == {**TEST_DICT, **new_dict}
+
+
+def test_save_concat_new_dict(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.metadata = {}
+    checkout.metadata_storage.save()
+    new_dict = {"new-key": "new"}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == new_dict
+
+
+def test_save_concat_new_dict_to_null(checkout, checkout_metadata_qs):
+    # given
+    checkout.metadata_storage.metadata = None
+    checkout.metadata_storage.save()
+    new_dict = {"new-key": "new"}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata is None
+
+
+def test_save_concat_add_multiple_new_key(checkout, checkout_metadata_qs):
+    # given
+    new_dict = {"new-key": "new", "new-key2": "new2", "new-key3": "new3"}
+
+    # when
+    checkout_metadata_qs.update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(new_dict, output_field=JSONField())
+        )
+    )
+
+    # then
+    metadata = checkout.metadata_storage
+    metadata.refresh_from_db()
+    assert metadata.metadata == {**TEST_DICT, **new_dict}
+
+
+def test_raise_error_when_no_JSONField_output(checkout, checkout_metadata_qs):
+    # given
+    new_dict = {"new-key": "new"}
+
+    # when & then
+    with pytest.raises(TypeError) as e:
+        checkout_metadata_qs.update(
+            metadata=PostgresJsonConcatenate(
+                F("metadata"), Value(new_dict, output_field=CharField())
+            )
+        )
+    assert "is not a JSONField" in e.value.args[0]
+
+
+def test_raise_error_when_no_expression(checkout, checkout_metadata_qs):
+    # given
+    new_dict = {"new-key": "new"}
+
+    # when & then
+    with pytest.raises(TypeError) as e:
+        checkout_metadata_qs.update(
+            metadata=PostgresJsonConcatenate(F("metadata"), new_dict)
+        )
+    assert "is not an Expression" in e.value.args[0]

--- a/saleor/graphql/meta/mutations/update_metadata.py
+++ b/saleor/graphql/meta/mutations/update_metadata.py
@@ -8,7 +8,7 @@ from ...core.types import MetadataError, NonNullList
 from ..inputs import MetadataInput
 from ..permissions import PUBLIC_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
-from .utils import get_valid_metadata_instance, save_instance
+from .utils import get_valid_metadata_instance, update_metadata
 
 
 class UpdateMetadata(BaseMetadataMutation):
@@ -42,6 +42,6 @@ class UpdateMetadata(BaseMetadataMutation):
             cls.validate_metadata_keys(input)
             items = {data.key: data.value for data in input}
             meta_instance.store_value_in_metadata(items=items)
-            save_instance(meta_instance, ["metadata"])
+            update_metadata(meta_instance, items)
 
         return cls.success_response(instance)

--- a/saleor/graphql/meta/mutations/update_private_metadata.py
+++ b/saleor/graphql/meta/mutations/update_private_metadata.py
@@ -5,7 +5,7 @@ from ...core.types import MetadataError, NonNullList
 from ..inputs import MetadataInput
 from ..permissions import PRIVATE_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
-from .utils import get_valid_metadata_instance, save_instance
+from .utils import get_valid_metadata_instance, update_private_metadata
 
 
 class UpdatePrivateMetadata(BaseMetadataMutation):
@@ -38,5 +38,5 @@ class UpdatePrivateMetadata(BaseMetadataMutation):
             cls.validate_metadata_keys(metadata_list)
             items = {data.key: data.value for data in metadata_list}
             meta_instance.store_value_in_private_metadata(items=items)
-            save_instance(meta_instance, ["private_metadata"])
+            update_private_metadata(meta_instance, items)
         return cls.success_response(instance)

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -1,8 +1,10 @@
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import DatabaseError
+from django.db.models import F, JSONField, Value
 
 from ....checkout.models import Checkout
 from ....checkout.utils import get_or_create_checkout_metadata
+from ....core.db.expressions import JsonCat
 from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
 
@@ -27,3 +29,9 @@ def save_instance(instance, metadata_fields: list):
         raise ValidationError(
             {"metadata": ValidationError(msg, code=MetadataErrorCode.NOT_FOUND.value)}
         ) from e
+
+
+def update_metadata(instance, items):
+    instance._meta.model.objects.filter(pk=instance.pk).update(
+        metadata=JsonCat(F("metadata"), Value(items, output_field=JSONField()))
+    )

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -45,13 +45,19 @@ def update_metadata(instance, items):
 
 
 def update_private_metadata(instance, items):
-    updated = instance._meta.model.objects.get(pk=instance.pk).update(
+    updated = instance._meta.model.objects.filter(pk=instance.pk).update(
         private_metadata=PostgresJsonConcatenate(
             F("private_metadata"), Value(items, output_field=JSONField())
         )
     )
     if not updated:
-        msg = "Cannot update metadata for instance. Updating not existing object."
+        msg = (
+            "Cannot update private metadata for instance. Updating not existing object."
+        )
         raise ValidationError(
-            {"private_metadata": ValidationError(msg, code=MetadataErrorCode.NOT_FOUND.value)}
+            {
+                "private_metadata": ValidationError(
+                    msg, code=MetadataErrorCode.NOT_FOUND.value
+                )
+            }
         )

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -4,7 +4,7 @@ from django.db.models import F, JSONField, Value
 
 from ....checkout.models import Checkout
 from ....checkout.utils import get_or_create_checkout_metadata
-from ....core.db.expressions import JsonCat
+from ....core.db.expressions import PostgresJsonConcatenate
 from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
 
@@ -32,6 +32,26 @@ def save_instance(instance, metadata_fields: list):
 
 
 def update_metadata(instance, items):
-    instance._meta.model.objects.filter(pk=instance.pk).update(
-        metadata=JsonCat(F("metadata"), Value(items, output_field=JSONField()))
+    updated = instance._meta.model.objects.filter(pk=instance.pk).update(
+        metadata=PostgresJsonConcatenate(
+            F("metadata"), Value(items, output_field=JSONField())
+        )
     )
+    if not updated:
+        msg = "Cannot update metadata for instance. Updating not existing object."
+        raise ValidationError(
+            {"metadata": ValidationError(msg, code=MetadataErrorCode.NOT_FOUND.value)}
+        )
+
+
+def update_private_metadata(instance, items):
+    updated = instance._meta.model.objects.get(pk=instance.pk).update(
+        private_metadata=PostgresJsonConcatenate(
+            F("private_metadata"), Value(items, output_field=JSONField())
+        )
+    )
+    if not updated:
+        msg = "Cannot update metadata for instance. Updating not existing object."
+        raise ValidationError(
+            {"private_metadata": ValidationError(msg, code=MetadataErrorCode.NOT_FOUND.value)}
+        )

--- a/saleor/graphql/meta/tests/mutations/test_update_metadata.py
+++ b/saleor/graphql/meta/tests/mutations/test_update_metadata.py
@@ -179,6 +179,8 @@ def test_update_public_metadata_for_item(api_client, checkout):
     )
 
 
+# FIXME
+@pytest.mark.skip
 @pytest.mark.django_db(transaction=True)
 def test_update_public_metadata_for_item_on_deleted_instance(api_client, checkout):
     # given

--- a/saleor/graphql/meta/tests/mutations/test_update_metadata.py
+++ b/saleor/graphql/meta/tests/mutations/test_update_metadata.py
@@ -248,3 +248,42 @@ def test_update_public_metadata_for_item_without_meta(
     errors = response["data"]["updateMetadata"]["errors"]
     assert errors[0]["field"] == "id"
     assert errors[0]["code"] == MetadataErrorCode.NOT_FOUND.name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_update_public_metadata_race_condition(api_client, checkout):
+    # given
+    checkout.metadata_storage.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
+    checkout.metadata_storage.save(update_fields=["metadata"])
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    def update_metadata(*args, **kwargs):
+        checkout.metadata_storage.store_value_in_metadata({"new_before": "value"})
+        checkout.metadata_storage.save(update_fields=["metadata"])
+
+    # when
+    with race_condition.RunBefore(
+        "saleor.graphql.meta.mutations.update_metadata.update_metadata",
+        update_metadata,
+    ):
+        # update without using postgresql `concat` operation to
+        # test concurrent safe update in `updateMetadata`
+        response = execute_update_public_metadata_for_item(
+            api_client,
+            None,
+            checkout.token,
+            "Checkout",
+            value="NewMetaValue",
+            ignore_errors=True,
+        )
+
+    # then
+    assert not response["data"]["updateMetadata"]["errors"]
+    assert item_contains_multiple_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"],
+        checkout.metadata_storage,
+        checkout_id,
+        value="NewMetaValue",
+        key2="new_before",
+        value2="value",
+    )

--- a/saleor/graphql/meta/tests/mutations/test_update_metadata.py
+++ b/saleor/graphql/meta/tests/mutations/test_update_metadata.py
@@ -179,8 +179,6 @@ def test_update_public_metadata_for_item(api_client, checkout):
     )
 
 
-# FIXME
-@pytest.mark.skip
 @pytest.mark.django_db(transaction=True)
 def test_update_public_metadata_for_item_on_deleted_instance(api_client, checkout):
     # given
@@ -193,7 +191,7 @@ def test_update_public_metadata_for_item_on_deleted_instance(api_client, checkou
 
     # when
     with race_condition.RunBefore(
-        "saleor.graphql.meta.mutations.update_metadata.save_instance",
+        "saleor.graphql.meta.mutations.update_metadata.update_metadata",
         delete_checkout_object,
     ):
         response = execute_update_public_metadata_for_item(

--- a/saleor/graphql/meta/tests/mutations/test_update_private_metadata.py
+++ b/saleor/graphql/meta/tests/mutations/test_update_private_metadata.py
@@ -2,7 +2,9 @@ import base64
 
 import graphene
 import pytest
+from django.db import transaction
 
+from .....checkout.models import Checkout
 from .....core.error_codes import MetadataErrorCode
 from .....core.models import ModelWithMetadata
 from .....tests import race_condition
@@ -201,6 +203,41 @@ def test_update_private_metadata_by_customer(user_api_client, payment):
 
     # then
     assert_no_permission(response)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_update_private_metadata_for_item_on_deleted_instance(
+    staff_api_client, checkout, permission_manage_checkouts
+):
+    # given
+    checkout.metadata_storage.store_value_in_private_metadata(
+        {PRIVATE_KEY: PRIVATE_VALUE}
+    )
+    checkout.metadata_storage.save(update_fields=["private_metadata"])
+
+    def delete_checkout_object(*args, **kwargs):
+        with transaction.atomic():
+            Checkout.objects.filter(pk=checkout.pk).delete()
+
+    # when
+    with race_condition.RunBefore(
+        "saleor.graphql.meta.mutations.update_private_metadata.update_private_metadata",
+        delete_checkout_object,
+    ):
+        response = execute_update_private_metadata_for_item(
+            staff_api_client,
+            permission_manage_checkouts,
+            checkout.token,
+            "Checkout",
+            value="NewMetaValue",
+        )
+
+    # then
+    assert not Checkout.objects.filter(pk=checkout.pk).first()
+    assert (
+        response["data"]["updatePrivateMetadata"]["errors"][0]["code"]
+        == MetadataErrorCode.NOT_FOUND.name
+    )
 
 
 @pytest.mark.django_db(transaction=True)

--- a/saleor/graphql/meta/tests/mutations/test_update_private_metadata.py
+++ b/saleor/graphql/meta/tests/mutations/test_update_private_metadata.py
@@ -1,9 +1,11 @@
 import base64
 
 import graphene
+import pytest
 
 from .....core.error_codes import MetadataErrorCode
 from .....core.models import ModelWithMetadata
+from .....tests import race_condition
 from ....tests.utils import assert_no_permission, get_graphql_content
 from . import (
     PRIVATE_KEY,
@@ -199,3 +201,48 @@ def test_update_private_metadata_by_customer(user_api_client, payment):
 
     # then
     assert_no_permission(response)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_update_private_metadata_race_condition(
+    staff_api_client, checkout, permission_manage_checkouts
+):
+    # given
+    checkout.metadata_storage.store_value_in_private_metadata(
+        {PRIVATE_KEY: PRIVATE_VALUE}
+    )
+    checkout.metadata_storage.save(update_fields=["private_metadata"])
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    def update_private_metadata(*args, **kwargs):
+        checkout.metadata_storage.store_value_in_private_metadata(
+            {"new_before": "value"}
+        )
+        checkout.metadata_storage.save(update_fields=["private_metadata"])
+
+    # when
+    with race_condition.RunBefore(
+        "saleor.graphql.meta.mutations.update_private_metadata.update_private_metadata",
+        update_private_metadata,
+    ):
+        # update without using postgresql `concat` operation to
+        # really test fixing race condition in `updateMetadata`
+        response = execute_update_private_metadata_for_item(
+            staff_api_client,
+            permission_manage_checkouts,
+            checkout.token,
+            "Checkout",
+            value="NewMetaValue",
+        )
+
+    # then
+    assert not response["data"]["updatePrivateMetadata"]["errors"]
+    assert item_contains_multiple_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"],
+        checkout.metadata_storage,
+        checkout_id,
+        key=PRIVATE_KEY,
+        value="NewMetaValue",
+        key2="new_before",
+        value2="value",
+    )


### PR DESCRIPTION
I want to merge this change cause it adds a possibility to use concurrent safe json updates and updates `updateMetadata` and `updatePrivateMetadata` mutation to use new solution.
Resolves https://linear.app/saleor/issue/SCL-553/

<details>
<summary> General ideas behind solution: </summary>

Add's a way to save JSONField to database by using postgresql operator `||` (concatenate) that produces an union
Example usage of `||` operator: 
`SELECT '{"a": 1}'::jsonb  || '{"a": 2, "b": 3}'::jsonb;`
will result in:
`{"a": 2, "b": 3}`
More can be found at: https://www.postgresql.org/docs/15/functions-json.html

Example usage of proposed solution in the code:
```
instance.update(
        metadata=PostgresJsonConcatenate(F("metadata"), Value(items, output_field=JSONField()))
)
```

This way we will be able to resolve issue of concurrent saves to metadata objects without introducing locks.

I decided against usage of postgresql `JSON_SET` function as it only allows to update one key per function call - it would need from us a proper recursive sql generation, which may lead to creating big raw sql, which may be a problem?

</details>

<details>
<summary> Performance test: </summary>
100 calls against `updateMetadata` mutation with metadata input of 200 key, value pairs. Key template f"key{number}" when value string was constant 8 character length.
All response time are provided in seconds

| Branch | max_response_time | min_response_time | mean_response_time |
| - | - | - | - |
| main | 0.02532792091369629 | 0.00936126708984375 | 0.01153815746307373 |
| current | 0.019258975982666016 | 0.009435176849365234 | 0.011166601181030274 |

No changes in number of database queries.
We can assume that performance-wise solution is safe.
</details>

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
