### PR TITLE
Add CORE_0255 e2e test

### DIFF
--- a/saleor/tests/e2e/orders/test_unable_to_update_save_settings_after_order_completion.py
+++ b/saleor/tests/e2e/orders/test_unable_to_update_save_settings_after_order_completion.py
@@ -1,0 +1,139 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..users.utils import create_customer
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+    raw_draft_order_update,
+)
+
+
+@pytest.mark.e2e
+def test_unable_to_update_save_settings_after_order_complete_CORE_0255(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_users,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_users,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    price = 10
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    customer_input = {
+        "email": "test0253@com.com",
+    }
+
+    user_data = create_customer(
+        e2e_staff_api_client,
+        customer_input,
+    )
+    user_id = user_data["id"]
+    user_email = user_data["email"]
+
+    # Step 1 - Create draft order
+    # use different address for shipping and billing
+    billing_address = {
+        "firstName": "John",
+        "lastName": "Muller",
+        "companyName": "Saleor Commerce DE",
+        "streetAddress1": "Potsdamer Platz 47",
+        "streetAddress2": "",
+        "postalCode": "85131",
+        "country": "DE",
+        "city": "Pollenfeld",
+        "phone": "+498421499469",
+        "countryArea": "",
+    }
+
+    draft_order_input = {
+        "channelId": channel_id,
+        "user": user_id,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": billing_address,
+        "saveShippingAddress": True,
+        "saveBillingAddress": False,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+    assert order_id is not None
+
+    # Step 2 - Add lines to the order
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_lines = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id == product_variant_id
+
+    # Step 3 - Update order's shipping method
+    input = {"shippingMethod": shipping_method_id}
+    draft_order = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id is not None
+
+    # Step 4 - Complete the order
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"
+    order_billing_address = order["order"]["billingAddress"]
+    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
+    order_shipping_address = order["order"]["shippingAddress"]
+    assert order_shipping_address["streetAddress1"] == DEFAULT_ADDRESS["streetAddress1"]
+    assert order["order"]["user"]["id"] == user_id
+    assert order["order"]["userEmail"] == user_email
+
+    # Step 5 - Try to update order's save settings
+    input = {
+        "billingAddress": billing_address,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "saveShippingAddress": True,
+        "saveBillingAddress": True,
+    }
+    response = raw_draft_order_update(e2e_staff_api_client, order_id, input)
+    errors = response["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "id"
+    assert error["code"] == "INVALID"

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -2,7 +2,7 @@ from .draft_order_bulk_delete import draft_order_bulk_delete
 from .draft_order_complete import draft_order_complete, raw_draft_order_complete
 from .draft_order_create import draft_order_create
 from .draft_order_delete import draft_order_delete
-from .draft_order_update import draft_order_update
+from .draft_order_update import draft_order_update, raw_draft_order_update
 from .order_by_checkout_id_query import order_by_checkout_id_query
 from .order_cancel import order_cancel
 from .order_create_from_checkout import (
@@ -48,4 +48,5 @@ __all__ = [
     "order_line_delete",
     "order_line_discount_update",
     "raw_order_create_from_checkout",
+    "raw_draft_order_update",
 ]

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -1,6 +1,8 @@
-from saleor.graphql.tests.utils import get_graphql_content
+from ...account.utils.fragments import ADDRESS_FRAGMENT
+from ...utils import get_graphql_content
 
-DRAFT_ORDER_COMPLETE_MUTATION = """
+DRAFT_ORDER_COMPLETE_MUTATION = (
+    """
 mutation DraftOrderComplete($id: ID!) {
   draftOrderComplete(id: $id) {
     errors {
@@ -13,6 +15,13 @@ mutation DraftOrderComplete($id: ID!) {
       user {
         id
         email
+      }
+      userEmail
+      billingAddress {
+        ...Address
+      }
+      shippingAddress {
+        ...Address
       }
       undiscountedTotal {
         ...BaseTaxedMoney
@@ -96,6 +105,8 @@ fragment BaseTaxedMoney on TaxedMoney {
   currency
 }
 """
+    + ADDRESS_FRAGMENT
+)
 
 
 def raw_draft_order_complete(api_client, id):

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -129,6 +129,20 @@ fragment BaseTaxedMoney on TaxedMoney {
 """
 
 
+def raw_draft_order_update(api_client, id, input):
+    variables = {"id": id, "input": input}
+
+    response = api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["draftOrderUpdate"]
+
+    return data
+
+
 def draft_order_update(
     api_client,
     id,


### PR DESCRIPTION
Ensure that after finalising draft order, the staff user is not able to update order with the use of `draftOrderUpdate` mutation, specially with `saveAddress` flags.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
