### PR TITLE
Block filter shipping methods for order bulk queries

### DIFF
--- a/saleor/graphql/order/tests/queries/shared_query_fragments.py
+++ b/saleor/graphql/order/tests/queries/shared_query_fragments.py
@@ -13,6 +13,15 @@ fragment order on Order {
   shippingMethods {
     id
   }
+  availableShippingMethods{
+    id
+  }
+  errors {
+    field
+    orderLines
+    code
+  }
+  canFinalize
   deliveryMethod {
     ... on ShippingMethod {
       id

--- a/saleor/graphql/order/tests/queries/test_orders.py
+++ b/saleor/graphql/order/tests/queries/test_orders.py
@@ -7,6 +7,7 @@ from .....order.events import (
     fulfillment_fulfilled_items_event,
     order_added_products_event,
 )
+from .....plugins.manager import PluginsManager
 from .....tax.calculations.order import update_order_prices_with_flat_rates
 from ....tests.utils import get_graphql_content
 from .shared_query_fragments import ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS
@@ -222,3 +223,33 @@ def test_query_orders_for_order_with_events_when_tax_app_active(
 
     mocked_update_order_prices_with_flat_rates.assert_not_called()
     mocked__recalculate_prices.assert_not_called()
+
+
+@patch.object(PluginsManager, "excluded_shipping_methods_for_order")
+def test_query_orders_with_active_filter_shipping_methods_webhook(
+    mocked_webhook_handler,
+    settings,
+    order_with_lines,
+    tax_configuration_flat_rates,
+    staff_api_client,
+    permission_group_manage_orders,
+):
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
+    # given
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    order_with_lines.should_refresh_prices = True
+    order_with_lines.total_gross_amount = Decimal(0)
+    order_with_lines.save()
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["orders"]["edges"]) == 1
+    order_with_lines.refresh_from_db()
+    assert not order_with_lines.should_refresh_prices
+    assert order_with_lines.total_gross_amount != Decimal(0)
+    mocked_webhook_handler.assert_not_called()

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -2352,6 +2352,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                         country=country,
                         manager=manager,
                         database_connection_name=database_connection_name,
+                        allow_sync_webhooks=root.allow_sync_webhooks,
                     )
                 except ValidationError:
                     return False
@@ -2498,6 +2499,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                     channel_listings,
                     manager,
                     database_connection_name=database_connection_name,
+                    allow_sync_webhooks=root.allow_sync_webhooks,
                 )
 
             return (
@@ -2615,6 +2617,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                         country=country,
                         manager=manager,
                         database_connection_name=database_connection_name,
+                        allow_sync_webhooks=root.allow_sync_webhooks,
                     )
                 except ValidationError as e:
                     return validation_error_to_error_type(e, OrderError)

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -59,6 +59,7 @@ def get_shipping_method_availability_error(
     method: Optional["ShippingMethodData"],
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ):
     """Validate whether shipping method is still available for the order."""
     is_valid = False
@@ -70,6 +71,7 @@ def get_shipping_method_availability_error(
                 order.channel.shipping_method_listings.all(),
                 manager,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=allow_sync_webhooks,
             )
             if m.active
         }
@@ -89,6 +91,7 @@ def validate_shipping_method(
     errors: T_ERRORS,
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ):
     if not order.shipping_method:
         error = ValidationError(
@@ -124,6 +127,7 @@ def validate_shipping_method(
                 convert_to_shipping_method_data(order.shipping_method, listing),
                 manager,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=allow_sync_webhooks,
             )
 
     if error:
@@ -344,6 +348,7 @@ def validate_draft_order(
     country: str,
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ):
     """Check if the given order contains the proper data.
 
@@ -363,7 +368,12 @@ def validate_draft_order(
     if is_shipping_required(lines):
         validate_shipping_address(order, errors)
         validate_shipping_method(
-            order, channel, errors, manager, database_connection_name
+            order,
+            channel,
+            errors,
+            manager,
+            database_connection_name,
+            allow_sync_webhooks=allow_sync_webhooks,
         )
     validate_total_quantity(lines, errors)
     validate_order_lines(

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -721,6 +721,7 @@ def get_valid_shipping_methods_for_order(
     shipping_channel_listings: Iterable["ShippingMethodChannelListing"],
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ) -> list[ShippingMethodData]:
     """Return a list of shipping methods according to Saleor's own business logic."""
     valid_methods = get_all_shipping_methods_for_order(
@@ -729,7 +730,7 @@ def get_valid_shipping_methods_for_order(
     if not valid_methods:
         return []
 
-    if order.status in ORDER_EDITABLE_STATUS:
+    if order.status in ORDER_EDITABLE_STATUS and allow_sync_webhooks:
         excluded_methods = manager.excluded_shipping_methods_for_order(
             order, valid_methods
         )


### PR DESCRIPTION
I want to merge this change because it blocks the filter shipping method webhooks for order, when calling bulk queries (like orders, draftOrders etc.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
