### PR TITLE
The City field should not be cleared during address validation for Japan.

### DIFF
--- a/saleor/account/i18n_rules_override.py
+++ b/saleor/account/i18n_rules_override.py
@@ -1,0 +1,28 @@
+import i18naddress
+
+original_load_validation_data = i18naddress.load_validation_data
+
+
+COUNTRIES_RULES_OVERRIDE = {
+    "JP": {
+        # Library `google-i18n-address` use `AddressValidationMetadata` form Google to provide required fields.
+        # During address normalization, unexpected or unnecessary fields are removed. In `Japanse` address, `city` field
+        # is not marked as `allowed_field` in `AddressValidationMetadata`. This causes the `city` field to be removed
+        # https://github.com/google/libaddressinput/issues/244
+        "fmt": "〒%Z%n%S%n%C%n%A%n%O%n%N",
+        "lfmt": "%N%n%O%n%A, %C, %S%n%Z",
+    },
+}
+
+
+def patched_load_validation_data(country_code="all"):
+    validation_data = original_load_validation_data(country_code)
+    upper_country_code = country_code.upper()
+    if rules_override := COUNTRIES_RULES_OVERRIDE.get(upper_country_code):
+        for key, value in rules_override.items():
+            validation_data[upper_country_code][key] = value
+    return validation_data
+
+
+def i18n_rules_override():
+    i18naddress.load_validation_data = patched_load_validation_data

--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -69,6 +69,39 @@ def test_address_form_postal_code_validation():
     assert "postal_code" in errors
 
 
+def test_address_form_Japanese_city_is_excluded_from_normalization():
+    # given
+    data = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "street_address_1": "2344 Oya",
+        "country": "JP",
+        "country_area": "Saitama",
+        "city": "Fukaya-Shi",
+        "postal_code": "366-0814",
+    }
+    form = forms.get_address_form(data, country_code="JP")
+
+    # when
+    validated_address = form.validate_address(data)
+
+    # then
+    assert validated_address["city"] == "Fukaya-Shi"
+    assert not form.errors
+
+
+def test_city_is_allowed_in_Japanese_addresses():
+    # given
+
+    # when
+    country_rules = i18naddress.get_validation_rules({"country_code": "JP"})
+
+    # the
+    assert "city" in country_rules.allowed_fields
+    assert "%C" in country_rules.address_format
+    assert "%C" in country_rules.address_latin_format
+
+
 def test_address_form_long_street_address_validation():
     # given
     data = {

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -28,6 +28,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scrubber import DEFAULT_DENYLIST, DEFAULT_PII_DENYLIST, EventScrubber
 
 from . import PatchedSubscriberExecutionContext, __version__
+from .account.i18n_rules_override import i18n_rules_override
 from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
@@ -1055,3 +1056,7 @@ BREAKER_BOARD_SYNC_EVENTS = get_list(os.environ.get("BREAKER_BOARD_SYNC_EVENTS",
 BREAKER_BOARD_DRY_RUN_SYNC_EVENTS = get_list(
     os.environ.get("BREAKER_BOARD_DRY_RUN_SYNC_EVENTS", "")
 )
+
+# Library `google-i18n-address` use `AddressValidationMetadata` form Google to provide address validation rules.
+# Patch `i18n` module to allows to override the default address rules.
+i18n_rules_override()


### PR DESCRIPTION
I want to merge this change because the City field should not be cleared during address validation for Japan.

[google-i18n-address](https://github.com/mirumee/google-i18n-address) use [AddressValidationMetadata](https://github.com/google/libaddressinput/wiki/AddressValidationMetadata) form Google to provide required fields. During address normalization, unexpected or unnecessary fields are removed. In Japanse address, city field is not marked as allowed_field in AddressValidationMetadata. This causes the city field to be removed.

Port #17472 



<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
