### PR TITLE
Fix missing prefetch on update_discounted_prices_for_promotion task

### DIFF
--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -55,9 +55,11 @@ def update_discounted_prices_for_promotion(
     changed_variant_listing_promotion_rule_to_create = []
     changed_variant_listing_promotion_rule_to_update = []
 
-    product_channel_listings = ProductChannelListing.objects.using(
-        settings.DATABASE_CONNECTION_REPLICA_NAME
-    ).filter(Exists(products.filter(id=OuterRef("product_id"))))
+    product_channel_listings = (
+        ProductChannelListing.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+        .filter(Exists(products.filter(id=OuterRef("product_id"))))
+        .prefetch_related("channel")
+    )
     if only_dirty_products:
         product_channel_listings.filter(discounted_price_dirty=True)
 


### PR DESCRIPTION
ℹ️ This is a 3.20 port of https://github.com/saleor/saleor/pull/17426

I want to merge this change because it adds missing prefetch on `update_discounted_prices_for_promotion` task.
Without, it will fetch tons of small SQLs below https://github.com/saleor/saleor/blob/main/saleor/product/utils/variant_prices.py#L80

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
