### PR TITLE
Update order mutations - explicitly save changed fields in `DraftOrderUpdate`

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_cleaner.py
+++ b/saleor/graphql/order/mutations/draft_order_cleaner.py
@@ -1,0 +1,140 @@
+from typing import Optional
+
+from django.core.exceptions import ValidationError
+
+from ....channel.models import Channel
+from ....core.utils.url import validate_storefront_url
+from ....discount.models import Voucher, VoucherCode
+from ....discount.utils.voucher import (
+    get_active_voucher_code,
+    get_voucher_code_instance,
+)
+from ....order.error_codes import OrderErrorCode
+
+
+class DraftOrderCleaner:
+    @staticmethod
+    def clean_redirect_url(redirect_url: str, cleaned_input: dict):
+        if not redirect_url:
+            return
+
+        try:
+            validate_storefront_url(redirect_url)
+        except ValidationError as error:
+            error.code = OrderErrorCode.INVALID.value
+            raise ValidationError({"redirect_url": error})
+
+        cleaned_input["redirect_url"] = redirect_url
+
+    @classmethod
+    def clean_voucher_and_voucher_code(cls, channel: "Channel", cleaned_input: dict):
+        voucher = cleaned_input.get("voucher", None)
+        voucher_code = cleaned_input.get("voucher_code", None)
+        if voucher and voucher_code:
+            raise ValidationError(
+                {
+                    "voucher": ValidationError(
+                        "You cannot use both a voucher and a voucher code for the same "
+                        "order. Please choose one.",
+                        code=OrderErrorCode.INVALID.value,
+                    )
+                }
+            )
+
+        if "voucher" in cleaned_input:
+            cls.clean_voucher(voucher, channel, cleaned_input)
+        elif "voucher_code" in cleaned_input:
+            cls.clean_voucher_code(voucher_code, channel, cleaned_input)
+
+    @classmethod
+    def clean_voucher(
+        cls, voucher: Optional[Voucher], channel: Channel, cleaned_input: dict
+    ):
+        # We need to clean voucher_code as well
+        if voucher is None:
+            cleaned_input["voucher_code"] = None
+            return
+
+        if isinstance(voucher, VoucherCode):
+            raise ValidationError(
+                {
+                    "voucher": ValidationError(
+                        "You cannot use voucherCode in the voucher input. "
+                        "Please use voucherCode input instead with a valid voucher code.",
+                        code=OrderErrorCode.INVALID_VOUCHER.value,
+                    )
+                }
+            )
+
+        code_instance = None
+        if channel.include_draft_order_in_voucher_usage:
+            # Validate voucher when it's included in voucher usage calculation
+            try:
+                code_instance = get_active_voucher_code(voucher, channel.slug)
+            except ValidationError:
+                raise ValidationError(
+                    {
+                        "voucher": ValidationError(
+                            "Voucher is invalid.",
+                            code=OrderErrorCode.INVALID_VOUCHER.value,
+                        )
+                    }
+                )
+        else:
+            cls.clean_voucher_listing(voucher, channel, "voucher")
+        if not code_instance:
+            code_instance = voucher.codes.first()
+        if code_instance:
+            cleaned_input["voucher_code"] = code_instance.code
+            cleaned_input["voucher_code_instance"] = code_instance
+
+    @classmethod
+    def clean_voucher_code(
+        cls, voucher_code: Optional[str], channel: Channel, cleaned_input: dict
+    ):
+        # We need to clean voucher instance as well
+        if voucher_code is None:
+            cleaned_input["voucher"] = None
+            return
+        if channel.include_draft_order_in_voucher_usage:
+            # Validate voucher when it's included in voucher usage calculation
+            try:
+                code_instance = get_voucher_code_instance(voucher_code, channel.slug)
+            except ValidationError:
+                raise ValidationError(
+                    {
+                        "voucher_code": ValidationError(
+                            "Voucher code is invalid.",
+                            code=OrderErrorCode.INVALID_VOUCHER_CODE.value,
+                        )
+                    }
+                )
+            voucher = code_instance.voucher
+        else:
+            code_instance = VoucherCode.objects.filter(code=voucher_code).first()
+            if not code_instance:
+                raise ValidationError(
+                    {
+                        "voucher": ValidationError(
+                            "Invalid voucher code.",
+                            code=OrderErrorCode.INVALID_VOUCHER_CODE.value,
+                        )
+                    }
+                )
+            voucher = code_instance.voucher
+            cls.clean_voucher_listing(voucher, channel, "voucher_code")
+        cleaned_input["voucher"] = voucher
+        cleaned_input["voucher_code"] = voucher_code
+        cleaned_input["voucher_code_instance"] = code_instance
+
+    @classmethod
+    def clean_voucher_listing(cls, voucher: "Voucher", channel: "Channel", field: str):
+        if not voucher.channel_listings.filter(channel=channel).exists():
+            raise ValidationError(
+                {
+                    field: ValidationError(
+                        "Voucher not available for this order.",
+                        code=OrderErrorCode.NOT_AVAILABLE_IN_CHANNEL.value,
+                    )
+                }
+            )

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -1,20 +1,55 @@
 import graphene
 from django.core.exceptions import ValidationError
 
