### PR TITLE
Allow setting shipping address in case CC was changed to standard delivery method

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1015,7 +1015,9 @@ def get_valid_collection_points_for_checkout(
     )
 
 
-def clear_delivery_method(checkout_info: "CheckoutInfo"):
+def clear_delivery_method(
+    checkout_info: "CheckoutInfo", save: bool = True
+) -> list[str]:
     checkout = checkout_info.checkout
     updated_fields = remove_delivery_method_from_checkout(checkout_info.checkout)
 
@@ -1031,12 +1033,11 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
         shipping_channel_listings=checkout_info.shipping_channel_listings,
     )
     if updated_fields:
-        checkout.save(
-            update_fields=updated_fields
-            + [
-                "last_change",
-            ]
-        )
+        updated_fields.append("last_change")
+
+    if save:
+        checkout.save(update_fields=updated_fields)
+    return updated_fields
 
 
 def is_fully_paid(

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1034,9 +1034,9 @@ def clear_delivery_method(
     )
     if updated_fields:
         updated_fields.append("last_change")
+        if save:
+            checkout.save(update_fields=updated_fields)
 
-    if save:
-        checkout.save(update_fields=updated_fields)
     return updated_fields
 
 

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -114,14 +114,17 @@ class CheckoutAddPromoCode(BaseMutation):
             shipping_channel_listings=shipping_channel_listings,
         )
 
