### PR TITLE
[POC] Telemetry - propagate context for Celery tasks

### DIFF
--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -1,6 +1,6 @@
 import datetime
 from decimal import Decimal
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 from django.test import override_settings
@@ -663,7 +663,10 @@ def test_call_checkout_event_triggers_sync_webhook_when_needed(
         webhook_id=checkout_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -757,7 +760,10 @@ def test_call_checkout_event_skips_tax_webhook_when_not_expired(
         webhook_id=checkout_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -875,7 +881,10 @@ def test_call_checkout_event_only_async_when_sync_missing(
     checkout_create_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1002,7 +1011,10 @@ def test_call_checkout_info_event_triggers_sync_webhook_when_needed(
         webhook_id=checkout_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1107,7 +1119,10 @@ def test_call_checkout_info_event_skips_tax_webhook_when_not_expired(
         webhook_id=checkout_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1197,7 +1212,10 @@ def test_call_checkout_info_event_only_async_when_sync_missing(
     checkout_create_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1323,7 +1341,10 @@ def test_transaction_amounts_for_checkout_fully_paid_triggers_sync_webhook(
         webhook_id=checkout_fully_paid_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_fully_paid_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_fully_paid_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1462,7 +1483,10 @@ def test_call_checkout_events_triggers_sync_webhook_when_needed(
         webhook_id=checkout_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1564,7 +1588,10 @@ def test_call_checkout_events_skips_tax_webhook_when_not_expired(
         webhook_id=checkout_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1693,7 +1720,10 @@ def test_call_checkout_events_only_async_when_sync_missing(
     checkout_create_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/core/telemetry/__init__.py
+++ b/saleor/core/telemetry/__init__.py
@@ -6,8 +6,14 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.util.types import AttributeValue
 
 from .metric import Meter, MeterProxy, MetricType
-from .trace import SpanKind, Tracer, TracerProxy
-from .utils import Scope, Unit, set_global_attributes
+from .trace import Link, SpanKind, Tracer, TracerProxy
+from .utils import (
+    Scope,
+    TaskTelemetryContext,
+    Unit,
+    set_global_attributes,
+    with_telemetry_context,
+)
 
 tracer = TracerProxy()
 meter = MeterProxy()
@@ -50,4 +56,7 @@ __all__ = [
     "SpanAttributes",
     "AttributeValue",
     "Scope",
+    "Link",
+    "TaskTelemetryContext",
+    "with_telemetry_context",
 ]

--- a/saleor/core/telemetry/__init__.py
+++ b/saleor/core/telemetry/__init__.py
@@ -3,16 +3,16 @@ from typing import Any
 
 from django.conf import settings
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.util.types import AttributeValue
+from opentelemetry.util.types import Attributes, AttributeValue
 
 from .metric import Meter, MeterProxy, MetricType
 from .trace import Link, SpanKind, Tracer, TracerProxy
 from .utils import (
     Scope,
-    TaskTelemetryContext,
+    TelemetryContext,
     Unit,
     set_global_attributes,
-    with_telemetry_context,
+    task_with_telemetry_context,
 )
 
 tracer = TracerProxy()
@@ -45,6 +45,11 @@ def initialize_telemetry() -> None:
     meter.initialize(meter_cls, saleor_version)
 
 
+def get_current_context(link_attributes: Attributes = None) -> TelemetryContext:
+    link = Link(tracer.get_current_span().get_span_context(), link_attributes)
+    return TelemetryContext(links=[link])
+
+
 __all__ = [
     "tracer",
     "meter",
@@ -57,6 +62,7 @@ __all__ = [
     "AttributeValue",
     "Scope",
     "Link",
-    "TaskTelemetryContext",
-    "with_telemetry_context",
+    "TelemetryContext",
+    "task_with_telemetry_context",
+    "get_current_context",
 ]

--- a/saleor/core/telemetry/__init__.py
+++ b/saleor/core/telemetry/__init__.py
@@ -9,7 +9,7 @@ from .metric import Meter, MeterProxy, MetricType
 from .trace import Link, SpanKind, Tracer, TracerProxy
 from .utils import (
     Scope,
-    TelemetryContext,
+    TelemetryTaskContext,
     Unit,
     set_global_attributes,
     task_with_telemetry_context,
@@ -45,9 +45,9 @@ def initialize_telemetry() -> None:
     meter.initialize(meter_cls, saleor_version)
 
 
-def get_current_context(link_attributes: Attributes = None) -> TelemetryContext:
+def get_task_context(link_attributes: Attributes = None) -> TelemetryTaskContext:
     link = Link(tracer.get_current_span().get_span_context(), link_attributes)
-    return TelemetryContext(links=[link])
+    return TelemetryTaskContext(links=[link])
 
 
 __all__ = [
@@ -62,7 +62,7 @@ __all__ = [
     "AttributeValue",
     "Scope",
     "Link",
-    "TelemetryContext",
+    "TelemetryTaskContext",
     "task_with_telemetry_context",
-    "get_current_context",
+    "get_task_context",
 ]

--- a/saleor/core/telemetry/__init__.py
+++ b/saleor/core/telemetry/__init__.py
@@ -46,6 +46,7 @@ def initialize_telemetry() -> None:
 
 
 def get_task_context(link_attributes: Attributes = None) -> TelemetryTaskContext:
+    """Create telemetry task context with a link to the current span."""
     link = Link(tracer.get_current_span().get_span_context(), link_attributes)
     return TelemetryTaskContext(links=[link])
 

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -1,7 +1,12 @@
+from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass, field
 from enum import Enum
+from functools import wraps
+from typing import Any
 
+from opentelemetry.trace import Link, SpanContext
 from opentelemetry.util.types import Attributes, AttributeValue
 
 Amount = int | float
@@ -49,6 +54,65 @@ def set_global_attributes(attributes: dict[str, AttributeValue]):
         _GLOBAL_ATTRS.reset(token)
 
 
+def get_global_attributes() -> dict[str, AttributeValue]:
+    return _GLOBAL_ATTRS.get({})
+
+
 def enrich_with_global_attributes(attributes: Attributes) -> Attributes:
-    trace_attributes = _GLOBAL_ATTRS.get({})
-    return {**(attributes or {}), **trace_attributes}
+    return {**(attributes or {}), **get_global_attributes()}
+
+
+@dataclass
+class TaskTelemetryContext:
+    links: list[Link] = field(default_factory=list)
+    global_attributes: dict[str, AttributeValue] = field(
+        default_factory=get_global_attributes
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "links": [
+                {
+                    "context": {
+                        "trace_id": link.context.trace_id,
+                        "span_id": link.context.span_id,
+                        "trace_flags": int(link.context.trace_flags),
+                    },
+                    "attributes": link.attributes,
+                }
+                for link in self.links
+            ],
+            "global_attributes": dict(self.global_attributes),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TaskTelemetryContext":
+        links = [
+            Link(
+                context=SpanContext(
+                    trace_id=link["context"]["trace_id"],
+                    span_id=link["context"]["span_id"],
+                    is_remote=True,
+                    trace_flags=link["context"]["trace_flags"],
+                ),
+                attributes=link.get("attributes"),
+            )
+            for link in data["links"]
+        ]
+        return cls(links=links, global_attributes=data["global_attributes"])
+
+
+def with_telemetry_context(func: Callable) -> Callable:
+    @wraps(func)
+    def wrapper(*args, **kwargs) -> Any:
+        context = TaskTelemetryContext()
+        if context_data := kwargs.pop("telemetry_context", {}):
+            if isinstance(context_data, TaskTelemetryContext):
+                context = context_data
+            else:
+                context = TaskTelemetryContext.from_dict(context_data)
+        kwargs["telemetry_context"] = context
+        with set_global_attributes(context.global_attributes):
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -1,8 +1,9 @@
+from collections.abc import Sequence
 from contextlib import contextmanager
 
 from django.db import transaction
 
-from ..core.telemetry import Scope, SpanKind, TaskTelemetryContext, tracer
+from ..core.telemetry import Link, Scope, SpanKind, tracer
 
 
 @contextmanager
@@ -28,17 +29,17 @@ def webhooks_otel_trace(
     payload_size: int,
     sync=False,
     app=None,
-    telemetry_context: TaskTelemetryContext | None = None,
+    span_links: Sequence[Link] | None = None,
 ):
     """Context manager for tracing webhooks.
 
     :param payload_size: size of the payload in bytes
     """
-    links = None
-    if telemetry_context:
-        links = telemetry_context.links
     with tracer.start_as_current_span(
-        f"webhooks.{span_name}", scope=Scope.SERVICE, kind=SpanKind.CLIENT, links=links
+        f"webhooks.{span_name}",
+        scope=Scope.SERVICE,
+        kind=SpanKind.CLIENT,
+        links=span_links,
     ) as span:
         if app:
             span.set_attribute("app.id", app.id)

--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 from django.db import transaction
 
-from ..core.telemetry import Scope, SpanKind, tracer
+from ..core.telemetry import Scope, SpanKind, TaskTelemetryContext, tracer
 
 
 @contextmanager
@@ -28,13 +28,17 @@ def webhooks_otel_trace(
     payload_size: int,
     sync=False,
     app=None,
+    telemetry_context: TaskTelemetryContext | None = None,
 ):
     """Context manager for tracing webhooks.
 
     :param payload_size: size of the payload in bytes
     """
+    links = None
+    if telemetry_context:
+        links = telemetry_context.links
     with tracer.start_as_current_span(
-        f"webhooks.{span_name}", scope=Scope.SERVICE, kind=SpanKind.CLIENT
+        f"webhooks.{span_name}", scope=Scope.SERVICE, kind=SpanKind.CLIENT, links=links
     ) as span:
         if app:
             span.set_attribute("app.id", app.id)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1,7 +1,7 @@
 import datetime
 from decimal import Decimal
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -1397,7 +1397,10 @@ def test_checkout_add_voucher_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test import override_settings
@@ -757,7 +757,10 @@ def test_checkout_billing_address_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -1,7 +1,7 @@
 import datetime
 import warnings
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -2758,7 +2758,10 @@ def test_checkout_create_triggers_webhooks(
         webhook_id=checkout_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_create_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_create_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -345,7 +345,10 @@ def test_checkout_customer_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test import override_settings
@@ -214,7 +214,10 @@ def test_checkout_customer_detach_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test import override_settings
@@ -176,7 +176,10 @@ def test_checkout_customer_note_update_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -1169,7 +1169,10 @@ def test_checkout_delivery_method_update_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1262,7 +1265,10 @@ def test_checkout_delivery_method_update_cc_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1372,7 +1378,10 @@ def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test import override_settings
@@ -180,7 +180,10 @@ def test_checkout_email_update_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test import override_settings
@@ -169,7 +169,10 @@ def test_checkout_update_language_code_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -396,7 +396,10 @@ def test_checkout_line_delete_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -394,7 +394,10 @@ def test_checkout_lines_delete_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -1,6 +1,6 @@
 import datetime
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test import override_settings
@@ -1210,7 +1210,10 @@ def test_checkout_shipping_address_update_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -762,7 +762,10 @@ def test_checkout_shipping_method_update_to_none_triggers_webhooks(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 from django.test import override_settings
@@ -419,7 +419,10 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
         webhook_id=checkout_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_update_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_update_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -513,7 +516,10 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
         webhook_id=checkout_metadata_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": checkout_metadata_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": checkout_metadata_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=None,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/meta/tests/mutations/test_order.py
+++ b/saleor/graphql/meta/tests/mutations/test_order.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 from django.test import override_settings
@@ -659,7 +659,10 @@ def test_change_in_public_metadata_triggers_webhooks(
     )
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_metadata_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": order_metadata_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -734,7 +737,10 @@ def test_change_in_private_metadata_triggers_webhooks(
         event_type=WebhookEventAsyncType.ORDER_METADATA_UPDATED,
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_metadata_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": order_metadata_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1,6 +1,6 @@
 import datetime
 from decimal import Decimal
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
 import graphene
 from django.db.models import Sum
@@ -1578,7 +1578,7 @@ def test_draft_order_complete_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -1,6 +1,6 @@
 import datetime
 from decimal import Decimal
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import graphene
 import pytest
@@ -3701,7 +3701,10 @@ def test_draft_order_create_triggers_webhooks(
         webhook_id=draft_order_created_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": draft_order_created_delivery.id},
+        kwargs={
+            "event_delivery_id": draft_order_created_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -338,7 +338,10 @@ def test_draft_order_delete_do_not_trigger_sync_webhooks(
     )
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": draft_order_deleted_delivery.id},
+        kwargs={
+            "event_delivery_id": draft_order_deleted_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -2336,7 +2336,10 @@ def test_draft_order_update_triggers_webhooks(
         webhook_id=draft_order_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": draft_order_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": draft_order_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -2423,7 +2426,10 @@ def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
         webhook_id=draft_order_updated_webhook.id
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": draft_order_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": draft_order_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_cancel.py
+++ b/saleor/graphql/order/tests/mutations/test_order_cancel.py
@@ -205,7 +205,7 @@ def test_order_cancel_skip_trigger_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -249,7 +249,7 @@ def test_order_capture_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -689,7 +689,7 @@ def test_order_confirm_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -1647,7 +1647,7 @@ def test_order_fulfill_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -364,7 +364,7 @@ def test_order_line_delete_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_line_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_update.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -641,7 +641,7 @@ def test_order_line_update_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -1,6 +1,6 @@
 import datetime
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -1302,7 +1302,7 @@ def test_order_lines_create_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_note_add.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_add.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -232,7 +232,7 @@ def test_order_note_add_user_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_note_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_update.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -276,7 +276,7 @@ def test_order_note_update_user_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 from django.test import override_settings
@@ -565,7 +565,7 @@ def test_order_update_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import graphene
 import pytest
@@ -591,7 +591,7 @@ def test_order_update_shipping_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -3,10 +3,9 @@ import hashlib
 import graphene
 import pytest
 from opentelemetry import trace as trace_api
-from opentelemetry.sdk.trace import TracerProvider, export
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
-    InMemorySpanExporter,
-)
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from ...core.telemetry import initialize_telemetry
 
@@ -14,9 +13,8 @@ from ...core.telemetry import initialize_telemetry
 @pytest.fixture(scope="session", autouse=True)
 def in_memory_span_exporter():
     span_exporter = InMemorySpanExporter()
-    exporter_processor = export.SimpleSpanProcessor(span_exporter)
     provider = TracerProvider()
-    provider.add_span_processor(exporter_processor)
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
     trace_api.set_tracer_provider(provider)
     initialize_telemetry()
     return span_exporter
@@ -24,22 +22,21 @@ def in_memory_span_exporter():
 
 @pytest.fixture
 def get_test_spans(in_memory_span_exporter):
+    # Clear buffer before test
+    in_memory_span_exporter.clear()
+    yield in_memory_span_exporter.get_finished_spans
+    # Clear buffer after test
     in_memory_span_exporter.clear()
 
-    def get_and_clear_spans():
-        spans = in_memory_span_exporter.get_finished_spans()
-        in_memory_span_exporter.clear()
-        return spans
 
-    return get_and_clear_spans
+def get_spans_by_name(spans, name) -> tuple[ReadableSpan, ...]:
+    return tuple(span for span in spans if span.name == name)
 
 
-def _get_graphql_span(spans):
-    return next(_get_graphql_spans(spans))
-
-
-def _get_graphql_spans(spans):
-    return filter(lambda item: item.attributes.get("graphql.query_fingerprint"), spans)
+def get_span_by_name(spans, name) -> ReadableSpan:
+    filtered = get_spans_by_name(spans, name)
+    assert len(filtered) == 1, f"Multiple '{name}' spans"
+    return filtered[0]
 
 
 def test_tracing_query_hashing(
@@ -64,10 +61,9 @@ def test_tracing_query_hashing(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     hash = hashlib.md5(span.attributes["graphql.query"].encode("utf-8")).hexdigest()
     assert span.attributes["graphql.query_fingerprint"] == f"query:test:{hash}"
 
@@ -100,10 +96,9 @@ def test_tracing_query_hashing_with_fragment(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     hash = hashlib.md5(span.attributes["graphql.query"].encode("utf-8")).hexdigest()
     assert span.attributes["graphql.query_fingerprint"] == f"query:test:{hash}"
 
@@ -136,7 +131,7 @@ def test_tracing_query_hashing_different_vars_same_checksum(
     # then
     fingerprints = [
         span.attributes["graphql.query_fingerprint"]
-        for span in _get_graphql_spans(get_test_spans())
+        for span in get_spans_by_name(get_test_spans(), "graphql_query")
     ]
     assert len(fingerprints) == QUERIES
     assert len(set(fingerprints)) == 1
@@ -164,10 +159,9 @@ def test_tracing_query_hashing_unnamed_query(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     hash = hashlib.md5(span.attributes["graphql.query"].encode("utf-8")).hexdigest()
     assert span.attributes["graphql.query_fingerprint"] == f"query:{hash}"
 
@@ -194,10 +188,9 @@ def test_tracing_query_hashing_unnamed_query_no_query_spec(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     hash = hashlib.md5(span.attributes["graphql.query"].encode("utf-8")).hexdigest()
     assert span.attributes["graphql.query_fingerprint"] == f"query:{hash}"
 
@@ -228,12 +221,14 @@ def test_tracing_mutation_hashing(
 
     # when
     staff_api_client.post_graphql(
-        mutation, variables, permissions=[permission_manage_orders]
+        mutation,
+        variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
     )
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     hash = hashlib.md5(span.attributes["graphql.query"].encode("utf-8")).hexdigest()
     assert (
         span.attributes["graphql.query_fingerprint"] == f"mutation:cancelOrder:{hash}"
@@ -271,10 +266,9 @@ def test_tracing_query_identifier_for_query(
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert span.attributes["graphql.query_identifier"] == "me, products"
 
 
@@ -305,10 +299,9 @@ def test_tracing_query_identifier_with_fragment(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert span.attributes["graphql.query_identifier"] == "products"
 
 
@@ -327,10 +320,9 @@ def test_tracing_query_identifier_for_unnamed_mutation(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert span.attributes["graphql.query_identifier"] == "tokenCreate"
 
 
@@ -349,10 +341,9 @@ def test_tracing_query_identifier_for_named_mutation(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert span.attributes["graphql.query_identifier"] == "tokenCreate"
 
 
@@ -378,10 +369,9 @@ def test_tracing_query_identifier_for_many_mutations(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert span.attributes["graphql.query_identifier"] == "deleteWarehouse, tokenCreate"
 
 
@@ -400,10 +390,9 @@ def test_tracing_query_identifier_undefined(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert span.attributes["graphql.query_identifier"] == "undefined"
 
 
@@ -429,10 +418,9 @@ def test_tracing_dont_have_app_data_staff_as_requestor(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert "app.name" not in span.attributes
     assert "app.id" not in span.attributes
 
@@ -460,10 +448,9 @@ def test_tracing_have_app_data_app_as_requestor(
 
     # when
     app_api_client.post_graphql(query)
-    span = _get_graphql_span(get_test_spans())
+    span = get_span_by_name(get_test_spans(), "graphql_query")
 
     # then
-    assert span
     assert span.attributes["app.name"] == app.name
     assert span.attributes["app.id"] == app.id
 
@@ -509,9 +496,5 @@ def test_tracing_have_source_service_name_set(
     app_api_client.post_graphql(query, headers={"source-service-name": header_source})
 
     # then
-    spans = list(
-        filter(lambda s: s.attributes.get("source.service.name"), get_test_spans())
-    )
-    assert len(spans) == 1
-    span = spans[0]
+    span = get_span_by_name(get_test_spans(), "graphql_query")
     assert span.attributes["source.service.name"] == expected_result

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -22,10 +22,10 @@ def in_memory_span_exporter():
 
 @pytest.fixture
 def get_test_spans(in_memory_span_exporter):
-    # Clear buffer before test
+    # Clear any existing spans from the buffer before test execution
     in_memory_span_exporter.clear()
     yield in_memory_span_exporter.get_finished_spans
-    # Clear buffer after test
+    # Clean up by clearing the buffer after test completion
     in_memory_span_exporter.clear()
 
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -171,20 +171,14 @@ class GraphQLView(View):
                 SpanAttributes.HTTP_URL,
                 request.build_absolute_uri(request.get_full_path()),
             )
-            accepted_encoding = request.META.get("HTTP_ACCEPT_ENCODING", "")
+            accepted_encoding = request.headers.get("accept-encoding", "")
             span.set_attribute(
                 "http.compression", "gzip" if "gzip" in accepted_encoding else "none"
             )
             span.set_attribute(
-                SpanAttributes.HTTP_USER_AGENT, request.META.get("HTTP_USER_AGENT", "")
+                SpanAttributes.HTTP_USER_AGENT, request.headers.get("user-agent", "")
             )
             span.set_attribute("span.type", "web")
-
-            source_service_name = get_source_service_name_value(
-                request.headers.get("source-service-name")
-            )
-            if source_service_name:
-                span.set_attribute("source.service.name", source_service_name)
 
             main_ip_header = settings.REAL_IP_ENVIRON[0]
             additional_ip_headers = settings.REAL_IP_ENVIRON[1:]

--- a/saleor/graphql/webhook/mutations/webhook_trigger.py
+++ b/saleor/graphql/webhook/mutations/webhook_trigger.py
@@ -8,7 +8,7 @@ from graphene.utils.str_converters import to_camel_case
 from ....app.models import App
 from ....core import EventDeliveryStatus
 from ....core import models as core_models
-from ....core.telemetry import get_current_context
+from ....core.telemetry import get_task_context
 from ....core.utils.events import get_is_deferred_payload
 from ....discount import models as discount_models
 from ....graphql.utils import get_user_or_app_from_context
@@ -181,7 +181,7 @@ class WebhookTrigger(BaseMutation):
                     kwargs={
                         "event_delivery_ids": [delivery.pk],
                         "deferred_payload_data": asdict(deferred_payload_data),
-                        "telemetry_context": get_current_context().to_dict(),
+                        "telemetry_context": get_task_context().to_dict(),
                     },
                     bind=True,
                 )
@@ -194,7 +194,7 @@ class WebhookTrigger(BaseMutation):
                     try:
                         send_webhook_request_async(
                             delivery.id,
-                            telemetry_context=get_current_context().to_dict(),
+                            telemetry_context=get_task_context().to_dict(),
                         )
                         return WebhookTrigger(delivery=delivery)
                     except Retry:

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -422,7 +422,7 @@ def test_handle_fully_paid_order_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -695,7 +695,7 @@ def test_cancel_order_dont_trigger_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -871,7 +871,7 @@ def test_order_refunded_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -969,7 +969,10 @@ def test_order_voided_triggers_webhooks(
         event_type=WebhookEventAsyncType.ORDER_UPDATED,
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": order_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1079,7 +1082,7 @@ def test_order_fulfilled_dont_trigger_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -1163,7 +1166,10 @@ def test_order_awaits_fulfillment_approval_triggers_webhooks(
     )
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": order_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1256,7 +1262,10 @@ def test_order_authorized_triggers_webhooks(
         event_type=WebhookEventAsyncType.ORDER_UPDATED,
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": order_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -1374,7 +1383,7 @@ def test_order_charged_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -1770,7 +1779,7 @@ def test_order_transaction_updated_for_charged_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -1885,7 +1894,10 @@ def test_order_transaction_updated_for_authorized_triggers_webhooks(
         event_type=WebhookEventAsyncType.ORDER_UPDATED,
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": order_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -2011,7 +2023,7 @@ def test_order_transaction_updated_for_refunded_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -2518,7 +2530,7 @@ def test_call_order_event_triggers_sync_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -2652,7 +2664,7 @@ def test_call_order_event_missing_filter_shipping_method_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -2735,7 +2747,7 @@ def test_call_order_event_skips_tax_webhook_when_prices_are_valid(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -2825,7 +2837,7 @@ def test_call_order_event_skips_sync_webhooks_when_order_not_editable(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -2887,7 +2899,7 @@ def test_call_order_event_skips_sync_webhooks_when_draft_order_deleted(
     assert not filter_shipping_delivery
     assert not tax_delivery
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -2987,7 +2999,7 @@ def test_call_order_event_skips_when_sync_webhooks_missing(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -3061,7 +3073,7 @@ def test_call_order_events_triggers_sync_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -3215,7 +3227,7 @@ def test_call_order_events_missing_filter_shipping_method_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -3310,7 +3322,7 @@ def test_call_order_events_skips_tax_webhook_when_prices_are_valid(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -3418,7 +3430,7 @@ def test_call_order_events_skips_sync_webhooks_when_order_not_editable(
     assert not filter_shipping_delivery
     assert not tax_delivery
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -3491,7 +3503,7 @@ def test_call_order_events_skips_sync_webhooks_when_draft_order_deleted(
     assert not filter_shipping_delivery
     assert not tax_delivery
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -3606,7 +3618,7 @@ def test_call_order_events_skips_when_sync_webhooks_missing(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id},
+        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,
@@ -3720,7 +3732,7 @@ def test_order_created_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -3830,7 +3842,10 @@ def test_order_confirmed_triggers_webhooks(
         event_type=WebhookEventAsyncType.ORDER_CONFIRMED,
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_confirmed_delivery.id},
+        kwargs={
+            "event_delivery_id": order_confirmed_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from unittest import mock
-from unittest.mock import call, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 from django.test import override_settings
@@ -449,7 +449,7 @@ def test_expire_orders_task_do_not_call_sync_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
                 bind=True,
                 retry_backoff=10,
@@ -824,7 +824,10 @@ def test_send_order_updated(
         event_type=WebhookEventAsyncType.ORDER_UPDATED,
     )
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_updated_delivery.id},
+        kwargs={
+            "event_delivery_id": order_updated_delivery.id,
+            "telemetry_context": ANY,
+        },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         bind=True,
         retry_backoff=10,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -17,6 +17,7 @@ from ...core import EventDeliveryStatus
 from ...core.models import EventDelivery
 from ...core.notify import NotifyEventType
 from ...core.taxes import TaxData, TaxType
+from ...core.telemetry import get_current_context
 from ...core.utils import build_absolute_uri
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...csv.notifications import get_default_export_payload
@@ -2668,7 +2669,9 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         delivery_update(delivery, status=EventDeliveryStatus.PENDING)
-        send_webhook_request_async.delay(delivery.pk)
+        send_webhook_request_async.delay(
+            delivery.pk, telemetry_context=get_current_context().to_dict()
+        )
         return previous_value
 
     def stored_payment_method_request_delete(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -17,7 +17,7 @@ from ...core import EventDeliveryStatus
 from ...core.models import EventDelivery
 from ...core.notify import NotifyEventType
 from ...core.taxes import TaxData, TaxType
-from ...core.telemetry import get_current_context
+from ...core.telemetry import get_task_context
 from ...core.utils import build_absolute_uri
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...csv.notifications import get_default_export_payload
@@ -2670,7 +2670,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         delivery_update(delivery, status=EventDeliveryStatus.PENDING)
         send_webhook_request_async.delay(
-            delivery.pk, telemetry_context=get_current_context().to_dict()
+            delivery.pk, telemetry_context=get_task_context().to_dict()
         )
         return previous_value
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1920,7 +1920,9 @@ def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
     manager.event_delivery_retry(event_delivery)
 
     # then
-    mocked_webhook_send.assert_called_once_with(event_delivery.pk)
+    mocked_webhook_send.assert_called_once_with(
+        event_delivery.pk, telemetry_context=ANY
+    )
 
 
 @mock.patch(

--- a/saleor/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_webhook.py
@@ -36,7 +36,10 @@ def test_trigger_webhooks_async(
     for delivery in deliveries:
         assert (
             mock.call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={
+                    "event_delivery_id": delivery.id,
+                    "telemetry_context": mock.ANY,
+                },
                 queue=None,
                 bind=True,
                 retry_backoff=10,
@@ -98,7 +101,10 @@ def test_trigger_webhooks_async_for_multiple_objects(
     for delivery in deliveries:
         assert (
             mock.call(
-                kwargs={"event_delivery_id": delivery.id},
+                kwargs={
+                    "event_delivery_id": delivery.id,
+                    "telemetry_context": mock.ANY,
+                },
                 queue=None,
                 bind=True,
                 retry_backoff=10,

--- a/saleor/webhook/tests/test_webhook_protocols.py
+++ b/saleor/webhook/tests/test_webhook_protocols.py
@@ -1,6 +1,6 @@
 import datetime
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import boto3
 import jwt
@@ -534,7 +534,7 @@ def test_trigger_webhooks_async_pick_up_queue_based_on_protocol(
     # then
     delivery = EventDelivery.objects.get()
     mock_async_apply.assert_called_once_with(
-        kwargs={"event_delivery_id": delivery.id},
+        kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
         queue=expected_queue_name,
         bind=True,
         retry_backoff=10,


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
