### PR TITLE
Add metadata to CheckoutCreateInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Deprecate `draftOrderInput.discount` field - #17294 by @zedzior
 - `GiftCardCreate` and `GiftCardUpdate` mutations now allows to set `metadata` and `privateMetadata` fields via `GiftCardCreateInput` and `GiftCardUpdateInput` - #17399 by @lkostrowski
 - Improved error handling when trying to set invalid metadata. Now, invalid metadata should properly return `error.field` containing `metadata` or `privateMetadata`, instead generic `input` - #17470 by @lkostrowski
-- `CheckoutCreateInput` now accepts `metadata` and `privateMetadata` fields, so `checkoutCreate` can now create checkout with metadata in a single call - #todo by @lkostrowski
+- `CheckoutCreateInput` now accepts `metadata` and `privateMetadata` fields, so `checkoutCreate` can now create checkout with metadata in a single call - #17503 by @lkostrowski
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Deprecate `draftOrderInput.discount` field - #17294 by @zedzior
 - `GiftCardCreate` and `GiftCardUpdate` mutations now allows to set `metadata` and `privateMetadata` fields via `GiftCardCreateInput` and `GiftCardUpdateInput` - #17399 by @lkostrowski
 - Improved error handling when trying to set invalid metadata. Now, invalid metadata should properly return `error.field` containing `metadata` or `privateMetadata`, instead generic `input` - #17470 by @lkostrowski
+- `CheckoutCreateInput` now accepts `metadata` and `privateMetadata` fields, so `checkoutCreate` can now create checkout with metadata in a single call - #todo by @lkostrowski
 
 ### Webhooks
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -337,8 +337,10 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
         user = info.context.user
         channel = data.pop("channel")
 
-        metadata_list: list[MetadataInput] = data.pop("metadata", None)
-        private_metadata_list: list[MetadataInput] = data.pop("private_metadata", None)
+        metadata_list: list[MetadataInput] | None = data.pop("metadata", None)
+        private_metadata_list: list[MetadataInput] | None = data.pop(
+            "private_metadata", None
+        )
 
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -538,7 +538,5 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
             metadata_manager.MetadataType.PRIVATE,
         )
 
-        checkout_metadata.save()
-
         with allow_writer():
             checkout_metadata.save()

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -349,18 +349,18 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
         trying_to_set_private_metadata = private_metadata_list is not None
 
         if trying_to_set_private_metadata:
+            private_metadata_permissions = [
+                CheckoutPermissions.HANDLE_CHECKOUTS,
+                CheckoutPermissions.MANAGE_CHECKOUTS,
+            ]
+
             can_set_private_metadata = cls.check_permissions(
                 info.context,
-                permissions=[
-                    CheckoutPermissions.HANDLE_CHECKOUTS,
-                    CheckoutPermissions.MANAGE_CHECKOUTS,
-                ],
+                permissions=private_metadata_permissions,
             )
 
             if not can_set_private_metadata:
