### PR TITLE
Fix app resolver calling update state

### DIFF
--- a/saleor/graphql/app/tests/queries/test_app.py
+++ b/saleor/graphql/app/tests/queries/test_app.py
@@ -714,11 +714,11 @@ def test_app_query_breaker_state(
     # given
     now = timezone.now()
     storage_mock = Mock()
-    breaker_board_mock.update_breaker_state.side_effect = lambda app: breaker_state
     breaker_board_mock.storage = storage_mock
     storage_mock.retrieve_last_state_change.return_value = bytes(
         now.isoformat(), "utf-8"
     )
+    storage_mock.last_open.return_value = (int(now.timestamp()), breaker_state)
     id = graphene.Node.to_global_id("App", app.id)
     variables = {"id": id}
 
@@ -793,6 +793,10 @@ def test_app_query_breaker_last_change(
     board_mock.storage = storage_mock
     storage_mock.retrieve_last_state_change.return_value = bytes(
         now.isoformat(), "utf-8"
+    )
+    storage_mock.last_open.return_value = (
+        int(now.timestamp()),
+        CircuitBreakerState.HALF_OPEN,
     )
     id = graphene.Node.to_global_id("App", app.id)
     variables = {"id": id}

--- a/saleor/graphql/app/tests/queries/test_app.py
+++ b/saleor/graphql/app/tests/queries/test_app.py
@@ -1,9 +1,8 @@
-from datetime import datetime
+import datetime
 from unittest.mock import Mock, patch
 
 import graphene
 import pytest
-from django.utils import timezone
 from freezegun import freeze_time
 
 from .....app.models import App
@@ -712,13 +711,9 @@ def test_app_query_breaker_state(
     app,
 ):
     # given
-    now = timezone.now()
     storage_mock = Mock()
     breaker_board_mock.storage = storage_mock
-    storage_mock.retrieve_last_state_change.return_value = bytes(
-        now.isoformat(), "utf-8"
-    )
-    storage_mock.last_open.return_value = (int(now.timestamp()), breaker_state)
+    storage_mock.get_app_state.return_value = breaker_state, 100
     id = graphene.Node.to_global_id("App", app.id)
     variables = {"id": id}
 
@@ -785,18 +780,15 @@ def test_app_query_breaker_last_change(
     app,
 ):
     # given
-    now = timezone.now()
+    now = datetime.datetime.now(tz=datetime.UTC)
     storage_mock = Mock()
     board_mock.update_breaker_state.side_effect = (
         lambda app: CircuitBreakerState.HALF_OPEN
     )
     board_mock.storage = storage_mock
-    storage_mock.retrieve_last_state_change.return_value = bytes(
-        now.isoformat(), "utf-8"
-    )
-    storage_mock.last_open.return_value = (
-        int(now.timestamp()),
+    storage_mock.get_app_state.return_value = (
         CircuitBreakerState.HALF_OPEN,
+        now.timestamp(),
     )
     id = graphene.Node.to_global_id("App", app.id)
     variables = {"id": id}
@@ -810,7 +802,7 @@ def test_app_query_breaker_last_change(
 
     # then
     content = get_graphql_content(response)
-    retrieved_date = datetime.fromisoformat(
+    retrieved_date = datetime.datetime.fromisoformat(
         content["data"]["app"]["breakerLastStateChange"]
     )
     assert retrieved_date == now

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -621,7 +621,8 @@ class App(ModelObjectType[models.App]):
     def resolve_breaker_state(root: models.App, _info: ResolveInfo):
         if not breaker_board:
             return CircuitBreakerState.CLOSED
-        return breaker_board.update_breaker_state(root)
+        _, state = breaker_board.storage.last_open(root.id)
+        return state
 
     @staticmethod
     def resolve_breaker_last_state_change(root: models.App, _info: ResolveInfo):

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -619,16 +619,17 @@ class App(ModelObjectType[models.App]):
 
     @staticmethod
     def resolve_breaker_state(root: models.App, _info: ResolveInfo):
-        if not breaker_board:
-            return CircuitBreakerState.CLOSED
-        _, state = breaker_board.storage.last_open(root.id)
-        return state
+        if breaker_board:
+            state, _ = breaker_board.storage.get_app_state(root.id)
+            return state
+        return CircuitBreakerState.CLOSED
 
     @staticmethod
     def resolve_breaker_last_state_change(root: models.App, _info: ResolveInfo):
         if breaker_board:
-            if last_change := breaker_board.storage.retrieve_last_state_change(root.id):
-                return datetime.datetime.fromisoformat(str(last_change, "utf-8"))
+            _, changed_at = breaker_board.storage.get_app_state(root.id)
+            if changed_at:
+                return datetime.datetime.fromtimestamp(changed_at, tz=datetime.UTC)
         return None
 
 

--- a/saleor/webhook/circuit_breaker/storage.py
+++ b/saleor/webhook/circuit_breaker/storage.py
@@ -29,6 +29,9 @@ class Storage:
     def register_state_change(self, app_id: int):
         pass
 
+    def retrieve_last_state_change(self, app_id: int):
+        pass
+
     def clear_state_for_app(self, app_id: int):
         pass
 


### PR DESCRIPTION
I want to merge this change because it fixes the `App` type resolver of `breakerState` calling `update_breaker_state` which it should not.

Also refactored some breaker methods - because we had separate for updating last open, last change, state, fetching all three. Now there is simply `set_app_state` / `get_app_state`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
