### PR TITLE
[WIP] Add metric for webhook delivery delay

### DIFF
--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -35,6 +35,7 @@ class Unit(Enum):
 UNIT_CONVERSIONS: dict[tuple[Unit, Unit], float] = {
     (Unit.NANOSECOND, Unit.MILLISECOND): 1e-6,
     (Unit.NANOSECOND, Unit.SECOND): 1e-9,
+    (Unit.SECOND, Unit.MILLISECOND): 1e3,
 }
 
 

--- a/saleor/webhook/metrics.py
+++ b/saleor/webhook/metrics.py
@@ -1,0 +1,27 @@
+from datetime import UTC, datetime
+
+from ..core.models import EventDelivery
+from ..core.telemetry import MetricType, Scope, Unit, meter
+
+# Initialize metrics
+METRIC_FIRST_EVENT_DELIVERY_ATTEMPT_DELAY = meter.create_metric(
+    "saleor.webhooks.async.first_event_delivery_attempt_delay",
+    scope=Scope.CORE,
+    type=MetricType.HISTOGRAM,
+    unit=Unit.MILLISECOND,
+    description="Delay for the first attempt of delivering async webhook event after creation of EventDeliver.",
+)
+
+
+def record_first_delivery_attempt_delay(event_delivery: EventDelivery) -> None:
+    delay = (datetime.now(UTC) - event_delivery.created_at).total_seconds()
+    attributes = {
+        "app.name": event_delivery.webhook.app.name,
+        "event_type": event_delivery.event_type,
+    }
+    meter.record(
+        METRIC_FIRST_EVENT_DELIVERY_ATTEMPT_DELAY,
+        delay,
+        unit=Unit.SECOND,
+        attributes=attributes,
+    )

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -35,6 +35,7 @@ from ....graphql.webhook.subscription_payload import (
 from ....graphql.webhook.subscription_types import WEBHOOK_TYPES_MAP
 from ... import observability
 from ...event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ...metrics import record_first_delivery_attempt_delay
 from ...observability import WebhookData
 from ..utils import (
     DeferredPayloadData,
@@ -603,6 +604,8 @@ def send_webhook_request_async(
         data = data if isinstance(data, bytes) else data.encode("utf-8")
         # Count payload size in bytes.
         payload_size = len(data)
+        if self.request.retries == 0:
+            record_first_delivery_attempt_delay(delivery)
         with webhooks_otel_trace(
             delivery.event_type,
             domain,


### PR DESCRIPTION
Metrics to measure performance of webhook delivery

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
