### PR TITLE
Add test cmd to poe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,7 +265,10 @@ To run tests, enter `poe test` in your terminal.
 poe test
 ```
 
-By default `poe test` is using the `reuse-db` flag to speed up testing time.
+By default `poe test` is using the `--reuse-db` flag to speed up testing time.
+
+> [!TIP]
+> If you need to ignore `--reuse-db` (e.g when testing Saleor on different versions that have different migrations) add `--create-db` argument: `poe test --create-db`
 
 ### How to run particular tests?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,17 +259,13 @@ In the case of testing the `API`, we would like to split all tests into `mutatio
 
 ### How to run tests?
 
-To run tests, enter `pytest` in your terminal.
+To run tests, enter `poe test` in your terminal.
 
 ```bash
-pytest
+poe test
 ```
 
-We recommend using the `reuse-db` flag to speed up testing time.
-
-```bash
-pytest --reuse-db
-```
+By default `poe test` is using the `reuse-db` flag to speed up testing time.
 
 ### How to run particular tests?
 
@@ -277,14 +273,14 @@ As running all tests is quite time-consuming, sometimes you want to run only tes
 You can use the following command for that. In the case of a particular directory or file, provide the path after the `pytest` command, like:
 
 ```bash
-pytest --reuse-db saleor/graphql/app/tests
+poe test saleor/graphql/app/tests
 ```
 
 If you want to run a particular test, you need to provide the path to the file where the test is and the file name after the `::` sign. In the case of running a single test, it's also worth using the `-n0` flag to run the test only in one thread. It will significantly decrease time.
 See an example below:
 
 ```bash
-pytest --reuse-db saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0
+poe test saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0
 ```
 
 ### Using pdb when testing
@@ -293,7 +289,7 @@ If you would like to use `pdb` in code when running a test, you need to use a fe
 So the previous example will look like this:
 
 ```bash
-pytest --reuse-db saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0 -s --allow-hosts=127.0.0.1
+poe test saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0 -s --allow-hosts=127.0.0.1
 ```
 
 ### Recording cassettes
@@ -301,7 +297,7 @@ pytest --reuse-db saleor/graphql/app/tests/mutations/test_app_create.py::test_ap
 Some of our tests use `VCR.py` cassettes to record requests and responses from external APIs. To record one, you need to use the `vcr-record` flag and specify `allow-hosts`:
 
 ```bash
-pytest --vcr-record=once saleor/app/tests/test_app_commands.py --allow-hosts=127.0.0.1
+poe test --vcr-record=once saleor/app/tests/test_app_commands.py --allow-hosts=127.0.0.1
 ```
 
 ### Writing benchmark tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ Populates database with sample data and creates admin user with credentials:
 - password: admin
 """
 
+test.cmd="pytest --reuse-db"
+test.help = "Run tests with db reuse to speed up testing time"
+
 [tool.poetry]
 name = "saleor"
 version = "3.21.0-a.0"


### PR DESCRIPTION
I want to merge this change because it adds `test` command to poe task runner.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
