### PR TITLE
Enable async payload generation for all async webhooks

### DIFF
--- a/saleor/core/utils/tests/test_events.py
+++ b/saleor/core/utils/tests/test_events.py
@@ -7,7 +7,7 @@ from ....webhook.utils import get_webhooks_for_multiple_events
 from ..events import (
     call_event,
     call_event_including_protected_events,
-    webhook_async_event_requires_sync_webhooks_to_trigger,
+    validate_async_event,
 )
 
 
@@ -23,7 +23,7 @@ def test_call_event_cannot_be_used_with_checkout_object(checkout, plugins_manage
         call_event(plugins_manager.checkout_updated, checkout)
 
 
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_requires_event_in_map():
+def test_validate_async_event_requires_event_in_map():
     # given
     event_name = WebhookEventAsyncType.ORDER_CREATED
     webhook_event_map = {}
@@ -32,114 +32,20 @@ def test_webhook_async_event_requires_sync_webhooks_to_trigger_requires_event_in
     with pytest.raises(
         ValueError, match=f"Event {event_name} not found in webhook_event_map."
     ):
-        webhook_async_event_requires_sync_webhooks_to_trigger(
-            event_name, webhook_event_map, []
-        )
+        validate_async_event(event_name, webhook_event_map, [])
 
 
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_not_async_event():
+def test_validate_async_event_not_async_event():
     # given
     event_name = WebhookEventSyncType.ORDER_CALCULATE_TAXES
     webhook_event_map = {}
 
     # when & then
     with pytest.raises(ValueError, match=f"Event {event_name} is not an async event."):
-        webhook_async_event_requires_sync_webhooks_to_trigger(
-            event_name, webhook_event_map, []
-        )
+        validate_async_event(event_name, webhook_event_map, [])
 
 
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_when_no_webhooks():
-    # given
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert not should_trigger
-
-
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_when_async_webhook(
-    webhook, permission_manage_orders
-):
-    # given
-    webhook.events.create(event_type=WebhookEventAsyncType.ORDER_CREATED)
-    webhook.app.permissions.set([permission_manage_orders])
-
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert not should_trigger
-
-
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_when_sync_webhook_active(
-    webhook, permission_manage_orders, setup_order_webhooks
-):
-    # given
-    different_event = WebhookEventAsyncType.ORDER_EXPIRED
-    (
-        tax_webhook,
-        shipping_filter_webhook,
-        order_created_webhook,
-    ) = setup_order_webhooks(different_event)
-
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert not should_trigger
-
-
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_webhooks_active(
-    setup_order_webhooks,
-):
-    # given
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    (
-        tax_webhook,
-        shipping_filter_webhook,
-        order_created_webhook,
-    ) = setup_order_webhooks(event_name)
-
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [event_name, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert should_trigger
-
-
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_missing_event_in_map():
+def test_validate_async_event_missing_event_in_map():
     # given
     event_name = WebhookEventAsyncType.ORDER_CREATED
     webhook_event_map = get_webhooks_for_multiple_events(
@@ -156,7 +62,7 @@ def test_webhook_async_event_requires_sync_webhooks_to_trigger_missing_event_in_
             "webhook_event_map."
         ),
     ):
-        webhook_async_event_requires_sync_webhooks_to_trigger(
+        validate_async_event(
             event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
         )
 
@@ -179,126 +85,3 @@ def test_call_event_including_protected_events(
     mocked_checkout_created.assert_called_once_with(
         checkout_with_items, webhooks=[webhook]
     )
-
-
-@pytest.mark.parametrize("subscription_query", ["", None])
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_no_subscription_for_event(
-    setup_order_webhooks, subscription_query, webhook, permission_manage_orders
-):
-    # given
-    (
-        tax_webhook,
-        shipping_filter_webhook,
-        order_created_webhook,
-    ) = setup_order_webhooks(WebhookEventAsyncType.ORDER_CREATED)
-
-    order_created_webhook.subscription_query = subscription_query
-    order_created_webhook.save(update_fields=["subscription_query"])
-
-    webhook.events.create(event_type=WebhookEventAsyncType.ORDER_CREATED)
-    webhook.app.permissions.set([permission_manage_orders])
-    webhook.subscription_query = subscription_query
-    webhook.save(update_fields=["subscription_query"])
-
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert not should_trigger
-
-
-@pytest.mark.parametrize("subscription_query", ["", None])
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_no_subscription_single_webhook(
-    setup_order_webhooks, subscription_query, webhook, permission_manage_orders
-):
-    # given
-    webhook.events.create(event_type=WebhookEventAsyncType.ORDER_CREATED)
-    webhook.app.permissions.set([permission_manage_orders])
-    webhook.subscription_query = subscription_query
-    webhook.save(update_fields=["subscription_query"])
-
-    (
-        tax_webhook,
-        shipping_filter_webhook,
-        order_created_webhook,
-    ) = setup_order_webhooks(WebhookEventAsyncType.ORDER_CREATED)
-
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert should_trigger
-
-
-@pytest.mark.parametrize("subscription_query", ["", None])
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_no_subscription_for_async_events(
-    setup_order_webhooks, subscription_query
-):
-    # given
-    (
-        tax_webhook,
-        shipping_filter_webhook,
-        order_created_webhook,
-    ) = setup_order_webhooks(WebhookEventAsyncType.ORDER_CREATED)
-    tax_webhook.subscription_query = subscription_query
-    tax_webhook.save(update_fields=["subscription_query"])
-    shipping_filter_webhook.subscription_query = subscription_query
-    shipping_filter_webhook.save(update_fields=["subscription_query"])
-
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert not should_trigger
-
-
-@pytest.mark.parametrize("subscription_query", ["", None])
-def test_webhook_async_event_requires_sync_webhooks_to_trigger_no_subscription_for_single_async_event(
-    setup_order_webhooks, subscription_query
-):
-    # given
-    (
-        tax_webhook,
-        shipping_filter_webhook,
-        order_created_webhook,
-    ) = setup_order_webhooks(WebhookEventAsyncType.ORDER_CREATED)
-    shipping_filter_webhook.subscription_query = subscription_query
-    shipping_filter_webhook.save(update_fields=["subscription_query"])
-
-    event_name = WebhookEventAsyncType.ORDER_CREATED
-    webhook_event_map = get_webhooks_for_multiple_events(
-        [WebhookEventAsyncType.ORDER_CREATED, *WebhookEventSyncType.ORDER_EVENTS]
-    )
-
-    # when
-
-    should_trigger = webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    )
-
-    # then
-    assert should_trigger

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -600,12 +600,10 @@ class WebhookEventAsyncType:
         CHECKOUT_CREATED: {
             "name": "Checkout created",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
-            "is_deferred_payload": True,
         },
         CHECKOUT_UPDATED: {
             "name": "Checkout updated",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
-            "is_deferred_payload": True,
         },
         CHECKOUT_FULLY_PAID: {
             "name": "Checkout fully paid",

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -325,10 +325,6 @@ def trigger_webhooks_async_for_multiple_objects(
 
     legacy_webhooks, subscription_webhooks = group_webhooks_by_subscription(webhooks)
 
-    is_deferred_payload = WebhookEventAsyncType.EVENT_MAP.get(event_type, {}).get(
-        "is_deferred_payload", False
-    )
-
     # List of deliveries with payloads.
     deliveries: list[EventDelivery] = []
 
@@ -366,29 +362,16 @@ def trigger_webhooks_async_for_multiple_objects(
             webhook_payload_data.subscribable_object
             for webhook_payload_data in webhook_payloads_data
         ]
-        if is_deferred_payload:
-            deferred_deliveries_per_object = (
-                create_deliveries_for_deferred_payload_subscriptions(
-                    event_type=event_type,
-                    subscribable_objects=subscribable_objects,
-                    webhooks=subscription_webhooks,
-                    requestor=requestor,
-                    allow_replica=allow_replica,
-                    request_time=request_time,
-                )
+        deferred_deliveries_per_object = (
+            create_deliveries_for_deferred_payload_subscriptions(
+                event_type=event_type,
+                subscribable_objects=subscribable_objects,
+                webhooks=subscription_webhooks,
+                requestor=requestor,
+                allow_replica=allow_replica,
+                request_time=request_time,
             )
-        else:
-            deliveries.extend(
-                create_deliveries_for_multiple_subscription_objects(
-                    event_type=event_type,
-                    subscribable_objects=subscribable_objects,
-                    webhooks=subscription_webhooks,
-                    requestor=requestor,
-                    allow_replica=allow_replica,
-                    pre_save_payloads=pre_save_payloads,
-                    request_time=request_time,
-                )
-            )
+        )
 
     for _, deferred_deliveries in deferred_deliveries_per_object.items():
         if not deferred_deliveries:


### PR DESCRIPTION
I want to merge this change because it enables the generation of payloads for all async webhooks in a deferred way - like it was introduced for checkout events.

⚠️ Still WIP - need to check couple of things

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
