### PR TITLE
Update order mutations - explicitly save changed fields in `OrderUpdate` and `DraftOrderComplete`

### DIFF
--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -1,7 +1,11 @@
+from typing import Union
+from uuid import UUID
+
 import graphene
 from django.core.exceptions import ValidationError
 
 from ....account.models import User
+from ....checkout import AddressType
 from ....core.postgres import FlatConcatSearchVector
 from ....core.tracing import traced_atomic_transaction
 from ....order import OrderStatus, models
@@ -11,6 +15,8 @@ from ....order.search import prepare_order_search_vector_value
 from ....order.utils import invalidate_order_prices
 from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
+from ...account.i18n import I18nMixin
+from ...account.mixins import AddressMetadataMixin
 from ...account.types import AddressInput
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_310
@@ -19,7 +25,7 @@ from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import BaseInputObjectType, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
-from .draft_order_create import DraftOrderCreate
+from .utils import save_addresses
 
 
 class OrderUpdateInput(BaseInputObjectType):
@@ -34,7 +40,7 @@ class OrderUpdateInput(BaseInputObjectType):
         doc_category = DOC_CATEGORY_ORDERS
 
 
-class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
+class OrderUpdate(AddressMetadataMixin, ModelWithExtRefMutation, I18nMixin):
     class Arguments:
         id = graphene.ID(required=False, description="ID of an order to update.")
         external_reference = graphene.String(
@@ -52,23 +58,6 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
-
-    @classmethod
-    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
-        draft_order_cleaned_input = super().clean_input(info, instance, data, **kwargs)
-
-        # We must to filter out field added by DraftOrderUpdate
-        editable_fields = [
-            "billing_address",
-            "shipping_address",
-            "user_email",
-            "external_reference",
-        ]
-        cleaned_input = {}
-        for key in draft_order_cleaned_input:
-            if key in editable_fields:
-                cleaned_input[key] = draft_order_cleaned_input[key]
-        return cleaned_input
 
     @classmethod
     def get_instance(cls, info: ResolveInfo, **data):
@@ -94,21 +83,75 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
 
     @classmethod
     def save(cls, info: ResolveInfo, instance, cleaned_input):
+        update_fields = list(cleaned_input.keys())
         with traced_atomic_transaction():
-            cls._save_addresses(instance, cleaned_input)
-            if instance.user_email:
-                user = User.objects.filter(email=instance.user_email).first()
-                instance.user = user
-            instance.search_vector = FlatConcatSearchVector(
-                *prepare_order_search_vector_value(instance)
-            )
+            save_addresses(instance, cleaned_input)
+
             manager = get_plugin_manager_promise(info.context).get()
             if cls.should_invalidate_prices(cleaned_input):
                 invalidate_order_prices(instance)
+                update_fields.append("should_refresh_prices")
 
-            instance.save()
-            call_order_event(
-                manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                instance,
+            if update_fields:
+                instance.search_vector = FlatConcatSearchVector(
+                    *prepare_order_search_vector_value(instance)
+                )
+                update_fields.extend(["updated_at", "search_vector"])
+
+            if update_fields:
+                instance.save(update_fields=update_fields)
+                call_order_event(
+                    manager,
+                    WebhookEventAsyncType.ORDER_UPDATED,
+                    instance,
+                )
+
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        shipping_address_data = data.pop("shipping_address", None)
+        billing_address_data = data.pop("billing_address", None)
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        if email := cleaned_input.get("user_email", None):
+            if email == instance.user_email:
+                cleaned_input.pop("user_email")
+            try:
+                user = User.objects.get(email=email, is_active=True)
+                if user.id != instance.user_id:
+                    cleaned_input["user"] = user
+            except User.DoesNotExist:
+                if instance.user_id:
+                    cleaned_input["user"] = None
+
+        if shipping_address_data:
+            cleaned_input["shipping_address"] = cls.validate_address(
+                shipping_address_data,
+                address_type=AddressType.SHIPPING,
+                info=info,
             )
+
+        if billing_address_data:
+            cleaned_input["billing_address"] = cls.validate_address(
+                billing_address_data,
+                address_type=AddressType.BILLING,
+                info=info,
+            )
+
+        return cleaned_input
+
+    @classmethod
+    def get_instance_channel_id(cls, instance, **data) -> Union[UUID, int]:
+        return instance.channel_id
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        instance = cls.get_instance(info, **data)
+        channel_id = cls.get_instance_channel_id(instance, **data)
+        cls.check_channel_permissions(info, [channel_id])
+        data = data.get("input")
+        cleaned_input = cls.clean_input(info, instance, data)
+        instance = cls.construct_instance(instance, cleaned_input)
+
+        cls.clean_instance(info, instance)
+        cls.save(info, instance, cleaned_input)
+        return cls.success_response(instance)

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 from ....checkout.fetch import get_variant_channel_listing
 from ....core.taxes import zero_money, zero_taxed_money
 from ....discount.interface import fetch_variant_rules_info
-from ....order import ORDER_EDITABLE_STATUS, OrderStatus, events
+from ....order import ORDER_EDITABLE_STATUS, OrderStatus, events, models
 from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
 from ....order.utils import invalidate_order_prices
@@ -212,3 +212,14 @@ def get_variant_rule_info_map(
         ] = VariantData(variant=variant, rules_info=rules_info)
 
     return variant_id_to_variant_and_rules_info_map
+
+
+def save_addresses(instance: models.Order, cleaned_input: dict):
+    shipping_address = cleaned_input.get("shipping_address")
+    if shipping_address:
+        shipping_address.save()
+        instance.shipping_address = shipping_address.get_copy()
+    billing_address = cleaned_input.get("billing_address")
+    if billing_address:
+        billing_address.save()
+        instance.billing_address = billing_address.get_copy()


### PR DESCRIPTION
Use `update_fields` in `OrderUpdate` and `DraftOrderComplete` mutations

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
