### PR TITLE
Telemetry - Improve metrics creation API

### DIFF
--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -3,14 +3,14 @@ from contextlib import AbstractContextManager
 from ..core.telemetry import AttributeValue, MetricType, Scope, Unit, meter
 
 # Initialize metrics
-meter.create_metric(
+METRIC_GRAPHQL_QUERIES = meter.create_metric(
     "saleor.graphql_queries",
     scope=Scope.SERVICE,
     type=MetricType.COUNTER,
     unit=Unit.REQUEST,
     description="Number of GraphQL queries.",
 )
-meter.create_metric(
+METRIC_GRAPHQL_QUERY_DURATION = meter.create_metric(
     "saleor.graphql_query_duration",
     scope=Scope.SERVICE,
     type=MetricType.HISTOGRAM,
@@ -21,10 +21,10 @@ meter.create_metric(
 
 # Helper functions
 def record_graphql_queries_count(amount: int = 1) -> None:
-    meter.record("saleor.graphql_queries", amount)
+    meter.record(METRIC_GRAPHQL_QUERIES, amount)
 
 
 def record_graphql_query_duration() -> AbstractContextManager[
     dict[str, AttributeValue]
 ]:
-    return meter.record_duration("saleor.graphql_query_duration")
+    return meter.record_duration(METRIC_GRAPHQL_QUERY_DURATION)


### PR DESCRIPTION
Change `create_metric` to return the name of the created metric. This will improve the developer experience so that the metric name can be easily stored in a variable and later used to address the metric

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
