### PR TITLE
Turn off pre-generated checkout paylaods for bulk checkouts queries

### DIFF
--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -620,3 +620,93 @@ def test_shipping_methods_and_taxes_use_pregenerated_payload(
     mock_tax_request.assert_called_once()
     mock_shipping_request.assert_called_once()
     mock_generate_payload.assert_not_called()
+
+
+CHECKOUTS_QUERY = """
+ query CheckoutsQuery {
+   checkouts(first: 1) {
+     edges {
+       node {
+         id
+         deliveryMethod {
+           __typename
+           ... on ShippingMethod {
+             id
+             name
+             price {
+               amount
+             }
+           }
+         }
+         shippingPrice {
+           gross {
+             amount
+           }
+         }
+         totalPrice {
+           gross {
+             amount
+           }
+         }
+         subtotalPrice {
+           gross {
+             amount
+           }
+         }
+         lines {
+           totalPrice {
+             gross {
+               amount
+             }
+           }
+           unitPrice {
+             gross {
+               amount
+             }
+           }
+         }
+         shippingMethods {
+           id
+           name
+           active
+         }
+         availableShippingMethods {
+           id
+           name
+           active
+         }
+       }
+     }
+   }
+ }
+ """
+
+
+@mock.patch(
+    "saleor.graphql.checkout.types.PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader"
+)
+def test_pregegenerated_payload_is_skipped_for_bulk_queries(
+    mocked_pregenerated_payload,
+    checkout_with_shipping_address,
+    staff_api_client,
+    permission_manage_checkouts,
+):
+    # given
+    checkout = checkout_with_shipping_address
+    checkout.price_expiration = timezone.now() - datetime.timedelta(days=1)
+    checkout.save()
+    checkout_global_id = to_global_id_or_none(checkout)
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHECKOUTS_QUERY,
+        permissions=[permission_manage_checkouts],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert len(content["data"]["checkouts"]["edges"]) == 1
+    checkout = content["data"]["checkouts"]["edges"][0]["node"]
+    assert checkout["id"] == checkout_global_id
+
+    mocked_pregenerated_payload.assert_not_called()


### PR DESCRIPTION
I want to merge this change because in case of calling queries like `checkouts`, `me.checkouts`, `checkoutLines`, we would not trigger the tax webhooks. In that case, it doesn't make sense to create the pre-generated payload. 

Internal task: https://linear.app/saleor/issue/EXT-1898/pre-generated-payload-should-be-skipped-when-sync-webhooks-are-blocked

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
