### PR TITLE
Skip sync webhooks for order bulk queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed `invoiceRequest` no longer throws an error, when only app with webhook `INVOICE_REQUESTED` is installed, without invoice plugin - #17355 by @witoszekdev
 - Queries: `checkouts`, `checkoutLines`, and `me.checkouts` will no longer trigger external calls to calculate taxes: the `CHECKOUT_CALCULATE_TAXES` webhooks and plugins (including AvataxPlugin) - #17268 by @korycins
 - Queries `checkouts`, `checkoutLines`, and `me.checkouts` will no longer trigger external calls to fetch shipping methods (`SHIPPING_LIST_METHODS_FOR_CHECKOUT`) or to filter the available shipping methods (`CHECKOUT_FILTER_SHIPPING_METHODS`) - #17387 by @korycins
+- Queries: `orders`, `draftOrders` and `me.orders` will no longer trigger external calls to calculate taxes: the `ORDER_CALCULATE_TAXES` webhooks and plugins (including AvataxPlugin) - #17421 by @korycins
+- Queries: `orders`, `draftOrders` and `me.orders` will no longer trigger external calls to filter the available shipping methods (`ORDER_FILTER_SHIPPING_METHODS`) - #17425 by @korycins
 
 ### GraphQL API
 

--- a/saleor/graphql/account/tests/queries/test_me.py
+++ b/saleor/graphql/account/tests/queries/test_me.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from unittest import mock
 
 import graphene
@@ -6,6 +7,7 @@ from django.utils import timezone
 
 from .....checkout.calculations import _fetch_checkout_prices_if_expired
 from .....checkout.fetch import fetch_checkout_lines
