### PR TITLE
Refactor: BaseCustomerCreate inheritance

### DIFF
--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -17,7 +17,7 @@ from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...mixins import AppImpersonateMixin
 from ...types import AddressInput, User
-from ..base import BILLING_ADDRESS_FIELD, SHIPPING_ADDRESS_FIELD, BaseCustomerCreate
+from ..base import BaseCustomerCreate
 from .base import AccountBaseInput
 
 
@@ -98,21 +98,18 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
     @classmethod
     @traced_atomic_transaction()
     def save(cls, info: ResolveInfo, instance: models.User, cleaned_input):
-        default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
         manager = get_plugin_manager_promise(info.context).get()
-        if default_shipping_address:
-            default_shipping_address.save()
-            instance.default_shipping_address = default_shipping_address
-        default_billing_address = cleaned_input.get(BILLING_ADDRESS_FIELD)
-        if default_billing_address:
-            default_billing_address.save()
-            instance.default_billing_address = default_billing_address
+
+        default_addresses = cls.save_and_apply_addresses_from_input(
+            cleaned_input=cleaned_input, user_instance=instance
+        )
 
         super().save(info, instance, cleaned_input)
-        if default_billing_address:
-            instance.addresses.add(default_billing_address)
-        if default_shipping_address:
-            instance.addresses.add(default_shipping_address)
+
+        if default_addresses["billing"]:
+            instance.addresses.add(default_addresses["billing"])
+        if default_addresses["shipping"]:
+            instance.addresses.add(default_addresses["shipping"])
 
         instance.search_document = prepare_user_search_document_value(instance)
         instance.save(update_fields=["search_document", "updated_at"])

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -13,7 +13,7 @@ from ....core.descriptions import ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
-from ....meta.inputs import MetadataInput
+from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...mixins import AppImpersonateMixin
 from ...types import AddressInput, User

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -104,14 +104,12 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
             cleaned_input=cleaned_input, user_instance=instance
         )
 
-        instance.save()
-
         if default_addresses["billing"]:
             instance.addresses.add(default_addresses["billing"])
         if default_addresses["shipping"]:
             instance.addresses.add(default_addresses["shipping"])
 
         instance.search_document = prepare_user_search_document_value(instance)
-        instance.save(update_fields=["search_document", "updated_at"])
+        instance.save()
 
         cls.call_event(manager.customer_updated, instance)

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -104,7 +104,7 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
             cleaned_input=cleaned_input, user_instance=instance
         )
 
-        super().save(info, instance, cleaned_input)
+        instance.save()
 
         if default_addresses["billing"]:
             instance.addresses.add(default_addresses["billing"])

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -118,11 +118,3 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
         instance.save(update_fields=["search_document", "updated_at"])
 
         cls.call_event(manager.customer_updated, instance)
