### PR TITLE
Wrap all resolvers related to order into SyncWebhookControlContext

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -21,6 +21,7 @@ from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...account.i18n import I18nMixin
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.fields import JSONString
@@ -267,7 +268,9 @@ class CheckoutComplete(BaseMutation, I18nMixin):
                 # checkoutComplete response. Order is anonymized for not logged in
                 # user
                 return CheckoutComplete(
-                    order=order, confirmation_needed=False, confirmation_data={}
+                    order=SyncWebhookControlContext(order),
+                    confirmation_needed=False,
+                    confirmation_data={},
                 )
             raise e
         if metadata is not None:
@@ -334,7 +337,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         # If gateway returns information that additional steps are required we need
         # to inform the frontend and pass all required data
         return CheckoutComplete(
-            order=order,
+            order=SyncWebhookControlContext(order) if order else None,
             confirmation_needed=action_required,
             confirmation_data=action_data,
         )

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -11,6 +11,7 @@ from ....permission.enums import CheckoutPermissions
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import Error, NonNullList
@@ -213,4 +214,4 @@ class OrderCreateFromCheckout(BaseMutation):
                 code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
             ) from e
 
-        return OrderCreateFromCheckout(order=order)
+        return OrderCreateFromCheckout(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -78,3 +78,7 @@ class BaseContext(Generic[N]):
 @dataclass
 class SyncWebhookControlContext(BaseContext[N]):
     allow_sync_webhooks: bool = True
+
+    def __init__(self, node: N, allow_sync_webhooks: bool = True):
+        self.node = node
+        self.allow_sync_webhooks = allow_sync_webhooks

--- a/saleor/graphql/core/federation/schema.py
+++ b/saleor/graphql/core/federation/schema.py
@@ -6,9 +6,9 @@ from django.conf import settings
 from graphene.utils.str_converters import to_snake_case
 from graphql import GraphQLArgument, GraphQLError, GraphQLField, GraphQLList
 
-from ...channel import ChannelContext
 from ...schema_printer import print_schema
 from .. import ResolveInfo
+from ..context import BaseContext
 from .entities import federated_entities
 
 
@@ -81,7 +81,7 @@ def create_entity_type_resolver(schema):
 
     def resolve_entity_type(instance, info: ResolveInfo):
         # Use new strategy to resolve GraphQL Type for `ObjectType`
-        if isinstance(instance, ChannelContext):
+        if isinstance(instance, BaseContext):
             model = type(instance.node)
         else:
             model = type(instance)

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -358,7 +358,9 @@ def test_from_global_id_or_error_wth_type(product):
     assert product_type == expected_product_type
 
 
-@mock.patch("saleor.graphql.order.schema.create_connection_slice")
+@mock.patch(
+    "saleor.graphql.order.schema.create_connection_slice_for_sync_webhook_control_context"
+)
 def test_query_allow_replica(
     mocked_resolver, staff_api_client, order, permission_manage_orders
 ):

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -156,9 +156,7 @@ class TaxableObjectLine(BaseObjectType):
 
     @staticmethod
     def resolve_source_line(root: CheckoutLine | OrderLine, _info: ResolveInfo):
-        if isinstance(root, CheckoutLine):
-            return SyncWebhookControlContext(node=root)
-        return root
+        return SyncWebhookControlContext(node=root)
 
     @staticmethod
     def resolve_charge_taxes(root: CheckoutLine | OrderLine, info: ResolveInfo):
@@ -336,9 +334,7 @@ class TaxableObject(BaseObjectType):
 
     @staticmethod
     def resolve_source_object(root: Checkout | Order, _info: ResolveInfo):
-        if isinstance(root, Checkout):
-            return SyncWebhookControlContext(node=root)
-        return root
+        return SyncWebhookControlContext(node=root)
 
     @staticmethod
     def resolve_prices_entered_with_tax(root: Checkout | Order, info: ResolveInfo):

--- a/saleor/graphql/invoice/mutations/invoice_request.py
+++ b/saleor/graphql/invoice/mutations/invoice_request.py
@@ -9,6 +9,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelMutation
 from ...core.types import InvoiceError
 from ...core.utils import WebhookEventInfo
@@ -114,4 +115,4 @@ class InvoiceRequest(ModelMutation):
             order=order,
             number=number,
         )
