### PR TITLE
Skip pre-generate payload for exclude shipping when webhooks are blocked

### DIFF
--- a/saleor/graphql/checkout/dataloaders/checkout_infos.py
+++ b/saleor/graphql/checkout/dataloaders/checkout_infos.py
@@ -3,10 +3,7 @@ from collections.abc import Sequence
 
 from promise import Promise
 
-from ....checkout.fetch import (
-    CheckoutInfo,
-    CheckoutLineInfo,
-)
+from ....checkout.fetch import CheckoutInfo, CheckoutLineInfo
 from ....core.db.connection import allow_writer_in_context
 from ....discount import VoucherType
 from ....discount.utils.voucher import apply_voucher_to_line
@@ -32,12 +29,7 @@ from ...shipping.dataloaders import (
     ShippingMethodChannelListingByChannelSlugLoader,
 )
 from ...tax.dataloaders import TaxClassByVariantIdLoader, TaxConfigurationByChannelId
-from ...warehouse.dataloaders import (
-    WarehouseByIdLoader,
-)
-from ...webhook.dataloaders.pregenerated_payloads_for_checkout_filter_shipping_methods import (
-    PregeneratedCheckoutFilterShippingMethodPayloadsByCheckoutTokenLoader,
-)
+from ...warehouse.dataloaders import WarehouseByIdLoader
 from .models import CheckoutByTokenLoader, CheckoutLinesByCheckoutTokenLoader
 from .promotion_rule_infos import VariantPromotionRuleInfoByCheckoutLineIdLoader
 
@@ -52,7 +44,6 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
                 checkout_line_infos,
                 checkout_discounts,
                 manager,
-                pregenerated_payloads_for_excluded_shipping_methods,
             ) = data
 
             channel_pks = [checkout.channel_id for checkout in checkouts]
@@ -148,14 +139,12 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
                         channel,
                         checkout_lines,
                         discounts,
-                        pregenerated_payloads_for_excluded_shipping_method,
                     ) in zip(
                         keys,
                         checkouts,
                         channels,
                         checkout_line_infos,
                         checkout_discounts,
-                        pregenerated_payloads_for_excluded_shipping_methods,
                         strict=False,
                     ):
                         shipping_method = shipping_method_map.get(
@@ -195,9 +184,6 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
                             voucher=voucher_code.voucher if voucher_code else None,
                             voucher_code=voucher_code,
                             database_connection_name=self.database_connection_name,
-                            pregenerated_payloads_for_excluded_shipping_method=(
-                                pregenerated_payloads_for_excluded_shipping_method
-                            ),
                         )
                         checkout_info_map[key] = checkout_info
 
@@ -227,18 +213,12 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):
         ).load_many(keys)
         discounts = CheckoutDiscountByCheckoutIdLoader(self.context).load_many(keys)
         manager = get_plugin_manager_promise(self.context)
-        pregenerated_payloads_for_excluded_shipping_methods_loader = (
-            PregeneratedCheckoutFilterShippingMethodPayloadsByCheckoutTokenLoader(
-                self.context
-            ).load_many(keys)
-        )
         return Promise.all(
             [
                 checkouts,
                 checkout_line_infos,
                 discounts,
                 manager,
-                pregenerated_payloads_for_excluded_shipping_methods_loader,
             ]
         ).then(with_checkout)
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1,5 +1,4 @@
 import datetime
-from collections import defaultdict
 from decimal import Decimal
 from unittest import mock
 
@@ -235,7 +234,6 @@ def test_checkout_available_payment_gateways_valid_info_sent(
     # then
     checkout_info.manager = mock.ANY
     checkout_info.database_connection_name = mock.ANY
-    checkout_info.pregenerated_payloads_for_excluded_shipping_method = defaultdict(dict)
     mocked_list_gateways.assert_called_with(
         currency=currency,
         checkout_info=checkout_info,


### PR DESCRIPTION
I want to merge this change because in case of calling queries like `checkouts`, `me.checkouts`, `checkoutLines`, we would not trigger the shipping webhooks. In that case, it doesn't make sense to create the pre-generated payload.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
