### PR TITLE
Release 3.20.76

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.75",
+  "version": "3.20.76",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.75",
+      "version": "3.20.76",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.75",
+  "version": "3.20.76",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.75"
+version = "3.20.76"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.75"
+__version__ = "3.20.76"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* The City field should not be cleared during address validation for Japan. (0a0651955c)


CI related changes:
* Separate lint & test jobs (#17440) (#17477) (7a2021607e)
* Use logical instead of physical cores to detect pytest workers (#17413) (#17476) (47e918fd2a)
* Cancel stale jobs after new push (#17390) (#17475) (92ccadd3e1)
* Use sys.monitoring for coverage tracking (#17404) (#17474) (940b00cf70)
