### PR TITLE
Improve `fetch_order_prices_if_expired` function structure

### DIFF
--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -50,7 +50,7 @@ def base_order_total(
 
     All discounts are included in this price.
     """
-    subtotal, shipping_price = apply_order_discounts(
+    subtotal, shipping_price = calculate_prices(
         order,
         lines,
         assign_prices=False,
@@ -168,7 +168,7 @@ def propagate_order_discount_on_order_prices(
     return subtotal, shipping_price
 
 
-def apply_order_discounts(
+def calculate_prices(
     order: "Order",
     lines: Iterable["OrderLine"],
     assign_prices=True,

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -87,20 +87,20 @@ def fetch_order_prices_if_expired(
     else:
         lines_info = fetch_draft_order_lines_info(order, lines)
 
-    # handle order promotion
+    # order promotion is qualified based on the most actual prices, therefor need to be assessed
+    # on the every recalculation
     handle_order_promotion(order, lines_info, database_connection_name)
 
     # update `OrderLine.unit_discount_...` fields
     update_unit_discount_data_on_order_line(lines_info)
 
-    # calculate prices
     lines = [line_info.line for line_info in lines_info]
     calculate_prices(
         order,
         lines,
         database_connection_name=database_connection_name,
     )
-    # calculate taxes
+
     calculate_taxes(
         order,
         manager,

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -41,7 +41,7 @@ from ..tax.utils import (
     validate_tax_data,
 )
 from . import ORDER_EDITABLE_STATUS, OrderStatus
-from .base_calculations import apply_order_discounts, base_order_line_total
+from .base_calculations import base_order_line_total, calculate_prices
 from .fetch import (
     EditableOrderLineInfo,
     fetch_draft_order_lines_info,
@@ -95,7 +95,7 @@ def fetch_order_prices_if_expired(
 
     # calculate prices
     lines = [line_info.line for line_info in lines_info]
-    _recalculate_prices(
+    calculate_prices(
         order,
         lines,
         database_connection_name=database_connection_name,
@@ -162,20 +162,6 @@ def get_expired_line_ids(order: Order, lines: Iterable[OrderLine] | None) -> lis
         for line in lines
         if line.draft_base_price_expire_at and line.draft_base_price_expire_at < now
     ]
-
-
-def _recalculate_prices(
-    order: Order,
-    lines: Iterable[OrderLine],
-    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
-):
-    """Calculate prices after handling order level discounts and taxes."""
-    # calculate untaxed prices including discounts
-    apply_order_discounts(
-        order,
-        lines,
-        database_connection_name=database_connection_name,
-    )
 
 
 def calculate_taxes(

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -428,7 +428,7 @@ def test_recalculate_with_plugins_order_discounts_and_total_undiscounted_price_c
     assert order.shipping_tax_rate == shipping_tax_rate
 
 
-def test_recalculate_prices_total_shipping_price_changed(
+def test_calculate_prices_total_shipping_price_changed(
     draft_order, order_lines, shipping_method_weight_based
 ):
     """Test that discounts are properly updated when shipping price changes."""
@@ -468,7 +468,7 @@ def test_recalculate_prices_total_shipping_price_changed(
     )
 
     # when
-    calculations._recalculate_prices(
+    calculations.calculate_prices(
         order, get_plugins_manager(allow_replica=True), order_lines
     )
 
@@ -480,7 +480,7 @@ def test_recalculate_prices_total_shipping_price_changed(
     assert order_discount.amount == order.undiscounted_total.net
 
 
-def test_recalculate_prices_line_quantity_changed(
+def test_calculate_prices_line_quantity_changed(
     draft_order, order_lines, shipping_method_weight_based
 ):
     """Test that discounts are properly updated when line quantities change."""
@@ -502,7 +502,7 @@ def test_recalculate_prices_line_quantity_changed(
     line.save(update_fields=["quantity"])
 
     # when
-    calculations._recalculate_prices(
+    calculations.calculate_prices(
         order, get_plugins_manager(allow_replica=True), order_lines
     )
 
@@ -1279,7 +1279,7 @@ def test_fetch_order_data_calls_inactive_plugin(
 
 
 @pytest.mark.parametrize("tax_app_id", [None, "test.app"])
-def test_recalculate_prices_empty_tax_data_logging_address(
+def test_calculate_prices_empty_tax_data_logging_address(
     tax_app_id, draft_order, order_lines, address, caplog
 ):
     # given
@@ -1312,7 +1312,7 @@ def test_recalculate_prices_empty_tax_data_logging_address(
     manager = Mock(**manager_methods)
 
     # when
-    calculations._recalculate_prices(order, manager, order_lines)
+    calculations.calculate_prices(order, manager, order_lines)
 
     # then
     assert (

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -468,9 +468,7 @@ def test_calculate_prices_total_shipping_price_changed(
     )
 
     # when
-    calculations.calculate_prices(
-        order, get_plugins_manager(allow_replica=True), order_lines
-    )
+    calculations.calculate_prices(order, order_lines)
 
     # then
     order_discount.refresh_from_db()
@@ -502,9 +500,7 @@ def test_calculate_prices_line_quantity_changed(
     line.save(update_fields=["quantity"])
 
     # when
-    calculations.calculate_prices(
-        order, get_plugins_manager(allow_replica=True), order_lines
-    )
+    calculations.calculate_prices(order, order_lines)
 
     # then
     order_discount.refresh_from_db()
@@ -1279,7 +1275,7 @@ def test_fetch_order_data_calls_inactive_plugin(
 
 
 @pytest.mark.parametrize("tax_app_id", [None, "test.app"])
-def test_calculate_prices_empty_tax_data_logging_address(
+def test_calculate_taxes_empty_tax_data_logging_address(
     tax_app_id, draft_order, order_lines, address, caplog
 ):
     # given
@@ -1312,7 +1308,7 @@ def test_calculate_prices_empty_tax_data_logging_address(
     manager = Mock(**manager_methods)
 
     # when
-    calculations.calculate_prices(order, manager, order_lines)
+    calculations.calculate_taxes(order, manager, order_lines)
 
     # then
     assert (

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -8,7 +8,7 @@ from ...core.prices import quantize_price
 from ...core.taxes import zero_money, zero_taxed_money
 from ...discount import DiscountType, DiscountValueType
 from ...order import OrderStatus
-from ...order.base_calculations import apply_order_discounts
+from ...order.base_calculations import calculate_prices
 from ...order.calculations import fetch_order_prices_if_expired
 from ...order.models import OrderLine
 from ...order.utils import get_order_country
@@ -164,7 +164,7 @@ def test_calculations_calculate_order_total_voucher(order_with_lines_untaxed, vo
         amount_value=10,
         voucher=voucher,
     )
-    apply_order_discounts(order, lines)
+    calculate_prices(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -193,7 +193,7 @@ def test_calculations_calculate_order_total_with_manual_discount(
         currency=order.currency,
         amount_value=10,
     )
-    apply_order_discounts(order, lines)
+    calculate_prices(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -248,7 +248,7 @@ def test_calculations_calculate_order_total_with_discount_for_subtotal_and_shipp
         currency=order.currency,
         amount_value=75,
     )
-    apply_order_discounts(order, lines)
+    calculate_prices(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -313,7 +313,7 @@ def test_calculations_calculate_order_total_with_manual_discount_and_voucher(
         amount_value=10,
         voucher=voucher,
     )
-    apply_order_discounts(order, lines)
+    calculate_prices(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -340,7 +340,7 @@ def test_calculate_order_shipping(order_line, shipping_zone):
     order.undiscounted_base_shipping_price = base_shipping_price
     order.save()
 
-    apply_order_discounts(order, lines)
+    calculate_prices(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -400,7 +400,7 @@ def test_calculate_order_shipping_voucher_on_shipping(
     shipping_channel_listings = method.channel_listings.get(channel=channel)
     shipping_price = shipping_channel_listings.price
 
-    apply_order_discounts(order, lines)
+    calculate_prices(order, lines)
 
     # when
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
@@ -516,7 +516,7 @@ def test_update_taxes_for_order_lines_voucher_on_entire_order(
     )
 
     # when
-    apply_order_discounts(order, lines)
+    calculate_prices(order, lines)
     lines, _ = update_taxes_for_order_lines(
         order, lines, country_code, Decimal(23), prices_entered_with_tax
     )


### PR DESCRIPTION
Improve `fetch_order_prices_if_expired` function structure for better readability.  It is a cleanup after changes introduced in https://github.com/saleor/saleor/pull/17160

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
