### PR TITLE
Call `DRAFT_ORDER_CREATED` webhhok in `FulfillmentReturnProducts` in case the replace order is created

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
@@ -1059,14 +1059,17 @@ def test_fulfillment_return_products_fulfillment_lines_and_order_lines(
     )
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.order_refunded")
 @patch("saleor.order.actions.gateway.refund")
-def test_fulfillment_return_products_calls_order_refunded(
+def test_fulfillment_return_and_replace_products_calls_order_refunded_and_webhooks(
     mocked_refund,
     mocked_order_refunded,
+    mocked_order_updated,
+    mocked_draft_order_created,
     warehouse,
     variant,
-    channel_USD,
     staff_api_client,
     permission_group_manage_orders,
     fulfilled_order,
@@ -1081,6 +1084,7 @@ def test_fulfillment_return_products_calls_order_refunded(
     stock = Stock.objects.create(
         warehouse=warehouse, product_variant=variant, quantity=5
     )
+    order_count = Order.objects.count()
     channel_listing = variant.channel_listings.get()
     net = variant.get_price(channel_listing)
     gross = Money(amount=net.amount * Decimal(1.23), currency=net.currency)
@@ -1115,7 +1119,7 @@ def test_fulfillment_return_products_calls_order_refunded(
         "input": {
             "refund": True,
             "orderLines": [
-                {"orderLineId": order_line_id, "quantity": 2, "replace": False}
+                {"orderLineId": order_line_id, "quantity": 2, "replace": True}
             ],
             "fulfillmentLines": [
                 {
@@ -1136,6 +1140,99 @@ def test_fulfillment_return_products_calls_order_refunded(
     amount = order_line.unit_price_gross_amount * 2
     amount = amount.quantize(Decimal("0.001"))
 
+    # refund not called as all lines are replaced
+    mocked_order_refunded.assert_not_called()
+    mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
+
+    assert Order.objects.count() == order_count + 1
+    replace_order = Order.objects.first()
+    assert fulfilled_order.id != replace_order.id
+    mocked_draft_order_created.assert_called_once_with(replace_order, webhooks=set())
+
+
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+@patch("saleor.order.actions.order_refunded")
+@patch("saleor.order.actions.gateway.refund")
+def test_fulfillment_return_products_calls_order_refunded_and_webhooks(
+    mocked_refund,
+    mocked_order_refunded,
+    mocked_order_updated,
+    mocked_draft_order_created,
+    warehouse,
+    variant,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+    payment_dummy,
+):
+    # given
+    payment_dummy.total = fulfilled_order.total_gross_amount
+    payment_dummy.captured_amount = payment_dummy.total
+    payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_dummy.save()
+    fulfilled_order.payments.add(payment_dummy)
+    stock = Stock.objects.create(
+        warehouse=warehouse, product_variant=variant, quantity=5
+    )
+    channel_listing = variant.channel_listings.get()
+    order_count = Order.objects.count()
+    net = variant.get_price(channel_listing)
+    gross = Money(amount=net.amount * Decimal(1.23), currency=net.currency)
+    variant.track_inventory = False
+    variant.save()
+    unit_price = TaxedMoney(net=net, gross=gross)
+    quantity = 5
+    order_line = fulfilled_order.lines.create(
+        product_name=str(variant.product),
+        variant_name=str(variant),
+        product_sku=variant.sku,
+        product_variant_id=variant.get_global_id(),
+        is_shipping_required=variant.is_shipping_required(),
+        is_gift_card=variant.is_gift_card(),
+        quantity=quantity,
+        quantity_fulfilled=2,
+        variant=variant,
+        unit_price=unit_price,
+        total_price=unit_price * quantity,
+        tax_rate=Decimal("0.23"),
+    )
+    fulfillment = fulfilled_order.fulfillments.get()
+    fulfillment.lines.create(order_line=order_line, quantity=2, stock=stock)
+    fulfillment_line_to_replace = fulfilled_order.fulfillments.first().lines.first()
+    order_id = graphene.Node.to_global_id("Order", fulfilled_order.pk)
+    fulfillment_line_id = graphene.Node.to_global_id(
+        "FulfillmentLine", fulfillment_line_to_replace.pk
+    )
+    order_line_id = graphene.Node.to_global_id("OrderLine", order_line.pk)
+    line_qty = 2
+    fulfillment_line_qty = 1
+    variables = {
+        "order": order_id,
+        "input": {
+            "refund": True,
+            "orderLines": [
+                {"orderLineId": order_line_id, "quantity": line_qty, "replace": False}
+            ],
+            "fulfillmentLines": [
+                {
+                    "fulfillmentLineId": fulfillment_line_id,
+                    "quantity": fulfillment_line_qty,
+                    "replace": False,
+                }
+            ],
+        },
+    }
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
+
+    # then
+    flush_post_commit_hooks()
+    amount = order_line.unit_price_gross_amount * (line_qty + fulfillment_line_qty)
+    amount = amount.quantize(Decimal("0.001"))
+
     mocked_order_refunded.assert_called_once_with(
         order=fulfilled_order,
         user=staff_api_client.user,
@@ -1145,3 +1242,6 @@ def test_fulfillment_return_products_calls_order_refunded(
         manager=mock.ANY,
         trigger_order_updated=False,
     )
+    assert Order.objects.count() == order_count
+    mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
+    mocked_draft_order_created.assert_not_called()

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -1957,6 +1957,10 @@ def create_fulfillments_for_returned_products(
         ).delete()
 
         call_order_event(manager, WebhookEventAsyncType.ORDER_UPDATED, order)
+        if new_order:
+            call_order_event(
+                manager, WebhookEventAsyncType.DRAFT_ORDER_CREATED, new_order
+            )
     return return_fulfillment, replace_fulfillment, new_order
 
 

--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -13,11 +13,13 @@ from ..fetch import OrderLineInfo
 from ..models import Fulfillment, FulfillmentLine
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -85,13 +87,16 @@ def test_create_return_fulfillment_only_order_lines(
     assert event_lines[1]["quantity"] == 2
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_refund(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -161,13 +166,16 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
     assert returned_fulfillment.shipping_refund_amount is None
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -243,13 +251,16 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     )
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_replace_request(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -374,13 +385,16 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
     assert replaced_line.tax_rate == expected_replaced_line.tax_rate
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_called_once_with(replace_order, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     fulfilled_order,
     payment_dummy_fully_charged,
     staff_user,
@@ -424,11 +438,13 @@ def test_create_return_fulfillment_only_fulfillment_lines(
     mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     fulfilled_order,
     payment_dummy_fully_charged,
     staff_user,
@@ -529,13 +545,16 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     assert replaced_line.tax_rate == expected_replaced_line.tax_rate
 
     mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
+    mocked_draft_order_created.assert_called_once_with(replace_order, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_with_lines_already_refunded(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     fulfilled_order,
     payment_dummy_fully_charged,
     staff_user,
@@ -637,13 +656,16 @@ def test_create_return_fulfillment_with_lines_already_refunded(
     assert returned_and_refunded_fulfillment.shipping_refund_amount is None
 
     mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_old_ids(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -713,3 +735,4 @@ def test_create_return_fulfillment_only_order_lines_with_old_ids(
     assert event_lines[1]["quantity"] == 2
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()


### PR DESCRIPTION
In case the `DraftOrder` is created as a result of `FulfillmentReturnProducts`mutation the `DRAFT_ORDER_CREATED` will be called.
The source of the draft order creation can be check in `order.origin` field. The `REISSUE` value suggest that order has be created as a replacement.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
