### PR TITLE
Add CORE_0253 and CORE_0254 e2e test

### DIFF
--- a/saleor/tests/e2e/orders/test_able_to_decide_if_address_is_saved_in_user_address_book.py
+++ b/saleor/tests/e2e/orders/test_able_to_decide_if_address_is_saved_in_user_address_book.py
@@ -1,0 +1,256 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..account.utils import get_user
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..users.utils import create_customer
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+)
+
+
+@pytest.mark.e2e
+def test_allow_save_shipping_and_not_save_billing_in_user_address_book_CORE_0253(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_users,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_users,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    price = 10
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    customer_input = {
+        "email": "test0253@com.com",
+    }
+
+    user_data = create_customer(
+        e2e_staff_api_client,
+        customer_input,
+    )
+    user_id = user_data["id"]
+    user_email = user_data["email"]
+
+    # Step 1 - Create draft order
+    # use different address for shipping and billing
+    billing_address = {
+        "firstName": "John",
+        "lastName": "Muller",
+        "companyName": "Saleor Commerce DE",
+        "streetAddress1": "Potsdamer Platz 47",
+        "streetAddress2": "",
+        "postalCode": "85131",
+        "country": "DE",
+        "city": "Pollenfeld",
+        "phone": "+498421499469",
+        "countryArea": "",
+    }
+
+    draft_order_input = {
+        "channelId": channel_id,
+        "user": user_id,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": billing_address,
+        "saveShippingAddress": True,
+        "saveBillingAddress": False,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+    assert order_id is not None
+
+    # Step 2 - Add lines to the order
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_lines = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id == product_variant_id
+
+    # Step 3 - Update order's shipping method
+    input = {"shippingMethod": shipping_method_id}
+    draft_order = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id is not None
+
+    # Step 4 - Complete the order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"
+    order_billing_address = order["order"]["billingAddress"]
+    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
+    order_shipping_address = order["order"]["shippingAddress"]
+    assert order_shipping_address["streetAddress1"] == DEFAULT_ADDRESS["streetAddress1"]
+    assert order["order"]["user"]["id"] == user_id
+    assert order["order"]["userEmail"] == user_email
+
+    # Step 5 - Verify the user address book
+    user = get_user(e2e_staff_api_client, user_id)
+
+    assert len(user["addresses"]) == 1
+    address = user["addresses"][0]
+    assert address["streetAddress1"] == order_shipping_address["streetAddress1"]
+    assert address["id"] != order_billing_address["id"]
+    assert address["id"] != order_shipping_address["id"]
+
+
+@pytest.mark.e2e
+def test_allow_not_save_shipping_and_save_billing_in_user_address_book_CORE_0254(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_users,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_users,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    price = 10
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    customer_input = {
+        "email": "test0253@com.com",
+    }
+
+    user_data = create_customer(
+        e2e_staff_api_client,
+        customer_input,
+    )
+    user_id = user_data["id"]
+    user_email = user_data["email"]
+
+    # Step 1 - Create draft order
+    # use different address for shipping and billing
+    billing_address = {
+        "firstName": "John",
+        "lastName": "Muller",
+        "companyName": "Saleor Commerce DE",
+        "streetAddress1": "Potsdamer Platz 47",
+        "streetAddress2": "",
+        "postalCode": "85131",
+        "country": "DE",
+        "city": "Pollenfeld",
+        "phone": "+498421499469",
+        "countryArea": "",
+    }
+
+    draft_order_input = {
+        "channelId": channel_id,
+        "user": user_id,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+    assert order_id is not None
+
+    # Step 2 - Add lines to the order
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_lines = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id == product_variant_id
+
+    # Step 3 - Update order's shipping method and save address settings
+    input = {
+        "shippingMethod": shipping_method_id,
+        "saveShippingAddress": False,
+        "saveBillingAddress": True,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": billing_address,
+    }
+    draft_order = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id is not None
+
+    # Step 4 - Complete the order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"
+    order_billing_address = order["order"]["billingAddress"]
+    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
+    order_shipping_address = order["order"]["shippingAddress"]
+    assert order_shipping_address["streetAddress1"] == DEFAULT_ADDRESS["streetAddress1"]
+    assert order["order"]["user"]["id"] == user_id
+    assert order["order"]["userEmail"] == user_email
+
+    # Step 5 - Verify the user address book
+    user = get_user(e2e_staff_api_client, user_id)
+
+    assert len(user["addresses"]) == 1
+    address = user["addresses"][0]
+    assert address["streetAddress1"] == order_billing_address["streetAddress1"]
+    assert address["id"] != order_billing_address["id"]
+    assert address["id"] != order_shipping_address["id"]


### PR DESCRIPTION
Verify if `draftOrderCreate` mutation with `saveShippingAddress` and `saveBillingAddress` allows to choose if the address will be saved to the client's address book.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
