### PR TITLE
Hardcode circuit breaker threshold settings, extend dry-run settings

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -35,7 +35,7 @@ django_stubs_ext.monkeypatch()
 
 
 def get_list(text):
-    return [item.strip() for item in text.split(",")]
+    return [item.strip() for item in text.split(",") if item]
 
 
 def get_bool_from_env(name, default_value):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -998,7 +998,6 @@ warnings.filterwarnings("ignore", category=CacheKeyWarning)
 
 # Breaker board configuration
 BREAKER_BOARD_ENABLED = get_bool_from_env("BREAKER_BOARD_ENABLED", False)
-BREAKER_BOARD_DRY_RUN = get_bool_from_env("BREAKER_BOARD_DRY_RUN", False)
 # Storage class string for the breaker board, for example:
 # "saleor.webhook.circuit_breaker.storage.RedisStorage"
 BREAKER_BOARD_STORAGE_CLASS = "saleor.webhook.circuit_breaker.storage.RedisStorage"
@@ -1010,27 +1009,8 @@ if BREAKER_BOARD_ENABLED and (CACHE_URL is None or not CACHE_URL.startswith("red
 # "checkout_calculate_taxes, shipping_list_methods_for_checkout".
 BREAKER_BOARD_SYNC_EVENTS = get_list(os.environ.get("BREAKER_BOARD_SYNC_EVENTS", ""))
 
-# Minimum failure events count to consider the breaker board threshold percentage.
-BREAKER_BOARD_FAILURE_MIN_COUNT = int(
-    os.environ.get("BREAKER_BOARD_FAILURE_MIN_COUNT", 10)
+# Subset of BREAKER_BOARD_SYNC_EVENTS that should be monitored by the breaker board,
+# but should not be disabled in case of exceeding failure thresholds
+BREAKER_BOARD_DRY_RUN_SYNC_EVENTS = get_list(
+    os.environ.get("BREAKER_BOARD_DRY_RUN_SYNC_EVENTS", "")
 )
-BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE = int(
-    os.environ.get("BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE", 50)
-)
-# Minimum failure events count to consider threshold percentage in half-open state.
-BREAKER_BOARD_FAILURE_MIN_COUNT_RECOVERY = int(
-    os.environ.get("BREAKER_BOARD_FAILURE_MIN_COUNT_RECOVERY", 10)
-)
-BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE_RECOVERY = int(
-    os.environ.get("BREAKER_BOARD_FAILURE_THRESHOLD_PERCENTAGE_RECOVERY", 50)
-)
-# Minimum success events count to recover (half-open to closed).
-BREAKER_BOARD_SUCCESS_COUNT_RECOVERY = int(
-    os.environ.get("BREAKER_BOARD_SUCCESS_COUNT_RECOVERY", 10)
-)
-# Time to switch from open to half-open state.
-BREAKER_BOARD_COOLDOWN_SECONDS = int(
-    os.environ.get("BREAKER_BOARD_COOLDOWN_SECONDS", 5 * 60)
-)
-# Time frame for events to be analyzed in the breaker board (last x seconds).
-BREAKER_BOARD_TTL_SECONDS = int(os.environ.get("BREAKER_BOARD_TTL_SECONDS", 5 * 60))

--- a/saleor/webhook/circuit_breaker/breaker_board.py
+++ b/saleor/webhook/circuit_breaker/breaker_board.py
@@ -69,7 +69,7 @@ class BreakerBoard:
         self.ttl_seconds = ttl_seconds
 
     def validate_sync_events(self):
-        if settings.BREAKER_BOARD_SYNC_EVENTS == [""]:
+        if not settings.BREAKER_BOARD_SYNC_EVENTS:
             raise ImproperlyConfigured("BREAKER_BOARD_SYNC_EVENTS cannot be empty.")
         for event in settings.BREAKER_BOARD_SYNC_EVENTS:
             if not WebhookEventSyncType.EVENT_MAP.get(event):
@@ -77,7 +77,7 @@ class BreakerBoard:
                     f'Event "{event}" is not supported by circuit breaker.'
                 )
         for event in settings.BREAKER_BOARD_DRY_RUN_SYNC_EVENTS:
-            if not event in settings.BREAKER_BOARD_SYNC_EVENTS:
+            if event not in settings.BREAKER_BOARD_SYNC_EVENTS:
                 raise ImproperlyConfigured(
                     f'Dry-run event "{event}" is not monitored by circuit breaker.'
                 )

--- a/saleor/webhook/tests/circuit_breaker/test_breaker_board.py
+++ b/saleor/webhook/tests/circuit_breaker/test_breaker_board.py
@@ -177,8 +177,7 @@ def test_breaker_board_configuration_invalid_events(settings, breaker_storage):
 
 def test_breaker_board_configuration_empty_event(settings, breaker_storage):
     # given
-    event_name = ""
-    settings.BREAKER_BOARD_SYNC_EVENTS = [event_name]
+    settings.BREAKER_BOARD_SYNC_EVENTS = []
 
     # when
     with pytest.raises(ImproperlyConfigured) as e:
@@ -188,7 +187,7 @@ def test_breaker_board_configuration_empty_event(settings, breaker_storage):
     assert e.value.args[0] == "BREAKER_BOARD_SYNC_EVENTS cannot be empty."
 
 
-def test_breaker_board_configuration_miexed_events(settings, breaker_storage):
+def test_breaker_board_configuration_mixed_events(settings, breaker_storage):
     # given
     bad_event_name = "bad_event"
     settings.BREAKER_BOARD_SYNC_EVENTS = [
@@ -205,4 +204,23 @@ def test_breaker_board_configuration_miexed_events(settings, breaker_storage):
     assert (
         e.value.args[0]
         == f'Event "{bad_event_name}" is not supported by circuit breaker.'
+    )
+
+
+def test_breaker_board_configuration_unexpected_dry_run_event(
+    settings, breaker_storage
+):
+    # given
+    event_name = "shipping_list_methods_for_checkout"
+    settings.BREAKER_BOARD_SYNC_EVENTS = ["checkout_calculate_taxes"]
+    settings.BREAKER_BOARD_DRY_RUN_SYNC_EVENTS = [event_name]
+
+    # when
+    with pytest.raises(ImproperlyConfigured) as e:
+        create_breaker_board(breaker_storage)
+
+    # then
+    assert (
+        e.value.args[0]
+        == f'Dry-run event "{event_name}" is not monitored by circuit breaker.'
     )


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
