### PR TITLE
Cancel stale jobs after new push

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,8 +27,14 @@ env:
   DATABASE_URL: "postgres://saleor:saleor@postgres:5432/saleor"
   SECRET_KEY: ci-test
 
+# Will group same workflow in the PR. Once new commit is pushed, old workflow will be cancelled
+# This is saving resources and prevents unnecessary queues when fresh jobs wait for stale ones
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  units:
     runs-on: ubuntu-latest
     container: python:3.12
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,9 +34,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  units:
+  units_and_linters:
     runs-on: ubuntu-latest
     container: python:3.12
+    name: Run units & linters
 
     services:
       postgres:


### PR DESCRIPTION
I want to merge this change because we don't want all stale commits to continue builds if new commits were pushed on the branch.

Now, new commits will cancel stale runs, free up workers, making it faster and greener

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
