### PR TITLE
Add warnings to GraphQL metadata inputs around information security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Use denormalized base prices during order update - #17160 by @zedzior
   - `UNCONFIRMED` orders will never refresh its base prices
   - `DRAFT` orders will refresh its base prices after default 24 hours
+- Added a warning to metadata input fields in GraphQL schema informing to never store sensitive data.
+  This ensures user awareness of potential security policy violations and compliance risks of storing
+  certain types of data. - #17506 by @NyanKiyoshi

--- a/saleor/graphql/account/mutations/account/account_register.py
+++ b/saleor/graphql/account/mutations/account/account_register.py
@@ -16,7 +16,7 @@ from ....core.enums import LanguageCodeEnum
 from ....core.mutations import DeprecatedModelMutation
 from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....site.dataloaders import get_site_promise
 from ...types import User
 from .base import AccountBaseInput
@@ -39,7 +39,9 @@ class AccountRegisterInput(AccountBaseInput):
     )
     metadata = NonNullList(
         MetadataInput,
-        description="User public metadata.",
+        description=(
+            f"User public metadata. {MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
     channel = graphene.String(

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -11,7 +11,7 @@ from ....core.descriptions import ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ...mixins import AppImpersonateMixin
 from ...types import AddressInput, User
 from ..base import BaseCustomerCreate
@@ -27,7 +27,10 @@ class AccountInput(AccountBaseInput):
     )
     metadata = NonNullList(
         MetadataInput,
-        description="Fields required to update the user metadata.",
+        description=(
+            "Fields required to update the user metadata. "
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
 

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -31,7 +31,7 @@ from ...core.doc_category import DOC_CATEGORY_USERS
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import DeprecatedModelMutation, ModelDeleteMutation
 from ...core.types import BaseInputObjectType, NonNullList
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..utils import (
     get_not_manageable_permissions_when_deactivate_or_remove_users,
@@ -188,12 +188,18 @@ class UserInput(BaseInputObjectType):
     note = graphene.String(description="A note about the user.")
     metadata = NonNullList(
         MetadataInput,
-        description="Fields required to update the user metadata.",
+        description=(
+            "Fields required to update the user metadata. "
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description="Fields required to update the user private metadata.",
+        description=(
+            "Fields required to update the user private metadata. "
+            f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
+        ),
         required=False,
     )
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -10,7 +10,7 @@ from promise import Promise
 from ...account import models
 from ...checkout.utils import get_user_checkout
 from ...core.exceptions import PermissionDenied
-from ...graphql.meta.inputs import MetadataInput
+from ...graphql.meta.inputs import MetadataInput, MetadataInputDescription
 from ...order import OrderStatus
 from ...payment.interface import ListStoredPaymentMethodsRequestData
 from ...permission.auth_filters import AuthorizationFilters
@@ -92,7 +92,9 @@ class AddressInput(BaseInputObjectType):
     )
     metadata = graphene.List(
         graphene.NonNull(MetadataInput),
-        description="Address public metadata.",
+        description=(
+            f"Address public metadata. {MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
     skip_validation = graphene.Boolean(

--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -27,7 +27,7 @@ from ...core.scalars import Day, Hour, Minute
 from ...core.types import BaseInputObjectType, ChannelError, NonNullList
 from ...core.types import common as common_types
 from ...core.utils import WebhookEventInfo
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import (
     AllocationStrategyEnum,
@@ -194,12 +194,15 @@ class ChannelInput(BaseInputObjectType):
     )
     metadata = common_types.NonNullList(
         MetadataInput,
-        description="Channel public metadata.",
+        description=(
+            f"Channel public metadata. {MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
     private_metadata = common_types.NonNullList(
         MetadataInput,
-        description="Channel private metadata.",
+        description="Channel private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -30,7 +30,7 @@ from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
 from ...core.utils import CHECKOUT_CALCULATE_TAXES_MESSAGE, WebhookEventInfo
 from ...core.validators import validate_one_of_args_is_in_mutation
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...order.types import Order
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
@@ -92,7 +92,8 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         )
         metadata = NonNullList(
             MetadataInput,
-            description=("Fields required to update the checkout metadata."),
+            description="Fields required to update the checkout metadata. "
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
             required=False,
         )
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from ....account.models import Address
     from .utils import CheckoutLineData
 
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 
 
 class CheckoutAddressValidationRules(BaseInputObjectType):
@@ -118,7 +118,8 @@ class CheckoutLineInput(BaseInputObjectType):
     )
     metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the object's metadata."),
+        description="Fields required to update the object's metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -16,7 +16,7 @@ from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import Error, NonNullList
 from ...core.utils import CHECKOUT_CALCULATE_TAXES_MESSAGE, WebhookEventInfo
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...order.types import Order
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import OrderCreateFromCheckoutErrorCode
@@ -60,12 +60,14 @@ class OrderCreateFromCheckout(BaseMutation):
         )
         private_metadata = NonNullList(
             MetadataInput,
-            description=("Fields required to update the checkout private metadata."),
+            description="Fields required to update the checkout private metadata. "
+            f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
             required=False,
         )
         metadata = NonNullList(
             MetadataInput,
-            description=("Fields required to update the checkout metadata."),
+            description="Fields required to update the checkout metadata. "
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
             required=False,
         )
 

--- a/saleor/graphql/giftcard/mutations/gift_card_create.py
+++ b/saleor/graphql/giftcard/mutations/gift_card_create.py
@@ -22,7 +22,7 @@ from ...core.scalars import Date
 from ...core.types import BaseInputObjectType, GiftCardError, NonNullList, PriceInput
 from ...core.utils import WebhookEventInfo
 from ...core.validators import validate_price_precision
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import GiftCard
 
@@ -36,12 +36,16 @@ class GiftCardInput(BaseInputObjectType):
 
     metadata = NonNullList(
         MetadataInput,
-        description="Gift Card public metadata." + ADDED_IN_321,
+        description=(
+            f"Gift Card public metadata. {ADDED_IN_321} "
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description="Gift Card private metadata." + ADDED_IN_321,
+        description=f"Gift Card private metadata. {ADDED_IN_321} "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/invoice/mutations/invoice_create.py
+++ b/saleor/graphql/invoice/mutations/invoice_create.py
@@ -11,7 +11,7 @@ from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import BaseInputObjectType, InvoiceError, NonNullList
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...order.types import Order
 from ..types import Invoice
 
@@ -21,12 +21,14 @@ class InvoiceCreateInput(BaseInputObjectType):
     url = graphene.String(required=True, description="URL of an invoice to download.")
     metadata = NonNullList(
         MetadataInput,
-        description="Fields required to update the invoice metadata.",
+        description="Fields required to update the invoice metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the invoice private metadata."),
+        description="Fields required to update the invoice private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/invoice/mutations/invoice_update.py
+++ b/saleor/graphql/invoice/mutations/invoice_update.py
@@ -11,7 +11,7 @@ from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import BaseInputObjectType, InvoiceError, NonNullList
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ..types import Invoice
 
 
@@ -20,12 +20,14 @@ class UpdateInvoiceInput(BaseInputObjectType):
     url = graphene.String(description="URL of an invoice to download.")
     metadata = NonNullList(
         MetadataInput,
-        description="Fields required to update the invoice metadata.",
+        description="Fields required to update the invoice metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the invoice private metadata."),
+        description="Fields required to update the invoice private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/meta/inputs.py
+++ b/saleor/graphql/meta/inputs.py
@@ -7,11 +7,13 @@ class MetadataInputDescription:
         "credit card details."
     )
     PRIVATE_METADATA_INPUT = (
-        "Requires staff or app authorization to the object to modify and access.\n\n"
+        "Requires permissions to modify and to read the metadata of the object "
+        "it's attached to.\n\n"
         f"{DATA_SECURITY_WARNING}"
     )
     PUBLIC_METADATA_INPUT = (
-        f"Can be accessed without permissions.\n\n{DATA_SECURITY_WARNING}"
+        f"Can be read by any API client authorized to read the object it's attached to."
+        f"\n\n{DATA_SECURITY_WARNING}"
     )
 
 

--- a/saleor/graphql/meta/inputs.py
+++ b/saleor/graphql/meta/inputs.py
@@ -1,6 +1,20 @@
 import graphene
 
 
+class MetadataInputDescription:
+    DATA_SECURITY_WARNING = (
+        "Warning: never store sensitive information, including financial data such as "
+        "credit card details."
+    )
+    PRIVATE_METADATA_INPUT = (
+        "Requires staff or app authorization to the object to modify and access.\n\n"
+        f"{DATA_SECURITY_WARNING}"
+    )
+    PUBLIC_METADATA_INPUT = (
+        f"Can be accessed without permissions.\n\n{DATA_SECURITY_WARNING}"
+    )
+
+
 class MetadataInput(graphene.InputObjectType):
     key = graphene.String(required=True, description="Key of a metadata item.")
     value = graphene.String(required=True, description="Value of a metadata item.")

--- a/saleor/graphql/meta/mutations/update_metadata.py
+++ b/saleor/graphql/meta/mutations/update_metadata.py
@@ -5,7 +5,7 @@ import graphene
 from ....core import models
 from ...core import ResolveInfo
 from ...core.types import MetadataError, NonNullList
-from ..inputs import MetadataInput
+from ..inputs import MetadataInput, MetadataInputDescription
 from ..permissions import PUBLIC_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
 from .utils import get_valid_metadata_instance, update_metadata
@@ -14,8 +14,8 @@ from .utils import get_valid_metadata_instance, update_metadata
 class UpdateMetadata(BaseMetadataMutation):
     class Meta:
         description = (
-            "Updates metadata of an object. To use it, you need to have access to the "
-            "modified object."
+            "Updates metadata of an object."
+            f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
         )
         permission_map = PUBLIC_META_PERMISSION_MAP
         error_type_class = MetadataError

--- a/saleor/graphql/meta/mutations/update_private_metadata.py
+++ b/saleor/graphql/meta/mutations/update_private_metadata.py
@@ -2,7 +2,7 @@ import graphene
 
 from ...core import ResolveInfo
 from ...core.types import MetadataError, NonNullList
-from ..inputs import MetadataInput
+from ..inputs import MetadataInput, MetadataInputDescription
 from ..permissions import PRIVATE_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
 from .utils import get_valid_metadata_instance, update_private_metadata
@@ -11,8 +11,8 @@ from .utils import get_valid_metadata_instance, update_private_metadata
 class UpdatePrivateMetadata(BaseMetadataMutation):
     class Meta:
         description = (
-            "Updates private metadata of an object. To use it, you need to be an "
-            "authenticated staff user or an app and have access to the modified object."
+            "Updates private metadata of an object. "
+            f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
         )
         permission_map = PRIVATE_META_PERMISSION_MAP
         error_type_class = MetadataError

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -46,31 +46,6 @@ def _get_metadata_instance(
     return root
 
 
-class MetadataDescription:
-    PRIVATE_METADATA = (
-        "List of private metadata items. Requires staff permissions to access."
-    )
-    PRIVATE_METAFIELD = (
-        "A single key from private metadata. "
-        "Requires staff permissions to access.\n\n"
-        "Tip: Use GraphQL aliases to fetch multiple keys."
-    )
-    PRIVATE_METAFIELDS = (
-        "Private metadata. Requires staff permissions to access. "
-        "Use `keys` to control which fields you want to include. "
-        "The default is to include everything."
-    )
-    METADATA = "List of public metadata items. Can be accessed without permissions."
-    METAFIELD = (
-        "A single key from public metadata.\n\n"
-        "Tip: Use GraphQL aliases to fetch multiple keys."
-    )
-    METAFIELDS = (
-        "Public metadata. Use `keys` to control which fields you want to include. "
-        "The default is to include everything."
-    )
-
-
 class ObjectWithMetadata(graphene.Interface):
     private_metadata = NonNullList(
         MetadataItem,

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -60,7 +60,7 @@ from ...core.types import BaseInputObjectType, BaseObjectType, NonNullList
 from ...core.types.common import OrderBulkCreateError
 from ...core.utils import from_global_id_or_error
 from ...discount.enums import DiscountValueTypeEnum
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...payment.mutations.transaction.transaction_create import (
     TransactionCreate,
     TransactionCreateInput,
@@ -365,9 +365,15 @@ class OrderBulkCreateInvoiceInput(BaseInputObjectType):
     )
     number = graphene.String(description="Invoice number.")
     url = graphene.String(description="URL of the invoice to download.")
-    metadata = NonNullList(MetadataInput, description="Metadata of the invoice.")
+    metadata = NonNullList(
+        MetadataInput,
+        description="Metadata of the invoice. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
+    )
     private_metadata = NonNullList(
-        MetadataInput, description="Private metadata of the invoice."
+        MetadataInput,
+        description="Private metadata of the invoice. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
     )
 
     class Meta:
@@ -388,10 +394,14 @@ class OrderBulkCreateDeliveryMethodInput(BaseInputObjectType):
     shipping_tax_class_id = graphene.ID(description="The ID of the tax class.")
     shipping_tax_class_name = graphene.String(description="The name of the tax class.")
     shipping_tax_class_metadata = NonNullList(
-        MetadataInput, description="Metadata of the tax class."
+        MetadataInput,
+        description="Metadata of the tax class. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
     )
     shipping_tax_class_private_metadata = NonNullList(
-        MetadataInput, description="Private metadata of the tax class."
+        MetadataInput,
+        description="Private metadata of the tax class. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
     )
 
     class Meta:
@@ -505,18 +515,28 @@ class OrderBulkCreateOrderLineInput(BaseInputObjectType):
         required=True,
         description="The ID of the warehouse, where the line will be allocated.",
     )
-    metadata = NonNullList(MetadataInput, description="Metadata of the order line.")
+    metadata = NonNullList(
+        MetadataInput,
+        description="Metadata of the order line. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
+    )
     private_metadata = NonNullList(
-        MetadataInput, description="Private metadata of the order line."
+        MetadataInput,
+        description="Private metadata of the order line. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
     )
     tax_rate = PositiveDecimal(description="Tax rate of the order line.")
     tax_class_id = graphene.ID(description="The ID of the tax class.")
     tax_class_name = graphene.String(description="The name of the tax class.")
     tax_class_metadata = NonNullList(
-        MetadataInput, description="Metadata of the tax class."
+        MetadataInput,
+        description="Metadata of the tax class. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
     )
     tax_class_private_metadata = NonNullList(
-        MetadataInput, description="Private metadata of the tax class."
+        MetadataInput,
+        description="Private metadata of the tax class. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
     )
 
     class Meta:
@@ -545,9 +565,15 @@ class OrderBulkCreateInput(BaseInputObjectType):
         AddressInput, description="Shipping address of the customer."
     )
     currency = graphene.String(required=True, description="Currency code.")
-    metadata = NonNullList(MetadataInput, description="Metadata of the order.")
+    metadata = NonNullList(
+        MetadataInput,
+        description="Metadata of the order. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
+    )
     private_metadata = NonNullList(
-        MetadataInput, description="Private metadata of the order."
+        MetadataInput,
+        description="Private metadata of the order. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
     )
     customer_note = graphene.String(description="Note about customer.")
     notes = NonNullList(

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -45,7 +45,7 @@ from ...core.mutations import ModelWithRestrictedChannelAccessMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
 from ...core.utils import from_global_id_or_error
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...product.types import ProductVariant
 from ...shipping.utils import get_shipping_model_by_object_id
@@ -156,12 +156,14 @@ class DraftOrderInput(BaseInputObjectType):
     )
     metadata = NonNullList(
         MetadataInput,
-        description="Order public metadata." + ADDED_IN_321,
+        description=f"Order public metadata. {ADDED_IN_321} "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description="Order private metadata." + ADDED_IN_321,
+        description=f"Order private metadata. {ADDED_IN_321} "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/payment/mutations/payment/checkout_payment_create.py
+++ b/saleor/graphql/payment/mutations/payment/checkout_payment_create.py
@@ -28,7 +28,7 @@ from ....core.mutations import BaseMutation
 from ....core.scalars import UUID, PositiveDecimal
 from ....core.types import BaseInputObjectType
 from ....core.types import common as common_types
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import StorePaymentMethodEnum
 from ...types import Payment
@@ -71,7 +71,8 @@ class PaymentInput(BaseInputObjectType):
     )
     metadata = common_types.NonNullList(
         MetadataInput,
-        description="User public metadata.",
+        description="User public metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -32,7 +32,7 @@ from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.mutations import BaseMutation
 from ....core.types import BaseInputObjectType
 from ....core.types import common as common_types
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import TransactionActionEnum
 from ...types import TransactionItem
@@ -57,12 +57,14 @@ class TransactionCreateInput(BaseInputObjectType):
 
     metadata = graphene.List(
         graphene.NonNull(MetadataInput),
-        description="Payment public metadata.",
+        description="Payment public metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = graphene.List(
         graphene.NonNull(MetadataInput),
-        description="Payment private metadata.",
+        description="Payment private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
     external_url = graphene.String(

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -41,7 +41,7 @@ from ....core.types import NonNullList
 from ....core.types import common as common_types
 from ....core.utils import WebhookEventInfo
 from ....core.validators import validate_one_of_args_is_in_mutation
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import TransactionActionEnum, TransactionEventTypeEnum
 from ...types import TransactionEvent, TransactionItem
@@ -122,12 +122,14 @@ class TransactionEventReport(DeprecatedModelMutation):
         )
         transaction_metadata = NonNullList(
             MetadataInput,
-            description=("Fields required to update the transaction metadata."),
+            description="Fields required to update the transaction metadata. "
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
             required=False,
         )
         transaction_private_metadata = NonNullList(
             MetadataInput,
-            description=("Fields required to update the transaction private metadata."),
+            description="Fields required to update the transaction private metadata."
+            f"\n\n{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
             required=False,
         )
 

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -43,7 +43,7 @@ from ...core.types import (
 from ...core.utils import get_duplicated_values
 from ...core.validators import clean_seo_fields
 from ...core.validators.file import clean_image_file, is_image_url, validate_image_url
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..mutations.product.product_create import ProductCreateInput
 from ..types import Product
@@ -137,12 +137,14 @@ class ProductBulkCreateInput(ProductCreateInput):
     rating = graphene.Float(description="Defines the product rating value.")
     metadata = NonNullList(
         MetadataInput,
-        description="Fields required to update the product metadata.",
+        description="Fields required to update the product metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the product private metadata."),
+        description="Fields required to update the product private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
     external_reference = graphene.String(

--- a/saleor/graphql/product/mutations/category/category_create.py
+++ b/saleor/graphql/product/mutations/category/category_create.py
@@ -19,7 +19,7 @@ from ....core.types import (
 )
 from ....core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
 from ....core.validators.file import clean_image_file
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Category
 
@@ -33,12 +33,14 @@ class CategoryInput(BaseInputObjectType):
     background_image_alt = graphene.String(description="Alt text for a product media.")
     metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the category metadata."),
+        description="Fields required to update the category metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the category private metadata."),
+        description="Fields required to update the category private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/product/mutations/collection/collection_create.py
+++ b/saleor/graphql/product/mutations/collection/collection_create.py
@@ -25,7 +25,7 @@ from ....core.types import (
 )
 from ....core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
 from ....core.validators.file import clean_image_file
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Collection
 
@@ -51,12 +51,14 @@ class CollectionInput(BaseInputObjectType):
     )
     metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the collection metadata."),
+        description="Fields required to update the collection metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the collection private metadata."),
+        description="Fields required to update the collection private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -12,7 +12,7 @@ from ...core.context import disallow_replica_in_context
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.mutations import BaseMutation, DeprecatedModelMutation
 from ...core.types import BaseInputObjectType, NonNullList, ProductError, Upload
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ..types import DigitalContent, DigitalContentUrl, ProductVariant
 
 
@@ -40,12 +40,14 @@ class DigitalContentInput(BaseInputObjectType):
     )
     metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the digital content metadata."),
+        description="Fields required to update the digital content metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the digital content private metadata."),
+        description="Fields required to update the digital content private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
 

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -21,7 +21,7 @@ from ....core.mutations import DeprecatedModelMutation
 from ....core.scalars import WeightScalar
 from ....core.types import BaseInputObjectType, NonNullList, ProductError, SeoInput
 from ....core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Product
 from ..utils import clean_tax_code
@@ -66,12 +66,14 @@ class ProductInput(BaseInputObjectType):
     rating = graphene.Float(description="Defines the product rating value.")
     metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the product metadata."),
+        description="Fields required to update the product metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the product private metadata."),
+        description="Fields required to update the product private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
     external_reference = graphene.String(

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -21,7 +21,7 @@ from ....core.mutations import DeprecatedModelMutation
 from ....core.scalars import DateTime, WeightScalar
 from ....core.types import BaseInputObjectType, NonNullList, ProductError
 from ....core.utils import get_duplicated_values
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ....shop.utils import get_track_inventory_by_default
 from ....warehouse.types import Warehouse
@@ -74,12 +74,14 @@ class ProductVariantInput(BaseInputObjectType):
     )
     metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the product variant metadata."),
+        description="Fields required to update the product variant metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=("Fields required to update the product variant private metadata."),
+        description="Fields required to update the product variant private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
     external_reference = graphene.String(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7288,7 +7288,11 @@ input AddressInput {
   """
   phone: String
 
-  """Address public metadata."""
+  """
+  Address public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
   """
@@ -15398,10 +15402,20 @@ type Mutation {
     """The token of the transaction. One of field id or token is required."""
     token: UUID
 
-    """Fields required to update the transaction metadata."""
+    """
+    Fields required to update the transaction metadata. Can be accessed without permissions.
+    
+    Warning: never store sensitive information, including financial data such as credit card details.
+    """
     transactionMetadata: [MetadataInput!]
 
-    """Fields required to update the transaction private metadata."""
+    """
+    Fields required to update the transaction private metadata.
+    
+    Requires staff or app authorization to the object to modify and access.
+    
+    Warning: never store sensitive information, including financial data such as credit card details.
+    """
     transactionPrivateMetadata: [MetadataInput!]
 
     """Current status of the event to report."""
@@ -16199,7 +16213,9 @@ type Mutation {
   ): DeletePrivateMetadata
 
   """
-  Updates metadata of an object. To use it, you need to have access to the modified object.
+  Updates metadata of an object.Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   updateMetadata(
     """ID or token (for Order and Checkout) of an object to update."""
@@ -16210,7 +16226,9 @@ type Mutation {
   ): UpdateMetadata
 
   """
-  Updates private metadata of an object. To use it, you need to be an authenticated staff user or an app and have access to the modified object.
+  Updates private metadata of an object. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   updatePrivateMetadata(
     """ID or token (for Order and Checkout) of an object to update."""
@@ -17153,7 +17171,11 @@ type Mutation {
     """The checkout's ID."""
     id: ID
 
-    """Fields required to update the checkout metadata."""
+    """
+    Fields required to update the checkout metadata. Can be accessed without permissions.
+    
+    Warning: never store sensitive information, including financial data such as credit card details.
+    """
     metadata: [MetadataInput!]
 
     """Client-side generated data required to finalize the payment."""
@@ -17496,10 +17518,18 @@ type Mutation {
     """ID of a checkout that will be converted to an order."""
     id: ID!
 
-    """Fields required to update the checkout metadata."""
+    """
+    Fields required to update the checkout metadata. Can be accessed without permissions.
+    
+    Warning: never store sensitive information, including financial data such as credit card details.
+    """
     metadata: [MetadataInput!]
 
-    """Fields required to update the checkout private metadata."""
+    """
+    Fields required to update the checkout private metadata. Requires staff or app authorization to the object to modify and access.
+    
+    Warning: never store sensitive information, including financial data such as credit card details.
+    """
     privateMetadata: [MetadataInput!]
 
     """
@@ -19503,10 +19533,18 @@ input ShopSettingsInput {
   """Enable possibility to login without account confirmation."""
   allowLoginWithoutConfirmation: Boolean
 
-  """Shop public metadata."""
+  """
+  Shop public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Shop private metadata."""
+  """
+  Shop private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """Include taxes in prices."""
@@ -20121,10 +20159,18 @@ input CategoryInput @doc(category: "Products") {
   """Alt text for a product media."""
   backgroundImageAlt: String
 
-  """Fields required to update the category metadata."""
+  """
+  Fields required to update the category metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the category private metadata."""
+  """
+  Fields required to update the category private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 }
 
@@ -20278,10 +20324,18 @@ input CollectionCreateInput @doc(category: "Products") {
   """Publication date. ISO 8601 standard."""
   publicationDate: Date @deprecated
 
-  """Fields required to update the collection metadata."""
+  """
+  Fields required to update the collection metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the collection private metadata."""
+  """
+  Fields required to update the collection private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """List of products to be added to the collection."""
@@ -20385,10 +20439,18 @@ input CollectionInput @doc(category: "Products") {
   """Publication date. ISO 8601 standard."""
   publicationDate: Date @deprecated
 
-  """Fields required to update the collection metadata."""
+  """
+  Fields required to update the collection metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the collection private metadata."""
+  """
+  Fields required to update the collection private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 }
 
@@ -20513,10 +20575,18 @@ input ProductCreateInput @doc(category: "Products") {
   """Defines the product rating value."""
   rating: Float
 
-  """Fields required to update the product metadata."""
+  """
+  Fields required to update the product metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the product private metadata."""
+  """
+  Fields required to update the product private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """External ID of this product."""
@@ -20714,10 +20784,18 @@ input ProductBulkCreateInput @doc(category: "Products") {
   """Defines the product rating value."""
   rating: Float
 
-  """Fields required to update the product metadata."""
+  """
+  Fields required to update the product metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the product private metadata."""
+  """
+  Fields required to update the product private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """External ID of this product."""
@@ -20799,10 +20877,18 @@ input ProductVariantBulkCreateInput @doc(category: "Products") {
   """
   quantityLimitPerCustomer: Int
 
-  """Fields required to update the product variant metadata."""
+  """
+  Fields required to update the product variant metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the product variant private metadata."""
+  """
+  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """External ID of this product variant."""
@@ -20969,10 +21055,18 @@ input ProductInput @doc(category: "Products") {
   """Defines the product rating value."""
   rating: Float
 
-  """Fields required to update the product metadata."""
+  """
+  Fields required to update the product metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the product private metadata."""
+  """
+  Fields required to update the product private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """External ID of this product."""
@@ -21374,10 +21468,18 @@ input DigitalContentUploadInput @doc(category: "Products") {
   """Overwrite default automatic_fulfillment setting for variant."""
   automaticFulfillment: Boolean
 
-  """Fields required to update the digital content metadata."""
+  """
+  Fields required to update the digital content metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the digital content private metadata."""
+  """
+  Fields required to update the digital content private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """Represents an file in a multipart request."""
@@ -21424,10 +21526,18 @@ input DigitalContentInput @doc(category: "Products") {
   """Overwrite default automatic_fulfillment setting for variant."""
   automaticFulfillment: Boolean
 
-  """Fields required to update the digital content metadata."""
+  """
+  Fields required to update the digital content metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the digital content private metadata."""
+  """
+  Fields required to update the digital content private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 }
 
@@ -21484,10 +21594,18 @@ input ProductVariantCreateInput @doc(category: "Products") {
   """
   quantityLimitPerCustomer: Int
 
-  """Fields required to update the product variant metadata."""
+  """
+  Fields required to update the product variant metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the product variant private metadata."""
+  """
+  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """External ID of this product variant."""
@@ -21658,10 +21776,18 @@ input ProductVariantBulkUpdateInput @doc(category: "Products") {
   """
   quantityLimitPerCustomer: Int
 
-  """Fields required to update the product variant metadata."""
+  """
+  Fields required to update the product variant metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the product variant private metadata."""
+  """
+  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """External ID of this product variant."""
@@ -21853,10 +21979,18 @@ input ProductVariantInput @doc(category: "Products") {
   """
   quantityLimitPerCustomer: Int
 
-  """Fields required to update the product variant metadata."""
+  """
+  Fields required to update the product variant metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the product variant private metadata."""
+  """
+  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """External ID of this product variant."""
@@ -22203,10 +22337,18 @@ input TransactionCreateInput @doc(category: "Payments") {
   """Amount canceled by this transaction."""
   amountCanceled: MoneyInput
 
-  """Payment public metadata."""
+  """
+  Payment public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Payment private metadata."""
+  """
+  Payment private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """
@@ -22280,10 +22422,18 @@ input TransactionUpdateInput @doc(category: "Payments") {
   """Amount canceled by this transaction."""
   amountCanceled: MoneyInput
 
-  """Payment public metadata."""
+  """
+  Payment public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Payment private metadata."""
+  """
+  Payment private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """
@@ -23114,16 +23264,20 @@ input DraftOrderCreateInput @doc(category: "Orders") {
   externalReference: String
 
   """
-  Order public metadata.
+  Order public metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Order private metadata.
+  Order private metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 
@@ -23253,16 +23407,20 @@ input DraftOrderInput @doc(category: "Orders") {
   externalReference: String
 
   """
-  Order public metadata.
+  Order public metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Order private metadata.
+  Order private metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 }
@@ -24116,10 +24274,18 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   """Currency code."""
   currency: String!
 
-  """Metadata of the order."""
+  """
+  Metadata of the order. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Private metadata of the order."""
+  """
+  Private metadata of the order. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """Note about customer."""
@@ -24273,10 +24439,18 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   """The ID of the warehouse, where the line will be allocated."""
   warehouse: ID!
 
-  """Metadata of the order line."""
+  """
+  Metadata of the order line. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Private metadata of the order line."""
+  """
+  Private metadata of the order line. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """Tax rate of the order line."""
@@ -24288,10 +24462,18 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   """The name of the tax class."""
   taxClassName: String
 
-  """Metadata of the tax class."""
+  """
+  Metadata of the tax class. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   taxClassMetadata: [MetadataInput!]
 
-  """Private metadata of the tax class."""
+  """
+  Private metadata of the tax class. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   taxClassPrivateMetadata: [MetadataInput!]
 }
 
@@ -24328,10 +24510,18 @@ input OrderBulkCreateDeliveryMethodInput @doc(category: "Orders") {
   """The name of the tax class."""
   shippingTaxClassName: String
 
-  """Metadata of the tax class."""
+  """
+  Metadata of the tax class. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   shippingTaxClassMetadata: [MetadataInput!]
 
-  """Private metadata of the tax class."""
+  """
+  Private metadata of the tax class. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   shippingTaxClassPrivateMetadata: [MetadataInput!]
 }
 
@@ -24373,10 +24563,18 @@ input OrderBulkCreateInvoiceInput @doc(category: "Orders") {
   """URL of the invoice to download."""
   url: String
 
-  """Metadata of the invoice."""
+  """
+  Metadata of the invoice. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Private metadata of the invoice."""
+  """
+  Private metadata of the invoice. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 }
 
@@ -24433,7 +24631,9 @@ type DeletePrivateMetadata {
 }
 
 """
-Updates metadata of an object. To use it, you need to have access to the modified object.
+Updates metadata of an object.Requires staff or app authorization to the object to modify and access.
+
+Warning: never store sensitive information, including financial data such as credit card details.
 """
 type UpdateMetadata {
   metadataErrors: [MetadataError!]! @deprecated(reason: "Use `errors` field instead.")
@@ -24442,7 +24642,9 @@ type UpdateMetadata {
 }
 
 """
-Updates private metadata of an object. To use it, you need to be an authenticated staff user or an app and have access to the modified object.
+Updates private metadata of an object. Requires staff or app authorization to the object to modify and access.
+
+Warning: never store sensitive information, including financial data such as credit card details.
 """
 type UpdatePrivateMetadata {
   metadataErrors: [MetadataError!]! @deprecated(reason: "Use `errors` field instead.")
@@ -24779,10 +24981,18 @@ input InvoiceCreateInput @doc(category: "Orders") {
   """URL of an invoice to download."""
   url: String!
 
-  """Fields required to update the invoice metadata."""
+  """
+  Fields required to update the invoice metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the invoice private metadata."""
+  """
+  Fields required to update the invoice private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 }
 
@@ -24815,10 +25025,18 @@ input UpdateInvoiceInput @doc(category: "Orders") {
   """URL of an invoice to download."""
   url: String
 
-  """Fields required to update the invoice metadata."""
+  """
+  Fields required to update the invoice metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the invoice private metadata."""
+  """
+  Fields required to update the invoice private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 }
 
@@ -24902,16 +25120,20 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   expiryDate: Date
 
   """
-  Gift Card public metadata.
+  Gift Card public metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Gift Card private metadata.
+  Gift Card private metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 
@@ -24999,16 +25221,20 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   expiryDate: Date
 
   """
-  Gift Card public metadata.
+  Gift Card public metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Gift Card private metadata.
+  Gift Card private metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 
@@ -26654,7 +26880,11 @@ input CheckoutLineInput @doc(category: "Checkout") {
   """
   forceNewLine: Boolean = false
 
-  """Fields required to update the object's metadata."""
+  """
+  Fields required to update the object's metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 }
 
@@ -26897,7 +27127,11 @@ input PaymentInput @doc(category: "Payments") {
   """Payment store type."""
   storePaymentMethod: StorePaymentMethodEnum = NONE
 
-  """User public metadata."""
+  """
+  User public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 }
 
@@ -27088,10 +27322,18 @@ input ChannelCreateInput @doc(category: "Channels") {
   """The channel order settings"""
   orderSettings: OrderSettingsInput
 
-  """Channel public metadata."""
+  """
+  Channel public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Channel private metadata."""
+  """
+  Channel private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """The channel checkout settings"""
@@ -27231,10 +27473,18 @@ input ChannelUpdateInput @doc(category: "Channels") {
   """The channel order settings"""
   orderSettings: OrderSettingsInput
 
-  """Channel public metadata."""
+  """
+  Channel public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Channel private metadata."""
+  """
+  Channel private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """The channel checkout settings"""
@@ -28664,7 +28914,11 @@ input AccountRegisterInput @doc(category: "Users") {
   """
   redirectUrl: String
 
-  """User public metadata."""
+  """
+  User public metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
   """
@@ -28705,7 +28959,11 @@ input AccountInput @doc(category: "Users") {
   """Shipping address of the customer."""
   defaultShippingAddress: AddressInput
 
-  """Fields required to update the user metadata."""
+  """
+  Fields required to update the user metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 }
 
@@ -28839,10 +29097,18 @@ input UserCreateInput @doc(category: "Users") {
   """A note about the user."""
   note: String
 
-  """Fields required to update the user metadata."""
+  """
+  Fields required to update the user metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the user private metadata."""
+  """
+  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """User language code."""
@@ -28902,10 +29168,18 @@ input CustomerInput @doc(category: "Users") {
   """A note about the user."""
   note: String
 
-  """Fields required to update the user metadata."""
+  """
+  Fields required to update the user metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the user private metadata."""
+  """
+  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """User language code."""
@@ -29066,10 +29340,18 @@ input StaffCreateInput @doc(category: "Users") {
   """A note about the user."""
   note: String
 
-  """Fields required to update the user metadata."""
+  """
+  Fields required to update the user metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the user private metadata."""
+  """
+  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """List of permission group IDs to which user should be assigned."""
@@ -29112,10 +29394,18 @@ input StaffUpdateInput @doc(category: "Users") {
   """A note about the user."""
   note: String
 
-  """Fields required to update the user metadata."""
+  """
+  Fields required to update the user metadata. Can be accessed without permissions.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   metadata: [MetadataInput!]
 
-  """Fields required to update the user private metadata."""
+  """
+  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
   privateMetadata: [MetadataInput!]
 
   """List of permission group IDs to which user should be assigned."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7289,7 +7289,7 @@ input AddressInput {
   phone: String
 
   """
-  Address public metadata. Can be accessed without permissions.
+  Address public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -15403,7 +15403,7 @@ type Mutation {
     token: UUID
 
     """
-    Fields required to update the transaction metadata. Can be accessed without permissions.
+    Fields required to update the transaction metadata. Can be read by any API client authorized to read the object it's attached to.
     
     Warning: never store sensitive information, including financial data such as credit card details.
     """
@@ -15412,7 +15412,7 @@ type Mutation {
     """
     Fields required to update the transaction private metadata.
     
-    Requires staff or app authorization to the object to modify and access.
+    Requires permissions to modify and to read the metadata of the object it's attached to.
     
     Warning: never store sensitive information, including financial data such as credit card details.
     """
@@ -16213,7 +16213,7 @@ type Mutation {
   ): DeletePrivateMetadata
 
   """
-  Updates metadata of an object.Requires staff or app authorization to the object to modify and access.
+  Updates metadata of an object.Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -16226,7 +16226,7 @@ type Mutation {
   ): UpdateMetadata
 
   """
-  Updates private metadata of an object. Requires staff or app authorization to the object to modify and access.
+  Updates private metadata of an object. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -17172,7 +17172,7 @@ type Mutation {
     id: ID
 
     """
-    Fields required to update the checkout metadata. Can be accessed without permissions.
+    Fields required to update the checkout metadata. Can be read by any API client authorized to read the object it's attached to.
     
     Warning: never store sensitive information, including financial data such as credit card details.
     """
@@ -17519,14 +17519,14 @@ type Mutation {
     id: ID!
 
     """
-    Fields required to update the checkout metadata. Can be accessed without permissions.
+    Fields required to update the checkout metadata. Can be read by any API client authorized to read the object it's attached to.
     
     Warning: never store sensitive information, including financial data such as credit card details.
     """
     metadata: [MetadataInput!]
 
     """
-    Fields required to update the checkout private metadata. Requires staff or app authorization to the object to modify and access.
+    Fields required to update the checkout private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
     
     Warning: never store sensitive information, including financial data such as credit card details.
     """
@@ -19534,14 +19534,14 @@ input ShopSettingsInput {
   allowLoginWithoutConfirmation: Boolean
 
   """
-  Shop public metadata. Can be accessed without permissions.
+  Shop public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Shop private metadata. Requires staff or app authorization to the object to modify and access.
+  Shop private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -20160,14 +20160,14 @@ input CategoryInput @doc(category: "Products") {
   backgroundImageAlt: String
 
   """
-  Fields required to update the category metadata. Can be accessed without permissions.
+  Fields required to update the category metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the category private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the category private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -20325,14 +20325,14 @@ input CollectionCreateInput @doc(category: "Products") {
   publicationDate: Date @deprecated
 
   """
-  Fields required to update the collection metadata. Can be accessed without permissions.
+  Fields required to update the collection metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the collection private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the collection private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -20440,14 +20440,14 @@ input CollectionInput @doc(category: "Products") {
   publicationDate: Date @deprecated
 
   """
-  Fields required to update the collection metadata. Can be accessed without permissions.
+  Fields required to update the collection metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the collection private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the collection private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -20576,14 +20576,14 @@ input ProductCreateInput @doc(category: "Products") {
   rating: Float
 
   """
-  Fields required to update the product metadata. Can be accessed without permissions.
+  Fields required to update the product metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the product private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the product private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -20785,14 +20785,14 @@ input ProductBulkCreateInput @doc(category: "Products") {
   rating: Float
 
   """
-  Fields required to update the product metadata. Can be accessed without permissions.
+  Fields required to update the product metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the product private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the product private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -20878,14 +20878,14 @@ input ProductVariantBulkCreateInput @doc(category: "Products") {
   quantityLimitPerCustomer: Int
 
   """
-  Fields required to update the product variant metadata. Can be accessed without permissions.
+  Fields required to update the product variant metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the product variant private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -21056,14 +21056,14 @@ input ProductInput @doc(category: "Products") {
   rating: Float
 
   """
-  Fields required to update the product metadata. Can be accessed without permissions.
+  Fields required to update the product metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the product private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the product private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -21469,14 +21469,14 @@ input DigitalContentUploadInput @doc(category: "Products") {
   automaticFulfillment: Boolean
 
   """
-  Fields required to update the digital content metadata. Can be accessed without permissions.
+  Fields required to update the digital content metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the digital content private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the digital content private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -21527,14 +21527,14 @@ input DigitalContentInput @doc(category: "Products") {
   automaticFulfillment: Boolean
 
   """
-  Fields required to update the digital content metadata. Can be accessed without permissions.
+  Fields required to update the digital content metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the digital content private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the digital content private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -21595,14 +21595,14 @@ input ProductVariantCreateInput @doc(category: "Products") {
   quantityLimitPerCustomer: Int
 
   """
-  Fields required to update the product variant metadata. Can be accessed without permissions.
+  Fields required to update the product variant metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the product variant private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -21777,14 +21777,14 @@ input ProductVariantBulkUpdateInput @doc(category: "Products") {
   quantityLimitPerCustomer: Int
 
   """
-  Fields required to update the product variant metadata. Can be accessed without permissions.
+  Fields required to update the product variant metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the product variant private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -21980,14 +21980,14 @@ input ProductVariantInput @doc(category: "Products") {
   quantityLimitPerCustomer: Int
 
   """
-  Fields required to update the product variant metadata. Can be accessed without permissions.
+  Fields required to update the product variant metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the product variant private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the product variant private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -22338,14 +22338,14 @@ input TransactionCreateInput @doc(category: "Payments") {
   amountCanceled: MoneyInput
 
   """
-  Payment public metadata. Can be accessed without permissions.
+  Payment public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Payment private metadata. Requires staff or app authorization to the object to modify and access.
+  Payment private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -22423,14 +22423,14 @@ input TransactionUpdateInput @doc(category: "Payments") {
   amountCanceled: MoneyInput
 
   """
-  Payment public metadata. Can be accessed without permissions.
+  Payment public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Payment private metadata. Requires staff or app authorization to the object to modify and access.
+  Payment private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -23266,7 +23266,7 @@ input DraftOrderCreateInput @doc(category: "Orders") {
   """
   Order public metadata. 
   
-  Added in Saleor 3.21. Can be accessed without permissions.
+  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -23275,7 +23275,7 @@ input DraftOrderCreateInput @doc(category: "Orders") {
   """
   Order private metadata. 
   
-  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -23409,7 +23409,7 @@ input DraftOrderInput @doc(category: "Orders") {
   """
   Order public metadata. 
   
-  Added in Saleor 3.21. Can be accessed without permissions.
+  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -23418,7 +23418,7 @@ input DraftOrderInput @doc(category: "Orders") {
   """
   Order private metadata. 
   
-  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -24275,14 +24275,14 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   currency: String!
 
   """
-  Metadata of the order. Can be accessed without permissions.
+  Metadata of the order. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Private metadata of the order. Requires staff or app authorization to the object to modify and access.
+  Private metadata of the order. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -24440,14 +24440,14 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   warehouse: ID!
 
   """
-  Metadata of the order line. Can be accessed without permissions.
+  Metadata of the order line. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Private metadata of the order line. Requires staff or app authorization to the object to modify and access.
+  Private metadata of the order line. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -24463,14 +24463,14 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   taxClassName: String
 
   """
-  Metadata of the tax class. Can be accessed without permissions.
+  Metadata of the tax class. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   taxClassMetadata: [MetadataInput!]
 
   """
-  Private metadata of the tax class. Requires staff or app authorization to the object to modify and access.
+  Private metadata of the tax class. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -24511,14 +24511,14 @@ input OrderBulkCreateDeliveryMethodInput @doc(category: "Orders") {
   shippingTaxClassName: String
 
   """
-  Metadata of the tax class. Can be accessed without permissions.
+  Metadata of the tax class. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   shippingTaxClassMetadata: [MetadataInput!]
 
   """
-  Private metadata of the tax class. Requires staff or app authorization to the object to modify and access.
+  Private metadata of the tax class. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -24564,14 +24564,14 @@ input OrderBulkCreateInvoiceInput @doc(category: "Orders") {
   url: String
 
   """
-  Metadata of the invoice. Can be accessed without permissions.
+  Metadata of the invoice. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Private metadata of the invoice. Requires staff or app authorization to the object to modify and access.
+  Private metadata of the invoice. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -24631,7 +24631,7 @@ type DeletePrivateMetadata {
 }
 
 """
-Updates metadata of an object.Requires staff or app authorization to the object to modify and access.
+Updates metadata of an object.Requires permissions to modify and to read the metadata of the object it's attached to.
 
 Warning: never store sensitive information, including financial data such as credit card details.
 """
@@ -24642,7 +24642,7 @@ type UpdateMetadata {
 }
 
 """
-Updates private metadata of an object. Requires staff or app authorization to the object to modify and access.
+Updates private metadata of an object. Requires permissions to modify and to read the metadata of the object it's attached to.
 
 Warning: never store sensitive information, including financial data such as credit card details.
 """
@@ -24982,14 +24982,14 @@ input InvoiceCreateInput @doc(category: "Orders") {
   url: String!
 
   """
-  Fields required to update the invoice metadata. Can be accessed without permissions.
+  Fields required to update the invoice metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the invoice private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the invoice private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -25026,14 +25026,14 @@ input UpdateInvoiceInput @doc(category: "Orders") {
   url: String
 
   """
-  Fields required to update the invoice metadata. Can be accessed without permissions.
+  Fields required to update the invoice metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the invoice private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the invoice private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -25122,7 +25122,7 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   """
   Gift Card public metadata. 
   
-  Added in Saleor 3.21. Can be accessed without permissions.
+  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -25131,7 +25131,7 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   """
   Gift Card private metadata. 
   
-  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -25223,7 +25223,7 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   """
   Gift Card public metadata. 
   
-  Added in Saleor 3.21. Can be accessed without permissions.
+  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -25232,7 +25232,7 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   """
   Gift Card private metadata. 
   
-  Added in Saleor 3.21. Requires staff or app authorization to the object to modify and access.
+  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -26881,7 +26881,7 @@ input CheckoutLineInput @doc(category: "Checkout") {
   forceNewLine: Boolean = false
 
   """
-  Fields required to update the object's metadata. Can be accessed without permissions.
+  Fields required to update the object's metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -27128,7 +27128,7 @@ input PaymentInput @doc(category: "Payments") {
   storePaymentMethod: StorePaymentMethodEnum = NONE
 
   """
-  User public metadata. Can be accessed without permissions.
+  User public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -27323,14 +27323,14 @@ input ChannelCreateInput @doc(category: "Channels") {
   orderSettings: OrderSettingsInput
 
   """
-  Channel public metadata. Can be accessed without permissions.
+  Channel public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Channel private metadata. Requires staff or app authorization to the object to modify and access.
+  Channel private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -27474,14 +27474,14 @@ input ChannelUpdateInput @doc(category: "Channels") {
   orderSettings: OrderSettingsInput
 
   """
-  Channel public metadata. Can be accessed without permissions.
+  Channel public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Channel private metadata. Requires staff or app authorization to the object to modify and access.
+  Channel private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -28915,7 +28915,7 @@ input AccountRegisterInput @doc(category: "Users") {
   redirectUrl: String
 
   """
-  User public metadata. Can be accessed without permissions.
+  User public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -28960,7 +28960,7 @@ input AccountInput @doc(category: "Users") {
   defaultShippingAddress: AddressInput
 
   """
-  Fields required to update the user metadata. Can be accessed without permissions.
+  Fields required to update the user metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -29098,14 +29098,14 @@ input UserCreateInput @doc(category: "Users") {
   note: String
 
   """
-  Fields required to update the user metadata. Can be accessed without permissions.
+  Fields required to update the user metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the user private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -29169,14 +29169,14 @@ input CustomerInput @doc(category: "Users") {
   note: String
 
   """
-  Fields required to update the user metadata. Can be accessed without permissions.
+  Fields required to update the user metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the user private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -29341,14 +29341,14 @@ input StaffCreateInput @doc(category: "Users") {
   note: String
 
   """
-  Fields required to update the user metadata. Can be accessed without permissions.
+  Fields required to update the user metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the user private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -29395,14 +29395,14 @@ input StaffUpdateInput @doc(category: "Users") {
   note: String
 
   """
-  Fields required to update the user metadata. Can be accessed without permissions.
+  Fields required to update the user metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Fields required to update the user private metadata. Requires staff or app authorization to the object to modify and access.
+  Fields required to update the user private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """

--- a/saleor/graphql/shop/mutations/shop_settings_update.py
+++ b/saleor/graphql/shop/mutations/shop_settings_update.py
@@ -14,7 +14,7 @@ from ...core.mutations import BaseMutation
 from ...core.types import ShopError
 from ...core.types import common as common_types
 from ...core.utils import WebhookEventInfo
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Shop
@@ -81,12 +81,14 @@ class ShopSettingsInput(graphene.InputObjectType):
     )
     metadata = common_types.NonNullList(
         MetadataInput,
-        description="Shop public metadata.",
+        description="Shop public metadata. "
+        f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = common_types.NonNullList(
         MetadataInput,
-        description="Shop private metadata.",
+        description="Shop private metadata. "
+        f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
     # deprecated


### PR DESCRIPTION
This adds a warning to each public & private metadata input field to not store sensitive data (especially not financial data regulated by PCI DSS). This ensures awareness is brought to users before storing data in a way that could violate their security policies or compliance.


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://docs.saleor.io/api-usage/metadata#:~:text=never%20store%20sensitive%20information

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
