### PR TITLE
Add `metadata` & `privateMetadata` to `GiftCardCreate` and `GiftCardUpdate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - The `checkoutShippingAddressUpdate` mutation anymore does not raise an error when a shipping address is updated for a checkout that does not require shipping - #17341 by @IKarbowiak
 - Mutation `draftOrderCreate` and `draftOrderUpdate` now supports adding metadata & privateMetadata (via `DraftOrderCreateInput`) - #17358 by @lkostrowski
 - Deprecate `draftOrderInput.discount` field - #17294 by @zedzior
+- `GiftCardCreate` and `GiftCardUpdate` mutations now allows to set `metadata` and `privateMetadata` fields via `GiftCardCreateInput` and `GiftCardUpdateInput` - #todo by @lkostrowski
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - The `checkoutShippingAddressUpdate` mutation anymore does not raise an error when a shipping address is updated for a checkout that does not require shipping - #17341 by @IKarbowiak
 - Mutation `draftOrderCreate` and `draftOrderUpdate` now supports adding metadata & privateMetadata (via `DraftOrderCreateInput`) - #17358 by @lkostrowski
 - Deprecate `draftOrderInput.discount` field - #17294 by @zedzior
-- `GiftCardCreate` and `GiftCardUpdate` mutations now allows to set `metadata` and `privateMetadata` fields via `GiftCardCreateInput` and `GiftCardUpdateInput` - #todo by @lkostrowski
+- `GiftCardCreate` and `GiftCardUpdate` mutations now allows to set `metadata` and `privateMetadata` fields via `GiftCardCreateInput` and `GiftCardUpdateInput` - #17399 by @lkostrowski
 
 ### Webhooks
 

--- a/saleor/graphql/giftcard/mutations/gift_card_create.py
+++ b/saleor/graphql/giftcard/mutations/gift_card_create.py
@@ -15,13 +15,14 @@ from ....permission.enums import GiftcardPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ...core.mutations import ModelMutation
 from ...core.scalars import Date
 from ...core.types import BaseInputObjectType, GiftCardError, NonNullList, PriceInput
 from ...core.utils import WebhookEventInfo
 from ...core.validators import validate_price_precision
+from ...meta.inputs import MetadataInput
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import GiftCard
 
@@ -32,6 +33,17 @@ class GiftCardInput(BaseInputObjectType):
         description="The gift card tags to add.",
     )
     expiry_date = Date(description="The gift card expiry date.")
+
+    metadata = NonNullList(
+        MetadataInput,
+        description="Gift Card public metadata." + ADDED_IN_321,
+        required=False,
+    )
+    private_metadata = NonNullList(
+        MetadataInput,
+        description="Gift Card private metadata." + ADDED_IN_321,
+        required=False,
+    )
 
     # DEPRECATED
     start_date = Date(
@@ -101,6 +113,8 @@ class GiftCardCreate(ModelMutation):
                 description="A notification for created gift card.",
             ),
         ]
+        support_meta_field = True
+        support_private_meta_field = True
 
     @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):

--- a/saleor/graphql/giftcard/mutations/gift_card_update.py
+++ b/saleor/graphql/giftcard/mutations/gift_card_update.py
@@ -128,13 +128,6 @@ class GiftCardUpdate(GiftCardCreate):
 
         cls.call_event(manager.gift_card_updated, instance)
 
-        if metadata_list:
-            cleaned_input["metadata"] = metadata_list
-        if private_metadata_list:
-            cleaned_input["private_metadata"] = private_metadata_list
-
-        cls.post_save_action(info, instance, cleaned_input)
-
         return cls.success_response(instance)
 
     @classmethod

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -865,3 +865,144 @@ def test_create_gift_card_with_to_short_code(
     assert len(errors) == 1
     assert errors[0]["field"] == "code"
     assert errors[0]["code"] == "INVALID"
+
+
+CREATE_GIFT_CARD_MUTATION_FOR_METADATA = """
+    mutation giftCardCreate($input: GiftCardCreateInput!){
+        giftCardCreate(input: $input) {
+            giftCard {
+                id
+                metadata { key value }
+                privateMetadata { key value }
+            }
+            errors {
+                field
+                message
+                code
+            }
+        }
+    }
+"""
+
+
+def test_create_gift_card_with_public_metadata(
+    staff_api_client,
+    permission_manage_gift_card,
+):
+    # given
+    code = "custom-code"
+    metadata_key = "key"
+    metadata_value = "value"
+
+    variables = {
+        "input": {
+            "balance": {
+                "amount": 1,
+                "currency": "USD",
+            },
+            "code": code,
+            "isActive": True,
+            "metadata": [{"key": metadata_key, "value": metadata_value}],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_GIFT_CARD_MUTATION_FOR_METADATA,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["giftCardCreate"]["errors"]
+    data = content["data"]["giftCardCreate"]["giftCard"]
+
+    assert not errors
+    assert data["metadata"][0]["key"] == metadata_key
+    assert data["metadata"][0]["value"] == metadata_value
+
+
+def test_create_gift_card_with_private_metadata(
+    staff_api_client,
+    permission_manage_gift_card,
+):
+    # given
+    code = "custom-code"
+    metadata_key = "key"
+    metadata_value = "value"
+
+    variables = {
+        "input": {
+            "balance": {
+                "amount": 1,
+                "currency": "USD",
+            },
+            "code": code,
+            "isActive": True,
+            "privateMetadata": [{"key": metadata_key, "value": metadata_value}],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_GIFT_CARD_MUTATION_FOR_METADATA,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["giftCardCreate"]["errors"]
+    data = content["data"]["giftCardCreate"]["giftCard"]
+
+    assert not errors
+    assert data["privateMetadata"][0]["key"] == metadata_key
+    assert data["privateMetadata"][0]["value"] == metadata_value
+
+
+def test_create_gift_card_with_private_and_public_metadata(
+    staff_api_client,
+    permission_manage_gift_card,
+):
+    # given
+    code = "custom-code"
+    metadata_key = "key"
+    metadata_value = "value"
+
+    variables = {
+        "input": {
+            "balance": {
+                "amount": 1,
+                "currency": "USD",
+            },
+            "code": code,
+            "isActive": True,
+            "privateMetadata": [{"key": metadata_key, "value": metadata_value}],
+            "metadata": [{"key": metadata_key, "value": metadata_value}],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_GIFT_CARD_MUTATION_FOR_METADATA,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["giftCardCreate"]["errors"]
+    data = content["data"]["giftCardCreate"]["giftCard"]
+
+    assert not errors
+    assert data["metadata"][0]["key"] == metadata_key
+    assert data["metadata"][0]["value"] == metadata_value
+    assert data["privateMetadata"][0]["key"] == metadata_key
+    assert data["privateMetadata"][0]["value"] == metadata_value

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -25151,6 +25151,20 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   expiryDate: Date
 
   """
+  Gift Card public metadata.
+  
+  Added in Saleor 3.21.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Gift Card private metadata.
+  
+  Added in Saleor 3.21.
+  """
+  privateMetadata: [MetadataInput!]
+
+  """
   Start date of the gift card in ISO 8601 format. 
   
   DEPRECATED: this field will be removed in Saleor 4.0.
@@ -25244,6 +25258,20 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
 
   """The gift card expiry date."""
   expiryDate: Date
+
+  """
+  Gift Card public metadata.
+  
+  Added in Saleor 3.21.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Gift Card private metadata.
+  
+  Added in Saleor 3.21.
+  """
+  privateMetadata: [MetadataInput!]
 
   """
   Start date of the gift card in ISO 8601 format. 


### PR DESCRIPTION
I want to merge this change because it add possibility to create and update gift cards with metadata within single mutations

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
