### PR TITLE
Apply address save setting during draft order completion

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -17,7 +17,11 @@ from ....order.calculations import fetch_order_prices_if_expired
 from ....order.error_codes import OrderErrorCode
 from ....order.fetch import OrderInfo, OrderLineInfo
 from ....order.search import prepare_order_search_vector_value
-from ....order.utils import get_order_country, update_order_display_gross_prices
+from ....order.utils import (
+    get_order_country,
+    store_user_addresses_from_draft_order,
+    update_order_display_gross_prices,
+)
 from ....permission.enums import OrderPermissions
 from ....warehouse.management import allocate_preorders, allocate_stocks
 from ....warehouse.reservations import is_reservation_enabled
@@ -176,6 +180,12 @@ class DraftOrderComplete(BaseMutation):
                 lines_data=order_lines_info,
             )
             app = get_app_promise(info.context).get()
+            transaction.on_commit(
+                lambda: store_user_addresses_from_draft_order(
+                    order=order,
+                    manager=manager,
+                )
+            )
             transaction.on_commit(
                 lambda: order_created(
                     order_info=order_info,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -75,6 +75,9 @@ DRAFT_ORDER_COMPLETE_MUTATION = """
 
 
 @patch(
+    "saleor.graphql.order.mutations.draft_order_complete.store_user_addresses_from_draft_order",
+)
+@patch(
     "saleor.graphql.order.mutations.draft_order_complete.order_created",
     wraps=order_created,
 )
@@ -82,6 +85,7 @@ DRAFT_ORDER_COMPLETE_MUTATION = """
 def test_draft_order_complete(
     product_variant_out_of_stock_webhook_mock,
     order_created_mock,
+    store_user_addresses_from_draft_order_mock,
     staff_api_client,
     permission_group_manage_orders,
     staff_user,
@@ -133,6 +137,7 @@ def test_draft_order_complete(
         Stock.objects.last()
     )
     assert order_created_mock.called
+    store_user_addresses_from_draft_order_mock.assert_called_once()
 
 
 def test_draft_order_complete_no_automatically_confirm_all_new_orders(
@@ -1610,3 +1615,119 @@ def test_draft_order_complete_triggers_webhooks(
     )
 
     assert wrapped_call_order_event.called
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_complete.order_created",
+)
+def test_draft_order_complete_save_user_addresses_in_customer_book(
+    order_created_mock,
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    customer_user,
+    address_usa,
+):
+    # given the order with user set
+    # and draft_save_shipping_address and draft_save_billing_address set to True
+    order = draft_order
+    order.user = customer_user
+    order.shipping_address = address_usa
+    order.draft_save_shipping_address = True
+    order.draft_save_billing_address = True
+    order.save(
+        update_fields=[
+            "user",
+            "draft_save_shipping_address",
+            "draft_save_billing_address",
+            "shipping_address",
+        ]
+    )
+
+    customer_user.addresses.clear()
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+
+    # when the draft order is completed
+    response = staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, variables)
+
+    # then the addresses are saved in the customer book
+    # the flags are cleared
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderComplete"]["order"]
+    order.refresh_from_db()
+    assert data["status"] == order.status.upper()
+    assert data["origin"] == OrderOrigin.DRAFT.upper()
+
+    order_created_mock.assert_called_once()
+
+    customer_user.refresh_from_db()
+    assert customer_user.addresses.count() == 2
+    # ensure that the addresses are not the same instances are addresses assigned to order
+    customer_address_ids = set(customer_user.addresses.values_list("id", flat=True))
+    order_address_ids = {order.billing_address_id, order.shipping_address_id}
+    assert not (customer_address_ids & order_address_ids)
+
+    assert order.draft_save_shipping_address is None
+    assert order.draft_save_billing_address is None
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_complete.order_created",
+)
+def test_draft_order_complete_do_not_save_user_addresses_in_customer_book(
+    order_created_mock,
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    customer_user,
+    address_usa,
+):
+    # given the order with user set
+    # and draft_save_shipping_address and draft_save_billing_address set to False
+    order = draft_order
+    order.user = customer_user
+    order.shipping_address = address_usa
+    order.draft_save_shipping_address = False
+    order.draft_save_billing_address = False
+    order.save(
+        update_fields=[
+            "user",
+            "draft_save_shipping_address",
+            "draft_save_billing_address",
+            "shipping_address",
+        ]
+    )
+
+    customer_user.addresses.clear()
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+
+    # when the draft order is completed
+    response = staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, variables)
+
+    # then the addresses are not saved in the customer book
+    # the flags are cleared
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderComplete"]["order"]
+    order.refresh_from_db()
+    assert data["status"] == order.status.upper()
+    assert data["origin"] == OrderOrigin.DRAFT.upper()
+
+    order_created_mock.assert_called_once()
+
+    customer_user.refresh_from_db()
+    assert customer_user.addresses.count() == 0
+    # ensure that the addresses are not the same instances are addresses assigned to order
+    customer_address_ids = set(customer_user.addresses.values_list("id", flat=True))
+    order_address_ids = {order.billing_address_id, order.shipping_address_id}
+    assert not (customer_address_ids & order_address_ids)
+
+    assert order.draft_save_shipping_address is None
+    assert order.draft_save_billing_address is None


### PR DESCRIPTION
Store billing and address in customer address book during draft order completion.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
