### PR TITLE
Separate lint & test jobs

### DIFF
--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -1,13 +1,13 @@
-name: Pytest
+name: Tests & Linters
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
     paths:
       - "**.py"
       - Dockerfile
       - "saleor/**"
-      - ".github/workflows/pytest.yml"
+      - "tests-and-linters.yml"
       - pyproject.toml
       - poetry.lock
   push:
@@ -18,7 +18,7 @@ on:
       - "**.py"
       - Dockerfile
       - "saleor/**"
-      - ".github/workflows/pytest.yml"
+      - "tests-and-linters.yml"
       - pyproject.toml
       - poetry.lock
 
@@ -34,10 +34,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  units_and_linters:
+  unit_tests:
     runs-on: ubuntu-latest
     container: python:3.12
-    name: Run units & linters
+    name: Run unit tests
 
     services:
       postgres:
@@ -82,14 +82,6 @@ jobs:
           # Ticket: https://github.com/python-poetry/poetry/issues/7190
           echo "$(poetry env info -p)"/bin >> $GITHUB_PATH
 
-      # Run linters and Django related checks
-      # `git config` command is a workaround for https://github.com/actions/runner-images/issues/6775
-      - name: Run Linters and Checks
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          pre-commit run --all
-        if: ${{ always() }}
-
       - name: Run unit tests
         env:
           COVERAGE_CORE: sysmon
@@ -101,13 +93,6 @@ jobs:
             --junitxml=junit/test-results.xml \
             --django-db-bench=${{ env.BENCH_PATH }} \
             -n logical
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
 
       # Publish coverage and test results
       - uses: codecov/codecov-action@v4
@@ -135,3 +120,54 @@ jobs:
           upload_endpoint: ${{ secrets.QUERIES_UPLOAD_ENDPOINT_URL }}
           upload_secret_key: ${{ secrets.QUERIES_UPLOAD_SECRET }}
         if: github.event_name == 'push' && github.repository == 'saleor/saleor'
+
+  linters:
+    runs-on: ubuntu-latest
+    container: python:3.12
+    name: Run linters
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get install -y libpq-dev
+
+      - name: Install and configure poetry
+        run: |
+          pip install poetry==2.0.1
+
+      - name: Cache the venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: |
+          poetry env use python3.12
+          poetry sync
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+
+      - name: Add Python Virtual Environment to PATH
+        run: |
+          # Note: requires `poetry env use` to be ran, otherwise poetry
+          # may not be able to find which virtual environment is in use.
+          # Ticket: https://github.com/python-poetry/poetry/issues/7190
+          echo "$(poetry env info -p)"/bin >> $GITHUB_PATH
+
+      # Run linters and Django related checks
+      # `git config` command is a workaround for https://github.com/actions/runner-images/issues/6775
+      - name: Run Linters and Checks
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          pre-commit run --all
+        if: ${{ always() }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-


### PR DESCRIPTION
I want to merge this change because

it runs linters and tests in parallel
it saves extra 2-3 minutes on the entire workflow
it will cancel both if one of them fails to save time and resources

Port #17440 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
