### PR TITLE
Add description to bulk order and checkout queries about skipping external calls

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -376,7 +376,12 @@ class User(ModelObjectType[models.User]):
     )
     checkouts = ConnectionField(
         CheckoutCountableConnection,
-        description="Returns checkouts assigned to this user.",
+        description=(
+            "Returns checkouts assigned to this user. The query will not initiate any "
+            "external requests, including fetching external shipping methods, "
+            "filtering available shipping methods, or performing external tax "
+            "calculations."
+        ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
@@ -393,7 +398,10 @@ class User(ModelObjectType[models.User]):
     orders = ConnectionField(
         "saleor.graphql.order.types.OrderCountableConnection",
         description=(
-            "List of user's orders. Requires one of the following permissions: "
+            "List of user's orders. The query will not initiate any external requests, "
+            "including filtering available shipping methods, or performing external "
+            "tax calculations. Requires one of the following"
+            " permissions: "
             f"{AccountPermissions.MANAGE_STAFF.name}, "
             f"{AuthorizationFilters.OWNER.name}."
         ),

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -77,12 +77,20 @@ class CheckoutQueries(graphene.ObjectType):
             CheckoutPermissions.MANAGE_CHECKOUTS,
             PaymentPermissions.HANDLE_PAYMENTS,
         ],
-        description="List of checkouts.",
+        description=(
+            "List of checkouts. The query will not initiate any external requests, "
+            "including fetching external shipping methods, filtering available "
+            "shipping methods, or performing external tax calculations."
+        ),
         doc_category=DOC_CATEGORY_CHECKOUT,
     )
     checkout_lines = ConnectionField(
         CheckoutLineCountableConnection,
-        description="List of checkout lines.",
+        description=(
+            "List of checkout lines. The query will not initiate any external "
+            "requests, including fetching external shipping methods, filtering "
+            "available shipping methods, or performing external tax calculations."
+        ),
         permissions=[
             CheckoutPermissions.MANAGE_CHECKOUTS,
         ],

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -125,7 +125,11 @@ class OrderQueries(graphene.ObjectType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="List of orders.",
+        description=(
+            "List of orders. The query will not initiate any external requests, "
+            "including filtering available shipping methods, or performing external "
+            "tax calculations."
+        ),
         permissions=[
             OrderPermissions.MANAGE_ORDERS,
         ],
@@ -135,7 +139,11 @@ class OrderQueries(graphene.ObjectType):
         OrderCountableConnection,
         sort_by=OrderSortingInput(description="Sort draft orders."),
         filter=OrderDraftFilterInput(description="Filtering options for draft orders."),
-        description="List of draft orders.",
+        description=(
+            "List of draft orders. The query will not initiate any external requests, "
+            "including filtering available shipping methods, or performing external "
+            "tax calculations."
+        ),
         permissions=[
             OrderPermissions.MANAGE_ORDERS,
         ],

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -772,7 +772,7 @@ type Query {
   ): Order @doc(category: "Orders")
 
   """
-  List of orders.
+  List of orders. The query will not initiate any external requests, including filtering available shipping methods, or performing external tax calculations.
   
   Requires one of the following permissions: MANAGE_ORDERS.
   """
@@ -804,7 +804,7 @@ type Query {
   ): OrderCountableConnection @doc(category: "Orders")
 
   """
-  List of draft orders.
+  List of draft orders. The query will not initiate any external requests, including filtering available shipping methods, or performing external tax calculations.
   
   Requires one of the following permissions: MANAGE_ORDERS.
   """
@@ -1254,7 +1254,7 @@ type Query {
   ): Checkout @doc(category: "Checkout")
 
   """
-  List of checkouts.
+  List of checkouts. The query will not initiate any external requests, including fetching external shipping methods, filtering available shipping methods, or performing external tax calculations.
   
   Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   """
@@ -1286,7 +1286,7 @@ type Query {
   ): CheckoutCountableConnection @doc(category: "Checkout")
 
   """
-  List of checkout lines.
+  List of checkout lines. The query will not initiate any external requests, including fetching external shipping methods, filtering available shipping methods, or performing external tax calculations.
   
   Requires one of the following permissions: MANAGE_CHECKOUTS.
   """
@@ -9805,7 +9805,9 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
     channel: String
   ): [ID!]
 
-  """Returns checkouts assigned to this user."""
+  """
+  Returns checkouts assigned to this user. The query will not initiate any external requests, including fetching external shipping methods, filtering available shipping methods, or performing external tax calculations.
+  """
   checkouts(
     """Slug of a channel for which the data should be returned."""
     channel: String
@@ -9854,7 +9856,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   note: String
 
   """
-  List of user's orders. Requires one of the following permissions: MANAGE_STAFF, OWNER.
+  List of user's orders. The query will not initiate any external requests, including filtering available shipping methods, or performing external tax calculations. Requires one of the following permissions: MANAGE_STAFF, OWNER.
   """
   orders(
     """Return the elements in the list that come before the specified cursor."""


### PR DESCRIPTION
I want to merge this change because it provides details about blocking external calls when querying multiple order or checkout objects.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
