### PR TITLE
`OrderUpdate` saving improvements

### DIFF
--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -82,10 +82,11 @@ class OrderUpdate(AddressMetadataMixin, ModelWithExtRefMutation, I18nMixin):
         )
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
-        update_fields = list(cleaned_input.keys())
+    def _save(cls, info: ResolveInfo, instance, cleaned_input, changed_fields):
+        update_fields = changed_fields
         with traced_atomic_transaction():
-            save_addresses(instance, cleaned_input)
+            address_fields = save_addresses(instance, cleaned_input)
+            update_fields.extend(address_fields)
 
             manager = get_plugin_manager_promise(info.context).get()
             if cls.should_invalidate_prices(cleaned_input):
@@ -98,13 +99,15 @@ class OrderUpdate(AddressMetadataMixin, ModelWithExtRefMutation, I18nMixin):
                 )
                 update_fields.extend(["updated_at", "search_vector"])
 
-            if update_fields:
                 instance.save(update_fields=update_fields)
-                call_order_event(
-                    manager,
-                    WebhookEventAsyncType.ORDER_UPDATED,
-                    instance,
-                )
+
+            # the webhhok is always called in 3.20 to not introduce a breaking change;
+            # the called will be skipped in 3.21 in case nothing has changed
+            call_order_event(
+                manager,
+                WebhookEventAsyncType.ORDER_UPDATED,
+                instance,
+            )
 
     @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
@@ -148,10 +151,17 @@ class OrderUpdate(AddressMetadataMixin, ModelWithExtRefMutation, I18nMixin):
         instance = cls.get_instance(info, **data)
         channel_id = cls.get_instance_channel_id(instance, **data)
         cls.check_channel_permissions(info, [channel_id])
+        old_instance_data = instance.serialize_for_comparison()
         data = data.get("input")
         cleaned_input = cls.clean_input(info, instance, data)
         instance = cls.construct_instance(instance, cleaned_input)
 
         cls.clean_instance(info, instance)
-        cls.save(info, instance, cleaned_input)
+        new_instance_data = instance.serialize_for_comparison()
+        changed_fields = cls.diff_instance_data_fields(
+            instance.comparison_fields,
+            old_instance_data,
+            new_instance_data,
+        )
+        cls._save(info, instance, cleaned_input, changed_fields)
         return cls.success_response(instance)


### PR DESCRIPTION
Use old and new instance comparison when saving data in `OrderUpdate` mutation

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