-        return InvoiceRequest(invoice=invoice, order=order)
+        return InvoiceRequest(invoice=invoice, order=SyncWebhookControlContext(order))

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -281,7 +281,13 @@ class BaseMetadataMutation(BaseMutation):
             instance = ChannelContext(node=instance, channel_slug=None)
 
         use_webhook_sync_control_context = isinstance(
-            instance, checkout_models.Checkout | checkout_models.CheckoutLine
+            instance,
+            checkout_models.Checkout
+            | checkout_models.CheckoutLine
+            | order_models.Order
+            | order_models.OrderLine
+            | order_models.Fulfillment
+            | order_models.FulfillmentLine,
         )
 
         if use_webhook_sync_control_context:

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -23,6 +23,7 @@ from ....warehouse.management import allocate_preorders, allocate_stocks
 from ....warehouse.reservations import is_reservation_enabled
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -185,4 +186,4 @@ class DraftOrderComplete(BaseMutation):
                     from_draft=True,
                 )
             )
-        return DraftOrderComplete(order=order)
+        return DraftOrderComplete(order=SyncWebhookControlContext(node=order))

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -34,6 +34,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...channel.types import Channel
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import (
     ADDED_IN_318,
     ADDED_IN_321,
@@ -646,3 +647,8 @@ class DraftOrderCreate(
             # handle removing voucher
             voucher_code = VoucherCode.objects.filter(code=old_voucher_code).first()
             release_voucher_code_usage(voucher_code, old_voucher, user_email)
+
+    @classmethod
+    def success_response(cls, order):
+        """Return a success response."""
+        return DraftOrderCreate(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -11,6 +11,7 @@ from ....payment.models import Payment, TransactionItem
 from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import (
     ModelDeleteWithRestrictedChannelAccessMutation,
     ModelWithExtRefMutation,
@@ -85,3 +86,8 @@ class DraftOrderDelete(
             if voucher_code := VoucherCode.objects.filter(code=code).first():
                 voucher = voucher_code.voucher
                 release_voucher_code_usage(voucher_code, voucher, None)
+
+    @classmethod
+    def success_response(cls, order):
+        """Return a success response."""
+        return cls(order=SyncWebhookControlContext(order), errors=[])

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -6,6 +6,7 @@ from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -100,7 +101,7 @@ class DraftOrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         )
         cls._save_m2m(info, instance, cleaned_input)
 
-        return cls.success_response(instance)
+        return DraftOrderUpdate(order=SyncWebhookControlContext(node=instance))
 
     @classmethod
     def save_draft_order(

--- a/saleor/graphql/order/mutations/fulfillment_approve.py
+++ b/saleor/graphql/order/mutations/fulfillment_approve.py
@@ -12,6 +12,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -105,4 +106,7 @@ class FulfillmentApprove(BaseMutation):
             raise ValidationError({"stocks": errors}) from e
 
         order.refresh_from_db(fields=["status"])
-        return FulfillmentApprove(fulfillment=fulfillment, order=order)
+        return FulfillmentApprove(
+            fulfillment=SyncWebhookControlContext(node=fulfillment),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/fulfillment_refund_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_refund_products.py
@@ -9,6 +9,7 @@ from ....payment import PaymentError
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.scalars import PositiveDecimal
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
@@ -157,4 +158,7 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
             )
         except PaymentError:
             cls.raise_error_for_payment_error()
-        return cls(order=order, fulfillment=refund_fulfillment)
+        return cls(
+            order=SyncWebhookControlContext(order),
+            fulfillment=SyncWebhookControlContext(node=refund_fulfillment),
+        )

--- a/saleor/graphql/order/mutations/fulfillment_return_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_return_products.py
@@ -9,6 +9,7 @@ from ....payment import PaymentError
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.scalars import PositiveDecimal
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
@@ -183,9 +184,18 @@ class FulfillmentReturnProducts(FulfillmentRefundAndReturnProductBase):
             cls.raise_error_for_payment_error()
 
         return_fulfillment, replace_fulfillment, replace_order = response
+        return_fulfillment_response = SyncWebhookControlContext(node=return_fulfillment)
+        replace_fulfillment_response = (
+            SyncWebhookControlContext(node=replace_fulfillment)
+            if replace_fulfillment
+            else None
+        )
+        replace_order_response = (
+            SyncWebhookControlContext(node=replace_order) if replace_order else None
+        )
         return cls(
-            order=order,
-            return_fulfillment=return_fulfillment,
-            replace_fulfillment=replace_fulfillment,
-            replace_order=replace_order,
+            order=SyncWebhookControlContext(order),
+            return_fulfillment=return_fulfillment_response,
+            replace_fulfillment=replace_fulfillment_response,
+            replace_order=replace_order_response,
         )

--- a/saleor/graphql/order/mutations/fulfillment_update_tracking.py
+++ b/saleor/graphql/order/mutations/fulfillment_update_tracking.py
@@ -9,6 +9,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -74,4 +75,7 @@ class FulfillmentUpdateTracking(BaseMutation):
         if notify_customer:
             send_fulfillment_update(order, fulfillment, manager)
 
-        return FulfillmentUpdateTracking(fulfillment=fulfillment, order=order)
+        return FulfillmentUpdateTracking(
+            fulfillment=SyncWebhookControlContext(node=fulfillment),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/order_cancel.py
+++ b/saleor/graphql/order/mutations/order_cancel.py
@@ -9,6 +9,7 @@ from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -60,4 +61,4 @@ class OrderCancel(BaseMutation):
                 manager=manager,
             )
             deactivate_order_gift_cards(order.id, user, app)
-        return OrderCancel(order=order)
+        return OrderCancel(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_capture.py
+++ b/saleor/graphql/order/mutations/order_capture.py
@@ -9,6 +9,7 @@ from ....payment import models as payment_models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
@@ -98,4 +99,4 @@ class OrderCapture(BaseMutation):
                 manager,
                 site.settings,
             )
-        return OrderCapture(order=order)
+        return OrderCapture(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -21,6 +21,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.utils import get_webhooks_for_multiple_events
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -114,4 +115,4 @@ class OrderConfirm(ModelMutation):
                     webhook_event_map=webhook_event_map,
                 )
             )
-        return OrderConfirm(order=order)
+        return OrderConfirm(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_discount_delete.py
+++ b/saleor/graphql/order/mutations/order_discount_delete.py
@@ -9,6 +9,7 @@ from ....order.utils import invalidate_order_prices, remove_order_discount_from_
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ...discount.types import OrderDiscount
@@ -69,4 +70,4 @@ class OrderDiscountDelete(OrderDiscountCommon):
             order.save(
                 update_fields=["should_refresh_prices", "search_vector", "updated_at"]
             )
-        return OrderDiscountDelete(order=order)
+        return OrderDiscountDelete(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_discount_update.py
+++ b/saleor/graphql/order/mutations/order_discount_update.py
@@ -10,6 +10,7 @@ from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ...discount.types import OrderDiscount
@@ -95,4 +96,4 @@ class OrderDiscountUpdate(OrderDiscountCommon):
                     order_discount=order_discount,
                     old_order_discount=order_discount_before_update,
                 )
-        return OrderDiscountUpdate(order=order)
+        return OrderDiscountUpdate(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -13,6 +13,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
@@ -295,4 +296,10 @@ class OrderFulfill(BaseMutation):
             errors = prepare_insufficient_stock_order_validation_errors(e)
             raise ValidationError({"stocks": errors}) from e
 
-        return OrderFulfill(fulfillments=fulfillments, order=instance)
+        return OrderFulfill(
+            fulfillments=[
+                SyncWebhookControlContext(node=fulfillment)
+                for fulfillment in fulfillments
+            ],
+            order=SyncWebhookControlContext(instance),
+        )

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -9,10 +9,8 @@ from ....order import models
 from ....order.utils import update_order_charge_data
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_320,
-    PREVIEW_FEATURE,
-)
+from ...core.context import SyncWebhookControlContext
+from ...core.descriptions import ADDED_IN_320, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
@@ -294,4 +292,7 @@ class OrderGrantRefundCreate(BaseMutation):
                 models.OrderGrantedRefundLine.objects.bulk_create(cleaned_input_lines)
             update_order_charge_data(order)
 
-        return cls(order=order, granted_refund=granted_refund)
+        return cls(
+            order=SyncWebhookControlContext(order),
+            granted_refund=SyncWebhookControlContext(node=granted_refund),
+        )

--- a/saleor/graphql/order/mutations/order_grant_refund_update.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_update.py
@@ -9,10 +9,8 @@ from ....order import OrderGrantedRefundStatus, models
 from ....order.utils import update_order_charge_data
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_320,
-    PREVIEW_FEATURE,
-)
+from ...core.context import SyncWebhookControlContext
+from ...core.descriptions import ADDED_IN_320, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
@@ -426,4 +424,7 @@ class OrderGrantRefundUpdate(BaseMutation):
         cleaned_input = cls.clean_input(info, granted_refund, input)
         cls.process_update_for_granted_refund(order, granted_refund, cleaned_input)
         update_order_charge_data(order)
-        return cls(order=order, granted_refund=granted_refund)
+        return cls(
+            order=SyncWebhookControlContext(order),
+            granted_refund=SyncWebhookControlContext(granted_refund),
+        )

--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -14,6 +14,7 @@ from ....order.utils import (
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -99,7 +100,10 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
             )
             order.save(update_fields=updated_fields)
             call_event_by_order_status(order, manager)
-        return OrderLineDelete(order=order, order_line=line)
+        return OrderLineDelete(
+            order=SyncWebhookControlContext(order),
+            order_line=SyncWebhookControlContext(line),
+        )
 
     @classmethod
     def validate(cls, info, order, line):

--- a/saleor/graphql/order/mutations/order_line_discount_remove.py
+++ b/saleor/graphql/order/mutations/order_line_discount_remove.py
@@ -6,6 +6,7 @@ from ....order.utils import invalidate_order_prices, remove_discount_from_order_
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ..types import Order, OrderLine
@@ -55,4 +56,7 @@ class OrderLineDiscountRemove(OrderDiscountCommon):
             )
 
             invalidate_order_prices(order, save=True)
-        return OrderLineDiscountRemove(order_line=order_line, order=order)
+        return OrderLineDiscountRemove(
+            order_line=SyncWebhookControlContext(order_line),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/order_line_discount_update.py
+++ b/saleor/graphql/order/mutations/order_line_discount_update.py
@@ -8,6 +8,7 @@ from ....order.utils import invalidate_order_prices, update_discount_for_order_l
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ..types import Order, OrderLine
@@ -82,4 +83,7 @@ class OrderLineDiscountUpdate(OrderDiscountCommon):
                     line_before_update=order_line_before_update,
                 )
                 invalidate_order_prices(order, save=True)
-        return OrderLineDiscountUpdate(order_line=order_line, order=order)
+        return OrderLineDiscountUpdate(
+            order_line=SyncWebhookControlContext(order_line),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -14,6 +14,7 @@ from ....order.utils import (
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelWithRestrictedChannelAccessMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -110,9 +111,11 @@ class OrderLineUpdate(
 
     @classmethod
     def success_response(cls, instance):
-        response = super().success_response(instance)
-        response.order = instance.order
-        return response
+        return cls(
+            orderLine=SyncWebhookControlContext(node=instance),
+            order=SyncWebhookControlContext(node=instance.order),
+            errors=[],
+        )
 
     @classmethod
     def get_instance_channel_id(cls, instance, **data):

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -17,6 +17,7 @@ from ....order.utils import (
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
@@ -204,7 +205,10 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             )
             call_event_by_order_status(order, manager)
 
-        return OrderLinesCreate(order=order, order_lines=added_lines)
+        return OrderLinesCreate(
+            order=SyncWebhookControlContext(order),
+            order_lines=[SyncWebhookControlContext(node=line) for line in added_lines],
+        )
 
     @classmethod
     def _find_line_id_for_variant_if_exist(cls, variant_id, lines_info) -> None | str:

--- a/saleor/graphql/order/mutations/order_mark_as_paid.py
+++ b/saleor/graphql/order/mutations/order_mark_as_paid.py
@@ -19,6 +19,7 @@ from ....payment import PaymentError
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -130,4 +131,4 @@ class OrderMarkAsPaid(BaseMutation):
 
         update_order_search_vector(order)
 
-        return OrderMarkAsPaid(order=order)
+        return OrderMarkAsPaid(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_note_add.py
+++ b/saleor/graphql/order/mutations/order_note_add.py
@@ -5,10 +5,8 @@ from ....order import error_codes, events
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    DEPRECATED_IN_3X_INPUT,
-    DEPRECATED_IN_3X_MUTATION,
-)
+from ...core.context import SyncWebhookControlContext
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT, DEPRECATED_IN_3X_MUTATION
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import BaseInputObjectType, Error, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -61,7 +59,10 @@ class OrderNoteAdd(OrderNoteCommon):
                 message=cleaned_input["message"],
             )
             call_event_by_order_status(order, manager)
-        return OrderNoteAdd(order=order, event=event)
+        return OrderNoteAdd(
+            order=SyncWebhookControlContext(order),
+            event=SyncWebhookControlContext(event),
+        )
 
 
 class OrderAddNoteInput(BaseInputObjectType):

--- a/saleor/graphql/order/mutations/order_note_update.py
+++ b/saleor/graphql/order/mutations/order_note_update.py
@@ -5,6 +5,7 @@ from ....order import OrderEvents, error_codes, events, models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import Error
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -63,4 +64,7 @@ class OrderNoteUpdate(OrderNoteCommon):
                 related_event=order_event_to_update,
             )
             call_event_by_order_status(order, manager)
-        return OrderNoteUpdate(order=order, event=event)
+        return OrderNoteUpdate(
+            order=SyncWebhookControlContext(order),
+            event=SyncWebhookControlContext(event),
+        )

--- a/saleor/graphql/order/mutations/order_refund.py
+++ b/saleor/graphql/order/mutations/order_refund.py
@@ -10,6 +10,7 @@ from ....payment import models as payment_models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
@@ -113,4 +114,4 @@ class OrderRefund(BaseMutation):
         order.fulfillments.create(
             status=FulfillmentStatus.REFUNDED, total_refund_amount=amount
         )
-        return OrderRefund(order=order)
+        return OrderRefund(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_update_shipping.py
+++ b/saleor/graphql/order/mutations/order_update_shipping.py
@@ -9,6 +9,7 @@ from ....shipping import models as shipping_models
 from ....shipping.utils import convert_to_shipping_method_data
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, OrderError
@@ -110,7 +111,7 @@ class OrderUpdateShipping(
 
             cls.clear_shipping_method_from_order(order)
             order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
-            return OrderUpdateShipping(order=order)
+            return OrderUpdateShipping(order=SyncWebhookControlContext(order))
 
         method_id: str = input["shipping_method"]
         method: shipping_models.ShippingMethod = cls.get_node_or_error(
@@ -137,4 +138,4 @@ class OrderUpdateShipping(
         order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
         # Post-process the results
         call_order_event(manager, WebhookEventAsyncType.ORDER_UPDATED, order)
-        return OrderUpdateShipping(order=order)
+        return OrderUpdateShipping(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_void.py
+++ b/saleor/graphql/order/mutations/order_void.py
@@ -8,6 +8,7 @@ from ....payment import models as payment_models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -76,4 +77,4 @@ class OrderVoid(BaseMutation):
                 payment,
                 manager,
             )
-        return OrderVoid(order=order)
+        return OrderVoid(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -7,7 +7,10 @@ from ...order import models
 from ...permission.enums import OrderPermissions
 from ...permission.utils import has_one_of_permissions
 from ..core import ResolveInfo
-from ..core.connection import create_connection_slice, filter_connection_queryset
+from ..core.connection import (
+    create_connection_slice_for_sync_webhook_control_context,
+    filter_connection_queryset,
+)
 from ..core.context import get_database_connection_name
 from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.doc_category import DOC_CATEGORY_ORDERS
@@ -163,7 +166,9 @@ class OrderQueries(graphene.ObjectType):
     @staticmethod
     def resolve_homepage_events(_root, info: ResolveInfo, **kwargs):
         qs = resolve_homepage_events(info)
-        return create_connection_slice(qs, info, kwargs, OrderEventCountableConnection)
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, OrderEventCountableConnection, allow_sync_webhooks=False
+        )
 
     @staticmethod
     def resolve_order(_root, info: ResolveInfo, *, external_reference=None, id=None):
@@ -204,7 +209,9 @@ class OrderQueries(graphene.ObjectType):
         qs = filter_connection_queryset(
             qs, kwargs, allow_replica=info.context.allow_replica
         )
-        return create_connection_slice(qs, info, kwargs, OrderCountableConnection)
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, OrderCountableConnection, allow_sync_webhooks=False
+        )
 
     @staticmethod
     def resolve_draft_orders(_root, info: ResolveInfo, **kwargs):
@@ -225,7 +232,9 @@ class OrderQueries(graphene.ObjectType):
         qs = filter_connection_queryset(
             qs, kwargs, allow_replica=info.context.allow_replica
         )
-        return create_connection_slice(qs, info, kwargs, OrderCountableConnection)
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, OrderCountableConnection, allow_sync_webhooks=False
+        )
 
     @staticmethod
     def resolve_orders_total(_root, info: ResolveInfo, *, period, channel=None):

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -276,6 +276,22 @@ class Payment(ModelObjectType[models.Payment]):
         return resolve_metadata(root.metadata)
 
     @staticmethod
+    def resolve_order(root: models.Payment, info):
+        if not root.order_id:
+            return None
+
+        def _wrap_with_webhook_sync_control(order):
+            if not order:
+                return None
+            return SyncWebhookControlContext(node=order)
+
+        return (
+            OrderByIdLoader(info.context)
+            .load(root.order_id)
+            .then(_wrap_with_webhook_sync_control)
+        )
+
+    @staticmethod
     def resolve_checkout(root: models.Payment, info):
         if not root.checkout_id:
             return None
@@ -547,7 +563,17 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     def resolve_order(root: models.TransactionItem, info):
         if not root.order_id:
             return None
-        return OrderByIdLoader(info.context).load(root.order_id)
+
+        def _wrap_with_webhook_sync_control(order):
+            if not order:
+                return None
+            return SyncWebhookControlContext(node=order)
+
+        return (
+            OrderByIdLoader(info.context)
+            .load(root.order_id)
+            .then(_wrap_with_webhook_sync_control)
+        )
 
     @staticmethod
     def resolve_checkout(root: models.TransactionItem, info):

--- a/saleor/graphql/tax/mutations/tax_exemption_manage.py
+++ b/saleor/graphql/tax/mutations/tax_exemption_manage.py
@@ -96,7 +96,6 @@ class TaxExemptionManage(BaseMutation):
         if isinstance(obj, Checkout):
             cls._invalidate_checkout(info, obj)
             obj.save(update_fields=["tax_exemption", "price_expiration", "last_change"])
-            obj = SyncWebhookControlContext(node=obj)
 
         if isinstance(obj, Order):
             cls.validate_order_status(obj)
@@ -105,4 +104,4 @@ class TaxExemptionManage(BaseMutation):
                 update_fields=["tax_exemption", "should_refresh_prices", "updated_at"]
             )
 
-        return TaxExemptionManage(taxable_object=obj)
+        return TaxExemptionManage(taxable_object=SyncWebhookControlContext(node=obj))


### PR DESCRIPTION
I want to merge this change because it adds a wrapper to all order's related objects. This will allow us to block the synchronous webhooks for queries like `draftOrders`, `orders` etc

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
