### PR TITLE
Clean address validation in checkout mutations

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -11,7 +11,7 @@ from .....product.models import ProductChannelListing, ProductVariantChannelList
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
-from .test_utils import assert_address_data
+from ..utils import assert_address_data
 
 MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
     mutation checkoutBillingAddressUpdate(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -24,7 +24,7 @@ from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ...mutations.utils import update_checkout_shipping_method_if_invalid
-from .test_utils import assert_address_data
+from ..utils import assert_address_data
 
 MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
     mutation checkoutShippingAddressUpdate(

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -185,21 +185,6 @@ def test_group_on_update_when_one_line_and_mixed_parameters_provided(
     )
 
 
-def assert_address_data(address, address_data, validation_skipped=False):
-    if metadata := address_data.get("metadata"):
-        assert address.metadata == {data["key"]: data["value"] for data in metadata}
-
-    assert address is not None
-    assert address.first_name == address_data["firstName"]
-    assert address.last_name == address_data["lastName"]
-    assert address.street_address_1 == address_data["streetAddress1"]
-    assert address.street_address_2 == address_data["streetAddress2"]
-    assert address.postal_code == address_data["postalCode"]
-    assert address.country == address_data["country"]
-    assert address.city == address_data["city"].upper()
-    assert address.validation_skipped == validation_skipped
-
-
 def test_assign_delivery_method_to_checkout_delivery_method_to_none(
     checkout_with_delivery_method_for_cc,
 ):

--- a/saleor/graphql/checkout/tests/utils.py
+++ b/saleor/graphql/checkout/tests/utils.py
@@ -1,0 +1,13 @@
+def assert_address_data(address, address_data, validation_skipped=False):
+    if metadata := address_data.get("metadata"):
+        assert address.metadata == {data["key"]: data["value"] for data in metadata}
+
+    assert address is not None
+    assert address.first_name == address_data["firstName"]
+    assert address.last_name == address_data["lastName"]
+    assert address.street_address_1 == address_data["streetAddress1"]
+    assert address.street_address_2 == address_data["streetAddress2"]
+    assert address.postal_code == address_data["postalCode"]
+    assert address.country == address_data["country"]
+    assert address.city == address_data["city"].upper()
+    assert address.validation_skipped == validation_skipped


### PR DESCRIPTION
Move the `assert_address_data` to `tests/utils.py` file

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
