### PR TITLE
Harden admin email plugin config

### DIFF
--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -15,6 +15,7 @@ from ..email_common import (
     DEFAULT_EMAIL_VALUE,
     DEFAULT_SUBJECT_HELP_TEXT,
     DEFAULT_TEMPLATE_HELP_TEXT,
+    REQUIRED_EMAIL_CONFIG_FIELDS,
     EmailConfig,
     validate_default_email_configuration,
     validate_format_of_provided_templates,
@@ -167,19 +168,40 @@ class AdminEmailPlugin(BasePlugin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        configuration = {item["name"]: item["value"] for item in self.configuration}
+        configuration = self._parse_email_config_or_get_default(self.configuration)
         self.config = EmailConfig(
-            host=configuration["host"] or settings.EMAIL_HOST,
-            port=configuration["port"] or str(settings.EMAIL_PORT),
-            username=configuration["username"] or settings.EMAIL_HOST_USER,
-            password=configuration["password"] or settings.EMAIL_HOST_PASSWORD,
+            host=configuration["host"],
+            port=configuration["port"],
+            username=configuration["username"],
+            password=configuration["password"],
             sender_name=configuration["sender_name"],
-            sender_address=(
-                configuration["sender_address"] or settings.DEFAULT_FROM_EMAIL
-            ),
-            use_tls=configuration["use_tls"] or settings.EMAIL_USE_TLS,
-            use_ssl=configuration["use_ssl"] or settings.EMAIL_USE_SSL,
+            sender_address=configuration["sender_address"],
+            use_tls=configuration["use_tls"],
+            use_ssl=configuration["use_ssl"],
         )
+
+    @classmethod
+    def _parse_email_config_or_get_default(
+        cls, configuration: PluginConfigurationType
+    ) -> dict:
+        configuration = {item["name"]: item["value"] for item in configuration}
+
+        configuration["username"] = configuration["username"] or ""
+        configuration["password"] = configuration["password"] or ""
+
+        set_any_required_field = any(
+            configuration.get(field) for field in REQUIRED_EMAIL_CONFIG_FIELDS
+        )
+        if not set_any_required_field:  # Use default email config
+            configuration["host"] = settings.EMAIL_HOST
+            configuration["port"] = str(settings.EMAIL_PORT)
+            configuration["username"] = settings.EMAIL_HOST_USER
+            configuration["password"] = settings.EMAIL_HOST_PASSWORD
+            configuration["sender_address"] = settings.DEFAULT_FROM_EMAIL
+            configuration["use_tls"] = settings.EMAIL_USE_TLS
+            configuration["use_ssl"] = settings.EMAIL_USE_SSL
+
+        return configuration
 
     def resolve_plugin_configuration(
         self, request
@@ -241,24 +263,9 @@ class AdminEmailPlugin(BasePlugin):
         cls, plugin_configuration: "PluginConfiguration", **kwargs
     ):
         """Validate if provided configuration is correct."""
-
-        configuration = plugin_configuration.configuration
-        configuration = {item["name"]: item["value"] for item in configuration}
-
-        configuration["host"] = configuration["host"] or settings.EMAIL_HOST
-        configuration["port"] = configuration["port"] or settings.EMAIL_PORT
-        configuration["username"] = (
-            configuration["username"] or settings.EMAIL_HOST_USER
+        configuration = cls._parse_email_config_or_get_default(
+            plugin_configuration.configuration
         )
-        configuration["password"] = (
-            configuration["password"] or settings.EMAIL_HOST_PASSWORD
-        )
-        configuration["sender_address"] = (
-            configuration["sender_address"] or settings.DEFAULT_FROM_EMAIL
-        )
-        configuration["use_tls"] = configuration["use_tls"] or settings.EMAIL_USE_TLS
-        configuration["use_ssl"] = configuration["use_ssl"] or settings.EMAIL_USE_SSL
-
         validate_default_email_configuration(plugin_configuration, configuration)
 
         email_templates_data = kwargs.get("email_templates_data", [])

--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -120,6 +120,8 @@ DEFAULT_EMAIL_CONFIG_STRUCTURE = {
     },
 }
 
+REQUIRED_EMAIL_CONFIG_FIELDS = ("host", "port", "sender_address")
+
 
 def format_address(this, address, include_phone=True, inline=False, latin=False):
     address["name"] = f"{address.get('first_name', '')} {address.get('last_name', '')}"
@@ -297,7 +299,7 @@ def validate_default_email_configuration(
     )
 
     errors = {}
-    for field in ("host", "port", "sender_address"):
+    for field in REQUIRED_EMAIL_CONFIG_FIELDS:
         if not getattr(config, field):
             errors[field] = ValidationError(
                 f"Missing {field.replace('_', ' ')} value.",


### PR DESCRIPTION
I want to merge this change to avoid mixing user-provided admin email config with default settings from env variables.
Currently all null values in user-provided config are getting overwritten by defaults.
From now defaults are going to be used only when none of required fields are provided.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
