### PR TITLE
Drop unused `change_user_address` from manager

### DIFF
--- a/saleor/account/utils.py
+++ b/saleor/account/utils.py
@@ -28,7 +28,6 @@ def store_user_address(
     if is_user_address_limit_reached(user):
         return
 
-    address = manager.change_user_address(address, address_type, user)
     address_data = address.as_data()
 
     address = user.addresses.filter(**address_data).first()
@@ -79,7 +78,6 @@ def set_user_default_shipping_address(user, address):
 def change_user_default_address(
     user: User, address: "Address", address_type: str, manager: "PluginsManager"
 ):
-    address = manager.change_user_address(address, address_type, user)
     if address_type == AddressType.BILLING:
         if user.default_billing_address:
             user.addresses.add(user.default_billing_address)

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
@@ -472,9 +472,6 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
             old_instances.append(customer_data["old_instance"])
 
             if shipping_address := customer_data[SHIPPING_ADDRESS_FIELD]:
-                shipping_address = manager.change_user_address(
-                    shipping_address, "shipping", customer, save=False
-                )
                 if customer.default_shipping_address:
                     addresses_to_update.append(shipping_address)
                 else:
@@ -485,10 +482,6 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                     )
 
             if billing_address := customer_data[BILLING_ADDRESS_FIELD]:
-                billing_address = manager.change_user_address(
-                    billing_address, "billing", customer, save=False
-                )
-
                 if customer.default_billing_address:
                     addresses_to_update.append(billing_address)
                 else:

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -108,7 +108,6 @@ class BaseAddressUpdate(ModelMutation, I18nMixin):
             user.search_document = prepare_user_search_document_value(user)
             user.save(update_fields=["search_document", "updated_at"])
         manager = get_plugin_manager_promise(info.context).get()
-        address = manager.change_user_address(address, None, user)
         cls.call_event(manager.address_updated, address)
 
         success_response = cls.success_response(address)
@@ -318,16 +317,10 @@ class BaseCustomerCreate(ModelMutation, I18nMixin):
         default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
         manager = get_plugin_manager_promise(info.context).get()
         if default_shipping_address:
-            default_shipping_address = manager.change_user_address(
-                default_shipping_address, "shipping", instance
-            )
             default_shipping_address.save()
             instance.default_shipping_address = default_shipping_address
         default_billing_address = cleaned_input.get(BILLING_ADDRESS_FIELD)
         if default_billing_address:
-            default_billing_address = manager.change_user_address(
-                default_billing_address, "billing", instance
-            )
             default_billing_address.save()
             instance.default_billing_address = default_billing_address
 

--- a/saleor/graphql/account/mutations/staff/address_create.py
+++ b/saleor/graphql/account/mutations/staff/address_create.py
@@ -61,10 +61,8 @@ class AddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
             cls.post_save_action(info, instance, cleaned_input)
             response = cls.success_response(instance)
             response.user = user
-            manager = get_plugin_manager_promise(info.context).get()
-            address = manager.change_user_address(instance, None, user)
             remove_the_oldest_user_address_if_address_limit_is_reached(user)
-            user.addresses.add(address)
+            user.addresses.add(instance)
             user.search_document = prepare_user_search_document_value(user)
 
             user.save(update_fields=["search_document", "updated_at"])

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -434,9 +434,6 @@ class DraftOrderCreate(
                 instance=instance.shipping_address,
                 info=info,
             )
-            shipping_address = manager.change_user_address(
-                shipping_address, "shipping", user=instance
-            )
             cleaned_input["shipping_address"] = shipping_address
         if billing_address:
             billing_address = cls.validate_address(
@@ -444,9 +441,6 @@ class DraftOrderCreate(
                 address_type=AddressType.BILLING,
                 instance=instance.billing_address,
                 info=info,
-            )
-            billing_address = manager.change_user_address(
-                billing_address, "billing", user=instance
             )
             cleaned_input["billing_address"] = billing_address
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -521,10 +521,6 @@ class BasePlugin:
     # Webhook-related functionality will be moved from the plugin to core modules.
     channel_metadata_updated: Callable[["Channel", None], None]
 
-    change_user_address: Callable[
-        ["Address", Union[str, None], Union["User", None], bool, "Address"], "Address"
-    ]
-
     # Retrieves the balance remaining on a shopper's gift card
     check_payment_balance: Callable[[dict, str], dict]
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -264,24 +264,6 @@ class PluginsManager(PaymentInterface):
             "check_payment_balance", None, details, channel_slug=channel_slug
         )
 
-    def change_user_address(
-        self,
-        address: "Address",
-        address_type: Optional[str],
-        user: Optional["User"],
-        save: bool = True,
-    ) -> "Address":
-        default_value = address
-        return self.__run_method_on_plugins(
-            "change_user_address",
-            default_value,
-            address,
-            address_type,
-            user,
-            save,
-            channel_slug=None,
-        )
-
     def calculate_checkout_total(
         self,
         checkout_info: "CheckoutInfo",


### PR DESCRIPTION
Drop `change_user_address` from manager that was a part of anonymized plugin, already removed from Saleor (https://github.com/saleor/saleor/pull/)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
