### PR TITLE
Make sure that clear_delivery_method handles external shipping

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -999,6 +999,7 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
     checkout = checkout_info.checkout
     checkout.collection_point = None
     checkout.shipping_method = None
+    checkout.shipping_method_name = None
     checkout_info.shipping_method = None
 
     update_delivery_method_lists_for_checkout_info(
@@ -1016,6 +1017,8 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
             "shipping_method",
             "collection_point",
             "last_change",
+            "shipping_method_name",
+            "external_shipping_method_id",
         ]
     )
     get_checkout_metadata(checkout).save()


### PR DESCRIPTION
I want to merge this change because previously we didn't include the fields for `shipping_method_name` and `external_shipping_method_id`, when removing the delivery method

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