-                raise PermissionDenied(
-                    "You need MANAGE_CHECKOUTS or HANDLE_CHECKOUTS permission to set privateMetadata"
-                )
+                raise PermissionDenied(permissions=private_metadata_permissions)
 
         cleaned_input["metadata_collection"] = cls.create_metadata_from_graphql_input(
             metadata_list, error_field_name="metadata"

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -184,7 +184,10 @@ class CheckoutCreateInput(BaseInputObjectType):
 
     metadata = NonNullList(
         MetadataInput,
-        description="Checkout public metadata." + ADDED_IN_321,
+        description=(
+            f"Checkout public metadata. {ADDED_IN_321}"
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
 
@@ -193,7 +196,8 @@ class CheckoutCreateInput(BaseInputObjectType):
         description=(
             "Checkout private metadata. Requires one of the following permissions:"
             f"{CheckoutPermissions.MANAGE_CHECKOUTS.name}, "
-            f"{CheckoutPermissions.HANDLE_CHECKOUTS.name}" + ADDED_IN_321
+            f"{CheckoutPermissions.HANDLE_CHECKOUTS.name} {ADDED_IN_321}"
+            f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
         ),
         required=False,
     )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -185,8 +185,9 @@ class CheckoutCreateInput(BaseInputObjectType):
     metadata = NonNullList(
         MetadataInput,
         description=(
-            f"Checkout public metadata. {ADDED_IN_321}"
+            f"Checkout public metadata. "
             f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+            f"{ADDED_IN_321}"
         ),
         required=False,
     )
@@ -194,10 +195,11 @@ class CheckoutCreateInput(BaseInputObjectType):
     private_metadata = NonNullList(
         MetadataInput,
         description=(
-            "Checkout private metadata. Requires one of the following permissions:"
+            "Checkout private metadata. Requires one of the following permissions: "
             f"{CheckoutPermissions.MANAGE_CHECKOUTS.name}, "
-            f"{CheckoutPermissions.HANDLE_CHECKOUTS.name} {ADDED_IN_321}"
+            f"{CheckoutPermissions.HANDLE_CHECKOUTS.name} \n\n"
             f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
+            f"{ADDED_IN_321}"
         ),
         required=False,
     )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -517,8 +517,8 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
         # Write metadata in post-save action because in "save" metadata doesn't exist in
         # cleaned_input.
 
-        metadata = cleaned_input.get("metadata")
-        private_metadata = cleaned_input.get("private_metadata")
+        metadata = cleaned_input.get("metadata", [])
+        private_metadata = cleaned_input.get("private_metadata", [])
 
         metadata_collection = cls.create_metadata_from_graphql_input(
             metadata, error_field_name="metadata"
@@ -537,6 +537,8 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
             checkout_metadata,
             metadata_manager.MetadataType.PRIVATE,
         )
+
+        checkout_metadata.save()
 
         with allow_writer():
             checkout_metadata.save()

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -520,6 +520,9 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
         metadata = cleaned_input.get("metadata", [])
         private_metadata = cleaned_input.get("private_metadata", [])
 
+        if (not metadata) and (not private_metadata):
+            return
+
         metadata_collection = cls.create_metadata_from_graphql_input(
             metadata, error_field_name="metadata"
         )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -338,20 +338,21 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
 
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 
-        can_set_private_metadata = cls.check_permissions(
-            info.context,
-            permissions=[
-                CheckoutPermissions.HANDLE_CHECKOUTS,
-                CheckoutPermissions.MANAGE_CHECKOUTS,
-            ],
-        )
-
         trying_to_set_private_metadata = private_metadata_list is not None
 
-        if trying_to_set_private_metadata and (not can_set_private_metadata):
-            raise PermissionDenied(
-                "You need MANAGE_CHECKOUTS or HANDLE_CHECKOUTS permission to set privateMetadata"
+        if trying_to_set_private_metadata:
+            can_set_private_metadata = cls.check_permissions(
+                info.context,
+                permissions=[
+                    CheckoutPermissions.HANDLE_CHECKOUTS,
+                    CheckoutPermissions.MANAGE_CHECKOUTS,
+                ],
             )
+
+            if not can_set_private_metadata:
+                raise PermissionDenied(
+                    "You need MANAGE_CHECKOUTS or HANDLE_CHECKOUTS permission to set privateMetadata"
+                )
 
         cleaned_input["metadata_collection"] = cls.create_metadata_from_graphql_input(
             metadata_list, error_field_name="metadata"

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26861,6 +26861,20 @@ input CheckoutCreateInput @doc(category: "Checkout") {
 
   """The checkout validation rules that can be changed."""
   validationRules: CheckoutValidationRules
+
+  """
+  Checkout public metadata.
+  
+  Added in Saleor 3.21.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Checkout private metadata. Requires one of the following permissions:MANAGE_CHECKOUTS, HANDLE_CHECKOUTS
+  
+  Added in Saleor 3.21.
+  """
+  privateMetadata: [MetadataInput!]
 }
 
 input CheckoutLineInput @doc(category: "Checkout") {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26863,16 +26863,20 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   validationRules: CheckoutValidationRules
 
   """
-  Checkout public metadata.
+  Checkout public metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21.Can be read by any API client authorized to read the object it's attached to.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Checkout private metadata. Requires one of the following permissions:MANAGE_CHECKOUTS, HANDLE_CHECKOUTS
+  Checkout private metadata. Requires one of the following permissions:MANAGE_CHECKOUTS, HANDLE_CHECKOUTS 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21.Requires permissions to modify and to read the metadata of the object it's attached to.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26881,20 +26881,22 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   validationRules: CheckoutValidationRules
 
   """
-  Checkout public metadata. 
-  
-  Added in Saleor 3.21.Can be read by any API client authorized to read the object it's attached to.
+  Checkout public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
+  
+  Added in Saleor 3.21.
   """
   metadata: [MetadataInput!]
 
   """
-  Checkout private metadata. Requires one of the following permissions:MANAGE_CHECKOUTS, HANDLE_CHECKOUTS 
+  Checkout private metadata. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_CHECKOUTS 
   
-  Added in Saleor 3.21.Requires permissions to modify and to read the metadata of the object it's attached to.
+  Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
+  
+  Added in Saleor 3.21.
   """
   privateMetadata: [MetadataInput!]
 }


### PR DESCRIPTION
I want to merge this change because it allows to set metadata and privateMetadata when checkout is created by checkoutCreate

It also introduces a small refactor - extracted "MetadataManager" to keep utils connected to metadata & private_metadata together.

Old code (base mutations) still contain methods for metadata, but these methods use MetadataManager now.
New code, can directly use MetadataManager, to avoid relying on inherited behavior.

For example, Checkout metadata is not saved on Checkout model, but CheckoutCreate mutation inherits the behavior, not matter what.

Now, CheckoutCreate can use MetadataManager under control, while the rest of the code is not changed.

- [ ] Benchmark test failing

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: Docs will automatically reflect built reference

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
