### PR TITLE
Verify if updating the address of unconfirmed order do not change the address in customer address book 

### DIFF
--- a/saleor/tests/e2e/channel/utils/channel_create.py
+++ b/saleor/tests/e2e/channel/utils/channel_create.py
@@ -66,10 +66,18 @@ def create_channel(
         warehouse_ids = []
     if slug is None:
         slug = f"channel_slug_{uuid.uuid4()}"
-    if order_settings is None:
-        order_settings = {}
     if checkout_settings is None:
         checkout_settings = {}
+
+    order_settings = {
+        "markAsPaidStrategy": "PAYMENT_FLOW",
+        "automaticallyFulfillNonShippableGiftCard": False,
+        "allowUnpaidOrders": False,
+        "automaticallyConfirmAllNewOrders": True,
+        "expireOrdersAfter": 60,
+        "deleteExpiredOrdersAfter": 1,
+        **(order_settings or {}),
+    }
 
     variables = {
         "input": {
@@ -81,12 +89,6 @@ def create_channel(
             "addWarehouses": warehouse_ids,
             "addShippingZones": shipping_zones,
             "orderSettings": {
-                "markAsPaidStrategy": "PAYMENT_FLOW",
-                "automaticallyFulfillNonShippableGiftCard": False,
-                "allowUnpaidOrders": False,
-                "automaticallyConfirmAllNewOrders": True,
-                "expireOrdersAfter": 60,
-                "deleteExpiredOrdersAfter": 1,
                 **order_settings,
             },
             "checkoutSettings": {
@@ -106,7 +108,10 @@ def create_channel(
     assert data["slug"] == slug
     assert data["currencyCode"] == currency
     assert data["defaultCountry"]["code"] == country
-    assert data["orderSettings"]["automaticallyConfirmAllNewOrders"] is True
+    assert (
+        data["orderSettings"]["automaticallyConfirmAllNewOrders"]
+        == order_settings["automaticallyConfirmAllNewOrders"]
+    )
     assert data["isActive"] is is_active
 
     return data

--- a/saleor/tests/e2e/checkout/utils/checkout_complete.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_complete.py
@@ -12,6 +12,7 @@ mutation CheckoutComplete($checkoutId: ID!) {
     }
     order {
       id
+      userEmail
       status
       paymentStatus
       isPaid

--- a/saleor/tests/e2e/orders/test_changing_order_address_not_update_the_customer_one.py
+++ b/saleor/tests/e2e/orders/test_changing_order_address_not_update_the_customer_one.py
@@ -1,0 +1,178 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..account.utils import get_own_data
+from ..checkout.utils import (
+    checkout_create,
+    checkout_delivery_method_update,
+    raw_checkout_complete,
+)
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..users.utils import get_user
+from ..utils import assign_permissions
+from .utils import (
+    order_update,
+)
+
+
+@pytest.mark.e2e
+def test_changing_order_address_do_not_influence_customer_address_CORE_0257(
+    e2e_staff_api_client,
+    e2e_logged_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_users,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_users,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    product_price = 10
+    shipping_price = 10
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+    }
+
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {
+                                    "price": shipping_price,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "order_settings": {
+                    "automaticallyConfirmAllNewOrders": False,
+                    "allowUnpaidOrders": True,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+
+    _product_id, product_variant_id, _product_variant_price = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        product_price,
+    )
+
+    # Step 1 - Create checkout.
+    # use different address for shipping and billing
+    billing_address = {
+        "firstName": "John",
+        "lastName": "Muller",
+        "companyName": "Saleor Commerce DE",
+        "streetAddress1": "Potsdamer Platz 47",
+        "streetAddress2": "",
+        "postalCode": "85131",
+        "country": "DE",
+        "city": "Pollenfeld",
+        "phone": "+498421499469",
+        "countryArea": "",
+    }
+    lines = [
+        {"variantId": product_variant_id, "quantity": 1},
+    ]
+    user = e2e_logged_api_client.user
+    checkout_data = checkout_create(
+        e2e_logged_api_client,
+        lines,
+        channel_slug,
+        billing_address=billing_address,
+        save_billing_address=True,
+        save_shipping_address=False,
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_data["deliveryMethod"] is None
+    assert checkout_data["shippingMethod"] is None
+    assert checkout_data["shippingAddress"]
+    assert checkout_data["billingAddress"]
+    assert (
+        checkout_data["shippingAddress"]["streetAddress1"]
+        == DEFAULT_ADDRESS["streetAddress1"]
+    )
+    assert (
+        checkout_data["billingAddress"]["streetAddress1"]
+        == billing_address["streetAddress1"]
+    )
+
+    # Step 2 - Set shipping address and DeliveryMethod for checkout
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+
+    # Step 3 - Checkout complete results in the order creation
+    data = raw_checkout_complete(
+        e2e_logged_api_client,
+        checkout_id,
+    )
+    order_data = data["order"]
+    order_id = order_data["id"]
+    assert order_data is not None
+    assert order_data["id"] is not None
+    assert order_data["isShippingRequired"] is True
+    assert order_data["paymentStatus"] == "NOT_CHARGED"
+    assert order_data["status"] == "UNCONFIRMED"
+    assert order_data["isPaid"] is False
+    order_billing_address = order_data["billingAddress"]
+    assert order_billing_address
+    order_shipping_address = order_data["shippingAddress"]
+    assert order_shipping_address
+    assert order_data["userEmail"] == user.email
+
+    # Step 5 - Verify the user address book
+    user = get_own_data(e2e_logged_api_client)
+
+    assert len(user["addresses"]) == 1
+    address = user["addresses"][0]
+    assert address["streetAddress1"] == order_billing_address["streetAddress1"]
+    assert address["id"] != order_billing_address["id"]
+    user_id = user["id"]
+
+    # Step 6 - Update order's shipping address
+    billing_address["streetAddress1"] = "New street 12"
+    updated_order_data = order_update(
+        e2e_staff_api_client,
+        order_id,
+        {"billingAddress": billing_address},
+    )
+
+    assert (
+        updated_order_data["order"]["billingAddress"]["streetAddress1"]
+        == billing_address["streetAddress1"]
+    )
+
+    # Step 7 - Verify if the user address stay unchanged
+    user = get_user(e2e_staff_api_client, user_id)
+    assert len(user["addresses"]) == 1
+    address = user["addresses"][0]
+    assert address["streetAddress1"] == order_billing_address["streetAddress1"]

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -20,6 +20,7 @@ from .order_line_update import order_line_update
 from .order_lines_create import order_lines_create
 from .order_mark_as_paid import mark_order_paid
 from .order_query import order_query
+from .order_update import order_update
 from .order_update_shipping import order_update_shipping
 from .order_void import order_void, raw_order_void
 
@@ -49,4 +50,5 @@ __all__ = [
     "order_line_discount_update",
     "raw_order_create_from_checkout",
     "raw_draft_order_update",
+    "order_update",
 ]

--- a/saleor/tests/e2e/orders/utils/order_update.py
+++ b/saleor/tests/e2e/orders/utils/order_update.py
@@ -1,0 +1,61 @@
+from ...account.utils.fragments import ADDRESS_FRAGMENT
+from ...utils import get_graphql_content
+
+ORDER_UPDATE_MUTATION = (
+    """
+    mutation orderUpdate(
+        $id: ID
+        $externalReference: String
+        $input: OrderUpdateInput!
+    ) {
+        orderUpdate(
+            id: $id
+            externalReference: $externalReference
+            input: $input
+        ) {
+            errors {
+                field
+                message
+                code
+            }
+            order {
+                id
+                externalReference
+                shippingAddress {
+                    ...Address
+                }
+                billingAddress {
+                    ...Address
+                }
+            }
+        }
+    }
+"""
+    + ADDRESS_FRAGMENT
+)
+
+
+def raw_order_update(api_client, id, input):
+    variables = {"id": id, "input": input}
+
+    response = api_client.post_graphql(
+        ORDER_UPDATE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["orderUpdate"]
+
+    return data
+
+
+def order_update(api_client, id, input):
+    response = raw_order_update(api_client, id, input)
+
+    assert response["order"] is not None
+
+    errors = response["errors"]
+
+    assert errors == []
+
+    return response

--- a/saleor/tests/e2e/users/utils/get_user.py
+++ b/saleor/tests/e2e/users/utils/get_user.py
@@ -1,25 +1,41 @@
+from ...account.utils.fragments import ADDRESS_FRAGMENT
 from ...utils import get_graphql_content
 
-USER_QUERY = """
-query CustomerDetails($id:ID!){
-  user(id: $id) {
-    id
-    email
-    isConfirmed
-    isActive
-    orders(first: 10){
-      edges {
-        node {
-          id
-          number
-          paymentStatus
-          created
+USER_QUERY = (
+    """
+    query User($id: ID!) {
+        user(id: $id) {
+            id
+            email
+            firstName
+            lastName
+            isStaff
+            isActive
+            isConfirmed
+            addresses {
+                ...Address
+            }
+            checkoutIds
+            orders(first: 10) {
+                totalCount
+                edges {
+                    node {
+                        id
+                        number
+                    }
+                }
+            }
+            defaultShippingAddress {
+                ...Address
+            }
+            defaultBillingAddress {
+                ...Address
+            }
         }
-      }
     }
-  }
-}
 """
+    + ADDRESS_FRAGMENT
+)
 
 
 def get_user(


### PR DESCRIPTION
Test ID: CORE_0257

Ensure that updating address on unconfirmed order do not influence the customer address saved in address book during checkout completion.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
