### PR TITLE
Remove channel to be required from request password reset mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ All notable, unreleased changes to this project will be documented in this file.
 - Dropped the deprecated "Stripe (Deprecated)" payment plugin. If your codebase refers to `mirumee.payments.stripe`, you will need to migrate to the supported plugin, `saleor.payments.stripe` - #17539 by @patrys
 - Change error codes related to user enumeration bad habbit. Included mutations will now not reveal information in error codes if email was already registered:
   - `AccountRegister`,
-    `AccountRegister` mutation will additionaly not return `ID` of the user.
   - `ConfirmAccount`,
   - `RequestPasswordReset`,
-    `RequestPasswordReset` will now require `channel` as input for staff users,
   - `SetPassword` - #16243 by @kadewu
+- `AccountRegister` mutation will not return `ID` of the user. - #16243 by @kadewu
+- `RequestPasswordReset` will not fail if `channel` was not provided for non-staff users. - #17540 by @kadewu
 - Require `MANAGE_ORDERS` for updating order and order line metadata - #17223 by @IKarbowiak
   - The `updateMetadata` for `Order` and `OrderLine` types requires the `MANAGE_ORDERS` permission
 - Fix updating `metadata` and `privateMetadata` in `transactionUpdate` - #17261 by @IKarbowiak

--- a/saleor/account/tasks.py
+++ b/saleor/account/tasks.py
@@ -1,3 +1,4 @@
+import logging
 from typing import cast
 from urllib.parse import urlencode
 
@@ -15,6 +16,8 @@ from .models import User
 from .notifications import send_password_reset_notification
 from .utils import RequestorAwareContext
 
+logger = logging.getLogger(__name__)
+
 
 def _prepare_redirect_url(user: User, redirect_url: str, token: str) -> str:
     params = urlencode({"email": user.email, "token": token})
@@ -31,6 +34,12 @@ def trigger_send_password_reset_notification(
 
     user = User.objects.filter(pk=user_pk).first()
     user = cast(User, user)
+
+    if not channel_slug and not user.is_staff:
+        logger.warning(
+            "Channel slug was not provided for user %s in request password reset.",
+            user_pk,
+        )
 
     context_data["allow_replica"] = True
     manager = get_plugin_manager_promise(

--- a/saleor/graphql/account/mutations/authentication/request_password_reset.py
+++ b/saleor/graphql/account/mutations/authentication/request_password_reset.py
@@ -8,7 +8,7 @@ from .....account.tasks import trigger_send_password_reset_notification
 from .....account.utils import RequestorAwareContext, retrieve_user_by_email
 from .....core.utils.url import validate_storefront_url
 from .....webhook.event_types import WebhookEventAsyncType
-from ....channel.utils import clean_channel, validate_channel
+from ....channel.utils import validate_channel
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import BaseMutation
@@ -30,7 +30,11 @@ class RequestPasswordReset(BaseMutation):
             ),
         )
         channel = graphene.String(
-            description="Slug of a channel which will be used for notify user."
+            description=(
+                "Slug of a channel which will be used for notify user. "
+                "It is needed for customers, if not provided the notify may not happen. "
+                "Please note that mutation will not fail if the channel is not provided. "
+            )
         )
 
     class Meta:
@@ -79,12 +83,10 @@ class RequestPasswordReset(BaseMutation):
         email = data["email"]
         redirect_url = data["redirect_url"]
         user = cls.clean_user(email, redirect_url)
-        channel_slug = data.get("channel")
+        channel = data.get("channel")
 
-        channel_slug = clean_channel(
-            channel_slug, error_class=AccountErrorCode, allow_replica=False
-        ).slug
-        channel_slug = validate_channel(channel_slug, error_class=AccountErrorCode).slug
+        if channel:
+            channel_slug = validate_channel(channel, error_class=AccountErrorCode).slug
 
         trigger_send_password_reset_notification.delay(
             redirect_url=redirect_url,

--- a/saleor/graphql/account/mutations/authentication/request_password_reset.py
+++ b/saleor/graphql/account/mutations/authentication/request_password_reset.py
@@ -8,7 +8,7 @@ from .....account.tasks import trigger_send_password_reset_notification
 from .....account.utils import RequestorAwareContext, retrieve_user_by_email
 from .....core.utils.url import validate_storefront_url
 from .....webhook.event_types import WebhookEventAsyncType
-from ....channel.utils import validate_channel
+from ....channel.utils import clean_channel
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import BaseMutation
@@ -31,8 +31,8 @@ class RequestPasswordReset(BaseMutation):
         )
         channel = graphene.String(
             description=(
-                "Slug of a channel which will be used for notify user. "
-                "It is needed for customers, if not provided the notify may not happen. "
+                "Slug of a channel which will be used to notify the user. "
+                "It is needed for customers, if not provided, the notification may not happen. "
                 "Please note that mutation will not fail if the channel is not provided. "
             )
         )
