### PR TITLE
Timeout handling for app installation task

### DIFF
--- a/saleor/app/tasks.py
+++ b/saleor/app/tasks.py
@@ -18,9 +18,15 @@ from .models import App, AppExtension, AppInstallation, AppToken
 
 logger = logging.getLogger(__name__)
 
+INSTALLATION_TIMEOUT = settings.APP_INSTALLATION_TIMEOUT_SECONDS
+# Add extra 5s for cleanup
+INSTALLATION_HARD_TIMEOUT = INSTALLATION_TIMEOUT + 5
+
 
 # TODO Move to settings
-@celeryconf.app.task(soft_time_limit=15, time_limit=20)
+@celeryconf.app.task(
+    soft_time_limit=INSTALLATION_TIMEOUT, time_limit=INSTALLATION_HARD_TIMEOUT
+)
 @allow_writer()
 def install_app_task(job_id, activate=False):
     app_installation: AppInstallation | None = None

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1060,3 +1060,6 @@ BREAKER_BOARD_DRY_RUN_SYNC_EVENTS = get_list(
 # Library `google-i18n-address` use `AddressValidationMetadata` form Google to provide address validation rules.
 # Patch `i18n` module to allows to override the default address rules.
 i18n_rules_override()
+
+# Does it have to be in envs?
+APP_INSTALLATION_TIMEOUT_SECONDS = 15


### PR DESCRIPTION
I want to merge this change because it adds hard timeout on app installations. Previously in some cases installation hanged infinitely. Now after 15s it will be killed and status will be set to FAILED

- [ ] how to test that?

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
