### PR TITLE
Block tax external calls for order bulk queries

### DIFF
--- a/saleor/graphql/account/tests/queries/test_me.py
+++ b/saleor/graphql/account/tests/queries/test_me.py
@@ -278,7 +278,6 @@ ME_WITH_ORDERS_QUERY = """
                         }
                     }
                 }
-                totalCount
             }
         }
     }
@@ -303,7 +302,6 @@ ME_WITH_ORDERS_WITH_LINES_TOTAL_PRICE_QUERY = """
                         }
                     }
                 }
-                totalCount
             }
         }
     }

--- a/saleor/graphql/order/tests/queries/shared_query_fragments.py
+++ b/saleor/graphql/order/tests/queries/shared_query_fragments.py
@@ -1,0 +1,115 @@
+ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS = """
+fragment price on Money {
+  amount
+}
+
+fragment taxPrice on TaxedMoney {
+  gross {
+    ...price
+  }
+}
+
+fragment order on Order {
+  shippingMethods {
+    id
+  }
+  deliveryMethod {
+    ... on ShippingMethod {
+      id
+    }
+  }
+  shippingMethodName
+  total {
+    ...taxPrice
+  }
+  undiscountedTotal {
+    ...taxPrice
+  }
+  subtotal {
+    ...taxPrice
+  }
+  shippingPrice {
+    ...taxPrice
+  }
+  totalRemainingGrant {
+    ...price
+  }
+  totalCancelPending {
+    ...price
+  }
+  totalChargePending {
+    ...price
+  }
+  totalAuthorizePending {
+    ...price
+  }
+  totalRefundPending {
+    ...price
+  }
+  totalRefunded {
+    ...price
+  }
+  totalGrantedRefund {
+    ...price
+  }
+  grantedRefunds {
+    amount {
+      ...price
+    }
+    lines {
+      orderLine {
+        unitPrice {
+          ...taxPrice
+        }
+      }
+    }
+  }
+  fulfillments {
+    lines {
+      orderLine {
+        unitPrice {
+          ...taxPrice
+        }
+      }
+    }
+  }
+  lines {
+    undiscountedTotalPrice {
+      ...taxPrice
+    }
+    unitPrice {
+      ...taxPrice
+    }
+    unitDiscount {
+      ...price
+    }
+    undiscountedUnitPrice {
+      ...taxPrice
+    }
+    totalPrice {
+      ...taxPrice
+    }
+  }
+  events {
+    relatedOrder {
+      total {
+        ...taxPrice
+      }
+    }
+    fulfilledItems {
+      quantity
+      orderLine {
+        productName
+        variantName
+      }
+    }
+    lines {
+      orderLine {
+        unitPrice {
+          ...taxPrice
+        }
+      }
+    }
+  }
+}
+"""

--- a/saleor/graphql/order/tests/queries/test_orders.py
+++ b/saleor/graphql/order/tests/queries/test_orders.py
@@ -7,122 +7,15 @@ from .....order.events import (
     fulfillment_fulfilled_items_event,
     order_added_products_event,
 )
-from .....order.models import Order
 from .....tax.calculations.order import update_order_prices_with_flat_rates
-from ....tests.utils import assert_no_permission, get_graphql_content
+from ....tests.utils import get_graphql_content
 from .shared_query_fragments import ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS
 
