### PR TITLE
Add Discord badge & remove GH Discussions mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <div align="center" width="100px">
 
-
-
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/76e3079f-696a-4fcd-8658-89739647090b">
    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/8477d643-a905-4c63-8ed3-03d0976f6fc3">
@@ -26,8 +24,6 @@
   <span> | </span>
   <a href="https://twitter.com/getsaleor">Twitter</a>
   <span> | </span>
-  <a href="https://github.com/saleor/saleor/discussions">GitHub Discussions</a>
-  <span> | </span>
   <a href="https://saleor.io/discord">Discord</a>
 </div>
 
@@ -38,6 +34,12 @@
 </div>
 
 <br>
+
+<div align="center">
+  
+[![Discord Badge](https://dcbadge.vercel.app/api/server/unUfh24R6d)](https://discord.gg/unUfh24R6d)
+
+</div>
 
 <div align="center">
   <a href="https://codecov.io/gh/saleor/saleor" >

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 <div align="center">
   
-[![Discord Badge](https://dcbadge.vercel.app/api/server/unUfh24R6d)](https://discord.gg/unUfh24R6d)
+[![Discord Badge](https://dcbadge.vercel.app/api/server/unUfh24R6d)](https://saleor.io/discord)
 
 </div>
 


### PR DESCRIPTION
Hello, it's me, your favorite README Developer. I removed the mention of GitHub Discussions because [we are moving away from it](https://github.com/saleor/saleor/discussions/17436). I also added a Discord badge.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
