### PR TITLE
Add good-first-issues-to-discord workflow

### DIFF
--- a/.github/workflows/good-first-issues-to-discord.yml
+++ b/.github/workflows/good-first-issues-to-discord.yml
@@ -1,0 +1,27 @@
+name: Notify Discord on Good First Issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify:
+    if: github.event.label.name == 'good first issue'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        uses: appleboy/discord-action@v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_GFI_WEBHOOK_URL }}
+          message: |
+            🎉 New Issue Labeled with "Good First Issue"
+
+            **Issue Details:**
+            - Title: ${{ github.event.issue.title }}
+            - Number: #${{ github.event.issue.number }}
+            - URL: ${{ github.event.issue.html_url }}
+
+            **Description:**
+            ${{ github.event.issue.body }}
+
+            Please take a look and help if you can! 🙏


### PR DESCRIPTION
I want to merge this change because I would like to post issues labeled with "good first issue" to Discord #good-first-issue channel.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
