### PR TITLE
Ensure the `save_shipping_address` is change in case the delivery method is set or unset

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1152,7 +1152,9 @@ def remove_click_and_collect_from_checkout(checkout: Checkout) -> list[str]:
         fields_to_update.append("collection_point_id")
         if checkout.shipping_address_id:
             checkout.shipping_address = None
-            fields_to_update.append("shipping_address_id")
+            # reset the save_shipping_address flag to the default value
+            checkout.save_shipping_address = True
+            fields_to_update.extend(["shipping_address_id", "save_shipping_address"])
     return fields_to_update
 
 
@@ -1212,7 +1214,8 @@ def assign_collection_point_to_checkout(
         fields_to_update.append("collection_point_id")
     if checkout.shipping_address != collection_point.address:
         checkout.shipping_address = collection_point.address.get_copy()
-        fields_to_update.append("shipping_address_id")
+        checkout.save_shipping_address = False
+        fields_to_update.extend(["shipping_address_id", "save_shipping_address"])
 
     return fields_to_update
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -1536,6 +1536,10 @@ def test_checkout_delivery_method_update_from_cc_to_external_shipping(
 ):
     # given
     checkout = checkout_with_delivery_method_for_cc
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = False
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
+
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     response_method_id = "abcd"
     response_shipping_name = "Provider - Economy"
@@ -1574,6 +1578,10 @@ def test_checkout_delivery_method_update_from_cc_to_external_shipping(
     assert checkout.shipping_method_id is None
     assert checkout.external_shipping_method_id == method_id
     assert checkout.shipping_method_name == response_shipping_name
+    assert checkout.save_billing_address is True
+    # should be reset to the default value as the shipping address is cleared
+    assert checkout.save_shipping_address is True
+
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
 
@@ -1594,6 +1602,9 @@ def test_checkout_delivery_method_update_from_cc_to_none(
 ):
     # given
     checkout = checkout_with_delivery_method_for_cc
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = False
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -1613,6 +1624,10 @@ def test_checkout_delivery_method_update_from_cc_to_none(
     assert checkout.shipping_method_id is None
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_name is None
+    assert checkout.save_billing_address is True
+    # should be reset to the default value as the shipping address is cleared
+    assert checkout.save_shipping_address is True
+
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
 
@@ -1634,6 +1649,9 @@ def test_checkout_delivery_method_update_from_cc_to_built_in_shipping(
 ):
     # given
     checkout = checkout_with_delivery_method_for_cc
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = False
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -1659,6 +1677,9 @@ def test_checkout_delivery_method_update_from_cc_to_built_in_shipping(
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id == shipping_method.id
     assert checkout.shipping_method_name == shipping_method.name
+    assert checkout.save_billing_address is True
+    # should be reset to the default value as the shipping address is cleared
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -1681,6 +1702,9 @@ def test_checkout_delivery_method_update_from_cc_to_the_same_cc(
     # given
     checkout = checkout_with_delivery_method_for_cc
     collection_point = checkout.collection_point
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -1708,6 +1732,9 @@ def test_checkout_delivery_method_update_from_cc_to_the_same_cc(
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id is None
     assert checkout.shipping_method_name is None
+    assert checkout.save_billing_address is True
+    # the flag remain unchanged as the address stay the same
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_not_called()
     mocked_call_checkout_info_event.assert_not_called()
@@ -1726,12 +1753,18 @@ def test_checkout_delivery_method_update_from_cc_to_different_cc(
     mocked_call_checkout_info_event,
     checkout_with_items,
     warehouses_for_cc,
+    address_usa,
     api_client,
 ):
     # given
+    warehouses_for_cc[0].address = address_usa
+    warehouses_for_cc[0].save(update_fields=["address"])
+
     checkout = checkout_with_items
     checkout.collection_point = warehouses_for_cc[0]
-    checkout.shipping_address = warehouses_for_cc[0].address.get_copy()
+    checkout.shipping_address = address_usa.get_copy()
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
     checkout.save()
 
     collection_point = warehouses_for_cc[1]
@@ -1762,6 +1795,9 @@ def test_checkout_delivery_method_update_from_cc_to_different_cc(
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id is None
     assert checkout.shipping_method_name is None
+    assert checkout.save_billing_address is True
+    # set the save_shipping_address setting to False for CC
+    assert checkout.save_shipping_address is False
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -1780,10 +1816,21 @@ def test_checkout_delivery_method_update_from_external_shipping_to_cc(
     mocked_call_checkout_info_event,
     checkout_with_delivery_method_for_external_shipping,
     warehouses_for_cc,
+    address_usa,
     api_client,
 ):
     # given
     checkout = checkout_with_delivery_method_for_external_shipping
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.shipping_address = address_usa
+    checkout.save(
+        update_fields=[
+            "save_billing_address",
+            "save_shipping_address",
+            "shipping_address",
+        ]
+    )
 
     collection_point = warehouses_for_cc[1]
 
@@ -1813,6 +1860,9 @@ def test_checkout_delivery_method_update_from_external_shipping_to_cc(
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id is None
     assert checkout.shipping_method_name is None
+    assert checkout.save_billing_address is True
+    # set the save_shipping_address setting to False for CC
+    assert checkout.save_shipping_address is False
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -1835,6 +1885,9 @@ def test_checkout_delivery_method_update_from_external_shipping_to_built_in_ship
 ):
     # given
     checkout = checkout_with_delivery_method_for_external_shipping
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -1860,6 +1913,8 @@ def test_checkout_delivery_method_update_from_external_shipping_to_built_in_ship
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id == shipping_method.id
     assert checkout.shipping_method_name == shipping_method.name
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -1885,6 +1940,9 @@ def test_checkout_delivery_method_update_from_external_shipping_to_different_ext
 ):
     # given
     checkout = checkout_with_delivery_method_for_external_shipping
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     response_method_id = "new-abcd"
@@ -1924,6 +1982,8 @@ def test_checkout_delivery_method_update_from_external_shipping_to_different_ext
     assert checkout.shipping_method_id is None
     assert checkout.external_shipping_method_id == method_id
     assert checkout.shipping_method_name == response_shipping_name
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -1945,6 +2005,9 @@ def test_checkout_delivery_method_update_from_external_shipping_to_none(
 ):
     # given
     checkout = checkout_with_delivery_method_for_external_shipping
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = False
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -1964,6 +2027,9 @@ def test_checkout_delivery_method_update_from_external_shipping_to_none(
     assert checkout.shipping_method_id is None
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_name is None
+    # the flags should not be changed as shipping address is not reset
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is False
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -2013,6 +2079,8 @@ def test_checkout_delivery_method_update_from_external_shipping_to_the_same_exte
     checkout.shipping_address = address
     checkout.external_shipping_method_id = method_id
     checkout.shipping_method_name = response_shipping_name
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
     checkout.save()
 
     # when
@@ -2034,6 +2102,8 @@ def test_checkout_delivery_method_update_from_external_shipping_to_the_same_exte
     assert checkout.shipping_method_id is None
     assert checkout.external_shipping_method_id == method_id
     assert checkout.shipping_method_name == response_shipping_name
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_not_called()
     mocked_call_checkout_info_event.assert_not_called()
@@ -2052,10 +2122,21 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_cc(
     mocked_call_checkout_info_event,
     checkout_with_shipping_method,
     warehouses_for_cc,
+    address_usa,
     api_client,
 ):
     # given
     checkout = checkout_with_shipping_method
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.shipping_address = address_usa
+    checkout.save(
+        update_fields=[
+            "save_billing_address",
+            "save_shipping_address",
+            "shipping_address",
+        ]
+    )
 
     collection_point = warehouses_for_cc[1]
 
@@ -2084,6 +2165,9 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_cc(
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id is None
     assert checkout.shipping_method_name is None
+    assert checkout.save_billing_address is True
+    # set the save_shipping_address setting to False for CC
+    assert checkout.save_shipping_address is False
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -2129,6 +2213,9 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_external_ship
     )
 
     checkout = checkout_with_shipping_method
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -2148,6 +2235,8 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_external_ship
     assert checkout.shipping_method_id is None
     assert checkout.external_shipping_method_id == method_id
     assert checkout.shipping_method_name == response_shipping_name
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -2170,6 +2259,9 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_differnt_buil
 ):
     # given
     checkout = checkout_with_shipping_method
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -2194,6 +2286,8 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_differnt_buil
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id == other_shipping_method.id
     assert checkout.shipping_method_name == other_shipping_method.name
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()
@@ -2215,6 +2309,9 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_the_same_ship
 ):
     # given
     checkout = checkout_with_shipping_method
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = True
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     shipping_method = checkout.shipping_method
 
@@ -2241,6 +2338,8 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_the_same_ship
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id == shipping_method.id
     assert checkout.shipping_method_name == shipping_method.name
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is True
 
     mocked_invalidate_checkout.assert_not_called()
     mocked_call_checkout_info_event.assert_not_called()
@@ -2262,6 +2361,9 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_none(
 ):
     # given
     checkout = checkout_with_shipping_method
+    checkout.save_billing_address = True
+    checkout.save_shipping_address = False
+    checkout.save(update_fields=["save_billing_address", "save_shipping_address"])
 
     # when
     response = api_client.post_graphql(
@@ -2280,6 +2382,9 @@ def test_checkout_delivery_method_update_from_built_in_shipping_to_none(
     assert checkout.external_shipping_method_id is None
     assert checkout.shipping_method_id is None
     assert checkout.shipping_method_name is None
+    # the flags should not be changed as shipping address is not reset
+    assert checkout.save_billing_address is True
+    assert checkout.save_shipping_address is False
 
     mocked_invalidate_checkout.assert_called_once()
     mocked_call_checkout_info_event.assert_called_once()


### PR DESCRIPTION
- Ensure that in case the CC delivery method is cleared, the `save_shipping_address` is reset to the default `True` value.
- Ensure that in case the CC delivery method is set, the `save_shipping_address` is changed to `False`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
