### PR TITLE
Release 3.20.77

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.76",
+  "version": "3.20.77",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.76",
+      "version": "3.20.77",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.76",
+  "version": "3.20.77",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.76"
+version = "3.20.77"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.76"
+__version__ = "3.20.77"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.20.77 (71963e8ce5)
* Update order mutations - explicitly save changed fields in `DraftOrderUpdate` - #17498 by @IKarbowiak 
* Fix media create with image containing query params - #17519 by @tomaszszymanski129 
* Add flag to create draft release - #17497 by @kadewu 
* Update order mutations - explicitly save changed fields in `OrderUpdate` and `DraftOrderComplete` - #17465 by @IKarbowiak 
