### PR TITLE
Fix product media create with an image URL containing query params

### DIFF
--- a/saleor/thumbnail/tests/test_utils.py
+++ b/saleor/thumbnail/tests/test_utils.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import graphene
 import pytest
@@ -185,3 +185,31 @@ def test_get_filename_from_url_with_short_name_is_not_trimmed():
     assert result.endswith(file_format)
     assert result != f"{file_name}.{file_format}"
     assert len(result.split("_")[0]) < FILE_NAME_MAX_LENGTH
+
+
+@patch("saleor.thumbnail.utils.secrets.token_hex")
+def test_get_filename_from_url_with_query_params(mock_token_hex):
+    # given
+    token_hex = 1234
+    mock_token_hex.return_value = token_hex
+    url = "http://example.com/image.jpg?query=param"
+
+    # when
+    result = get_filename_from_url(url)
+
+    # then
+    assert result == f"image_{token_hex}.jpg"
+
+
+@patch("saleor.thumbnail.utils.secrets.token_hex")
+def test_get_filename_from_url_with_query_params_path(mock_token_hex):
+    # given
+    token_hex = 1234
+    mock_token_hex.return_value = token_hex
+    url = "http://example.com/image.jpg?token=12345/6789"
+
+    # when
+    result = get_filename_from_url(url)
+
+    # then
+    assert result == f"image_{token_hex}.jpg"

--- a/saleor/thumbnail/utils.py
+++ b/saleor/thumbnail/utils.py
@@ -2,6 +2,7 @@ import os
 import secrets
 from io import BytesIO
 from typing import TYPE_CHECKING, Optional, Union
+from urllib.parse import urlparse
 
 import graphene
 import magic
@@ -256,7 +257,7 @@ class ProcessedIconImage(ProcessedImage):
 
 def get_filename_from_url(url: str) -> str:
     """Prepare a unique filename for file from the URL to avoid overwriting."""
-    file_name = os.path.basename(url)
+    file_name = os.path.basename(urlparse(url).path)
     name, format = os.path.splitext(file_name)
     name = name[:FILE_NAME_MAX_LENGTH]
     hash = secrets.token_hex(nbytes=4)


### PR DESCRIPTION
ℹ️ This is a 3.19 port of https://github.com/saleor/saleor/pull/17519

I want to merge this change because it fixes ProductMediaCreate when provided with an URL to an image containing query params or a path in query params.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