@@ -85,10 +85,16 @@ class RequestPasswordReset(BaseMutation):
         user = cls.clean_user(email, redirect_url)
         channel = data.get("channel")
 
-        if channel:
-            channel_slug = validate_channel(channel, error_class=AccountErrorCode).slug
-        else:
-            channel_slug = ""
+        # Catching exception for backwards compatibility
+        # Previously channel_slug was validated and error returner, we don't want to
+        # return error to end user to prevent user enumeration.
+        # Exception catching should be removed after logic for default_channel is removed
+        try:
+            channel_slug = clean_channel(
+                channel, error_class=AccountErrorCode, allow_replica=False
+            ).slug
+        except ValidationError:
+            channel_slug = None
 
         trigger_send_password_reset_notification.delay(
             redirect_url=redirect_url,

--- a/saleor/graphql/account/mutations/authentication/request_password_reset.py
+++ b/saleor/graphql/account/mutations/authentication/request_password_reset.py
@@ -87,6 +87,8 @@ class RequestPasswordReset(BaseMutation):
 
         if channel:
             channel_slug = validate_channel(channel, error_class=AccountErrorCode).slug
+        else:
+            channel_slug = ""
 
         trigger_send_password_reset_notification.delay(
             redirect_url=redirect_url,

--- a/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
@@ -471,3 +471,64 @@ def test_account_reset_password_for_not_confirmed_user(
     mocked_account_set_password_requested.assert_called_once_with(
         user, channel_PLN.slug, token, reset_url
     )
+
+
+@freeze_time("2018-05-31 12:00:01")
+@patch("saleor.plugins.manager.PluginsManager.notify")
+@patch("saleor.plugins.manager.PluginsManager.account_set_password_requested")
+@patch("saleor.account.tasks.logger.warning")
+def test_account_reset_password_no_channel_provided(
+    mocked_logger_warning,
+    mocked_account_set_password_requested,
+    mocked_notify,
+    api_client,
+    customer_user,
+    channel_PLN,
+    site_settings,
+):
+    # given
+    redirect_url = "https://www.example.com"
+    variables = {
+        "email": customer_user.email,
+        "redirectUrl": redirect_url,
+    }
+
+    # when
+    response = api_client.post_graphql(REQUEST_PASSWORD_RESET_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["requestPasswordReset"]
+    assert not data["errors"]
+    token = default_token_generator.make_token(customer_user)
+    params = urlencode({"email": customer_user.email, "token": token})
+    reset_url = prepare_url(params, redirect_url)
+    expected_payload = {
+        "user": get_default_user_payload(customer_user),
+        "reset_url": reset_url,
+        "token": token,
+        "recipient_email": customer_user.email,
+        "channel_slug": "",
+        **get_site_context_payload(site_settings.site),
+    }
+
+    assert mocked_notify.call_count == 1
+    call_args = mocked_notify.call_args_list[0]
+    called_args = call_args.args
+    called_kwargs = call_args.kwargs
+    assert called_args[0] == NotifyEventType.ACCOUNT_PASSWORD_RESET
+    assert len(called_kwargs) == 2
+    assert called_kwargs["payload_func"]() == expected_payload
+    assert called_kwargs["channel_slug"] == ""
+
+    customer_user.refresh_from_db()
+    assert customer_user.last_password_reset_request == timezone.now()
+
+    mocked_account_set_password_requested.assert_called_once_with(
+        customer_user, "", token, reset_url
+    )
+
+    mocked_logger_warning.assert_called_once_with(
+        "Channel slug was not provided for user %s in request password reset.",
+        customer_user.pk,
+    )

--- a/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
@@ -477,13 +477,14 @@ def test_account_reset_password_for_not_confirmed_user(
 @patch("saleor.plugins.manager.PluginsManager.notify")
 @patch("saleor.plugins.manager.PluginsManager.account_set_password_requested")
 @patch("saleor.account.tasks.logger.warning")
-def test_account_reset_password_no_channel_provided(
+def test_account_reset_password_no_channel_provided_multiple_channels(
     mocked_logger_warning,
     mocked_account_set_password_requested,
     mocked_notify,
     api_client,
     customer_user,
     channel_PLN,
+    channel_USD,
     site_settings,
 ):
     # given
@@ -508,7 +509,7 @@ def test_account_reset_password_no_channel_provided(
         "reset_url": reset_url,
         "token": token,
         "recipient_email": customer_user.email,
-        "channel_slug": "",
+        "channel_slug": None,
         **get_site_context_payload(site_settings.site),
     }
 
@@ -519,16 +520,74 @@ def test_account_reset_password_no_channel_provided(
     assert called_args[0] == NotifyEventType.ACCOUNT_PASSWORD_RESET
     assert len(called_kwargs) == 2
     assert called_kwargs["payload_func"]() == expected_payload
-    assert called_kwargs["channel_slug"] == ""
+    assert called_kwargs["channel_slug"] is None
 
     customer_user.refresh_from_db()
     assert customer_user.last_password_reset_request == timezone.now()
 
     mocked_account_set_password_requested.assert_called_once_with(
-        customer_user, "", token, reset_url
+        customer_user, None, token, reset_url
     )
 
     mocked_logger_warning.assert_called_once_with(
         "Channel slug was not provided for user %s in request password reset.",
         customer_user.pk,
     )
+
+
+@freeze_time("2018-05-31 12:00:01")
+@patch("saleor.plugins.manager.PluginsManager.notify")
+@patch("saleor.plugins.manager.PluginsManager.account_set_password_requested")
+@patch("saleor.account.tasks.logger.warning")
+def test_account_reset_password_no_channel_provided_one_channel(
+    mocked_logger_warning,
+    mocked_account_set_password_requested,
+    mocked_notify,
+    api_client,
+    customer_user,
+    channel_USD,
+    site_settings,
+):
+    # given
+    redirect_url = "https://www.example.com"
+    variables = {
+        "email": customer_user.email,
+        "redirectUrl": redirect_url,
+    }
+
+    # when
+    response = api_client.post_graphql(REQUEST_PASSWORD_RESET_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["requestPasswordReset"]
+    assert not data["errors"]
+    token = default_token_generator.make_token(customer_user)
+    params = urlencode({"email": customer_user.email, "token": token})
+    reset_url = prepare_url(params, redirect_url)
+    expected_payload = {
+        "user": get_default_user_payload(customer_user),
+        "reset_url": reset_url,
+        "token": token,
+        "recipient_email": customer_user.email,
+        "channel_slug": channel_USD.slug,
+        **get_site_context_payload(site_settings.site),
+    }
+
+    assert mocked_notify.call_count == 1
+    call_args = mocked_notify.call_args_list[0]
+    called_args = call_args.args
+    called_kwargs = call_args.kwargs
+    assert called_args[0] == NotifyEventType.ACCOUNT_PASSWORD_RESET
+    assert len(called_kwargs) == 2
+    assert called_kwargs["payload_func"]() == expected_payload
+    assert called_kwargs["channel_slug"] == channel_USD.slug
+
+    customer_user.refresh_from_db()
+    assert customer_user.last_password_reset_request == timezone.now()
+
+    mocked_account_set_password_requested.assert_called_once_with(
+        customer_user, channel_USD.slug, token, reset_url
+    )
+
+    mocked_logger_warning.assert_not_called()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18159,7 +18159,7 @@ type Mutation {
   """
   requestPasswordReset(
     """
-    Slug of a channel which will be used for notify user. It is needed for customers, if not provided the notify may not happen. Please note that mutation will not fail if the channel is not provided.
+    Slug of a channel which will be used to notify the user. It is needed for customers, if not provided, the notification may not happen. Please note that mutation will not fail if the channel is not provided.
     """
     channel: String
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18158,7 +18158,9 @@ type Mutation {
   - STAFF_SET_PASSWORD_REQUESTED (async): Setting a new password for the staff account is requested.
   """
   requestPasswordReset(
-    """Slug of a channel which will be used for notify user."""
+    """
+    Slug of a channel which will be used for notify user. It is needed for customers, if not provided the notify may not happen. Please note that mutation will not fail if the channel is not provided.
+    """
     channel: String
 
     """Email of the user that will be used for password recovery."""


### PR DESCRIPTION
Remove channel to be required from request password reset mutation
This way we will not introduce breaking change in upcoming new Saleor version
Logging was added to delegated celery task responsible for handling user processing, in case channel slug is missing for nonstaff users.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
