### PR TITLE
Fix incorrectly deprecated `OrderAddNoteInput.message`

### DIFF
--- a/saleor/graphql/order/mutations/order_note_add.py
+++ b/saleor/graphql/order/mutations/order_note_add.py
@@ -6,7 +6,6 @@ from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.types import BaseInputObjectType, Error, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -67,7 +66,7 @@ class OrderNoteAdd(OrderNoteCommon):
 
 class OrderAddNoteInput(BaseInputObjectType):
     message = graphene.String(
-        description="Note message." + DEPRECATED_IN_3X_INPUT,
+        description="Note message.",
         name="message",
         required=True,
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23284,7 +23284,7 @@ type OrderAddNote @doc(category: "Orders") {
 
 input OrderAddNoteInput @doc(category: "Orders") {
   """Note message."""
-  message: String! @deprecated
+  message: String!
 }
 
 """


### PR DESCRIPTION
The entire mutation is getting deprecated, deprecating a required field in its input does not make sense.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
