### PR TITLE
Call `DRAFT_ORDER_CREATED` webhhok in `FulfillmentReturnProducts` in case the replace order is created

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -1956,6 +1956,10 @@ def create_fulfillments_for_returned_products(
         ).delete()
 
         call_order_event(manager, WebhookEventAsyncType.ORDER_UPDATED, order)
+        if new_order:
+            call_order_event(
+                manager, WebhookEventAsyncType.DRAFT_ORDER_CREATED, new_order
+            )
     return return_fulfillment, replace_fulfillment, new_order
 
 

--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -12,11 +12,13 @@ from ..fetch import OrderLineInfo
 from ..models import Fulfillment, FulfillmentLine
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -85,13 +87,16 @@ def test_create_return_fulfillment_only_order_lines(
     assert event_lines[1]["quantity"] == 2
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_refund(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -162,13 +167,16 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
     assert returned_fulfillment.shipping_refund_amount is None
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -245,13 +253,16 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     )
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_replace_request(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -377,13 +388,16 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
     assert replaced_line.tax_rate == expected_replaced_line.tax_rate
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_called_once_with(replace_order, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     fulfilled_order,
     payment_dummy_fully_charged,
     staff_user,
@@ -428,11 +442,13 @@ def test_create_return_fulfillment_only_fulfillment_lines(
     mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     fulfilled_order,
     payment_dummy_fully_charged,
     staff_user,
@@ -534,13 +550,16 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     assert replaced_line.tax_rate == expected_replaced_line.tax_rate
 
     mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
+    mocked_draft_order_created.assert_called_once_with(replace_order, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_with_lines_already_refunded(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     fulfilled_order,
     payment_dummy_fully_charged,
     staff_user,
@@ -644,13 +663,16 @@ def test_create_return_fulfillment_with_lines_already_refunded(
     assert returned_and_refunded_fulfillment.shipping_refund_amount is None
 
     mocked_order_updated.assert_called_once_with(fulfilled_order, webhooks=set())
+    mocked_draft_order_created.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_old_ids(
     mocked_refund,
     mocked_order_updated,
+    mocked_draft_order_created,
     order_with_lines,
     payment_dummy_fully_charged,
     staff_user,
@@ -721,3 +743,4 @@ def test_create_return_fulfillment_only_order_lines_with_old_ids(
     assert event_lines[1]["quantity"] == 2
 
     mocked_order_updated.assert_called_once_with(order_with_lines, webhooks=set())
+    mocked_draft_order_created.assert_not_called()


### PR DESCRIPTION
In case the `DraftOrder` is created as a result of `FulfillmentReturnProducts`mutation the `DRAFT_ORDER_CREATED` will be called.
The source of the draft order creation can be check in `order.origin` field. The `REISSUE` value suggest that order has be created as a replacement.

Port of https://github.com/saleor/saleor/pull/17501

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