-DRAFT_ORDER_QUERY = """
-    query DraftOrdersQuery {
-        draftOrders(first: 10) {
-            edges {
-                node {
-                    id
-                    number
-                }
-            }
-        }
-    }
-"""
-
-
-def test_draft_order_query(
-    staff_api_client, permission_group_manage_orders, order, draft_order_list
-):
-    # given
-    permission_group_manage_orders.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
-
-    assert len(edges) == Order.objects.drafts().count()
-
-
-def test_query_draft_orders_by_user_with_access_to_all_channels(
-    staff_api_client,
-    permission_group_all_perms_all_channels,
-    draft_orders_in_different_channels,
-):
-    # given
-    permission_group_all_perms_all_channels.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
-
-    assert len(edges) == len(draft_orders_in_different_channels)
-
-
-def test_query_draft_orders_by_user_with_restricted_access_to_channels(
-    staff_api_client,
-    permission_group_all_perms_channel_USD_only,
-    draft_orders_in_different_channels,
-):
-    # given
-    permission_group_all_perms_channel_USD_only.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    content = get_graphql_content(response)
-
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
-    assert content["data"]["draftOrders"]["edges"][0]["node"]["number"] == str(
-        draft_orders_in_different_channels[0].number
-    )
-
-
-def test_query_draft_orders_by_user_with_restricted_access_to_channels_no_acc_channels(
-    staff_api_client,
-    permission_group_all_perms_without_any_channel,
-    draft_orders_in_different_channels,
-):
-    # given
-    permission_group_all_perms_without_any_channel.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 0
-
-
-def test_query_draft_orders_by_app(
-    app_api_client, permission_manage_orders, draft_orders_in_different_channels
-):
-    # when
-    response = app_api_client.post_graphql(
-        DRAFT_ORDER_QUERY, permissions=(permission_manage_orders,)
-    )
-
-    # then
-    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
-
-    assert len(edges) == len(draft_orders_in_different_channels)
-
-
-def test_query_draft_orders_by_customer(
-    user_api_client, draft_orders_in_different_channels
-):
-    # when
-    response = user_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    assert_no_permission(response)
-
-
-QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS = (
+QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS = (
     ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS
     + """
-query DraftOrders {
-  draftOrders(first: 10) {
+query Orders {
+  orders(first: 10) {
     edges {
       node {
         ...order
@@ -146,20 +39,18 @@ def test_query_orders_when_flat_rates_active(
     permission_group_manage_orders,
 ):
     # given
-    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.status = OrderStatus.UNCONFIRMED
     order_with_lines.should_refresh_prices = True
     order_with_lines.total_gross_amount = Decimal(0)
     order_with_lines.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order_with_lines.refresh_from_db()
     assert not order_with_lines.should_refresh_prices
     assert order_with_lines.total_gross_amount != Decimal(0)
@@ -177,20 +68,18 @@ def test_query_orders_for_order_with_lines_when_tax_app_active(
     permission_group_manage_orders,
 ):
     # given
-    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.status = OrderStatus.UNCONFIRMED
     order_with_lines.should_refresh_prices = True
     order_with_lines.total_gross_amount = Decimal(0)
     order_with_lines.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order_with_lines.refresh_from_db()
 
     assert order_with_lines.should_refresh_prices
@@ -225,20 +114,18 @@ def test_query_orders_for_order_with_granted_refunds_when_tax_app_active(
     order_line = order.lines.first()
     granted_refund.lines.create(order_line=order_line, quantity=1)
 
-    order.status = OrderStatus.DRAFT
+    order.status = OrderStatus.UNCONFIRMED
     order.should_refresh_prices = True
     order.total_gross_amount = Decimal(0)
     order.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order.refresh_from_db()
 
     assert order.should_refresh_prices
@@ -263,20 +150,18 @@ def test_query_orders_for_order_with_fulfillments_when_tax_app_active(
     fulfillment = order.fulfillments.create()
     fulfillment.lines.create(order_line=order_with_lines.lines.first(), quantity=1)
 
-    order.status = OrderStatus.DRAFT
+    order.status = OrderStatus.UNCONFIRMED
     order.should_refresh_prices = True
     order.total_gross_amount = Decimal(0)
     order.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order.refresh_from_db()
 
     assert order.should_refresh_prices
@@ -318,20 +203,18 @@ def test_query_orders_for_order_with_events_when_tax_app_active(
         lines=[order_line],
     )
 
-    order.status = OrderStatus.DRAFT
+    order.status = OrderStatus.UNCONFIRMED
     order.should_refresh_prices = True
     order.total_gross_amount = Decimal(0)
     order.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order.refresh_from_db()
 
     assert order.should_refresh_prices

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1170,6 +1170,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).price_with_discounts
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1201,6 +1202,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).undiscounted_price
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1219,7 +1221,11 @@ class OrderLine(
         def _resolve_unit_discount_type(data):
             order, lines, manager = data
             return calculations.order_line_unit_discount_type(
-                order, order_line, manager, lines
+                order,
+                order_line,
+                manager,
+                lines,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1236,7 +1242,11 @@ class OrderLine(
         def _resolve_unit_discount_value(data):
             order, lines, manager = data
             return calculations.order_line_unit_discount_value(
-                order, order_line, manager, lines
+                order,
+                order_line,
+                manager,
+                lines,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1251,7 +1261,11 @@ class OrderLine(
         def _resolve_unit_discount(data):
             order, lines, manager = data
             return calculations.order_line_unit_discount(
-                order, order_line, manager, lines
+                order,
+                order_line,
+                manager,
+                lines,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1274,6 +1288,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ) or Decimal(0)
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1297,6 +1312,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).price_with_discounts
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1322,6 +1338,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).undiscounted_price
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1803,7 +1820,9 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
         @allow_writer_in_context(info.context)
         def with_manager(manager):
             order = root.node
-            fetch_order_prices_if_expired(order, manager)
+            fetch_order_prices_if_expired(
+                order, manager, allow_sync_webhooks=root.allow_sync_webhooks
+            )
             return OrderDiscountsByOrderIDLoader(info.context).load(order.id)
 
         return get_plugin_manager_promise(info.context).then(with_manager)
@@ -1938,7 +1957,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_undiscounted_shipping(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -1956,7 +1979,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_shipping(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -1974,7 +2001,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_shipping_tax_rate(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ) or Decimal(0)
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -2016,6 +2047,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                 manager,
                 order_lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order_lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -2034,7 +2066,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
         def _resolve_total(lines):
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_total(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         return (
@@ -2052,7 +2088,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = lines_and_manager
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_undiscounted_total(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -2146,7 +2186,9 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                     fulfillments,
                 )
             return [
-                SyncWebhookControlContext(node=fulfillment)
+                SyncWebhookControlContext(
+                    node=fulfillment, allow_sync_webhooks=root.allow_sync_webhooks
+                )
                 for fulfillment in fulfillments_to_return
             ]
 

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -440,8 +440,13 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
     def get_subtotal(self):
         return get_subtotal(self.lines.all(), self.currency)
 
-    def is_shipping_required(self):
-        return any(line.is_shipping_required for line in self.lines.all())
+    def is_shipping_required(
+        self, database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME
+    ):
+        return any(
+            line.is_shipping_required
+            for line in self.lines.using(database_connection_name).all()
+        )
 
     def get_total_quantity(self):
         return sum([line.quantity for line in self.lines.all()])

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -23,6 +23,7 @@ from ...plugins.manager import get_plugins_manager
 from ...plugins.tests.sample_plugins import PluginSample
 from ...tax import TaxCalculationStrategy
 from ...tax.calculations.order import update_order_prices_with_flat_rates
+from ...tax.utils import get_tax_calculation_strategy_for_order
 from .. import OrderStatus, calculations
 from ..interface import OrderTaxedPricesData
 
@@ -665,10 +666,14 @@ def test_recalculate_prices_total_shipping_price_changed(
             "shipping_method_name",
         ]
     )
+    tax_calculation_strategy = get_tax_calculation_strategy_for_order(order)
 
     # when
     calculations._recalculate_prices(
-        order, get_plugins_manager(allow_replica=True), order_lines
+        order,
+        get_plugins_manager(allow_replica=True),
+        order_lines,
+        tax_calculation_strategy=tax_calculation_strategy,
     )
 
     # then
@@ -699,10 +704,14 @@ def test_recalculate_prices_line_quantity_changed(
     line = order_lines.first()
     line.quantity += 1
     line.save(update_fields=["quantity"])
+    tax_calculation_strategy = get_tax_calculation_strategy_for_order(order)
 
     # when
     calculations._recalculate_prices(
-        order, get_plugins_manager(allow_replica=True), order_lines
+        order,
+        get_plugins_manager(allow_replica=True),
+        order_lines,
+        tax_calculation_strategy=tax_calculation_strategy,
     )
 
     # then
@@ -975,6 +984,99 @@ def test_fetch_order_prices_if_expired_webhooks_success(
         assert order_line.unit_price == line_total / order_line.quantity
         assert order_line.tax_rate == tax_line.tax_rate / 100
     assert order_with_lines.total == subtotal + shipping_price
+
+
+def test_fetch_order_prices_if_expired_plugins_with_allow_sync_webhooks_to_false(
+    plugins_manager,
+    fetch_kwargs_with_lines,
+    order_with_lines,
+    tax_data,
+):
+    # given
+    plugins_manager.calculate_order_line_unit = Mock(side_effect=None)
+    plugins_manager.calculate_order_line_total = Mock(side_effect=None)
+    plugins_manager.get_order_line_tax_rate = Mock(side_effect=None)
+    plugins_manager.calculate_order_shipping = Mock(return_value=None)
+    plugins_manager.get_order_shipping_tax_rate = Mock(return_value=None)
+    plugins_manager.get_taxes_for_order = Mock(return_value=None)
+    plugins_manager.calculate_order_total = Mock(return_value=None)
+
+    fetch_kwargs_with_lines["allow_sync_webhooks"] = False
+    order_from_input = fetch_kwargs_with_lines["order"]
+    lines_from_input = fetch_kwargs_with_lines["lines"]
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(**fetch_kwargs_with_lines)
+
+    # then
+    assert order_from_input == order
+    assert lines_from_input == lines
+
+    plugins_manager.calculate_order_line_unit.assert_not_called()
+    plugins_manager.calculate_order_line_total.assert_not_called()
+    plugins_manager.get_order_line_tax_rate.assert_not_called()
+    plugins_manager.calculate_order_shipping.assert_not_called()
+    plugins_manager.get_order_shipping_tax_rate.assert_not_called()
+    plugins_manager.get_taxes_for_order.assert_not_called()
+    plugins_manager.calculate_order_total.assert_not_called()
+
+
+@patch(
+    "saleor.order.calculations.update_order_prices_with_flat_rates",
+    wraps=update_order_prices_with_flat_rates,
+)
+@pytest.mark.parametrize("prices_entered_with_tax", [True, False])
+def test_fetch_order_prices_if_expired_flat_rates_with_allow_sync_webhook_set_to_false(
+    mocked_update_order_prices_with_flat_rates,
+    order_with_lines,
+    fetch_kwargs,
+    prices_entered_with_tax,
+):
+    # given
+    order = order_with_lines
+    tc = order.channel.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.prices_entered_with_tax = prices_entered_with_tax
+    tc.tax_calculation_strategy = TaxCalculationStrategy.FLAT_RATES
+    tc.save()
+
+    fetch_kwargs["allow_sync_webhooks"] = False
+
+    # when
+    calculations.fetch_order_prices_if_expired(**fetch_kwargs)
+    order.refresh_from_db()
+    line = order.lines.first()
+
+    # then
+    mocked_update_order_prices_with_flat_rates.assert_called_once_with(
+        order,
+        list(order.lines.all()),
+        prices_entered_with_tax,
+        database_connection_name=order.lines.db,
+    )
+    assert line.tax_rate == Decimal("0.2300")
+    assert order.shipping_tax_rate == Decimal("0.2300")
+
+
+def test_fetch_order_prices_tax_app_with_allow_sync_webhook_set_to_false(
+    plugins_manager,
+    fetch_kwargs_with_lines,
+    order_with_lines,
+):
+    # given
+    plugins_manager.get_taxes_for_order = Mock(return_value=None)
+
+    fetch_kwargs_with_lines["allow_sync_webhooks"] = False
+    order_from_input = fetch_kwargs_with_lines["order"]
+    lines_from_input = fetch_kwargs_with_lines["lines"]
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(**fetch_kwargs_with_lines)
+
+    # then
+    assert order_from_input == order
+    assert lines_from_input == lines
+    plugins_manager.get_taxes_for_order.assert_not_called()
 
 
 @pytest.mark.parametrize("prices_entered_with_tax", [True, False])
@@ -1509,9 +1611,12 @@ def test_recalculate_prices_empty_tax_data_logging_address(
         "get_taxes_for_order": Mock(return_value=None),
     }
     manager = Mock(**manager_methods)
+    tax_calculation_strategy = get_tax_calculation_strategy_for_order(order)
 
     # when
-    calculations._recalculate_prices(order, manager, order_lines)
+    calculations._recalculate_prices(
+        order, manager, order_lines, tax_calculation_strategy=tax_calculation_strategy
+    )
 
     # then
     assert (

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -680,7 +680,9 @@ def get_all_shipping_methods_for_order(
     shipping_channel_listings: Iterable["ShippingMethodChannelListing"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ) -> list[ShippingMethodData]:
-    if not order.is_shipping_required():
+    if not order.is_shipping_required(
+        database_connection_name=database_connection_name
+    ):
         return []
 
     shipping_address = order.shipping_address
@@ -697,6 +699,7 @@ def get_all_shipping_methods_for_order(
             price=order.subtotal.gross,
             shipping_address=shipping_address,
             country_code=shipping_address.country.code,
+            database_connection_name=database_connection_name,
         )
         .prefetch_related("channel_listings")
     )

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -177,6 +177,7 @@ class ShippingMethodQueryset(models.QuerySet["ShippingMethod"]):
         shipping_address: Optional["Address"] = None,
         country_code: str | None = None,
         lines: list["CheckoutLineInfo"] | list["OrderLineInfo"] | None = None,
+        database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     ):
         if not shipping_address:
             return None
@@ -186,7 +187,11 @@ class ShippingMethodQueryset(models.QuerySet["ShippingMethod"]):
 
         if lines is None:
             # TODO: lines should comes from args in get_valid_shipping_methods_for_order
-            lines = list(instance.lines.prefetch_related("variant__product").all())  # type: ignore[misc] # this is hack # noqa: E501
+            lines = list(
+                instance.lines.prefetch_related("variant__product")  # type: ignore[misc] # this is hack # noqa: E501
+                .using(database_connection_name)
+                .all()
+            )
         instance_product_ids = {
             line.variant.product_id for line in lines if line.variant
         }


### PR DESCRIPTION
I want to merge this change because it block the external tax calculations for order, when calling bulk queries (like `orders`, `draftOrders` etc. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
