### PR TITLE
Allow setting `metadata` and `privateMetadata` from `orderUpdate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Deprecate `draftOrderInput.discount` field - #17294 by @zedzior
 - `GiftCardCreate` and `GiftCardUpdate` mutations now allows to set `metadata` and `privateMetadata` fields via `GiftCardCreateInput` and `GiftCardUpdateInput` - #17399 by @lkostrowski
 - Improved error handling when trying to set invalid metadata. Now, invalid metadata should properly return `error.field` containing `metadata` or `privateMetadata`, instead generic `input` - #17470 by @lkostrowski
+- `orderUpdate` mutation now allows to update `metadata` and `privateMetadata` via `OrderUpdateInput` - #1508 by @lkostrowski
 
 ### Webhooks
 

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -64,8 +64,8 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
-        support_meta_field = (True,)
-        support_private_meta_field = (True,)
+        support_meta_field = True
+        support_private_meta_field = True
 
     @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
@@ -77,6 +77,8 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
             "shipping_address",
             "user_email",
             "external_reference",
+            "metadata",
+            "private_metadata",
         ]
         cleaned_input = {}
         for key in draft_order_cleaned_input:

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -13,9 +13,11 @@ from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import AddressInput
 from ...core import ResolveInfo
+from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import ModelWithExtRefMutation
-from ...core.types import BaseInputObjectType, OrderError
+from ...core.types import BaseInputObjectType, NonNullList, OrderError
+from ...meta.inputs import MetadataInput
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .draft_order_create import DraftOrderCreate
@@ -27,6 +29,17 @@ class OrderUpdateInput(BaseInputObjectType):
     shipping_address = AddressInput(description="Shipping address of the customer.")
     external_reference = graphene.String(
         description="External ID of this order.", required=False
+    )
+    metadata = NonNullList(
+        MetadataInput,
+        description="Order public metadata." + ADDED_IN_321,
+        required=False,
+    )
+
+    private_metadata = NonNullList(
+        MetadataInput,
+        description="Order private metadata." + ADDED_IN_321,
+        required=False,
     )
 
     class Meta:
@@ -51,6 +64,8 @@ class OrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
+        support_meta_field = (True,)
+        support_private_meta_field = (True,)
 
     @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -17,7 +17,7 @@ from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
-from ...meta.inputs import MetadataInput
+from ...meta.inputs import MetadataInput, MetadataInputDescription
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .draft_order_create import DraftOrderCreate
@@ -32,13 +32,19 @@ class OrderUpdateInput(BaseInputObjectType):
     )
     metadata = NonNullList(
         MetadataInput,
-        description="Order public metadata." + ADDED_IN_321,
+        description=(
+            f"Order public metadata. {ADDED_IN_321}"
+            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+        ),
         required=False,
     )
 
     private_metadata = NonNullList(
         MetadataInput,
-        description="Order private metadata." + ADDED_IN_321,
+        description=(
+            f"Order private metadata. {ADDED_IN_321}"
+            f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
+        ),
         required=False,
     )
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -24148,6 +24148,20 @@ input OrderUpdateInput @doc(category: "Orders") {
 
   """External ID of this order."""
   externalReference: String
+
+  """
+  Order public metadata.
+  
+  Added in Saleor 3.21.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Order private metadata.
+  
+  Added in Saleor 3.21.
+  """
+  privateMetadata: [MetadataInput!]
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -24150,16 +24150,20 @@ input OrderUpdateInput @doc(category: "Orders") {
   externalReference: String
 
   """
-  Order public metadata.
+  Order public metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21.Can be read by any API client authorized to read the object it's attached to.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Order private metadata.
+  Order private metadata. 
   
-  Added in Saleor 3.21.
+  Added in Saleor 3.21.Requires permissions to modify and to read the metadata of the object it's attached to.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 }


### PR DESCRIPTION
I want to merge this change because it allows to set metadata on OrderUpdate mutation

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