+from ....account.models import User
+from ....checkout import AddressType
+from ....core.tracing import traced_atomic_transaction
+from ....discount.models import VoucherCode
+from ....discount.utils.voucher import (
+    increase_voucher_usage,
+    release_voucher_code_usage,
+)
 from ....order import OrderStatus, models
+from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
+from ....order.search import update_order_search_vector
+from ....order.utils import (
+    invalidate_order_prices,
+    update_order_display_gross_prices,
+)
 from ....permission.enums import OrderPermissions
-from ...app.dataloaders import get_app_promise
+from ....shipping.utils import convert_to_shipping_method_data
+from ....webhook.event_types import WebhookEventAsyncType
+from ...account.i18n import I18nMixin
+from ...account.mixins import AddressMetadataMixin
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_310
-from ...core.mutations import ModelWithExtRefMutation
+from ...core.descriptions import (
+    ADDED_IN_310,
+)
+from ...core.mutations import (
+    ModelWithExtRefMutation,
+    ModelWithRestrictedChannelAccessMutation,
+)
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
+from ...shipping.utils import get_shipping_model_by_object_id
 from ..types import Order
-from .draft_order_create import DraftOrderCreate, DraftOrderInput
+from .draft_order_cleaner import DraftOrderCleaner
+from .draft_order_create import DraftOrderInput
+from .utils import (
+    SHIPPING_METHOD_UPDATE_FIELDS,
+    ShippingMethodUpdateMixin,
+    save_addresses,
+)
 
 
-class DraftOrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
+class DraftOrderUpdate(
+    AddressMetadataMixin,
+    ModelWithRestrictedChannelAccessMutation,
+    ShippingMethodUpdateMixin,
+    ModelWithExtRefMutation,
+    I18nMixin,
+):
     class Arguments:
         id = graphene.ID(required=False, description="ID of a draft order to update.")
         external_reference = graphene.String(
@@ -63,48 +98,207 @@ class DraftOrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         )
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
-        manager = get_plugin_manager_promise(info.context).get()
-        app = get_app_promise(info.context).get()
-        return cls._save_draft_order(
-            info,
-            instance,
-            cleaned_input,
-            is_new_instance=False,
-            app=app,
-            manager=manager,
+    def clean_input(
+        cls, info: ResolveInfo, instance: models.Order, data: dict, **kwargs
+    ):
+        cls.clean_channel_id(instance, data)
+        shipping_address = data.pop("shipping_address", None)
+        billing_address = data.pop("billing_address", None)
+        redirect_url = data.pop("redirect_url", None)
+
+        shipping_method_input = {}
+        if "shipping_method" in data:
+            shipping_method_input["shipping_method"] = get_shipping_model_by_object_id(
+                object_id=data.pop("shipping_method", None),
+                error_field="shipping_method",
+            )
+
+        if email := data.get("user_email", None):
+            try:
+                user = User.objects.get(email=email, is_active=True)
+                data["user"] = graphene.Node.to_global_id("User", user.id)
+            except User.DoesNotExist:
+                data["user"] = None
+
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        cleaned_input.update(shipping_method_input)
+
+        channel = instance.channel or cleaned_input.get("channel_id")
+        DraftOrderCleaner.clean_voucher_and_voucher_code(channel, cleaned_input)
+
+        cls.clean_addresses(
+            info, instance, cleaned_input, shipping_address, billing_address
         )
+
+        DraftOrderCleaner.clean_redirect_url(redirect_url, cleaned_input)
+
+        return cleaned_input
+
+    @classmethod
+    def clean_channel_id(cls, instance, data):
+        if data.get("channel_id"):
+            if hasattr(instance, "channel"):
+                raise ValidationError(
+                    {
+                        "channel_id": ValidationError(
+                            "Can't update existing order channel id.",
+                            code=OrderErrorCode.NOT_EDITABLE.value,
+                        )
+                    }
+                )
+
+    @classmethod
+    def clean_addresses(
+        cls,
+        info: ResolveInfo,
+        instance,
+        cleaned_input,
+        shipping_address,
+        billing_address,
+    ):
+        if shipping_address:
+            shipping_address = cls.validate_address(
+                shipping_address,
+                address_type=AddressType.SHIPPING,
+                instance=instance.shipping_address,
+                info=info,
+            )
+            cleaned_input["shipping_address"] = shipping_address
+        if billing_address:
+            billing_address = cls.validate_address(
+                billing_address,
+                address_type=AddressType.BILLING,
+                instance=instance.billing_address,
+                info=info,
+            )
+            cleaned_input["billing_address"] = billing_address
+
+    @classmethod
+    def _save(
+        cls,
+        info: ResolveInfo,
+        instance,
+        cleaned_input,
+        old_voucher,
+        old_voucher_code,
+        changed_fields,
+    ):
+        updated_fields = changed_fields
+        manager = get_plugin_manager_promise(info.context).get()
+        with traced_atomic_transaction():
+            shipping_channel_listing = None
+            # Process addresses
+            address_fields = save_addresses(instance, cleaned_input)
+            updated_fields.extend(address_fields)
+
+            if "shipping_method" in cleaned_input:
+                method = cleaned_input["shipping_method"]
+                if method is None:
+                    cls.clear_shipping_method_from_order(instance)
+                else:
+                    shipping_channel_listing = cls.validate_shipping_channel_listing(
+                        method, instance
+                    )
+                    shipping_method_data = convert_to_shipping_method_data(
+                        method,
+                        shipping_channel_listing,
+                    )
+                    cls.update_shipping_method(instance, method, shipping_method_data)
+                    cls._update_shipping_price(instance, shipping_channel_listing)
+                updated_fields.extend(SHIPPING_METHOD_UPDATE_FIELDS)
+
+            if instance.undiscounted_base_shipping_price_amount is None:
+                instance.undiscounted_base_shipping_price_amount = (
+                    instance.base_shipping_price_amount
+                )
+                updated_fields.append("undiscounted_base_shipping_price_amount")
+
+            if "voucher" in cleaned_input:
+                cls.handle_order_voucher(
+                    cleaned_input,
+                    instance,
+                    old_voucher,
+                    old_voucher_code,
+                )
+
+            if not updated_fields:
+                return
+
+            if (
+                "shipping_address" in updated_fields
+                or "billing_address" in updated_fields
+            ):
+                update_order_display_gross_prices(instance)
+                updated_fields.append("display_gross_prices")
+
+            update_order_search_vector(instance, save=False)
+            # Post-process the results
+            updated_fields.extend(
+                [
+                    "search_vector",
+                    "updated_at",
+                ]
+            )
+
+            if cls.should_invalidate_prices(cleaned_input):
+                invalidate_order_prices(instance)
+                updated_fields.extend(["should_refresh_prices"])
+
+            instance.save(update_fields=updated_fields)
+            call_order_event(
+                manager,
+                WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
+                instance,
+            )
+
+    @classmethod
+    def handle_order_voucher(
+        cls, cleaned_input, instance, old_voucher, old_voucher_code
+    ):
+        user_email = instance.user_email or instance.user and instance.user.email
+        channel = instance.channel
+        if not channel.include_draft_order_in_voucher_usage:
+            return
+
+        if voucher := cleaned_input["voucher"]:
+            code_instance = cleaned_input.pop("voucher_code_instance", None)
+            increase_voucher_usage(
+                voucher,
+                code_instance,
+                user_email,
+                increase_voucher_customer_usage=False,
+            )
+        elif old_voucher:
+            # handle removing voucher
+            voucher_code = VoucherCode.objects.filter(code=old_voucher_code).first()
+            release_voucher_code_usage(voucher_code, old_voucher, user_email)
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
         instance = cls.get_instance(info, **data)
         channel_id = cls.get_instance_channel_id(instance, **data)
         cls.check_channel_permissions(info, [channel_id])
+        old_instance_data = instance.serialize_for_comparison()
         old_voucher = instance.voucher
         old_voucher_code = instance.voucher_code
-        data = data.get("input")
+        data = data["input"]
         cleaned_input = cls.clean_input(info, instance, data)
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(info, instance)
-        cls.save_draft_order(
-            info, instance, cleaned_input, old_voucher, old_voucher_code
+        new_instance_data = instance.serialize_for_comparison()
+        changed_fields = cls.diff_instance_data_fields(
+            instance.comparison_fields,
+            old_instance_data,
+            new_instance_data,
+        )
+        cls._save(
+            info, instance, cleaned_input, old_voucher, old_voucher_code, changed_fields
         )
         cls._save_m2m(info, instance, cleaned_input)
         return cls.success_response(instance)
 
     @classmethod
-    def save_draft_order(
-        cls, info: ResolveInfo, instance, cleaned_input, old_voucher, old_voucher_code
-    ):
-        manager = get_plugin_manager_promise(info.context).get()
-        app = get_app_promise(info.context).get()
-        return cls._save_draft_order(
-            info,
-            instance,
-            cleaned_input,
-            is_new_instance=False,
-            app=app,
-            manager=manager,
-            old_voucher=old_voucher,
-            old_voucher_code=old_voucher_code,
-        )
+    def get_instance_channel_id(cls, instance, **data):
+        if channel_id := instance.channel_id:
+            return channel_id

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -1,7 +1,11 @@
+from typing import Union
+from uuid import UUID
+
 import graphene
 from django.core.exceptions import ValidationError
 
 from ....account.models import User
+from ....checkout import AddressType
 from ....core.postgres import FlatConcatSearchVector
 from ....core.tracing import traced_atomic_transaction
 from ....order import OrderStatus, models
@@ -11,6 +15,8 @@ from ....order.search import prepare_order_search_vector_value
 from ....order.utils import invalidate_order_prices
 from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
+from ...account.i18n import I18nMixin
+from ...account.mixins import AddressMetadataMixin
 from ...account.types import AddressInput
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_310
@@ -19,7 +25,7 @@ from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import BaseInputObjectType, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
-from .draft_order_create import DraftOrderCreate
+from .utils import save_addresses
 
 
 class OrderUpdateInput(BaseInputObjectType):
@@ -34,7 +40,7 @@ class OrderUpdateInput(BaseInputObjectType):
         doc_category = DOC_CATEGORY_ORDERS
 
 
-class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
+class OrderUpdate(AddressMetadataMixin, ModelWithExtRefMutation, I18nMixin):
     class Arguments:
         id = graphene.ID(required=False, description="ID of an order to update.")
         external_reference = graphene.String(
@@ -52,23 +58,6 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
-
-    @classmethod
-    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
-        draft_order_cleaned_input = super().clean_input(info, instance, data, **kwargs)
-
-        # We must to filter out field added by DraftOrderUpdate
-        editable_fields = [
-            "billing_address",
-            "shipping_address",
-            "user_email",
-            "external_reference",
-        ]
-        cleaned_input = {}
-        for key in draft_order_cleaned_input:
-            if key in editable_fields:
-                cleaned_input[key] = draft_order_cleaned_input[key]
-        return cleaned_input
 
     @classmethod
     def get_instance(cls, info: ResolveInfo, **data):
@@ -94,21 +83,75 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
 
     @classmethod
     def save(cls, info: ResolveInfo, instance, cleaned_input):
+        update_fields = list(cleaned_input.keys())
         with traced_atomic_transaction():
-            cls._save_addresses(instance, cleaned_input)
-            if instance.user_email:
-                user = User.objects.filter(email=instance.user_email).first()
-                instance.user = user
-            instance.search_vector = FlatConcatSearchVector(
-                *prepare_order_search_vector_value(instance)
-            )
+            save_addresses(instance, cleaned_input)
+
             manager = get_plugin_manager_promise(info.context).get()
             if cls.should_invalidate_prices(cleaned_input):
                 invalidate_order_prices(instance)
+                update_fields.append("should_refresh_prices")
 
-            instance.save()
-            call_order_event(
-                manager,
-                WebhookEventAsyncType.ORDER_UPDATED,
-                instance,
+            if update_fields:
+                instance.search_vector = FlatConcatSearchVector(
+                    *prepare_order_search_vector_value(instance)
+                )
+                update_fields.extend(["updated_at", "search_vector"])
+
+            if update_fields:
+                instance.save(update_fields=update_fields)
+                call_order_event(
+                    manager,
+                    WebhookEventAsyncType.ORDER_UPDATED,
+                    instance,
+                )
+
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        shipping_address_data = data.pop("shipping_address", None)
+        billing_address_data = data.pop("billing_address", None)
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        if email := cleaned_input.get("user_email", None):
+            if email == instance.user_email:
+                cleaned_input.pop("user_email")
+            try:
+                user = User.objects.get(email=email, is_active=True)
+                if user.id != instance.user_id:
+                    cleaned_input["user"] = user
+            except User.DoesNotExist:
+                if instance.user_id:
+                    cleaned_input["user"] = None
+
+        if shipping_address_data:
+            cleaned_input["shipping_address"] = cls.validate_address(
+                shipping_address_data,
+                address_type=AddressType.SHIPPING,
+                info=info,
             )
+
+        if billing_address_data:
+            cleaned_input["billing_address"] = cls.validate_address(
+                billing_address_data,
+                address_type=AddressType.BILLING,
+                info=info,
+            )
+
+        return cleaned_input
+
+    @classmethod
+    def get_instance_channel_id(cls, instance, **data) -> Union[UUID, int]:
+        return instance.channel_id
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        instance = cls.get_instance(info, **data)
+        channel_id = cls.get_instance_channel_id(instance, **data)
+        cls.check_channel_permissions(info, [channel_id])
+        data = data.get("input")
+        cleaned_input = cls.clean_input(info, instance, data)
+        instance = cls.construct_instance(instance, cleaned_input)
+
+        cls.clean_instance(info, instance)
+        cls.save(info, instance, cleaned_input)
+        return cls.success_response(instance)

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -214,12 +214,16 @@ def get_variant_rule_info_map(
     return variant_id_to_variant_and_rules_info_map
 
 
-def save_addresses(instance: models.Order, cleaned_input: dict):
+def save_addresses(instance: models.Order, cleaned_input: dict) -> list[str]:
+    update_fields = []
     shipping_address = cleaned_input.get("shipping_address")
     if shipping_address:
         shipping_address.save()
         instance.shipping_address = shipping_address.get_copy()
+        update_fields.append("shipping_address")
     billing_address = cleaned_input.get("billing_address")
     if billing_address:
         billing_address.save()
         instance.billing_address = billing_address.get_copy()
+    update_fields.append("billing_address")
+    return update_fields

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 from ....checkout.fetch import get_variant_channel_listing
 from ....core.taxes import zero_money, zero_taxed_money
 from ....discount.interface import fetch_variant_rules_info
-from ....order import ORDER_EDITABLE_STATUS, OrderStatus, events
+from ....order import ORDER_EDITABLE_STATUS, OrderStatus, events, models
 from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
 from ....order.utils import invalidate_order_prices
@@ -212,3 +212,14 @@ def get_variant_rule_info_map(
         ] = VariantData(variant=variant, rules_info=rules_info)
 
     return variant_id_to_variant_and_rules_info_map
+
+
+def save_addresses(instance: models.Order, cleaned_input: dict):
+    shipping_address = cleaned_input.get("shipping_address")
+    if shipping_address:
+        shipping_address.save()
+        instance.shipping_address = shipping_address.get_copy()
+    billing_address = cleaned_input.get("billing_address")
+    if billing_address:
+        billing_address.save()
+        instance.billing_address = billing_address.get_copy()

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -2265,7 +2265,7 @@ def test_draft_order_update_replace_entire_order_voucher_with_shipping_voucher(
 
 
 @patch(
-    "saleor.graphql.order.mutations.draft_order_create.call_order_event",
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
     wraps=call_order_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
@@ -2362,7 +2362,7 @@ def test_draft_order_update_triggers_webhooks(
 
 
 @patch(
-    "saleor.graphql.order.mutations.draft_order_create.call_order_event",
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
     wraps=call_order_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -1,3 +1,4 @@
+import copy
 from decimal import Decimal
 from operator import attrgetter
 from re import match
@@ -11,6 +12,7 @@ from django.core.validators import MinValueValidator
 from django.db import connection, models
 from django.db.models import F, JSONField, Max
 from django.db.models.expressions import Exists, OuterRef
+from django.forms.models import model_to_dict
 from django.utils.timezone import now
 from django_measurement.models import MeasurementField
 from django_prices.models import MoneyField, TaxedMoneyField
@@ -512,6 +514,23 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
     @property
     def total_balance(self):
         return self.total_charged - self.total.gross
+
+    @property
+    def comparison_fields(self):
+        return [
+            "discount",
+            "voucher",
+            "voucher_code",
+            "customer_note",
+            "redirect_url",
+            "external_reference",
+            "user",
+            "user_email",
+            "channel",
+        ]
+
+    def serialize_for_comparison(self):
+        return copy.deepcopy(model_to_dict(self, fields=self.comparison_fields))
 
 
 class OrderLineQueryset(models.QuerySet["OrderLine"]):


### PR DESCRIPTION
- Refactor `DraftOrderUpdate` and `DraftOrderCreate` - do not inherit from `draftOrderCreate` in `draftOrderUpdate` mutation.
- Save only changed fields in `DraftOrderUpdate`.

Contains changes from https://github.com/saleor/saleor/pull/17465

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
