### PR TITLE
Use logical instead of physical cores to detect pytest workers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -99,7 +99,8 @@ jobs:
             --cov \
             --cov-report= \
             --junitxml=junit/test-results.xml \
-            --django-db-bench=${{ env.BENCH_PATH }}
+            --django-db-bench=${{ env.BENCH_PATH }} \
+            -n logical
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
I want to merge this change because by default pytest is assigning physical CPUs to spawn workers (2 on CICD) but with `logical` setting it can use logical threads (4 on CICD)

https://pytest-xdist.readthedocs.io/en/stable/distribution.html#running-tests-across-multiple-cpus

This doesn't yield a lot of improvement - approx 2 minutes, but it's something.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