+from .....order import OrderStatus
 from .....order.models import FulfillmentStatus
 from .....payment.interface import (
     ListStoredPaymentMethodsRequestData,
@@ -13,6 +15,7 @@ from .....payment.interface import (
     PaymentMethodCreditCardInfo,
     PaymentMethodData,
 )
+from .....tax.calculations.order import update_order_prices_with_flat_rates
 from ....payment.enums import TokenizedPaymentFlowEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -256,6 +259,134 @@ def test_me_query_checkouts_calculate_flat_taxes(
         manager=mock.ANY,
         pregenerated_subscription_payloads=mock.ANY,
     )
+
+
+ME_WITH_ORDERS_QUERY = """
+    query Me {
+        me {
+            id
+            email
+            orders(first: 10) {
+                edges {
+                    node {
+                        id
+                        total {
+                            currency
+                            gross {
+                                amount
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+ME_WITH_ORDERS_WITH_LINES_TOTAL_PRICE_QUERY = """
+    query Me {
+        me {
+            id
+            email
+            orders(first: 10) {
+                edges {
+                    node {
+                        id
+                        lines{
+                            totalPrice {
+                                currency
+                                gross {
+                                    amount
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize(
+    "query", [ME_WITH_ORDERS_QUERY, ME_WITH_ORDERS_WITH_LINES_TOTAL_PRICE_QUERY]
+)
+@mock.patch("saleor.order.calculations._recalculate_prices")
+@mock.patch("saleor.order.calculations.update_order_prices_with_flat_rates")
+def test_me_query_orders_do_not_trigger_sync_tax_webhooks(
+    mocked_update_order_prices_with_flat_rates,
+    mocked__recalculate_prices,
+    query,
+    user_api_client,
+    order_with_lines,
+    tax_configuration_tax_app,
+):
+    # given
+    user = user_api_client.user
+    order_with_lines.user = user
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    order_with_lines.should_refresh_prices = True
+    order_with_lines.total_gross_amount = Decimal(0)
+    order_with_lines.save()
+
+    # when
+    response = user_api_client.post_graphql(query)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["me"]
+    assert data["orders"]["edges"][0]["node"]["id"] == graphene.Node.to_global_id(
+        "Order", order_with_lines.pk
+    )
+
+    order_with_lines.refresh_from_db()
+
+    assert order_with_lines.should_refresh_prices
+    assert order_with_lines.total_gross_amount == Decimal(0)
+
+    mocked_update_order_prices_with_flat_rates.assert_not_called()
+    mocked__recalculate_prices.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "query", [ME_WITH_ORDERS_QUERY, ME_WITH_ORDERS_WITH_LINES_TOTAL_PRICE_QUERY]
+)
+@mock.patch(
+    "saleor.order.calculations.update_order_prices_with_flat_rates",
+    wraps=update_order_prices_with_flat_rates,
+)
+def test_me_query_orders_calculate_flat_taxes(
+    mocked_update_order_prices_with_flat_rates,
+    query,
+    user_api_client,
+    order_with_lines,
+    tax_configuration_flat_rates,
+):
+    # given
+    user = user_api_client.user
+    order_with_lines.user = user
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    order_with_lines.should_refresh_prices = True
+    order_with_lines.total_gross_amount = Decimal(0)
+    order_with_lines.save()
+
+    # when
+    response = user_api_client.post_graphql(query)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["me"]
+    assert data["orders"]["edges"][0]["node"]["id"] == graphene.Node.to_global_id(
+        "Order", order_with_lines.pk
+    )
+
+    order_with_lines.refresh_from_db()
+
+    order_with_lines.refresh_from_db()
+    assert not order_with_lines.should_refresh_prices
+    assert order_with_lines.total_gross_amount != Decimal(0)
+
+    mocked_update_order_prices_with_flat_rates.assert_called_once()
 
 
 def test_me_query_checkout_with_inactive_channel(user_api_client, checkout):

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -21,6 +21,7 @@ from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...account.i18n import I18nMixin
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.fields import JSONString
@@ -267,7 +268,9 @@ class CheckoutComplete(BaseMutation, I18nMixin):
                 # checkoutComplete response. Order is anonymized for not logged in
                 # user
                 return CheckoutComplete(
-                    order=order, confirmation_needed=False, confirmation_data={}
+                    order=SyncWebhookControlContext(order),
+                    confirmation_needed=False,
+                    confirmation_data={},
                 )
             raise e
         if metadata is not None:
@@ -334,7 +337,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         # If gateway returns information that additional steps are required we need
         # to inform the frontend and pass all required data
         return CheckoutComplete(
-            order=order,
+            order=SyncWebhookControlContext(order) if order else None,
             confirmation_needed=action_required,
             confirmation_data=action_data,
         )

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -11,6 +11,7 @@ from ....permission.enums import CheckoutPermissions
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import Error, NonNullList
@@ -213,4 +214,4 @@ class OrderCreateFromCheckout(BaseMutation):
                 code=OrderCreateFromCheckoutErrorCode.TAX_ERROR.value,
             ) from e
 
-        return OrderCreateFromCheckout(order=order)
+        return OrderCreateFromCheckout(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -78,3 +78,7 @@ class BaseContext(Generic[N]):
 @dataclass
 class SyncWebhookControlContext(BaseContext[N]):
     allow_sync_webhooks: bool = True
+
+    def __init__(self, node: N, allow_sync_webhooks: bool = True):
+        self.node = node
+        self.allow_sync_webhooks = allow_sync_webhooks

--- a/saleor/graphql/core/federation/schema.py
+++ b/saleor/graphql/core/federation/schema.py
@@ -6,9 +6,9 @@ from django.conf import settings
 from graphene.utils.str_converters import to_snake_case
 from graphql import GraphQLArgument, GraphQLError, GraphQLField, GraphQLList
 
-from ...channel import ChannelContext
 from ...schema_printer import print_schema
 from .. import ResolveInfo
+from ..context import BaseContext
 from .entities import federated_entities
 
 
@@ -81,7 +81,7 @@ def create_entity_type_resolver(schema):
 
     def resolve_entity_type(instance, info: ResolveInfo):
         # Use new strategy to resolve GraphQL Type for `ObjectType`
-        if isinstance(instance, ChannelContext):
+        if isinstance(instance, BaseContext):
             model = type(instance.node)
         else:
             model = type(instance)

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -358,7 +358,9 @@ def test_from_global_id_or_error_wth_type(product):
     assert product_type == expected_product_type
 
 
-@mock.patch("saleor.graphql.order.schema.create_connection_slice")
+@mock.patch(
+    "saleor.graphql.order.schema.create_connection_slice_for_sync_webhook_control_context"
+)
 def test_query_allow_replica(
     mocked_resolver, staff_api_client, order, permission_manage_orders
 ):

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -156,9 +156,7 @@ class TaxableObjectLine(BaseObjectType):
 
     @staticmethod
     def resolve_source_line(root: CheckoutLine | OrderLine, _info: ResolveInfo):
-        if isinstance(root, CheckoutLine):
-            return SyncWebhookControlContext(node=root)
-        return root
+        return SyncWebhookControlContext(node=root)
 
     @staticmethod
     def resolve_charge_taxes(root: CheckoutLine | OrderLine, info: ResolveInfo):
@@ -336,9 +334,7 @@ class TaxableObject(BaseObjectType):
 
     @staticmethod
     def resolve_source_object(root: Checkout | Order, _info: ResolveInfo):
-        if isinstance(root, Checkout):
-            return SyncWebhookControlContext(node=root)
-        return root
+        return SyncWebhookControlContext(node=root)
 
     @staticmethod
     def resolve_prices_entered_with_tax(root: Checkout | Order, info: ResolveInfo):

--- a/saleor/graphql/invoice/mutations/invoice_request.py
+++ b/saleor/graphql/invoice/mutations/invoice_request.py
@@ -9,6 +9,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelMutation
 from ...core.types import InvoiceError
 from ...core.utils import WebhookEventInfo
@@ -114,4 +115,4 @@ class InvoiceRequest(ModelMutation):
             order=order,
             number=number,
         )
-        return InvoiceRequest(invoice=invoice, order=order)
+        return InvoiceRequest(invoice=invoice, order=SyncWebhookControlContext(order))

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -281,7 +281,13 @@ class BaseMetadataMutation(BaseMutation):
             instance = ChannelContext(node=instance, channel_slug=None)
 
         use_webhook_sync_control_context = isinstance(
-            instance, checkout_models.Checkout | checkout_models.CheckoutLine
+            instance,
+            checkout_models.Checkout
+            | checkout_models.CheckoutLine
+            | order_models.Order
+            | order_models.OrderLine
+            | order_models.Fulfillment
+            | order_models.FulfillmentLine,
         )
 
         if use_webhook_sync_control_context:

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -23,6 +23,7 @@ from ....warehouse.management import allocate_preorders, allocate_stocks
 from ....warehouse.reservations import is_reservation_enabled
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -185,4 +186,4 @@ class DraftOrderComplete(BaseMutation):
                     from_draft=True,
                 )
             )
-        return DraftOrderComplete(order=order)
+        return DraftOrderComplete(order=SyncWebhookControlContext(node=order))

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -34,6 +34,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...channel.types import Channel
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import (
     ADDED_IN_318,
     ADDED_IN_321,
@@ -646,3 +647,8 @@ class DraftOrderCreate(
             # handle removing voucher
             voucher_code = VoucherCode.objects.filter(code=old_voucher_code).first()
             release_voucher_code_usage(voucher_code, old_voucher, user_email)
+
+    @classmethod
+    def success_response(cls, order):
+        """Return a success response."""
+        return DraftOrderCreate(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -11,6 +11,7 @@ from ....payment.models import Payment, TransactionItem
 from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import (
     ModelDeleteWithRestrictedChannelAccessMutation,
     ModelWithExtRefMutation,
@@ -85,3 +86,8 @@ class DraftOrderDelete(
             if voucher_code := VoucherCode.objects.filter(code=code).first():
                 voucher = voucher_code.voucher
                 release_voucher_code_usage(voucher_code, voucher, None)
+
+    @classmethod
+    def success_response(cls, order):
+        """Return a success response."""
+        return cls(order=SyncWebhookControlContext(order), errors=[])

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -6,6 +6,7 @@ from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -100,7 +101,7 @@ class DraftOrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         )
         cls._save_m2m(info, instance, cleaned_input)
 
-        return cls.success_response(instance)
+        return DraftOrderUpdate(order=SyncWebhookControlContext(node=instance))
 
     @classmethod
     def save_draft_order(

--- a/saleor/graphql/order/mutations/fulfillment_approve.py
+++ b/saleor/graphql/order/mutations/fulfillment_approve.py
@@ -12,6 +12,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -105,4 +106,7 @@ class FulfillmentApprove(BaseMutation):
             raise ValidationError({"stocks": errors}) from e
 
         order.refresh_from_db(fields=["status"])
-        return FulfillmentApprove(fulfillment=fulfillment, order=order)
+        return FulfillmentApprove(
+            fulfillment=SyncWebhookControlContext(node=fulfillment),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/fulfillment_refund_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_refund_products.py
@@ -9,6 +9,7 @@ from ....payment import PaymentError
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.scalars import PositiveDecimal
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
@@ -157,4 +158,7 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
             )
         except PaymentError:
             cls.raise_error_for_payment_error()
-        return cls(order=order, fulfillment=refund_fulfillment)
+        return cls(
+            order=SyncWebhookControlContext(order),
+            fulfillment=SyncWebhookControlContext(node=refund_fulfillment),
+        )

--- a/saleor/graphql/order/mutations/fulfillment_return_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_return_products.py
@@ -9,6 +9,7 @@ from ....payment import PaymentError
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.scalars import PositiveDecimal
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
@@ -183,9 +184,18 @@ class FulfillmentReturnProducts(FulfillmentRefundAndReturnProductBase):
             cls.raise_error_for_payment_error()
 
         return_fulfillment, replace_fulfillment, replace_order = response
+        return_fulfillment_response = SyncWebhookControlContext(node=return_fulfillment)
+        replace_fulfillment_response = (
+            SyncWebhookControlContext(node=replace_fulfillment)
+            if replace_fulfillment
+            else None
+        )
+        replace_order_response = (
+            SyncWebhookControlContext(node=replace_order) if replace_order else None
+        )
         return cls(
-            order=order,
-            return_fulfillment=return_fulfillment,
-            replace_fulfillment=replace_fulfillment,
-            replace_order=replace_order,
+            order=SyncWebhookControlContext(order),
+            return_fulfillment=return_fulfillment_response,
+            replace_fulfillment=replace_fulfillment_response,
+            replace_order=replace_order_response,
         )

--- a/saleor/graphql/order/mutations/fulfillment_update_tracking.py
+++ b/saleor/graphql/order/mutations/fulfillment_update_tracking.py
@@ -9,6 +9,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -74,4 +75,7 @@ class FulfillmentUpdateTracking(BaseMutation):
         if notify_customer:
             send_fulfillment_update(order, fulfillment, manager)
 
-        return FulfillmentUpdateTracking(fulfillment=fulfillment, order=order)
+        return FulfillmentUpdateTracking(
+            fulfillment=SyncWebhookControlContext(node=fulfillment),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/order_cancel.py
+++ b/saleor/graphql/order/mutations/order_cancel.py
@@ -9,6 +9,7 @@ from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -60,4 +61,4 @@ class OrderCancel(BaseMutation):
                 manager=manager,
             )
             deactivate_order_gift_cards(order.id, user, app)
-        return OrderCancel(order=order)
+        return OrderCancel(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_capture.py
+++ b/saleor/graphql/order/mutations/order_capture.py
@@ -9,6 +9,7 @@ from ....payment import models as payment_models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
@@ -98,4 +99,4 @@ class OrderCapture(BaseMutation):
                 manager,
                 site.settings,
             )
-        return OrderCapture(order=order)
+        return OrderCapture(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -21,6 +21,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.utils import get_webhooks_for_multiple_events
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -114,4 +115,4 @@ class OrderConfirm(ModelMutation):
                     webhook_event_map=webhook_event_map,
                 )
             )
-        return OrderConfirm(order=order)
+        return OrderConfirm(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_discount_delete.py
+++ b/saleor/graphql/order/mutations/order_discount_delete.py
@@ -9,6 +9,7 @@ from ....order.utils import invalidate_order_prices, remove_order_discount_from_
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ...discount.types import OrderDiscount
@@ -69,4 +70,4 @@ class OrderDiscountDelete(OrderDiscountCommon):
             order.save(
                 update_fields=["should_refresh_prices", "search_vector", "updated_at"]
             )
-        return OrderDiscountDelete(order=order)
+        return OrderDiscountDelete(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_discount_update.py
+++ b/saleor/graphql/order/mutations/order_discount_update.py
@@ -10,6 +10,7 @@ from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ...discount.types import OrderDiscount
@@ -95,4 +96,4 @@ class OrderDiscountUpdate(OrderDiscountCommon):
                     order_discount=order_discount,
                     old_order_discount=order_discount_before_update,
                 )
-        return OrderDiscountUpdate(order=order)
+        return OrderDiscountUpdate(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -13,6 +13,7 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
@@ -295,4 +296,10 @@ class OrderFulfill(BaseMutation):
             errors = prepare_insufficient_stock_order_validation_errors(e)
             raise ValidationError({"stocks": errors}) from e
 
-        return OrderFulfill(fulfillments=fulfillments, order=instance)
+        return OrderFulfill(
+            fulfillments=[
+                SyncWebhookControlContext(node=fulfillment)
+                for fulfillment in fulfillments
+            ],
+            order=SyncWebhookControlContext(instance),
+        )

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -9,10 +9,8 @@ from ....order import models
 from ....order.utils import update_order_charge_data
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_320,
-    PREVIEW_FEATURE,
-)
+from ...core.context import SyncWebhookControlContext
+from ...core.descriptions import ADDED_IN_320, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
@@ -294,4 +292,7 @@ class OrderGrantRefundCreate(BaseMutation):
                 models.OrderGrantedRefundLine.objects.bulk_create(cleaned_input_lines)
             update_order_charge_data(order)
 
-        return cls(order=order, granted_refund=granted_refund)
+        return cls(
+            order=SyncWebhookControlContext(order),
+            granted_refund=SyncWebhookControlContext(node=granted_refund),
+        )

--- a/saleor/graphql/order/mutations/order_grant_refund_update.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_update.py
@@ -9,10 +9,8 @@ from ....order import OrderGrantedRefundStatus, models
 from ....order.utils import update_order_charge_data
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_320,
-    PREVIEW_FEATURE,
-)
+from ...core.context import SyncWebhookControlContext
+from ...core.descriptions import ADDED_IN_320, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
@@ -426,4 +424,7 @@ class OrderGrantRefundUpdate(BaseMutation):
         cleaned_input = cls.clean_input(info, granted_refund, input)
         cls.process_update_for_granted_refund(order, granted_refund, cleaned_input)
         update_order_charge_data(order)
-        return cls(order=order, granted_refund=granted_refund)
+        return cls(
+            order=SyncWebhookControlContext(order),
+            granted_refund=SyncWebhookControlContext(granted_refund),
+        )

--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -14,6 +14,7 @@ from ....order.utils import (
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -99,7 +100,10 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
             )
             order.save(update_fields=updated_fields)
             call_event_by_order_status(order, manager)
-        return OrderLineDelete(order=order, order_line=line)
+        return OrderLineDelete(
+            order=SyncWebhookControlContext(order),
+            order_line=SyncWebhookControlContext(line),
+        )
 
     @classmethod
     def validate(cls, info, order, line):

--- a/saleor/graphql/order/mutations/order_line_discount_remove.py
+++ b/saleor/graphql/order/mutations/order_line_discount_remove.py
@@ -6,6 +6,7 @@ from ....order.utils import invalidate_order_prices, remove_discount_from_order_
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ..types import Order, OrderLine
@@ -55,4 +56,7 @@ class OrderLineDiscountRemove(OrderDiscountCommon):
             )
 
             invalidate_order_prices(order, save=True)
-        return OrderLineDiscountRemove(order_line=order_line, order=order)
+        return OrderLineDiscountRemove(
+            order_line=SyncWebhookControlContext(order_line),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/order_line_discount_update.py
+++ b/saleor/graphql/order/mutations/order_line_discount_update.py
@@ -8,6 +8,7 @@ from ....order.utils import invalidate_order_prices, update_discount_for_order_l
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import OrderError
 from ..types import Order, OrderLine
@@ -82,4 +83,7 @@ class OrderLineDiscountUpdate(OrderDiscountCommon):
                     line_before_update=order_line_before_update,
                 )
                 invalidate_order_prices(order, save=True)
-        return OrderLineDiscountUpdate(order_line=order_line, order=order)
+        return OrderLineDiscountUpdate(
+            order_line=SyncWebhookControlContext(order_line),
+            order=SyncWebhookControlContext(order),
+        )

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -14,6 +14,7 @@ from ....order.utils import (
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.mutations import ModelWithRestrictedChannelAccessMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -110,9 +111,11 @@ class OrderLineUpdate(
 
     @classmethod
     def success_response(cls, instance):
-        response = super().success_response(instance)
-        response.order = instance.order
-        return response
+        return cls(
+            orderLine=SyncWebhookControlContext(node=instance),
+            order=SyncWebhookControlContext(node=instance.order),
+            errors=[],
+        )
 
     @classmethod
     def get_instance_channel_id(cls, instance, **data):

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -17,6 +17,7 @@ from ....order.utils import (
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
@@ -204,7 +205,10 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             )
             call_event_by_order_status(order, manager)
 
-        return OrderLinesCreate(order=order, order_lines=added_lines)
+        return OrderLinesCreate(
+            order=SyncWebhookControlContext(order),
+            order_lines=[SyncWebhookControlContext(node=line) for line in added_lines],
+        )
 
     @classmethod
     def _find_line_id_for_variant_if_exist(cls, variant_id, lines_info) -> None | str:

--- a/saleor/graphql/order/mutations/order_mark_as_paid.py
+++ b/saleor/graphql/order/mutations/order_mark_as_paid.py
@@ -19,6 +19,7 @@ from ....payment import PaymentError
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -130,4 +131,4 @@ class OrderMarkAsPaid(BaseMutation):
 
         update_order_search_vector(order)
 
-        return OrderMarkAsPaid(order=order)
+        return OrderMarkAsPaid(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_note_add.py
+++ b/saleor/graphql/order/mutations/order_note_add.py
@@ -5,10 +5,8 @@ from ....order import error_codes, events
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    DEPRECATED_IN_3X_INPUT,
-    DEPRECATED_IN_3X_MUTATION,
-)
+from ...core.context import SyncWebhookControlContext
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT, DEPRECATED_IN_3X_MUTATION
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import BaseInputObjectType, Error, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -61,7 +59,10 @@ class OrderNoteAdd(OrderNoteCommon):
                 message=cleaned_input["message"],
             )
             call_event_by_order_status(order, manager)
-        return OrderNoteAdd(order=order, event=event)
+        return OrderNoteAdd(
+            order=SyncWebhookControlContext(order),
+            event=SyncWebhookControlContext(event),
+        )
 
 
 class OrderAddNoteInput(BaseInputObjectType):

--- a/saleor/graphql/order/mutations/order_note_update.py
+++ b/saleor/graphql/order/mutations/order_note_update.py
@@ -5,6 +5,7 @@ from ....order import OrderEvents, error_codes, events, models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import Error
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -63,4 +64,7 @@ class OrderNoteUpdate(OrderNoteCommon):
                 related_event=order_event_to_update,
             )
             call_event_by_order_status(order, manager)
-        return OrderNoteUpdate(order=order, event=event)
+        return OrderNoteUpdate(
+            order=SyncWebhookControlContext(order),
+            event=SyncWebhookControlContext(event),
+        )

--- a/saleor/graphql/order/mutations/order_refund.py
+++ b/saleor/graphql/order/mutations/order_refund.py
@@ -10,6 +10,7 @@ from ....payment import models as payment_models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
@@ -113,4 +114,4 @@ class OrderRefund(BaseMutation):
         order.fulfillments.create(
             status=FulfillmentStatus.REFUNDED, total_refund_amount=amount
         )
-        return OrderRefund(order=order)
+        return OrderRefund(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_update_shipping.py
+++ b/saleor/graphql/order/mutations/order_update_shipping.py
@@ -9,6 +9,7 @@ from ....shipping import models as shipping_models
 from ....shipping.utils import convert_to_shipping_method_data
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, OrderError
@@ -110,7 +111,7 @@ class OrderUpdateShipping(
 
             cls.clear_shipping_method_from_order(order)
             order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
-            return OrderUpdateShipping(order=order)
+            return OrderUpdateShipping(order=SyncWebhookControlContext(order))
 
         method_id: str = input["shipping_method"]
         method: shipping_models.ShippingMethod = cls.get_node_or_error(
@@ -137,4 +138,4 @@ class OrderUpdateShipping(
         order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
         # Post-process the results
         call_order_event(manager, WebhookEventAsyncType.ORDER_UPDATED, order)
-        return OrderUpdateShipping(order=order)
+        return OrderUpdateShipping(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/mutations/order_void.py
+++ b/saleor/graphql/order/mutations/order_void.py
@@ -8,6 +8,7 @@ from ....payment import models as payment_models
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
+from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -76,4 +77,4 @@ class OrderVoid(BaseMutation):
                 payment,
                 manager,
             )
-        return OrderVoid(order=order)
+        return OrderVoid(order=SyncWebhookControlContext(order))

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -7,7 +7,10 @@ from ...order import models
 from ...permission.enums import OrderPermissions
 from ...permission.utils import has_one_of_permissions
 from ..core import ResolveInfo
-from ..core.connection import create_connection_slice, filter_connection_queryset
+from ..core.connection import (
+    create_connection_slice_for_sync_webhook_control_context,
+    filter_connection_queryset,
+)
 from ..core.context import get_database_connection_name
 from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.doc_category import DOC_CATEGORY_ORDERS
@@ -163,7 +166,9 @@ class OrderQueries(graphene.ObjectType):
     @staticmethod
     def resolve_homepage_events(_root, info: ResolveInfo, **kwargs):
         qs = resolve_homepage_events(info)
-        return create_connection_slice(qs, info, kwargs, OrderEventCountableConnection)
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, OrderEventCountableConnection, allow_sync_webhooks=False
+        )
 
     @staticmethod
     def resolve_order(_root, info: ResolveInfo, *, external_reference=None, id=None):
@@ -204,7 +209,9 @@ class OrderQueries(graphene.ObjectType):
         qs = filter_connection_queryset(
             qs, kwargs, allow_replica=info.context.allow_replica
         )
-        return create_connection_slice(qs, info, kwargs, OrderCountableConnection)
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, OrderCountableConnection, allow_sync_webhooks=False
+        )
 
     @staticmethod
     def resolve_draft_orders(_root, info: ResolveInfo, **kwargs):
@@ -225,7 +232,9 @@ class OrderQueries(graphene.ObjectType):
         qs = filter_connection_queryset(
             qs, kwargs, allow_replica=info.context.allow_replica
         )
-        return create_connection_slice(qs, info, kwargs, OrderCountableConnection)
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, OrderCountableConnection, allow_sync_webhooks=False
+        )
 
     @staticmethod
     def resolve_orders_total(_root, info: ResolveInfo, *, period, channel=None):

--- a/saleor/graphql/order/tests/queries/shared_query_fragments.py
+++ b/saleor/graphql/order/tests/queries/shared_query_fragments.py
@@ -1,0 +1,115 @@
+ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS = """
+fragment price on Money {
+  amount
+}
+
+fragment taxPrice on TaxedMoney {
+  gross {
+    ...price
+  }
+}
+
+fragment order on Order {
+  shippingMethods {
+    id
+  }
+  deliveryMethod {
+    ... on ShippingMethod {
+      id
+    }
+  }
+  shippingMethodName
+  total {
+    ...taxPrice
+  }
+  undiscountedTotal {
+    ...taxPrice
+  }
+  subtotal {
+    ...taxPrice
+  }
+  shippingPrice {
+    ...taxPrice
+  }
+  totalRemainingGrant {
+    ...price
+  }
+  totalCancelPending {
+    ...price
+  }
+  totalChargePending {
+    ...price
+  }
+  totalAuthorizePending {
+    ...price
+  }
+  totalRefundPending {
+    ...price
+  }
+  totalRefunded {
+    ...price
+  }
+  totalGrantedRefund {
+    ...price
+  }
+  grantedRefunds {
+    amount {
+      ...price
+    }
+    lines {
+      orderLine {
+        unitPrice {
+          ...taxPrice
+        }
+      }
+    }
+  }
+  fulfillments {
+    lines {
+      orderLine {
+        unitPrice {
+          ...taxPrice
+        }
+      }
+    }
+  }
+  lines {
+    undiscountedTotalPrice {
+      ...taxPrice
+    }
+    unitPrice {
+      ...taxPrice
+    }
+    unitDiscount {
+      ...price
+    }
+    undiscountedUnitPrice {
+      ...taxPrice
+    }
+    totalPrice {
+      ...taxPrice
+    }
+  }
+  events {
+    relatedOrder {
+      total {
+        ...taxPrice
+      }
+    }
+    fulfilledItems {
+      quantity
+      orderLine {
+        productName
+        variantName
+      }
+    }
+    lines {
+      orderLine {
+        unitPrice {
+          ...taxPrice
+        }
+      }
+    }
+  }
+}
+"""

--- a/saleor/graphql/order/tests/queries/shared_query_fragments.py
+++ b/saleor/graphql/order/tests/queries/shared_query_fragments.py
@@ -13,6 +13,15 @@ fragment order on Order {
   shippingMethods {
     id
   }
+  availableShippingMethods{
+    id
+  }
+  errors {
+    field
+    orderLines
+    code
+  }
+  canFinalize
   deliveryMethod {
     ... on ShippingMethod {
       id

--- a/saleor/graphql/order/tests/queries/test_orders.py
+++ b/saleor/graphql/order/tests/queries/test_orders.py
@@ -7,122 +7,15 @@ from .....order.events import (
     fulfillment_fulfilled_items_event,
     order_added_products_event,
 )
-from .....order.models import Order
 from .....tax.calculations.order import update_order_prices_with_flat_rates
-from ....tests.utils import assert_no_permission, get_graphql_content
+from ....tests.utils import get_graphql_content
 from .shared_query_fragments import ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS
 
-DRAFT_ORDER_QUERY = """
-    query DraftOrdersQuery {
-        draftOrders(first: 10) {
-            edges {
-                node {
-                    id
-                    number
-                }
-            }
-        }
-    }
-"""
-
-
-def test_draft_order_query(
-    staff_api_client, permission_group_manage_orders, order, draft_order_list
-):
-    # given
-    permission_group_manage_orders.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
-
-    assert len(edges) == Order.objects.drafts().count()
-
-
-def test_query_draft_orders_by_user_with_access_to_all_channels(
-    staff_api_client,
-    permission_group_all_perms_all_channels,
-    draft_orders_in_different_channels,
-):
-    # given
-    permission_group_all_perms_all_channels.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
-
-    assert len(edges) == len(draft_orders_in_different_channels)
-
-
-def test_query_draft_orders_by_user_with_restricted_access_to_channels(
-    staff_api_client,
-    permission_group_all_perms_channel_USD_only,
-    draft_orders_in_different_channels,
-):
-    # given
-    permission_group_all_perms_channel_USD_only.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    content = get_graphql_content(response)
-
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
-    assert content["data"]["draftOrders"]["edges"][0]["node"]["number"] == str(
-        draft_orders_in_different_channels[0].number
-    )
-
-
-def test_query_draft_orders_by_user_with_restricted_access_to_channels_no_acc_channels(
-    staff_api_client,
-    permission_group_all_perms_without_any_channel,
-    draft_orders_in_different_channels,
-):
-    # given
-    permission_group_all_perms_without_any_channel.user_set.add(staff_api_client.user)
-
-    # when
-    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 0
-
-
-def test_query_draft_orders_by_app(
-    app_api_client, permission_manage_orders, draft_orders_in_different_channels
-):
-    # when
-    response = app_api_client.post_graphql(
-        DRAFT_ORDER_QUERY, permissions=(permission_manage_orders,)
-    )
-
-    # then
-    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
-
-    assert len(edges) == len(draft_orders_in_different_channels)
-
-
-def test_query_draft_orders_by_customer(
-    user_api_client, draft_orders_in_different_channels
-):
-    # when
-    response = user_api_client.post_graphql(DRAFT_ORDER_QUERY)
-
-    # then
-    assert_no_permission(response)
-
-
-QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS = (
+QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS = (
     ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS
     + """
-query DraftOrders {
-  draftOrders(first: 10) {
+query Orders {
+  orders(first: 10) {
     edges {
       node {
         ...order
@@ -146,20 +39,18 @@ def test_query_orders_when_flat_rates_active(
     permission_group_manage_orders,
 ):
     # given
-    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.status = OrderStatus.UNCONFIRMED
     order_with_lines.should_refresh_prices = True
     order_with_lines.total_gross_amount = Decimal(0)
     order_with_lines.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order_with_lines.refresh_from_db()
     assert not order_with_lines.should_refresh_prices
     assert order_with_lines.total_gross_amount != Decimal(0)
@@ -177,20 +68,18 @@ def test_query_orders_for_order_with_lines_when_tax_app_active(
     permission_group_manage_orders,
 ):
     # given
-    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.status = OrderStatus.UNCONFIRMED
     order_with_lines.should_refresh_prices = True
     order_with_lines.total_gross_amount = Decimal(0)
     order_with_lines.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order_with_lines.refresh_from_db()
 
     assert order_with_lines.should_refresh_prices
@@ -225,20 +114,18 @@ def test_query_orders_for_order_with_granted_refunds_when_tax_app_active(
     order_line = order.lines.first()
     granted_refund.lines.create(order_line=order_line, quantity=1)
 
-    order.status = OrderStatus.DRAFT
+    order.status = OrderStatus.UNCONFIRMED
     order.should_refresh_prices = True
     order.total_gross_amount = Decimal(0)
     order.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order.refresh_from_db()
 
     assert order.should_refresh_prices
@@ -263,20 +150,18 @@ def test_query_orders_for_order_with_fulfillments_when_tax_app_active(
     fulfillment = order.fulfillments.create()
     fulfillment.lines.create(order_line=order_with_lines.lines.first(), quantity=1)
 
-    order.status = OrderStatus.DRAFT
+    order.status = OrderStatus.UNCONFIRMED
     order.should_refresh_prices = True
     order.total_gross_amount = Decimal(0)
     order.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order.refresh_from_db()
 
     assert order.should_refresh_prices
@@ -318,20 +203,18 @@ def test_query_orders_for_order_with_events_when_tax_app_active(
         lines=[order_line],
     )
 
-    order.status = OrderStatus.DRAFT
+    order.status = OrderStatus.UNCONFIRMED
     order.should_refresh_prices = True
     order.total_gross_amount = Decimal(0)
     order.save()
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_DRAFT_ORDERS_WITH_WEBHOOK_RELATED_FIELDS
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
 
     # then
     content = get_graphql_content(response)
-    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert len(content["data"]["orders"]["edges"]) == 1
     order.refresh_from_db()
 
     assert order.should_refresh_prices

--- a/saleor/graphql/order/tests/queries/test_orders.py
+++ b/saleor/graphql/order/tests/queries/test_orders.py
@@ -7,6 +7,7 @@ from .....order.events import (
     fulfillment_fulfilled_items_event,
     order_added_products_event,
 )
+from .....plugins.manager import PluginsManager
 from .....tax.calculations.order import update_order_prices_with_flat_rates
 from ....tests.utils import get_graphql_content
 from .shared_query_fragments import ORDER_FRAGMENT_WITH_WEBHOOK_RELATED_FIELDS
@@ -222,3 +223,33 @@ def test_query_orders_for_order_with_events_when_tax_app_active(
 
     mocked_update_order_prices_with_flat_rates.assert_not_called()
     mocked__recalculate_prices.assert_not_called()
+
+
+@patch.object(PluginsManager, "excluded_shipping_methods_for_order")
+def test_query_orders_with_active_filter_shipping_methods_webhook(
+    mocked_webhook_handler,
+    settings,
+    order_with_lines,
+    tax_configuration_flat_rates,
+    staff_api_client,
+    permission_group_manage_orders,
+):
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
+    # given
+    order_with_lines.status = OrderStatus.UNCONFIRMED
+    order_with_lines.should_refresh_prices = True
+    order_with_lines.total_gross_amount = Decimal(0)
+    order_with_lines.save()
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_WEBHOOK_RELATED_FIELDS)
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["orders"]["edges"]) == 1
+    order_with_lines.refresh_from_db()
+    assert not order_with_lines.should_refresh_prices
+    assert order_with_lines.total_gross_amount != Decimal(0)
+    mocked_webhook_handler.assert_not_called()

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -2352,6 +2352,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                         country=country,
                         manager=manager,
                         database_connection_name=database_connection_name,
+                        allow_sync_webhooks=root.allow_sync_webhooks,
                     )
                 except ValidationError:
                     return False
@@ -2498,6 +2499,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                     channel_listings,
                     manager,
                     database_connection_name=database_connection_name,
+                    allow_sync_webhooks=root.allow_sync_webhooks,
                 )
 
             return (
@@ -2615,6 +2617,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                         country=country,
                         manager=manager,
                         database_connection_name=database_connection_name,
+                        allow_sync_webhooks=root.allow_sync_webhooks,
                     )
                 except ValidationError as e:
                     return validation_error_to_error_type(e, OrderError)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1170,6 +1170,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).price_with_discounts
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1201,6 +1202,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).undiscounted_price
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1219,7 +1221,11 @@ class OrderLine(
         def _resolve_unit_discount_type(data):
             order, lines, manager = data
             return calculations.order_line_unit_discount_type(
-                order, order_line, manager, lines
+                order,
+                order_line,
+                manager,
+                lines,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1236,7 +1242,11 @@ class OrderLine(
         def _resolve_unit_discount_value(data):
             order, lines, manager = data
             return calculations.order_line_unit_discount_value(
-                order, order_line, manager, lines
+                order,
+                order_line,
+                manager,
+                lines,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1251,7 +1261,11 @@ class OrderLine(
         def _resolve_unit_discount(data):
             order, lines, manager = data
             return calculations.order_line_unit_discount(
-                order, order_line, manager, lines
+                order,
+                order_line,
+                manager,
+                lines,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1274,6 +1288,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ) or Decimal(0)
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1297,6 +1312,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).price_with_discounts
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1322,6 +1338,7 @@ class OrderLine(
                 manager,
                 lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ).undiscounted_price
 
         order = OrderByIdLoader(info.context).load(order_line.order_id)
@@ -1803,7 +1820,9 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
         @allow_writer_in_context(info.context)
         def with_manager(manager):
             order = root.node
-            fetch_order_prices_if_expired(order, manager)
+            fetch_order_prices_if_expired(
+                order, manager, allow_sync_webhooks=root.allow_sync_webhooks
+            )
             return OrderDiscountsByOrderIDLoader(info.context).load(order.id)
 
         return get_plugin_manager_promise(info.context).then(with_manager)
@@ -1938,7 +1957,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_undiscounted_shipping(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -1956,7 +1979,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_shipping(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -1974,7 +2001,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = data
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_shipping_tax_rate(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             ) or Decimal(0)
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -2016,6 +2047,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                 manager,
                 order_lines,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         order_lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -2034,7 +2066,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
         def _resolve_total(lines):
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_total(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         return (
@@ -2052,7 +2088,11 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             lines, manager = lines_and_manager
             database_connection_name = get_database_connection_name(info.context)
             return calculations.order_undiscounted_total(
-                order, manager, lines, database_connection_name=database_connection_name
+                order,
+                manager,
+                lines,
+                database_connection_name=database_connection_name,
+                allow_sync_webhooks=root.allow_sync_webhooks,
             )
 
         lines = OrderLinesByOrderIdLoader(info.context).load(order.id)
@@ -2146,7 +2186,9 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                     fulfillments,
                 )
             return [
-                SyncWebhookControlContext(node=fulfillment)
+                SyncWebhookControlContext(
+                    node=fulfillment, allow_sync_webhooks=root.allow_sync_webhooks
+                )
                 for fulfillment in fulfillments_to_return
             ]
 

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -59,6 +59,7 @@ def get_shipping_method_availability_error(
     method: Optional["ShippingMethodData"],
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ):
     """Validate whether shipping method is still available for the order."""
     is_valid = False
@@ -70,6 +71,7 @@ def get_shipping_method_availability_error(
                 order.channel.shipping_method_listings.all(),
                 manager,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=allow_sync_webhooks,
             )
             if m.active
         }
@@ -89,6 +91,7 @@ def validate_shipping_method(
     errors: T_ERRORS,
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ):
     if not order.shipping_method:
         error = ValidationError(
@@ -124,6 +127,7 @@ def validate_shipping_method(
                 convert_to_shipping_method_data(order.shipping_method, listing),
                 manager,
                 database_connection_name=database_connection_name,
+                allow_sync_webhooks=allow_sync_webhooks,
             )
 
     if error:
@@ -344,6 +348,7 @@ def validate_draft_order(
     country: str,
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ):
     """Check if the given order contains the proper data.
 
@@ -363,7 +368,12 @@ def validate_draft_order(
     if is_shipping_required(lines):
         validate_shipping_address(order, errors)
         validate_shipping_method(
-            order, channel, errors, manager, database_connection_name
+            order,
+            channel,
+            errors,
+            manager,
+            database_connection_name,
+            allow_sync_webhooks=allow_sync_webhooks,
         )
     validate_total_quantity(lines, errors)
     validate_order_lines(

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -276,6 +276,22 @@ class Payment(ModelObjectType[models.Payment]):
         return resolve_metadata(root.metadata)
 
     @staticmethod
+    def resolve_order(root: models.Payment, info):
+        if not root.order_id:
+            return None
+
+        def _wrap_with_webhook_sync_control(order):
+            if not order:
+                return None
+            return SyncWebhookControlContext(node=order)
+
+        return (
+            OrderByIdLoader(info.context)
+            .load(root.order_id)
+            .then(_wrap_with_webhook_sync_control)
+        )
+
+    @staticmethod
     def resolve_checkout(root: models.Payment, info):
         if not root.checkout_id:
             return None
@@ -547,7 +563,17 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     def resolve_order(root: models.TransactionItem, info):
         if not root.order_id:
             return None
-        return OrderByIdLoader(info.context).load(root.order_id)
+
+        def _wrap_with_webhook_sync_control(order):
+            if not order:
+                return None
+            return SyncWebhookControlContext(node=order)
+
+        return (
+            OrderByIdLoader(info.context)
+            .load(root.order_id)
+            .then(_wrap_with_webhook_sync_control)
+        )
 
     @staticmethod
     def resolve_checkout(root: models.TransactionItem, info):

--- a/saleor/graphql/tax/mutations/tax_exemption_manage.py
+++ b/saleor/graphql/tax/mutations/tax_exemption_manage.py
@@ -96,7 +96,6 @@ class TaxExemptionManage(BaseMutation):
         if isinstance(obj, Checkout):
             cls._invalidate_checkout(info, obj)
             obj.save(update_fields=["tax_exemption", "price_expiration", "last_change"])
-            obj = SyncWebhookControlContext(node=obj)
 
         if isinstance(obj, Order):
             cls.validate_order_status(obj)
@@ -105,4 +104,4 @@ class TaxExemptionManage(BaseMutation):
                 update_fields=["tax_exemption", "should_refresh_prices", "updated_at"]
             )
 
-        return TaxExemptionManage(taxable_object=obj)
+        return TaxExemptionManage(taxable_object=SyncWebhookControlContext(node=obj))

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -440,8 +440,13 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
     def get_subtotal(self):
         return get_subtotal(self.lines.all(), self.currency)
 
-    def is_shipping_required(self):
-        return any(line.is_shipping_required for line in self.lines.all())
+    def is_shipping_required(
+        self, database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME
+    ):
+        return any(
+            line.is_shipping_required
+            for line in self.lines.using(database_connection_name).all()
+        )
 
     def get_total_quantity(self):
         return sum([line.quantity for line in self.lines.all()])

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -23,6 +23,7 @@ from ...plugins.manager import get_plugins_manager
 from ...plugins.tests.sample_plugins import PluginSample
 from ...tax import TaxCalculationStrategy
 from ...tax.calculations.order import update_order_prices_with_flat_rates
+from ...tax.utils import get_tax_calculation_strategy_for_order
 from .. import OrderStatus, calculations
 from ..interface import OrderTaxedPricesData
 
@@ -665,10 +666,14 @@ def test_recalculate_prices_total_shipping_price_changed(
             "shipping_method_name",
         ]
     )
+    tax_calculation_strategy = get_tax_calculation_strategy_for_order(order)
 
     # when
     calculations._recalculate_prices(
-        order, get_plugins_manager(allow_replica=True), order_lines
+        order,
+        get_plugins_manager(allow_replica=True),
+        order_lines,
+        tax_calculation_strategy=tax_calculation_strategy,
     )
 
     # then
@@ -699,10 +704,14 @@ def test_recalculate_prices_line_quantity_changed(
     line = order_lines.first()
     line.quantity += 1
     line.save(update_fields=["quantity"])
+    tax_calculation_strategy = get_tax_calculation_strategy_for_order(order)
 
     # when
     calculations._recalculate_prices(
-        order, get_plugins_manager(allow_replica=True), order_lines
+        order,
+        get_plugins_manager(allow_replica=True),
+        order_lines,
+        tax_calculation_strategy=tax_calculation_strategy,
     )
 
     # then
@@ -975,6 +984,99 @@ def test_fetch_order_prices_if_expired_webhooks_success(
         assert order_line.unit_price == line_total / order_line.quantity
         assert order_line.tax_rate == tax_line.tax_rate / 100
     assert order_with_lines.total == subtotal + shipping_price
+
+
+def test_fetch_order_prices_if_expired_plugins_with_allow_sync_webhooks_to_false(
+    plugins_manager,
+    fetch_kwargs_with_lines,
+    order_with_lines,
+    tax_data,
+):
+    # given
+    plugins_manager.calculate_order_line_unit = Mock(side_effect=None)
+    plugins_manager.calculate_order_line_total = Mock(side_effect=None)
+    plugins_manager.get_order_line_tax_rate = Mock(side_effect=None)
+    plugins_manager.calculate_order_shipping = Mock(return_value=None)
+    plugins_manager.get_order_shipping_tax_rate = Mock(return_value=None)
+    plugins_manager.get_taxes_for_order = Mock(return_value=None)
+    plugins_manager.calculate_order_total = Mock(return_value=None)
+
+    fetch_kwargs_with_lines["allow_sync_webhooks"] = False
+    order_from_input = fetch_kwargs_with_lines["order"]
+    lines_from_input = fetch_kwargs_with_lines["lines"]
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(**fetch_kwargs_with_lines)
+
+    # then
+    assert order_from_input == order
+    assert lines_from_input == lines
+
+    plugins_manager.calculate_order_line_unit.assert_not_called()
+    plugins_manager.calculate_order_line_total.assert_not_called()
+    plugins_manager.get_order_line_tax_rate.assert_not_called()
+    plugins_manager.calculate_order_shipping.assert_not_called()
+    plugins_manager.get_order_shipping_tax_rate.assert_not_called()
+    plugins_manager.get_taxes_for_order.assert_not_called()
+    plugins_manager.calculate_order_total.assert_not_called()
+
+
+@patch(
+    "saleor.order.calculations.update_order_prices_with_flat_rates",
+    wraps=update_order_prices_with_flat_rates,
+)
+@pytest.mark.parametrize("prices_entered_with_tax", [True, False])
+def test_fetch_order_prices_if_expired_flat_rates_with_allow_sync_webhook_set_to_false(
+    mocked_update_order_prices_with_flat_rates,
+    order_with_lines,
+    fetch_kwargs,
+    prices_entered_with_tax,
+):
+    # given
+    order = order_with_lines
+    tc = order.channel.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.prices_entered_with_tax = prices_entered_with_tax
+    tc.tax_calculation_strategy = TaxCalculationStrategy.FLAT_RATES
+    tc.save()
+
+    fetch_kwargs["allow_sync_webhooks"] = False
+
+    # when
+    calculations.fetch_order_prices_if_expired(**fetch_kwargs)
+    order.refresh_from_db()
+    line = order.lines.first()
+
+    # then
+    mocked_update_order_prices_with_flat_rates.assert_called_once_with(
+        order,
+        list(order.lines.all()),
+        prices_entered_with_tax,
+        database_connection_name=order.lines.db,
+    )
+    assert line.tax_rate == Decimal("0.2300")
+    assert order.shipping_tax_rate == Decimal("0.2300")
+
+
+def test_fetch_order_prices_tax_app_with_allow_sync_webhook_set_to_false(
+    plugins_manager,
+    fetch_kwargs_with_lines,
+    order_with_lines,
+):
+    # given
+    plugins_manager.get_taxes_for_order = Mock(return_value=None)
+
+    fetch_kwargs_with_lines["allow_sync_webhooks"] = False
+    order_from_input = fetch_kwargs_with_lines["order"]
+    lines_from_input = fetch_kwargs_with_lines["lines"]
+
+    # when
+    order, lines = calculations.fetch_order_prices_if_expired(**fetch_kwargs_with_lines)
+
+    # then
+    assert order_from_input == order
+    assert lines_from_input == lines
+    plugins_manager.get_taxes_for_order.assert_not_called()
 
 
 @pytest.mark.parametrize("prices_entered_with_tax", [True, False])
@@ -1509,9 +1611,12 @@ def test_recalculate_prices_empty_tax_data_logging_address(
         "get_taxes_for_order": Mock(return_value=None),
     }
     manager = Mock(**manager_methods)
+    tax_calculation_strategy = get_tax_calculation_strategy_for_order(order)
 
     # when
-    calculations._recalculate_prices(order, manager, order_lines)
+    calculations._recalculate_prices(
+        order, manager, order_lines, tax_calculation_strategy=tax_calculation_strategy
+    )
 
     # then
     assert (

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -680,7 +680,9 @@ def get_all_shipping_methods_for_order(
     shipping_channel_listings: Iterable["ShippingMethodChannelListing"],
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
 ) -> list[ShippingMethodData]:
-    if not order.is_shipping_required():
+    if not order.is_shipping_required(
+        database_connection_name=database_connection_name
+    ):
         return []
 
     shipping_address = order.shipping_address
@@ -697,6 +699,7 @@ def get_all_shipping_methods_for_order(
             price=order.subtotal.gross,
             shipping_address=shipping_address,
             country_code=shipping_address.country.code,
+            database_connection_name=database_connection_name,
         )
         .prefetch_related("channel_listings")
     )

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -721,6 +721,7 @@ def get_valid_shipping_methods_for_order(
     shipping_channel_listings: Iterable["ShippingMethodChannelListing"],
     manager: "PluginsManager",
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+    allow_sync_webhooks: bool = True,
 ) -> list[ShippingMethodData]:
     """Return a list of shipping methods according to Saleor's own business logic."""
     valid_methods = get_all_shipping_methods_for_order(
@@ -729,7 +730,7 @@ def get_valid_shipping_methods_for_order(
     if not valid_methods:
         return []
 
-    if order.status in ORDER_EDITABLE_STATUS:
+    if order.status in ORDER_EDITABLE_STATUS and allow_sync_webhooks:
         excluded_methods = manager.excluded_shipping_methods_for_order(
             order, valid_methods
         )

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -177,6 +177,7 @@ class ShippingMethodQueryset(models.QuerySet["ShippingMethod"]):
         shipping_address: Optional["Address"] = None,
         country_code: str | None = None,
         lines: list["CheckoutLineInfo"] | list["OrderLineInfo"] | None = None,
+        database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     ):
         if not shipping_address:
             return None
@@ -186,7 +187,11 @@ class ShippingMethodQueryset(models.QuerySet["ShippingMethod"]):
 
         if lines is None:
             # TODO: lines should comes from args in get_valid_shipping_methods_for_order
-            lines = list(instance.lines.prefetch_related("variant__product").all())  # type: ignore[misc] # this is hack # noqa: E501
+            lines = list(
+                instance.lines.prefetch_related("variant__product")  # type: ignore[misc] # this is hack # noqa: E501
+                .using(database_connection_name)
+                .all()
+            )
         instance_product_ids = {
             line.variant.product_id for line in lines if line.variant
         }


### PR DESCRIPTION
I want to merge this change because it blocks the external calls when making a bulk queries like: `orders`, `draftOrders`, `me.orders`. The calls like:
- ORDER_CALCULATE_TAXES (#17421)
- requests to AvataxAPI via AvataxPlugin (#17421)
- ORDER_FILTER_SHIPPING_METHODS (#17425)

will be skipped for bulk queries


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1483

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
