### PR TITLE
Introduce `ADDRESS_DE` and utils for address validation

### DIFF
--- a/saleor/tests/e2e/__init__.py
+++ b/saleor/tests/e2e/__init__.py
@@ -11,7 +11,6 @@ DEFAULT_ADDRESS = {
     "phone": "+12025550163",
 }
 
-
 DEFAULT_WAREHOUSE_ADDRESS = {
     "firstName": "Saleor",
     "lastName": "Mirumee",
@@ -23,4 +22,17 @@ DEFAULT_WAREHOUSE_ADDRESS = {
     "city": "Wrocław",
     "countryArea": "",
     "phone": "+48321321888",
+}
+
+ADDRESS_DE = {
+    "firstName": "John",
+    "lastName": "Muller",
+    "companyName": "Saleor Commerce DE",
+    "streetAddress1": "Potsdamer Platz 47",
+    "streetAddress2": "",
+    "postalCode": "85131",
+    "country": "DE",
+    "city": "Pollenfeld",
+    "phone": "+498421499469",
+    "countryArea": "",
 }

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ... import ADDRESS_DE
 from ...product.utils.preparing_product import prepare_product
 from ...shop.utils import prepare_shop
 from ...taxes.utils import update_country_tax_rates
@@ -152,18 +153,7 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
     assert len(checkout_data["shippingMethods"]) == 1
 
     # Step 3 - Set billing address for checkout
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     checkout_billing_address_update(e2e_staff_api_client, checkout_id, billing_address)
 
     # Step 4 - Get checkout and verify taxes

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_with_click_and_collect_calculate_simple_taxes_based_on_shipping_address.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_with_click_and_collect_calculate_simple_taxes_based_on_shipping_address.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ... import ADDRESS_DE
 from ...product.utils.preparing_product import prepare_product
 from ...shop.utils import prepare_shop
 from ...taxes.utils import update_country_tax_rates
@@ -122,18 +123,7 @@ def test_calculate_simple_taxes_order_with_click_and_collect_with_prices_entered
     assert len(checkout_data["shippingMethods"]) == 1
 
     # Step 2 - Set billing address for checkout
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     checkout_billing_address_update(e2e_staff_api_client, checkout_id, billing_address)
 
     # Step 3 - Get checkout and verify taxes
@@ -292,18 +282,7 @@ def test_calculate_simple_taxes_order_with_click_and_collect_with_prices_entered
     assert len(checkout_data["shippingMethods"]) == 1
 
     # Step 2 - Set billing address for checkout
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     checkout_billing_address_update(e2e_staff_api_client, checkout_id, billing_address)
 
     # Step 3 - Get checkout and verify taxes

--- a/saleor/tests/e2e/checkout/test_checkout_complete_not_save_cc_address_in_customer_address_book.py
+++ b/saleor/tests/e2e/checkout/test_checkout_complete_not_save_cc_address_in_customer_address_book.py
@@ -4,7 +4,7 @@ from .. import ADDRESS_DE
 from ..account.utils import get_own_data
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from ..warehouse.utils import update_warehouse
 from .utils import (
     checkout_complete,
@@ -86,7 +86,6 @@ def test_checkout_complete_not_save_cc_address_in_customer_address_book_CORE_013
     assert checkout_data["email"] == expected_email
     assert checkout_data["user"]["email"] == expected_email
     assert checkout_data["isShippingRequired"] is True
-    checkout_billing_address = checkout_data["billingAddress"]
     checkout_shipping_address = checkout_data["shippingAddress"]
 
     collection_point = checkout_data["availableCollectionPoints"][0]
@@ -134,12 +133,13 @@ def test_checkout_complete_not_save_cc_address_in_customer_address_book_CORE_013
     assert order_data["deliveryMethod"]["id"] == warehouse_id
     assert order_data["shippingAddress"]
     assert order_data["billingAddress"]
+    assert_address_data(order_data["billingAddress"], billing_address)
 
     # Step 5 - Verify the user address book
     me = get_own_data(e2e_logged_api_client)
 
     assert len(me["addresses"]) == 1
     address = me["addresses"][0]
-    assert address["streetAddress1"] == checkout_billing_address["streetAddress1"]
+    assert_address_data(address, billing_address)
     assert address["id"] != order_data["billingAddress"]["id"]
     assert address["id"] != order_data["shippingAddress"]["id"]

--- a/saleor/tests/e2e/checkout/test_checkout_complete_not_save_cc_address_in_customer_address_book.py
+++ b/saleor/tests/e2e/checkout/test_checkout_complete_not_save_cc_address_in_customer_address_book.py
@@ -1,5 +1,6 @@
 import pytest
 
+from .. import ADDRESS_DE
 from ..account.utils import get_own_data
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
@@ -56,18 +57,7 @@ def test_checkout_complete_not_save_cc_address_in_customer_address_book_CORE_013
     lines = [
         {"variantId": product_variant_id, "quantity": 1},
     ]
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     shipping_address = {
         "firstName": "John",
         "lastName": "Muller",

--- a/saleor/tests/e2e/checkout/test_checkout_complete_respect_saving_address_settings.py
+++ b/saleor/tests/e2e/checkout/test_checkout_complete_respect_saving_address_settings.py
@@ -1,5 +1,6 @@
 import pytest
 
+from .. import ADDRESS_DE
 from ..account.utils import get_own_data
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
@@ -46,18 +47,7 @@ def test_respect_saving_address_setting_in_checkout_process_CORE_0132(
 
     # Step 1 - Create checkout.
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     shipping_address = {
         "firstName": "John",
         "lastName": "Muller",

--- a/saleor/tests/e2e/checkout/test_checkout_complete_respect_saving_address_settings.py
+++ b/saleor/tests/e2e/checkout/test_checkout_complete_respect_saving_address_settings.py
@@ -4,7 +4,7 @@ from .. import ADDRESS_DE
 from ..account.utils import get_own_data
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from .utils import (
     checkout_complete,
     checkout_create,
@@ -118,10 +118,8 @@ def test_respect_saving_address_setting_in_checkout_process_CORE_0132(
     assert order_billing_address
     order_shipping_address = order_data["shippingAddress"]
     assert order_shipping_address
-    assert (
-        order_shipping_address["streetAddress1"] == shipping_address["streetAddress1"]
-    )
-    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
+    assert_address_data(order_shipping_address, shipping_address)
+    assert_address_data(order_billing_address, billing_address)
     assert order_data["userEmail"] == user.email
 
     # Step 5 - Verify the user address book
@@ -129,6 +127,6 @@ def test_respect_saving_address_setting_in_checkout_process_CORE_0132(
 
     assert len(user["addresses"]) == 1
     address = user["addresses"][0]
-    assert address["streetAddress1"] == shipping_address["streetAddress1"]
+    assert_address_data(address, shipping_address)
     assert address["id"] != order_billing_address["id"]
     assert address["id"] != order_shipping_address["id"]

--- a/saleor/tests/e2e/checkout/test_checkout_complete_store_address_in_customer_addresses_after_updating_the_address.py
+++ b/saleor/tests/e2e/checkout/test_checkout_complete_store_address_in_customer_addresses_after_updating_the_address.py
@@ -4,7 +4,7 @@ from .. import ADDRESS_DE, DEFAULT_ADDRESS
 from ..account.utils import get_own_data
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from .utils import (
     checkout_complete,
     checkout_create,
@@ -126,11 +126,8 @@ def test_updating_the_address_without_the_save_flag_esnures_that_the_address_is_
     assert order_billing_address
     order_shipping_address = order_data["shippingAddress"]
     assert order_shipping_address
-    assert (
-        order_shipping_address["streetAddress1"]
-        == new_shipping_address["streetAddress1"]
-    )
-    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
+    assert_address_data(order_shipping_address, new_shipping_address)
+    assert_address_data(order_billing_address, billing_address)
     assert order_data["userEmail"] == user.email
 
     # Step 6 - Verify the user address book
@@ -138,6 +135,6 @@ def test_updating_the_address_without_the_save_flag_esnures_that_the_address_is_
 
     assert len(user["addresses"]) == 1
     address = user["addresses"][0]
-    assert address["streetAddress1"] == new_shipping_address["streetAddress1"]
+    assert_address_data(address, new_shipping_address)
     assert address["id"] != order_billing_address["id"]
     assert address["id"] != order_shipping_address["id"]

--- a/saleor/tests/e2e/checkout/test_checkout_complete_store_address_in_customer_addresses_after_updating_the_address.py
+++ b/saleor/tests/e2e/checkout/test_checkout_complete_store_address_in_customer_addresses_after_updating_the_address.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import DEFAULT_ADDRESS
+from .. import ADDRESS_DE, DEFAULT_ADDRESS
 from ..account.utils import get_own_data
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
@@ -48,18 +48,7 @@ def test_updating_the_address_without_the_save_flag_esnures_that_the_address_is_
 
     # Step 1 - Create checkout.
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     lines = [
         {"variantId": product_variant_id, "quantity": 1},
     ]

--- a/saleor/tests/e2e/checkout/test_guest_user_can_complete_checkout_without_saving_addresses.py
+++ b/saleor/tests/e2e/checkout/test_guest_user_can_complete_checkout_without_saving_addresses.py
@@ -1,5 +1,6 @@
 import pytest
 
+from .. import ADDRESS_DE
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
@@ -55,18 +56,7 @@ def test_guest_user_can_complete_checkout_without_saving_addresses_CORE_0129(
         {"variantId": product_variant_id, "quantity": 1},
     ]
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     email = "test0129@example.com"
     checkout_data = checkout_create(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_guest_user_can_complete_checkout_without_saving_addresses.py
+++ b/saleor/tests/e2e/checkout/test_guest_user_can_complete_checkout_without_saving_addresses.py
@@ -3,7 +3,7 @@ import pytest
 from .. import ADDRESS_DE
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from .utils import (
     checkout_complete,
     checkout_create,
@@ -102,11 +102,7 @@ def test_guest_user_can_complete_checkout_without_saving_addresses_CORE_0129(
     assert order_data["deliveryMethod"]["id"] == shipping_method_id
     assert order_data["shippingAddress"]
     assert order_data["billingAddress"]
-    assert (
-        order_data["shippingAddress"]["streetAddress1"]
-        == checkout_shipping_address["streetAddress1"]
-    )
-    assert (
-        order_data["billingAddress"]["streetAddress1"]
-        == checkout_billing_address["streetAddress1"]
-    )
+    checkout_billing_address["country"] = checkout_billing_address["country"]["code"]
+    checkout_shipping_address["country"] = checkout_shipping_address["country"]["code"]
+    assert_address_data(order_data["shippingAddress"], checkout_shipping_address)
+    assert_address_data(order_data["billingAddress"], checkout_billing_address)

--- a/saleor/tests/e2e/checkout/utils/checkout_billing_address_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_billing_address_update.py
@@ -1,5 +1,5 @@
 from ... import DEFAULT_ADDRESS
-from ...utils import get_graphql_content
+from ...utils import assert_address_data, get_graphql_content
 
 CHECKOUT_BILLING_ADDRESS_UPDATE_MUTATION = """
 mutation CheckoutBillingAddressUpdate(
@@ -45,14 +45,6 @@ def checkout_billing_address_update(api_client, checkout_id, address=DEFAULT_ADD
     assert content["data"]["checkoutBillingAddressUpdate"]["errors"] == []
 
     data = content["data"]["checkoutBillingAddressUpdate"]["checkout"]
-    assert data["billingAddress"]["firstName"] == address["firstName"]
-    assert data["billingAddress"]["lastName"] == address["lastName"]
-    assert data["billingAddress"]["companyName"] == address["companyName"]
-    assert data["billingAddress"]["streetAddress1"] == address["streetAddress1"]
-    assert data["billingAddress"]["postalCode"] == address["postalCode"]
-    assert data["billingAddress"]["country"]["code"] == address["country"]
-    assert data["billingAddress"]["city"] == address["city"].upper()
-    assert data["billingAddress"]["countryArea"] == address["countryArea"]
-    assert data["billingAddress"]["phone"] == address["phone"]
+    assert_address_data(data["billingAddress"], address)
 
     return data

--- a/saleor/tests/e2e/checkout/utils/checkout_shipping_address_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_shipping_address_update.py
@@ -1,5 +1,5 @@
 from ... import DEFAULT_ADDRESS
-from ...utils import get_graphql_content
+from ...utils import assert_address_data, get_graphql_content
 
 CHECKOUT_SHIPPING_ADDRESS_UPDATE_MUTATION = """
 mutation CheckoutShippingAddressUpdate(
@@ -66,14 +66,6 @@ def checkout_shipping_address_update(
     assert response["errors"] == []
 
     data = response["checkout"]
-    assert data["shippingAddress"]["firstName"] == address["firstName"]
-    assert data["shippingAddress"]["lastName"] == address["lastName"]
-    assert data["shippingAddress"]["companyName"] == address["companyName"]
-    assert data["shippingAddress"]["streetAddress1"] == address["streetAddress1"]
-    assert data["shippingAddress"]["postalCode"] == address["postalCode"]
-    assert data["shippingAddress"]["country"]["code"] == address["country"]
-    assert data["shippingAddress"]["city"] == address["city"].upper()
-    assert data["shippingAddress"]["countryArea"] == address["countryArea"]
-    assert data["shippingAddress"]["phone"] == address["phone"]
+    assert_address_data(data["shippingAddress"], address)
 
     return data

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_address.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_address.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ... import ADDRESS_DE
 from ...product.utils.preparing_product import prepare_product
 from ...shop.utils.preparing_shop import prepare_shop
 from ...taxes.utils import update_country_tax_rates
@@ -119,18 +120,7 @@ def test_order_calculate_simple_tax_based_on_shipping_address_CORE_2002(
     assert order_data["total"]["gross"]["amount"] == product_variant_price
 
     # Step 3 - Add shipping and billing addresses
-    shipping_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    shipping_address = ADDRESS_DE
     billing_address = {
         "firstName": "John",
         "lastName": "Muller",

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_for_digital_product.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_for_digital_product.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ... import ADDRESS_DE
 from ...product.utils.preparing_product import prepare_digital_product
 from ...shop.utils.preparing_shop import prepare_shop
 from ...taxes.utils import update_country_tax_rates
@@ -77,18 +78,7 @@ def test_digital_order_calculate_simple_tax_based_on_billing_country_CORE_2008(
     )
 
     # Step 1 - Create a draft order
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     input = {
         "channelId": channel_id,
         "billingAddress": billing_address,

--- a/saleor/tests/e2e/orders/test_able_to_decide_if_address_is_saved_in_user_address_book.py
+++ b/saleor/tests/e2e/orders/test_able_to_decide_if_address_is_saved_in_user_address_book.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import DEFAULT_ADDRESS
+from .. import ADDRESS_DE, DEFAULT_ADDRESS
 from ..account.utils import get_user
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
@@ -62,18 +62,7 @@ def test_allow_save_shipping_and_not_save_billing_in_user_address_book_CORE_0253
 
     # Step 1 - Create draft order
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
 
     draft_order_input = {
         "channelId": channel_id,
@@ -182,18 +171,7 @@ def test_allow_not_save_shipping_and_save_billing_in_user_address_book_CORE_0254
 
     # Step 1 - Create draft order
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
 
     draft_order_input = {
         "channelId": channel_id,

--- a/saleor/tests/e2e/orders/test_able_to_decide_if_address_is_saved_in_user_address_book.py
+++ b/saleor/tests/e2e/orders/test_able_to_decide_if_address_is_saved_in_user_address_book.py
@@ -5,7 +5,7 @@ from ..account.utils import get_user
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
 from ..users.utils import create_customer
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from .utils import (
     draft_order_complete,
     draft_order_create,
@@ -107,9 +107,9 @@ def test_allow_save_shipping_and_not_save_billing_in_user_address_book_CORE_0253
     assert order_line["productVariantId"] == product_variant_id
     assert order["order"]["status"] == "UNFULFILLED"
     order_billing_address = order["order"]["billingAddress"]
-    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
     order_shipping_address = order["order"]["shippingAddress"]
-    assert order_shipping_address["streetAddress1"] == DEFAULT_ADDRESS["streetAddress1"]
+    assert_address_data(order_billing_address, billing_address)
+    assert_address_data(order_shipping_address, DEFAULT_ADDRESS)
     assert order["order"]["user"]["id"] == user_id
     assert order["order"]["userEmail"] == user_email
 
@@ -118,7 +118,8 @@ def test_allow_save_shipping_and_not_save_billing_in_user_address_book_CORE_0253
 
     assert len(user["addresses"]) == 1
     address = user["addresses"][0]
-    assert address["streetAddress1"] == order_shipping_address["streetAddress1"]
+    order_shipping_address["country"] = order_shipping_address["country"]["code"]
+    assert_address_data(address, order_shipping_address)
     assert address["id"] != order_billing_address["id"]
     assert address["id"] != order_shipping_address["id"]
 
@@ -218,9 +219,9 @@ def test_allow_not_save_shipping_and_save_billing_in_user_address_book_CORE_0254
     assert order_line["productVariantId"] == product_variant_id
     assert order["order"]["status"] == "UNFULFILLED"
     order_billing_address = order["order"]["billingAddress"]
-    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
     order_shipping_address = order["order"]["shippingAddress"]
-    assert order_shipping_address["streetAddress1"] == DEFAULT_ADDRESS["streetAddress1"]
+    assert_address_data(order_billing_address, billing_address)
+    assert_address_data(order_shipping_address, DEFAULT_ADDRESS)
     assert order["order"]["user"]["id"] == user_id
     assert order["order"]["userEmail"] == user_email
 
@@ -229,6 +230,7 @@ def test_allow_not_save_shipping_and_save_billing_in_user_address_book_CORE_0254
 
     assert len(user["addresses"]) == 1
     address = user["addresses"][0]
-    assert address["streetAddress1"] == order_billing_address["streetAddress1"]
+    order_billing_address["country"] = order_billing_address["country"]["code"]
+    assert_address_data(address, order_billing_address)
     assert address["id"] != order_billing_address["id"]
     assert address["id"] != order_shipping_address["id"]

--- a/saleor/tests/e2e/orders/test_changing_order_address_not_update_the_customer_one.py
+++ b/saleor/tests/e2e/orders/test_changing_order_address_not_update_the_customer_one.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import DEFAULT_ADDRESS
+from .. import ADDRESS_DE, DEFAULT_ADDRESS
 from ..account.utils import get_own_data
 from ..checkout.utils import (
     checkout_create,
@@ -82,18 +82,7 @@ def test_changing_order_address_do_not_influence_customer_address_CORE_0257(
 
     # Step 1 - Create checkout.
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
     lines = [
         {"variantId": product_variant_id, "quantity": 1},
     ]

--- a/saleor/tests/e2e/orders/test_changing_order_address_not_update_the_customer_one.py
+++ b/saleor/tests/e2e/orders/test_changing_order_address_not_update_the_customer_one.py
@@ -10,7 +10,7 @@ from ..checkout.utils import (
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_shop
 from ..users.utils import get_user
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from .utils import (
     order_update,
 )
@@ -102,14 +102,8 @@ def test_changing_order_address_do_not_influence_customer_address_CORE_0257(
     assert checkout_data["shippingMethod"] is None
     assert checkout_data["shippingAddress"]
     assert checkout_data["billingAddress"]
-    assert (
-        checkout_data["shippingAddress"]["streetAddress1"]
-        == DEFAULT_ADDRESS["streetAddress1"]
-    )
-    assert (
-        checkout_data["billingAddress"]["streetAddress1"]
-        == billing_address["streetAddress1"]
-    )
+    assert_address_data(checkout_data["shippingAddress"], DEFAULT_ADDRESS)
+    assert_address_data(checkout_data["billingAddress"], billing_address)
 
     # Step 2 - Set shipping address and DeliveryMethod for checkout
     checkout_data = checkout_delivery_method_update(
@@ -143,7 +137,8 @@ def test_changing_order_address_do_not_influence_customer_address_CORE_0257(
 
     assert len(user["addresses"]) == 1
     address = user["addresses"][0]
-    assert address["streetAddress1"] == order_billing_address["streetAddress1"]
+    order_billing_address["country"] = order_billing_address["country"]["code"]
+    assert_address_data(address, order_billing_address)
     assert address["id"] != order_billing_address["id"]
     user_id = user["id"]
 
@@ -164,4 +159,4 @@ def test_changing_order_address_do_not_influence_customer_address_CORE_0257(
     user = get_user(e2e_staff_api_client, user_id)
     assert len(user["addresses"]) == 1
     address = user["addresses"][0]
-    assert address["streetAddress1"] == order_billing_address["streetAddress1"]
+    assert_address_data(address, order_billing_address)

--- a/saleor/tests/e2e/orders/test_order_keep_address_information.py
+++ b/saleor/tests/e2e/orders/test_order_keep_address_information.py
@@ -5,7 +5,7 @@ from ..account.utils import account_address_delete, get_user
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
 from ..users.utils import create_customer
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from .utils import (
     draft_order_complete,
     draft_order_create,
@@ -108,9 +108,9 @@ def test_order_keep_address_information_CORE_0256(
     assert order_line["productVariantId"] == product_variant_id
     assert order["order"]["status"] == "UNFULFILLED"
     order_billing_address = order["order"]["billingAddress"]
-    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
     order_shipping_address = order["order"]["shippingAddress"]
-    assert order_shipping_address["streetAddress1"] == DEFAULT_ADDRESS["streetAddress1"]
+    assert_address_data(order_billing_address, billing_address)
+    assert_address_data(order_shipping_address, DEFAULT_ADDRESS)
     assert order["order"]["user"]["id"] == user_id
     assert order["order"]["userEmail"] == user_email
 
@@ -128,11 +128,5 @@ def test_order_keep_address_information_CORE_0256(
     order_data = order_query(e2e_staff_api_client, order_id)
     assert order_data["shippingAddress"]
     assert order_data["billingAddress"]
-    assert (
-        order_data["shippingAddress"]["streetAddress1"]
-        == DEFAULT_ADDRESS["streetAddress1"]
-    )
-    assert (
-        order_data["billingAddress"]["streetAddress1"]
-        == billing_address["streetAddress1"]
-    )
+    assert_address_data(order_data["shippingAddress"], DEFAULT_ADDRESS)
+    assert_address_data(order_data["billingAddress"], billing_address)

--- a/saleor/tests/e2e/orders/test_order_keep_address_information.py
+++ b/saleor/tests/e2e/orders/test_order_keep_address_information.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import DEFAULT_ADDRESS
+from .. import ADDRESS_DE, DEFAULT_ADDRESS
 from ..account.utils import account_address_delete, get_user
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
@@ -63,18 +63,7 @@ def test_order_keep_address_information_CORE_0256(
 
     # Step 1 - Create draft order
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
 
     draft_order_input = {
         "channelId": channel_id,

--- a/saleor/tests/e2e/orders/test_unable_to_update_save_settings_after_order_completion.py
+++ b/saleor/tests/e2e/orders/test_unable_to_update_save_settings_after_order_completion.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import DEFAULT_ADDRESS
+from .. import ADDRESS_DE, DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
 from ..users.utils import create_customer
@@ -62,18 +62,7 @@ def test_unable_to_update_save_settings_after_order_complete_CORE_0255(
 
     # Step 1 - Create draft order
     # use different address for shipping and billing
-    billing_address = {
-        "firstName": "John",
-        "lastName": "Muller",
-        "companyName": "Saleor Commerce DE",
-        "streetAddress1": "Potsdamer Platz 47",
-        "streetAddress2": "",
-        "postalCode": "85131",
-        "country": "DE",
-        "city": "Pollenfeld",
-        "phone": "+498421499469",
-        "countryArea": "",
-    }
+    billing_address = ADDRESS_DE
 
     draft_order_input = {
         "channelId": channel_id,

--- a/saleor/tests/e2e/orders/test_unable_to_update_save_settings_after_order_completion.py
+++ b/saleor/tests/e2e/orders/test_unable_to_update_save_settings_after_order_completion.py
@@ -4,7 +4,7 @@ from .. import ADDRESS_DE, DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_default_shop
 from ..users.utils import create_customer
-from ..utils import assign_permissions
+from ..utils import assert_address_data, assign_permissions
 from .utils import (
     draft_order_complete,
     draft_order_create,
@@ -107,9 +107,9 @@ def test_unable_to_update_save_settings_after_order_complete_CORE_0255(
     assert order_line["productVariantId"] == product_variant_id
     assert order["order"]["status"] == "UNFULFILLED"
     order_billing_address = order["order"]["billingAddress"]
-    assert order_billing_address["streetAddress1"] == billing_address["streetAddress1"]
     order_shipping_address = order["order"]["shippingAddress"]
-    assert order_shipping_address["streetAddress1"] == DEFAULT_ADDRESS["streetAddress1"]
+    assert_address_data(order_billing_address, billing_address)
+    assert_address_data(order_shipping_address, DEFAULT_ADDRESS)
     assert order["order"]["user"]["id"] == user_id
     assert order["order"]["userEmail"] == user_email
 

--- a/saleor/tests/e2e/utils.py
+++ b/saleor/tests/e2e/utils.py
@@ -40,3 +40,15 @@ def request_matcher(r1, r2):
             return False
 
     return True
+
+
+def assert_address_data(address_data, address):
+    assert address_data["firstName"] == address["firstName"]
+    assert address_data["lastName"] == address["lastName"]
+    assert address_data["companyName"] == address["companyName"]
+    assert address_data["streetAddress1"] == address["streetAddress1"]
+    assert address_data["postalCode"] == address["postalCode"]
+    assert address_data["country"]["code"] == address["country"]
+    assert address_data["city"] == address["city"].upper()
+    assert address_data["countryArea"] == address["countryArea"]
+    assert address_data["phone"] == address["phone"]


### PR DESCRIPTION
Clean e2e tests:
- replace multiple usage of the same address with the constant - introduce `ADDRESS_DE` and reuse it in e2e tests
- add utils for validating the address data

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