-        update_checkout_shipping_method_if_invalid(checkout_info, lines)
-        invalidate_checkout(
+        shipping_update_fields = update_checkout_shipping_method_if_invalid(
+            checkout_info, lines
+        )
+        invalidate_update_fields = invalidate_checkout(
             checkout_info,
             lines,
             manager,
             recalculate_discount=False,
-            save=True,
+            save=False,
         )
+        checkout.save(update_fields=shipping_update_fields + invalidate_update_fields)
         call_checkout_info_event(
             manager=manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,

--- a/saleor/graphql/checkout/mutations/checkout_line_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_line_delete.py
@@ -81,8 +81,13 @@ class CheckoutLineDelete(BaseMutation):
         manager = get_plugin_manager_promise(info.context).get()
         lines, _ = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(checkout, lines, manager)
-        update_checkout_shipping_method_if_invalid(checkout_info, lines)
-        invalidate_checkout(checkout_info, lines, manager, save=True)
+        shipping_update_fields = update_checkout_shipping_method_if_invalid(
+            checkout_info, lines
+        )
+        invalidate_update_fields = invalidate_checkout(
+            checkout_info, lines, manager, save=False
+        )
+        checkout.save(update_fields=shipping_update_fields + invalidate_update_fields)
         call_checkout_info_event(
             manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -228,8 +228,13 @@ class CheckoutLinesAdd(BaseMutation):
         )
 
         update_checkout_external_shipping_method_if_invalid(checkout_info, lines)
-        update_checkout_shipping_method_if_invalid(checkout_info, lines)
-        invalidate_checkout(checkout_info, lines, manager, save=True)
+        shipping_update_fields = update_checkout_shipping_method_if_invalid(
+            checkout_info, lines
+        )
+        invalidate_update_fields = invalidate_checkout(
+            checkout_info, lines, manager, save=False
+        )
+        checkout.save(update_fields=shipping_update_fields + invalidate_update_fields)
         call_checkout_info_event(
             manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -100,8 +100,13 @@ class CheckoutLinesDelete(BaseMutation):
 
         manager = get_plugin_manager_promise(info.context).get()
         checkout_info = fetch_checkout_info(checkout, lines, manager)
-        update_checkout_shipping_method_if_invalid(checkout_info, lines)
-        invalidate_checkout(checkout_info, lines, manager, save=True)
+        shipping_update_fields = update_checkout_shipping_method_if_invalid(
+            checkout_info, lines
+        )
+        invalidate_update_fields = invalidate_checkout(
+            checkout_info, lines, manager, save=False
+        )
+        checkout.save(update_fields=shipping_update_fields + invalidate_update_fields)
         call_checkout_info_event(
             manager,
             event_name=WebhookEventAsyncType.CHECKOUT_UPDATED,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -195,8 +195,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
                 checkout_info.get_delivery_method_info(),
             )
 
-        update_checkout_shipping_method_if_invalid(checkout_info, lines)
-
         shipping_address_updated_fields = []
         with traced_atomic_transaction():
             shipping_address_instance.save()
@@ -207,12 +205,18 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
                 lines,
                 shipping_channel_listings,
             )
+
+        shipping_update_fields = update_checkout_shipping_method_if_invalid(
+            checkout_info, lines, save=False
+        )
+
         invalidate_prices_updated_fields = invalidate_checkout(
             checkout_info, lines, manager, save=False
         )
         checkout.save(
             update_fields=shipping_address_updated_fields
             + invalidate_prices_updated_fields
+            + shipping_update_fields
         )
 
         call_checkout_info_event(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -207,7 +207,7 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             )
 
         shipping_update_fields = update_checkout_shipping_method_if_invalid(
-            checkout_info, lines, save=False
+            checkout_info, lines
         )
 
         invalidate_prices_updated_fields = invalidate_checkout(

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -111,13 +111,14 @@ def update_checkout_external_shipping_method_if_invalid(
 
 
 def update_checkout_shipping_method_if_invalid(
-    checkout_info: "CheckoutInfo", lines: list[CheckoutLineInfo]
+    checkout_info: "CheckoutInfo", lines: list[CheckoutLineInfo], save: bool = True
 ):
     quantity = calculate_checkout_quantity(lines)
+    update_fields = []
 
     # remove shipping method when empty checkout
     if quantity == 0 or not is_shipping_required(lines):
-        clear_delivery_method(checkout_info)
+        update_fields = clear_delivery_method(checkout_info, save)
 
     is_valid = clean_delivery_method(
         checkout_info=checkout_info,
@@ -125,7 +126,9 @@ def update_checkout_shipping_method_if_invalid(
     )
 
     if not is_valid:
-        clear_delivery_method(checkout_info)
+        update_fields = clear_delivery_method(checkout_info, save)
+
+    return update_fields
 
 
 def get_variants_and_total_quantities(

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -111,14 +111,18 @@ def update_checkout_external_shipping_method_if_invalid(
 
 
 def update_checkout_shipping_method_if_invalid(
-    checkout_info: "CheckoutInfo", lines: list[CheckoutLineInfo], save: bool = True
-):
+    checkout_info: "CheckoutInfo", lines: list[CheckoutLineInfo]
+) -> list[str]:
+    """Check if current shipping method is valid and clean it if not.
+
+    The method is not saving the applied changes on checkout.
+    """
     quantity = calculate_checkout_quantity(lines)
     update_fields = []
 
     # remove shipping method when empty checkout
     if quantity == 0 or not is_shipping_required(lines):
-        update_fields = clear_delivery_method(checkout_info, save)
+        update_fields = clear_delivery_method(checkout_info)
 
     is_valid = clean_delivery_method(
         checkout_info=checkout_info,
@@ -126,7 +130,7 @@ def update_checkout_shipping_method_if_invalid(
     )
 
     if not is_valid:
-        update_fields = clear_delivery_method(checkout_info, save)
+        update_fields = clear_delivery_method(checkout_info)
 
     return update_fields
 

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
@@ -69,9 +69,7 @@ def test_checkout_shipping_address_update_by_id(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, save=False
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
 @mock.patch(
@@ -117,9 +115,7 @@ def test_checkout_shipping_address_update_by_token(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, save=False
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
 def test_checkout_shipping_address_update_neither_token_and_id_given(

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
@@ -69,7 +69,9 @@ def test_checkout_shipping_address_update_by_id(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    mocked_update_shipping_method.assert_called_once_with(
+        checkout_info, lines, save=False
+    )
 
 
 @mock.patch(
@@ -115,7 +117,9 @@ def test_checkout_shipping_address_update_by_token(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    mocked_update_shipping_method.assert_called_once_with(
+        checkout_info, lines, save=False
+    )
 
 
 def test_checkout_shipping_address_update_neither_token_and_id_given(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -133,9 +133,7 @@ def test_checkout_shipping_address_with_metadata_update(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, save=False
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout.call_count == 1
     assert checkout.save_shipping_address is True
@@ -198,9 +196,7 @@ def test_checkout_shipping_address_when_variant_without_listing(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, save=False
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout.call_count == 1
     assert checkout.save_shipping_address is True
@@ -249,9 +245,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, save=False
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.country == shipping_address["country"]
     assert checkout.last_change != previous_last_change
     assert checkout.save_shipping_address is True

--- a/saleor/tests/e2e/__init__.py
+++ b/saleor/tests/e2e/__init__.py
@@ -15,13 +15,13 @@ DEFAULT_WAREHOUSE_ADDRESS = {
     "firstName": "Saleor",
     "lastName": "Mirumee",
     "companyName": "Mirumee Software",
-    "streetAddress1": "Tęczowa 7",
+    "streetAddress1": "2137 Cantebury Drive",
     "streetAddress2": "",
-    "postalCode": "53-601",
-    "country": "PL",
-    "city": "Wrocław",
-    "countryArea": "",
-    "phone": "+48321321888",
+    "postalCode": "10013",
+    "country": "US",
+    "city": "New York",
+    "countryArea": "NY",
+    "phone": "+19179920814",
 }
 
 ADDRESS_DE = {

--- a/saleor/tests/e2e/checkout/test_checkout_switch_from_cc_to_standard_delivery_method.py
+++ b/saleor/tests/e2e/checkout/test_checkout_switch_from_cc_to_standard_delivery_method.py
@@ -1,0 +1,119 @@
+import pytest
+
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_default_shop
+from ..utils import assign_permissions
+from ..warehouse.utils import update_warehouse
+from .utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+    checkout_shipping_address_update,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_switch_from_cc_to_standard_delivery_method_CORE_0133(
+    e2e_staff_api_client,
+    e2e_logged_api_client,
+    permission_manage_product_types_and_attributes,
+    shop_permissions,
+):
+    # Before
+    permissions = [
+        permission_manage_product_types_and_attributes,
+        *shop_permissions,
+    ]
+
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+    update_warehouse(
+        e2e_staff_api_client,
+        warehouse_id,
+        is_private=False,
+        click_and_collect_option="LOCAL",
+    )
+    variant_price = 10
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+
+    # Step 1 - Create checkout.
+    lines = [
+        {"variantId": product_variant_id, "quantity": 1},
+    ]
+    checkout_data = checkout_create(
+        e2e_logged_api_client,
+        lines,
+        channel_slug,
+        email=None,
+    )
+    checkout_id = checkout_data["id"]
+
+    expected_email = e2e_logged_api_client.user.email
+    assert checkout_data["email"] == expected_email
+    assert checkout_data["user"]["email"] == expected_email
+    assert checkout_data["isShippingRequired"] is True
+    checkout_shipping_address = checkout_data["shippingAddress"]
+
+    collection_point = checkout_data["availableCollectionPoints"][0]
+    assert collection_point["id"] == warehouse_id
+    assert collection_point["isPrivate"] is False
+    assert collection_point["clickAndCollectOption"] == "LOCAL"
+
+    # Step 2 - Assign CC as a delivery method
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        collection_point["id"],
+    )
+    assert checkout_data["deliveryMethod"]["id"] == warehouse_id
+    # Ensure the address has been changed
+    assert (
+        checkout_data["shippingAddress"]["streetAddress1"]
+        != checkout_shipping_address["streetAddress1"]
+    )
+
+    # Step 3 - Change the delivery method to standard shipping method
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingAddress"] is None
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+
+    # Step 4 - Update shipping address
+    checkout_data = checkout_shipping_address_update(e2e_logged_api_client, checkout_id)
+    assert checkout_data["shippingAddress"]
+
+    # Step 5 - Create payment
+    checkout_dummy_payment_create(
+        e2e_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 6 - Complete the checkout
+    order_data = checkout_complete(
+        e2e_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_data["deliveryMethod"]["id"] == shipping_method_id

--- a/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
@@ -50,6 +50,9 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID) {
           amount
         }
       }
+      shippingAddress {
+        ...Address
+      }
       deliveryMethod {
         ... on ShippingMethod {
           id

--- a/saleor/tests/e2e/warehouse/utils/create_warehouse.py
+++ b/saleor/tests/e2e/warehouse/utils/create_warehouse.py
@@ -1,6 +1,6 @@
 import uuid
 
-from ... import DEFAULT_ADDRESS
+from ... import DEFAULT_WAREHOUSE_ADDRESS
 from ...utils import get_graphql_content
 
 WAREHOUSE_CREATE_MUTATION = """
@@ -37,7 +37,7 @@ def create_warehouse(
     staff_api_client,
     name="Test warehouse",
     slug=None,
-    address=DEFAULT_ADDRESS,
+    address=DEFAULT_WAREHOUSE_ADDRESS,
 ):
     if slug is None:
         slug = f"warehouse_slug_{uuid.uuid4()}"


### PR DESCRIPTION
Previously, running `checkoutShippingAddressUpdate` after switching from CC to standard delivery method raised an error.

Port of https://github.com/saleor/saleor/pull/17509

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
