### PR TITLE
Fix circuit breaker wrapper for trigger_webhook_sync

### DIFF
--- a/saleor/webhook/circuit_breaker/breaker_board.py
+++ b/saleor/webhook/circuit_breaker/breaker_board.py
@@ -163,8 +163,8 @@ class BreakerBoard:
 
     def __call__(self, func):
         def inner(*args, **kwargs):
-            event_type: str = args[0]
-            webhook: Webhook = args[2]
+            event_type: str = kwargs.get("event_type") or args[0]
+            webhook: Webhook = kwargs.get("webhook") or args[2]
 
             if event_type not in settings.BREAKER_BOARD_SYNC_EVENTS:
                 # Execute webhook without affecting breaker state

--- a/saleor/webhook/tests/circuit_breaker/test_breaker_board_decorator.py
+++ b/saleor/webhook/tests/circuit_breaker/test_breaker_board_decorator.py
@@ -30,7 +30,10 @@ def test_breaker_board(
         new=Mock(return_value=expected_data),
     ):
         response_data = transport.trigger_webhook_sync(
-            WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, "", webhook, True
+            event_type=WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+            payload="",
+            webhook=webhook,
+            allow_replica=True,
         )
     state = breaker_board.update_breaker_state(webhook.app)
 


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
