### PR TITLE
Allow setting shipping address in case CC was changed to standard delivery method

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -995,7 +995,9 @@ def get_valid_collection_points_for_checkout(
     )
 
 
-def clear_delivery_method(checkout_info: "CheckoutInfo"):
+def clear_delivery_method(
+    checkout_info: "CheckoutInfo", save: bool = True
+) -> list[str]:
     checkout = checkout_info.checkout
     checkout.collection_point = None
     checkout.shipping_method = None
@@ -1012,16 +1014,17 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
     )
 
     remove_external_shipping(checkout=checkout)
-    checkout.save(
-        update_fields=[
-            "shipping_method",
-            "collection_point",
-            "last_change",
-            "shipping_method_name",
-            "external_shipping_method_id",
-        ]
-    )
+    update_fields = [
+        "shipping_method",
+        "collection_point",
+        "last_change",
+        "shipping_method_name",
+        "external_shipping_method_id",
+    ]
+    if save:
+        checkout.save(update_fields=update_fields)
     get_checkout_metadata(checkout).save()
+    return update_fields
 
 
 def is_fully_paid(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -196,8 +196,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
                 checkout_info.delivery_method_info,
             )
 
-        update_checkout_shipping_method_if_invalid(checkout_info, lines)
-
         shipping_address_updated_fields = []
         with traced_atomic_transaction():
             shipping_address_instance.save()
@@ -208,12 +206,18 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
                 manager,
                 shipping_channel_listings,
             )