-
-        if redirect_url := cleaned_input.get("redirect_url"):
-            cls.process_account_confirmation(
-                redirect_url=redirect_url,
-                instance=instance,
-                channel_slug_from_input=cleaned_input.get("channel"),
-                plugins_manager=manager,
-            )

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -100,14 +100,9 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
     def save(cls, info: ResolveInfo, instance: models.User, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
 
-        default_addresses = cls.save_and_apply_addresses_from_input(
-            cleaned_input=cleaned_input, user_instance=instance
+        cls.save_default_addresses(
+            cleaned_input=cleaned_input, user_instance=instance, save_user=False
         )
-
-        if default_addresses["billing"]:
-            instance.addresses.add(default_addresses["billing"])
-        if default_addresses["shipping"]:
-            instance.addresses.add(default_addresses["shipping"])
 
         instance.search_document = prepare_user_search_document_value(instance)
         instance.save()

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -1,20 +1,30 @@
 from typing import cast
+from urllib.parse import urlencode
 
 import graphene
+from django.contrib.auth.tokens import default_token_generator
 
+from .....account import events as account_events
 from .....account import models
+from .....account.error_codes import AccountErrorCode
+from .....account.notifications import send_set_password_notification
+from .....account.search import prepare_user_search_document_value
+from .....core.tracing import traced_atomic_transaction
+from .....core.utils.url import prepare_url
 from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.mixins import AddressMetadataMixin
+from ....channel.utils import clean_channel, validate_channel
 from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
-from ....meta.inputs import MetadataInput, MetadataInputDescription
+from ....meta.inputs import MetadataInput
+from ....plugins.dataloaders import get_plugin_manager_promise
 from ...mixins import AppImpersonateMixin
 from ...types import AddressInput, User
-from ..base import BaseCustomerCreate
+from ..base import BILLING_ADDRESS_FIELD, SHIPPING_ADDRESS_FIELD, BaseCustomerCreate
 from .base import AccountBaseInput
 
 
@@ -91,3 +101,59 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
         user = cast(models.User, user)
         data["id"] = graphene.Node.to_global_id("User", user.id)
         return super().perform_mutation(root, info, **data)
+
+    @classmethod
+    @traced_atomic_transaction()
+    def save(cls, info: ResolveInfo, instance, cleaned_input):
+        default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
+        manager = get_plugin_manager_promise(info.context).get()
+        if default_shipping_address:
+            default_shipping_address.save()
+            instance.default_shipping_address = default_shipping_address
+        default_billing_address = cleaned_input.get(BILLING_ADDRESS_FIELD)
+        if default_billing_address:
+            default_billing_address.save()
+            instance.default_billing_address = default_billing_address
+
+        is_creation = instance.pk is None
+        super().save(info, instance, cleaned_input)
+        if default_billing_address:
+            instance.addresses.add(default_billing_address)
+        if default_shipping_address:
+            instance.addresses.add(default_shipping_address)
+
+        instance.search_document = prepare_user_search_document_value(instance)
+        instance.save(update_fields=["search_document", "updated_at"])
+
+        # The instance is a new object in db, create an event
+        if is_creation:
+            cls.call_event(manager.customer_created, instance)
+            account_events.customer_account_created_event(user=instance)
+        else:
+            cls.call_event(manager.customer_updated, instance)
+
+        if redirect_url := cleaned_input.get("redirect_url"):
+            channel_slug = cleaned_input.get("channel")
+            if not instance.is_staff:
+                channel_slug = clean_channel(
+                    channel_slug, error_class=AccountErrorCode, allow_replica=False
+                ).slug
+            elif channel_slug is not None:
+                channel_slug = validate_channel(
+                    channel_slug, error_class=AccountErrorCode
+                ).slug
+            send_set_password_notification(
+                redirect_url,
+                instance,
+                manager,
+                channel_slug,
+            )
+            token = default_token_generator.make_token(instance)
+            params = urlencode({"email": instance.email, "token": token})
+            cls.call_event(
+                manager.account_set_password_requested,
+                instance,
+                channel_slug,
+                token,
+                prepare_url(params, redirect_url),
+            )

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -1,23 +1,29 @@
 from collections import defaultdict
+from urllib.parse import urlencode
 
 import graphene
+from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 
 from ....account import events as account_events
+from ....account import models
 from ....account.error_codes import AccountErrorCode
+from ....account.notifications import send_set_password_notification
 from ....account.search import prepare_user_search_document_value
 from ....checkout import AddressType
 from ....core.exceptions import PermissionDenied
 from ....core.utils import metadata_manager
-from ....core.utils.url import validate_storefront_url
+from ....core.utils.url import prepare_url, validate_storefront_url
 from ....giftcard.search import mark_gift_cards_search_index_as_dirty
 from ....giftcard.utils import get_user_gift_cards
 from ....graphql.utils import get_user_or_app_from_context
 from ....permission.auth_filters import AuthorizationFilters
 from ....permission.enums import AccountPermissions
+from ....plugins.manager import PluginsManager
 from ...account.i18n import I18nMixin
 from ...account.types import Address, AddressInput, User
 from ...app.dataloaders import get_app_promise
+from ...channel.utils import clean_channel, validate_channel
 from ...core import ResolveInfo, SaleorContext
 from ...core.descriptions import (
     DEPRECATED_IN_3X_INPUT,
@@ -352,6 +358,43 @@ class BaseCustomerCreate(DeprecatedModelMutation, I18nMixin):
         if cleaned_input.get("first_name") or cleaned_input.get("last_name"):
             if user_gift_cards := get_user_gift_cards(instance):
                 mark_gift_cards_search_index_as_dirty(user_gift_cards)
+
+    @classmethod
+    def process_account_confirmation(
+        cls,
+        *,
+        redirect_url: str,
+        instance: models.User,
+        plugins_manager: PluginsManager,
+        channel_slug_from_input: str,
+    ):
+        channel_slug = channel_slug_from_input
+
+        if not instance.is_staff:
+            channel_slug = clean_channel(
+                channel_slug, error_class=AccountErrorCode, allow_replica=False
+            ).slug
+        elif channel_slug is not None:
+            channel_slug = validate_channel(
+                channel_slug, error_class=AccountErrorCode
+            ).slug
+
+        send_set_password_notification(
+            redirect_url,
+            instance,
+            plugins_manager,
+            channel_slug,
+        )
+        token = default_token_generator.make_token(instance)
+        params = urlencode({"email": instance.email, "token": token})
+
+        cls.call_event(
+            plugins_manager.account_set_password_requested,
+            instance,
+            channel_slug,
+            token,
+            prepare_url(params, redirect_url),
+        )
 
 
 class UserDeleteMixin:

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -355,8 +355,8 @@ class BaseCustomerCreate(DeprecatedModelMutation, I18nMixin):
                 mark_gift_cards_search_index_as_dirty(user_gift_cards)
 
     @classmethod
-    def save_and_apply_addresses_from_input(
-        cls, *, cleaned_input: dict, user_instance: models.User
+    def save_default_addresses(
+        cls, *, cleaned_input: dict, user_instance: models.User, save_user: bool
     ):
         default_shipping_address: models.Address | None = cleaned_input.get(
             SHIPPING_ADDRESS_FIELD
@@ -374,10 +374,13 @@ class BaseCustomerCreate(DeprecatedModelMutation, I18nMixin):
             default_billing_address.save()
             user_instance.default_billing_address = default_billing_address
 
-        return {
-            "shipping": default_shipping_address,
-            "billing": default_billing_address,
-        }
+        if save_user:
+            user_instance.save()
+
+        if default_billing_address:
+            user_instance.addresses.add(default_billing_address)
+        if default_shipping_address:
+            user_instance.addresses.add(default_shipping_address)
 
 
 class UserDeleteMixin:

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -1,19 +1,15 @@
 from collections import defaultdict
-from urllib.parse import urlencode
 
 import graphene
-from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 
 from ....account import events as account_events
 from ....account.error_codes import AccountErrorCode
-from ....account.notifications import send_set_password_notification
 from ....account.search import prepare_user_search_document_value
 from ....checkout import AddressType
 from ....core.exceptions import PermissionDenied
-from ....core.tracing import traced_atomic_transaction
 from ....core.utils import metadata_manager
-from ....core.utils.url import prepare_url, validate_storefront_url
+from ....core.utils.url import validate_storefront_url
 from ....giftcard.search import mark_gift_cards_search_index_as_dirty
 from ....giftcard.utils import get_user_gift_cards
 from ....graphql.utils import get_user_or_app_from_context
@@ -22,7 +18,6 @@ from ....permission.enums import AccountPermissions
 from ...account.i18n import I18nMixin
 from ...account.types import Address, AddressInput, User
 from ...app.dataloaders import get_app_promise
-from ...channel.utils import clean_channel, validate_channel
 from ...core import ResolveInfo, SaleorContext
 from ...core.descriptions import (
     DEPRECATED_IN_3X_INPUT,
@@ -347,62 +342,6 @@ class BaseCustomerCreate(DeprecatedModelMutation, I18nMixin):
             cleaned_input["is_confirmed"] = False
 
         return cleaned_input
-
-    @classmethod
-    @traced_atomic_transaction()
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
-        default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
-        manager = get_plugin_manager_promise(info.context).get()
-        if default_shipping_address:
-            default_shipping_address.save()
-            instance.default_shipping_address = default_shipping_address
-        default_billing_address = cleaned_input.get(BILLING_ADDRESS_FIELD)
-        if default_billing_address:
-            default_billing_address.save()
-            instance.default_billing_address = default_billing_address
-
-        is_creation = instance.pk is None
-        super().save(info, instance, cleaned_input)
-        if default_billing_address:
-            instance.addresses.add(default_billing_address)
-        if default_shipping_address:
-            instance.addresses.add(default_shipping_address)
-
-        instance.search_document = prepare_user_search_document_value(instance)
-        instance.save(update_fields=["search_document", "updated_at"])
-
-        # The instance is a new object in db, create an event
-        if is_creation:
-            cls.call_event(manager.customer_created, instance)
-            account_events.customer_account_created_event(user=instance)
-        else:
-            cls.call_event(manager.customer_updated, instance)
-
-        if redirect_url := cleaned_input.get("redirect_url"):
-            channel_slug = cleaned_input.get("channel")
-            if not instance.is_staff:
-                channel_slug = clean_channel(
-                    channel_slug, error_class=AccountErrorCode, allow_replica=False
-                ).slug
-            elif channel_slug is not None:
-                channel_slug = validate_channel(
-                    channel_slug, error_class=AccountErrorCode
-                ).slug
-            send_set_password_notification(
-                redirect_url,
-                instance,
-                manager,
-                channel_slug,
-            )
-            token = default_token_generator.make_token(instance)
-            params = urlencode({"email": instance.email, "token": token})
-            cls.call_event(
-                manager.account_set_password_requested,
-                instance,
-                channel_slug,
-                token,
-                prepare_url(params, redirect_url),
-            )
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -1,11 +1,24 @@
+from urllib.parse import urlencode
+
+from django.contrib.auth.tokens import default_token_generator
+
+from .....account import events as account_events
 from .....account import models
+from .....account.error_codes import AccountErrorCode
+from .....account.notifications import send_set_password_notification
+from .....account.search import prepare_user_search_document_value
+from .....core.tracing import traced_atomic_transaction
+from .....core.utils.url import prepare_url
 from .....permission.enums import AccountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.types import User
+from ....channel.utils import clean_channel, validate_channel
+from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError
 from ....core.utils import WebhookEventInfo
-from ..base import BaseCustomerCreate
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ..base import BILLING_ADDRESS_FIELD, SHIPPING_ADDRESS_FIELD, BaseCustomerCreate
 
 
 class CustomerCreate(BaseCustomerCreate):
@@ -38,3 +51,59 @@ class CustomerCreate(BaseCustomerCreate):
                 description="Setting a new password for the account is requested.",
             ),
         ]
+
+    @classmethod
+    @traced_atomic_transaction()
+    def save(cls, info: ResolveInfo, instance, cleaned_input):
+        default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
+        manager = get_plugin_manager_promise(info.context).get()
+        if default_shipping_address:
+            default_shipping_address.save()
+            instance.default_shipping_address = default_shipping_address
+        default_billing_address = cleaned_input.get(BILLING_ADDRESS_FIELD)
+        if default_billing_address:
+            default_billing_address.save()
+            instance.default_billing_address = default_billing_address
+
+        is_creation = instance.pk is None
+        super().save(info, instance, cleaned_input)
+        if default_billing_address:
+            instance.addresses.add(default_billing_address)
+        if default_shipping_address:
+            instance.addresses.add(default_shipping_address)
+
+        instance.search_document = prepare_user_search_document_value(instance)
+        instance.save(update_fields=["search_document", "updated_at"])
+
+        # The instance is a new object in db, create an event
+        if is_creation:
+            cls.call_event(manager.customer_created, instance)
+            account_events.customer_account_created_event(user=instance)
+        else:
+            cls.call_event(manager.customer_updated, instance)
+
+        if redirect_url := cleaned_input.get("redirect_url"):
+            channel_slug = cleaned_input.get("channel")
+            if not instance.is_staff:
+                channel_slug = clean_channel(
+                    channel_slug, error_class=AccountErrorCode, allow_replica=False
+                ).slug
+            elif channel_slug is not None:
+                channel_slug = validate_channel(
+                    channel_slug, error_class=AccountErrorCode
+                ).slug
+            send_set_password_notification(
+                redirect_url,
+                instance,
+                manager,
+                channel_slug,
+            )
+            token = default_token_generator.make_token(instance)
+            params = urlencode({"email": instance.email, "token": token})
+            cls.call_event(
+                manager.account_set_password_requested,
+                instance,
+                channel_slug,
+                token,
+                prepare_url(params, redirect_url),
+            )

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -1,12 +1,21 @@
+from urllib.parse import urlencode
+
+from django.contrib.auth.tokens import default_token_generator
+
 from .....account import events as account_events
 from .....account import models
+from .....account.notifications import send_set_password_notification
 from .....account.search import prepare_user_search_document_value
 from .....core.tracing import traced_atomic_transaction
+from .....core.utils.url import prepare_url
 from .....permission.enums import AccountPermissions
+from .....plugins.manager import PluginsManager
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.types import User
+from ....channel.utils import clean_channel, validate_channel
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
+from ....core.enums import AccountErrorCode
 from ....core.types import AccountError
 from ....core.utils import WebhookEventInfo
 from ....plugins.dataloaders import get_plugin_manager_promise
@@ -73,9 +82,46 @@ class CustomerCreate(BaseCustomerCreate):
         account_events.customer_account_created_event(user=instance)
 
         if redirect_url := cleaned_input.get("redirect_url"):
-            cls.process_account_confirmation(
+            cls._process_sending_password(
                 redirect_url=redirect_url,
                 instance=instance,
                 channel_slug_from_input=cleaned_input.get("channel"),
                 plugins_manager=manager,
             )
+
+    @classmethod
+    def _process_sending_password(
+        cls,
+        *,
+        redirect_url: str,
+        instance: models.User,
+        plugins_manager: PluginsManager,
+        channel_slug_from_input: str,
+    ):
+        channel_slug = channel_slug_from_input
+
+        if not instance.is_staff:
+            channel_slug = clean_channel(
+                channel_slug, error_class=AccountErrorCode, allow_replica=False
+            ).slug
+        elif channel_slug is not None:
+            channel_slug = validate_channel(
+                channel_slug, error_class=AccountErrorCode
+            ).slug
+
+        send_set_password_notification(
+            redirect_url,
+            instance,
+            plugins_manager,
+            channel_slug,
+        )
+        token = default_token_generator.make_token(instance)
+        params = urlencode({"email": instance.email, "token": token})
+
+        cls.call_event(
+            plugins_manager.account_set_password_requested,
+            instance,
+            channel_slug,
+            token,
+            prepare_url(params, redirect_url),
+        )

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -62,7 +62,7 @@ class CustomerCreate(BaseCustomerCreate):
             cleaned_input=cleaned_input, user_instance=instance
         )
 
-        super().save(info, instance, cleaned_input)
+        instance.save()
 
         if default_addresses["billing"]:
             instance.addresses.add(default_addresses["billing"])

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -58,19 +58,12 @@ class CustomerCreate(BaseCustomerCreate):
     def save(cls, info: ResolveInfo, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
 
-        default_addresses = cls.save_and_apply_addresses_from_input(
-            cleaned_input=cleaned_input, user_instance=instance
+        cls.save_default_addresses(
+            cleaned_input=cleaned_input, user_instance=instance, save_user=True
         )
 
-        instance.save()
-
-        if default_addresses["billing"]:
-            instance.addresses.add(default_addresses["billing"])
-        if default_addresses["shipping"]:
-            instance.addresses.add(default_addresses["shipping"])
-
         instance.search_document = prepare_user_search_document_value(instance)
-        instance.save()
+        instance.save(update_fields=["search_document"])
 
         cls.call_event(manager.customer_created, instance)
         account_events.customer_account_created_event(user=instance)

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -62,6 +62,8 @@ class CustomerCreate(BaseCustomerCreate):
             cleaned_input=cleaned_input, user_instance=instance
         )
 
+        instance.save()
+
         if default_addresses["billing"]:
             instance.addresses.add(default_addresses["billing"])
         if default_addresses["shipping"]:

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -62,15 +62,13 @@ class CustomerCreate(BaseCustomerCreate):
             cleaned_input=cleaned_input, user_instance=instance
         )
 
-        instance.save()
-
         if default_addresses["billing"]:
             instance.addresses.add(default_addresses["billing"])
         if default_addresses["shipping"]:
             instance.addresses.add(default_addresses["shipping"])
 
         instance.search_document = prepare_user_search_document_value(instance)
-        instance.save(update_fields=["search_document", "updated_at"])
+        instance.save()
 
         cls.call_event(manager.customer_created, instance)
         account_events.customer_account_created_event(user=instance)

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -19,7 +19,7 @@ from ....core.enums import AccountErrorCode
 from ....core.types import AccountError
 from ....core.utils import WebhookEventInfo
 from ....plugins.dataloaders import get_plugin_manager_promise
-from ..base import BILLING_ADDRESS_FIELD, SHIPPING_ADDRESS_FIELD, BaseCustomerCreate
+from ..base import BaseCustomerCreate
 
 
 class CustomerCreate(BaseCustomerCreate):
@@ -56,24 +56,18 @@ class CustomerCreate(BaseCustomerCreate):
     @classmethod
     @traced_atomic_transaction()
     def save(cls, info: ResolveInfo, instance, cleaned_input):
-        default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
         manager = get_plugin_manager_promise(info.context).get()
 
-        if default_shipping_address:
-            default_shipping_address.save()
-            instance.default_shipping_address = default_shipping_address
-
-        default_billing_address = cleaned_input.get(BILLING_ADDRESS_FIELD)
-
-        if default_billing_address:
-            default_billing_address.save()
-            instance.default_billing_address = default_billing_address
+        default_addresses = cls.save_and_apply_addresses_from_input(
+            cleaned_input=cleaned_input, user_instance=instance
+        )
 
         super().save(info, instance, cleaned_input)
-        if default_billing_address:
-            instance.addresses.add(default_billing_address)
-        if default_shipping_address:
-            instance.addresses.add(default_shipping_address)
+
+        if default_addresses["billing"]:
+            instance.addresses.add(default_addresses["billing"])
+        if default_addresses["shipping"]:
+            instance.addresses.add(default_addresses["shipping"])
 
         instance.search_document = prepare_user_search_document_value(instance)
         instance.save(update_fields=["search_document", "updated_at"])

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -65,7 +65,6 @@ class CustomerCreate(BaseCustomerCreate):
             default_billing_address.save()
             instance.default_billing_address = default_billing_address
 
-        is_creation = instance.pk is None
         super().save(info, instance, cleaned_input)
         if default_billing_address:
             instance.addresses.add(default_billing_address)
@@ -75,12 +74,8 @@ class CustomerCreate(BaseCustomerCreate):
         instance.search_document = prepare_user_search_document_value(instance)
         instance.save(update_fields=["search_document", "updated_at"])
 
-        # The instance is a new object in db, create an event
-        if is_creation:
-            cls.call_event(manager.customer_created, instance)
-            account_events.customer_account_created_event(user=instance)
-        else:
-            cls.call_event(manager.customer_updated, instance)
+        cls.call_event(manager.customer_created, instance)
+        account_events.customer_account_created_event(user=instance)
 
         if redirect_url := cleaned_input.get("redirect_url"):
             channel_slug = cleaned_input.get("channel")

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -1,10 +1,17 @@
 from copy import copy
+from urllib.parse import urlencode
 
 import graphene
+from django.contrib.auth.tokens import default_token_generator
 from django.db.models import QuerySet
 
 from .....account import events as account_events
 from .....account import models
+from .....account.error_codes import AccountErrorCode
+from .....account.notifications import send_set_password_notification
+from .....account.search import prepare_user_search_document_value
+from .....core.tracing import traced_atomic_transaction
+from .....core.utils.url import prepare_url
 from .....giftcard.search import mark_gift_cards_search_index_as_dirty
 from .....giftcard.utils import assign_user_gift_cards, get_user_gift_cards
 from .....order.utils import match_orders_with_new_user
@@ -12,6 +19,7 @@ from .....permission.enums import AccountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.types import User
 from ....app.dataloaders import get_app_promise
+from ....channel.utils import clean_channel, validate_channel
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import ModelWithExtRefMutation
@@ -19,7 +27,7 @@ from ....core.types import AccountError
 from ....core.utils import WebhookEventInfo
 from ....meta.inputs import MetadataInput
 from ....plugins.dataloaders import get_plugin_manager_promise
-from ..base import CustomerInput
+from ..base import BILLING_ADDRESS_FIELD, SHIPPING_ADDRESS_FIELD, CustomerInput
 from .customer_create import CustomerCreate
 
 
@@ -162,3 +170,59 @@ class CustomerUpdate(CustomerCreate, ModelWithExtRefMutation):
 
         # Return the response
         return cls.success_response(new_instance)
+
+    @classmethod
+    @traced_atomic_transaction()
+    def save(cls, info: ResolveInfo, instance, cleaned_input):
+        default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
+        manager = get_plugin_manager_promise(info.context).get()
+        if default_shipping_address:
+            default_shipping_address.save()
+            instance.default_shipping_address = default_shipping_address
+        default_billing_address = cleaned_input.get(BILLING_ADDRESS_FIELD)
+        if default_billing_address:
+            default_billing_address.save()
+            instance.default_billing_address = default_billing_address
+
+        is_creation = instance.pk is None
+        super().save(info, instance, cleaned_input)
+        if default_billing_address:
+            instance.addresses.add(default_billing_address)
+        if default_shipping_address:
+            instance.addresses.add(default_shipping_address)
+
+        instance.search_document = prepare_user_search_document_value(instance)
+        instance.save(update_fields=["search_document", "updated_at"])
+
+        # The instance is a new object in db, create an event
+        if is_creation:
+            cls.call_event(manager.customer_created, instance)
+            account_events.customer_account_created_event(user=instance)
+        else:
+            cls.call_event(manager.customer_updated, instance)
+
+        if redirect_url := cleaned_input.get("redirect_url"):
+            channel_slug = cleaned_input.get("channel")
+            if not instance.is_staff:
+                channel_slug = clean_channel(
+                    channel_slug, error_class=AccountErrorCode, allow_replica=False
+                ).slug
+            elif channel_slug is not None:
+                channel_slug = validate_channel(
+                    channel_slug, error_class=AccountErrorCode
+                ).slug
+            send_set_password_notification(
+                redirect_url,
+                instance,
+                manager,
+                channel_slug,
+            )
+            token = default_token_generator.make_token(instance)
+            params = urlencode({"email": instance.email, "token": token})
+            cls.call_event(
+                manager.account_set_password_requested,
+                instance,
+                channel_slug,
+                token,
+                prepare_url(params, redirect_url),
+            )

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -176,14 +176,12 @@ class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
             cleaned_input=cleaned_input, user_instance=instance
         )
 
-        instance.save()
-
         if default_addresses["billing"]:
             instance.addresses.add(default_addresses["billing"])
         if default_addresses["shipping"]:
             instance.addresses.add(default_addresses["shipping"])
 
         instance.search_document = prepare_user_search_document_value(instance)
-        instance.save(update_fields=["search_document", "updated_at"])
+        instance.save()
 
         cls.call_event(manager.customer_updated, instance)

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -176,7 +176,7 @@ class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
             cleaned_input=cleaned_input, user_instance=instance
         )
 
-        super().save(info, instance, cleaned_input)
+        instance.save()
 
         if default_addresses["billing"]:
             instance.addresses.add(default_addresses["billing"])

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -27,11 +27,15 @@ from ....core.types import AccountError
 from ....core.utils import WebhookEventInfo
 from ....meta.inputs import MetadataInput
 from ....plugins.dataloaders import get_plugin_manager_promise
-from ..base import BILLING_ADDRESS_FIELD, SHIPPING_ADDRESS_FIELD, CustomerInput
-from .customer_create import CustomerCreate
+from ..base import (
+    BILLING_ADDRESS_FIELD,
+    SHIPPING_ADDRESS_FIELD,
+    BaseCustomerCreate,
+    CustomerInput,
+)
 
 
-class CustomerUpdate(CustomerCreate, ModelWithExtRefMutation):
+class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
     class Arguments:
         id = graphene.ID(description="ID of a customer to update.", required=False)
         external_reference = graphene.String(

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -195,11 +195,3 @@ class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
         instance.save(update_fields=["search_document", "updated_at"])
 
         cls.call_event(manager.customer_updated, instance)
-
-        if redirect_url := cleaned_input.get("redirect_url"):
-            cls.process_account_confirmation(
-                redirect_url=redirect_url,
-                instance=instance,
-                channel_slug_from_input=cleaned_input.get("channel"),
-                plugins_manager=manager,
-            )

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -1,17 +1,12 @@
 from copy import copy
-from urllib.parse import urlencode
 
 import graphene
-from django.contrib.auth.tokens import default_token_generator
 from django.db.models import QuerySet
 
 from .....account import events as account_events
 from .....account import models
-from .....account.error_codes import AccountErrorCode
-from .....account.notifications import send_set_password_notification
 from .....account.search import prepare_user_search_document_value
 from .....core.tracing import traced_atomic_transaction
-from .....core.utils.url import prepare_url
 from .....giftcard.search import mark_gift_cards_search_index_as_dirty
 from .....giftcard.utils import assign_user_gift_cards, get_user_gift_cards
 from .....order.utils import match_orders_with_new_user
@@ -19,7 +14,6 @@ from .....permission.enums import AccountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.types import User
 from ....app.dataloaders import get_app_promise
-from ....channel.utils import clean_channel, validate_channel
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import ModelWithExtRefMutation
@@ -203,29 +197,9 @@ class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
         cls.call_event(manager.customer_updated, instance)
 
         if redirect_url := cleaned_input.get("redirect_url"):
-            channel_slug = cleaned_input.get("channel")
-            if not instance.is_staff:
-                channel_slug = clean_channel(
-                    channel_slug, error_class=AccountErrorCode, allow_replica=False
-                ).slug
-            elif channel_slug is not None:
-                channel_slug = validate_channel(
-                    channel_slug, error_class=AccountErrorCode
-                ).slug
-
-            send_set_password_notification(
-                redirect_url,
-                instance,
-                manager,
-                channel_slug,
-            )
-            token = default_token_generator.make_token(instance)
-            params = urlencode({"email": instance.email, "token": token})
-
-            cls.call_event(
-                manager.account_set_password_requested,
-                instance,
-                channel_slug,
-                token,
-                prepare_url(params, redirect_url),
+            cls.process_account_confirmation(
+                redirect_url=redirect_url,
+                instance=instance,
+                channel_slug_from_input=cleaned_input.get("channel"),
+                plugins_manager=manager,
             )

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -172,14 +172,9 @@ class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
     def save(cls, info: ResolveInfo, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
 
-        default_addresses = cls.save_and_apply_addresses_from_input(
-            cleaned_input=cleaned_input, user_instance=instance
+        cls.save_default_addresses(
+            cleaned_input=cleaned_input, user_instance=instance, save_user=False
         )
-
-        if default_addresses["billing"]:
-            instance.addresses.add(default_addresses["billing"])
-        if default_addresses["shipping"]:
-            instance.addresses.add(default_addresses["shipping"])
 
         instance.search_document = prepare_user_search_document_value(instance)
         instance.save()


### PR DESCRIPTION
I want to merge this change because it refactors derived classes from BaseCustomerCreate

Previously base class containes "save" method that needs to know about what is it's child classes, checking if it's either creation or updating operation

Now each child class has it's own `save` method implementation that is not shared

This change is also needed for upcoming fixes in these mutations

- [x] Verify if save() is called once
- [x] Refactor address management to shared logic

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