+
+        shipping_update_fields = update_checkout_shipping_method_if_invalid(
+            checkout_info, lines, save=False
+        )
+
         invalidate_prices_updated_fields = invalidate_checkout(
             checkout_info, lines, manager, save=False
         )
         checkout.save(
             update_fields=shipping_address_updated_fields
             + invalidate_prices_updated_fields
+            + shipping_update_fields
         )
 
         call_checkout_info_event(

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -113,13 +113,14 @@ def update_checkout_external_shipping_method_if_invalid(
 
 
 def update_checkout_shipping_method_if_invalid(
-    checkout_info: "CheckoutInfo", lines: Iterable[CheckoutLineInfo]
+    checkout_info: "CheckoutInfo", lines: Iterable[CheckoutLineInfo], save: bool = True
 ):
     quantity = calculate_checkout_quantity(lines)
+    update_fields = []
 
     # remove shipping method when empty checkout
     if quantity == 0 or not is_shipping_required(lines):
-        clear_delivery_method(checkout_info)
+        update_fields = clear_delivery_method(checkout_info, save)
 
     is_valid = clean_delivery_method(
         checkout_info=checkout_info,
@@ -128,7 +129,9 @@ def update_checkout_shipping_method_if_invalid(
     )
 
     if not is_valid:
-        clear_delivery_method(checkout_info)
+        update_fields = clear_delivery_method(checkout_info, save)
+
+    return update_fields
 
 
 def get_variants_and_total_quantities(

--- a/saleor/tests/e2e/__init__.py
+++ b/saleor/tests/e2e/__init__.py
@@ -10,3 +10,17 @@ DEFAULT_ADDRESS = {
     "countryArea": "CA",
     "phone": "+12025550163",
 }
+
+
+DEFAULT_WAREHOUSE_ADDRESS = {
+    "firstName": "Saleor",
+    "lastName": "Mirumee",
+    "companyName": "Mirumee Software",
+    "streetAddress1": "2137 Cantebury Drive",
+    "streetAddress2": "",
+    "postalCode": "10013",
+    "country": "US",
+    "city": "New York",
+    "countryArea": "NY",
+    "phone": "+19179920814",
+}

--- a/saleor/tests/e2e/account/utils/fragments.py
+++ b/saleor/tests/e2e/account/utils/fragments.py
@@ -1,0 +1,18 @@
+ADDRESS_FRAGMENT = """
+  fragment Address on Address {
+    id
+    firstName
+    lastName
+    companyName
+    streetAddress1
+    streetAddress2
+    city
+    cityArea
+    postalCode
+    countryArea
+    phone
+    country {
+        code
+    }
+  }
+"""

--- a/saleor/tests/e2e/checkout/test_checkout_switch_from_cc_to_standard_delivery_method.py
+++ b/saleor/tests/e2e/checkout/test_checkout_switch_from_cc_to_standard_delivery_method.py
@@ -1,0 +1,121 @@
+import pytest
+
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..utils import assign_permissions
+from ..warehouse.utils import update_warehouse
+from .utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+    checkout_shipping_address_update,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_switch_from_cc_to_standard_delivery_method_CORE_0133(
+    e2e_staff_api_client,
+    e2e_logged_api_client,
+    permission_manage_product_types_and_attributes,
+    shop_permissions,
+):
+    # Before
+    permissions = [
+        permission_manage_product_types_and_attributes,
+        *shop_permissions,
+    ]
+
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+    update_warehouse(
+        e2e_staff_api_client,
+        warehouse_id,
+        is_private=False,
+        click_and_collect_option="LOCAL",
+    )
+    variant_price = 10
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+
+    # Step 1 - Create checkout.
+    lines = [
+        {"variantId": product_variant_id, "quantity": 1},
+    ]
+    checkout_data = checkout_create(
+        e2e_logged_api_client,
+        lines,
+        channel_slug,
+        email=None,
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+
+    expected_email = e2e_logged_api_client.user.email
+    assert checkout_data["email"] == expected_email
+    assert checkout_data["user"]["email"] == expected_email
+    assert checkout_data["isShippingRequired"] is True
+    checkout_shipping_address = checkout_data["shippingAddress"]
+
+    collection_point = checkout_data["availableCollectionPoints"][0]
+    assert collection_point["id"] == warehouse_id
+    assert collection_point["isPrivate"] is False
+    assert collection_point["clickAndCollectOption"] == "LOCAL"
+
+    # Step 2 - Assign CC as a delivery method
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        collection_point["id"],
+    )
+    assert checkout_data["deliveryMethod"]["id"] == warehouse_id
+    # Ensure the address has been changed
+    assert (
+        checkout_data["shippingAddress"]["streetAddress1"]
+        != checkout_shipping_address["streetAddress1"]
+    )
+
+    # Step 3 - Change the delivery method to standard shipping method
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingAddress"] is None
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+
+    # Step 4 - Update shipping address
+    checkout_data = checkout_shipping_address_update(e2e_logged_api_client, checkout_id)
+    assert checkout_data["shippingAddress"]
+
+    # Step 5 - Create payment
+    checkout_dummy_payment_create(
+        e2e_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 6 - Complete the checkout
+    order_data = checkout_complete(
+        e2e_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_data["deliveryMethod"]["id"] == shipping_method_id

--- a/saleor/tests/e2e/checkout/utils/checkout_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create.py
@@ -1,7 +1,9 @@
 from ... import DEFAULT_ADDRESS
+from ...account.utils.fragments import ADDRESS_FRAGMENT
 from ...utils import get_graphql_content
 
-CHECKOUT_CREATE_MUTATION = """
+CHECKOUT_CREATE_MUTATION = (
+    """
 mutation CreateCheckout($input: CheckoutCreateInput!) {
   checkoutCreate(input: $input) {
     errors {
@@ -47,14 +49,10 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
       created
       isShippingRequired
       billingAddress {
-        country {
-          code
-        }
+        ...Address
       }
       shippingAddress {
-        country {
-          code
-        }
+        ...Address
       }
       shippingMethods {
         id
@@ -116,6 +114,8 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
   }
 }
 """
+    + ADDRESS_FRAGMENT
+)
 
 
 def raw_checkout_create(

--- a/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
@@ -1,6 +1,8 @@
+from ...account.utils.fragments import ADDRESS_FRAGMENT
 from ...utils import get_graphql_content
 
-CHECKOUT_DELIVERY_METHOD_UPDATE_MUTATION = """
+CHECKOUT_DELIVERY_METHOD_UPDATE_MUTATION = (
+    """
 mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID) {
   checkoutDeliveryMethodUpdate(
     id: $checkoutId
@@ -48,6 +50,9 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID) {
           amount
         }
       }
+      shippingAddress {
+        ...Address
+      }
       deliveryMethod {
         ... on ShippingMethod {
           id
@@ -63,6 +68,8 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID) {
   }
 }
 """
+    + ADDRESS_FRAGMENT
+)
 
 
 def checkout_delivery_method_update(

--- a/saleor/tests/e2e/warehouse/utils/create_warehouse.py
+++ b/saleor/tests/e2e/warehouse/utils/create_warehouse.py
@@ -1,6 +1,6 @@
 import uuid
 
-from ... import DEFAULT_ADDRESS
+from ... import DEFAULT_WAREHOUSE_ADDRESS
 from ...utils import get_graphql_content
 
 WAREHOUSE_CREATE_MUTATION = """
@@ -37,7 +37,7 @@ def create_warehouse(
     staff_api_client,
     name="Test warehouse",
     slug=f"warehouse_slug_{uuid.uuid4()}",
-    address=DEFAULT_ADDRESS,
+    address=DEFAULT_WAREHOUSE_ADDRESS,
 ):
     variables = {
         "input": {


### PR DESCRIPTION
Previously, running `checkoutShippingAddressUpdate` after switching from CC to standard delivery method raised an error.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
