### PR TITLE
Fix flaky test in export

### DIFF
--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -332,13 +332,13 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     product_page_ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
         reference_page=page_list[0],
-        slug=f"{product.pk}_{page_list[0].pk}",
+        slug=f"product_{product.pk}_page_{page_list[0].pk}",
         name=page_list[0].title,
     )
     variant_page_ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
         reference_page=page_list[1],
-        slug=f"{variant_with_many_stocks.pk}_{page_list[1].pk}",
+        slug=f"variant_{variant_with_many_stocks.pk}_page_{page_list[1].pk}",
         name=page_list[1].title,
     )
     associate_attribute_values_to_instance(
@@ -354,15 +354,15 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
         attribute=product_type_product_reference_attribute,
         reference_product=product_with_variant_with_two_attributes,
         slug=(
-            f"{variant_with_many_stocks.pk}"
-            f"_{product_with_variant_with_two_attributes.pk}"
+            f"variant_{variant_with_many_stocks.pk}"
+            f"_product_{product_with_variant_with_two_attributes.pk}"
         ),
         name=product_with_variant_with_two_attributes.name,
     )
     product_product_ref_value = AttributeValue.objects.create(
         attribute=product_type_product_reference_attribute,
         reference_product=product_with_image,
-        slug=f"{product.pk}_{product_with_image.pk}",
+        slug=f"product_{product.pk}_product_{product_with_image.pk}",
         name=product_with_image.name,
     )
     associate_attribute_values_to_instance(
@@ -378,13 +378,13 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     variant_variant_ref_value = AttributeValue.objects.create(
         attribute=product_type_variant_reference_attribute,
         reference_variant=variant,
-        slug=(f"{variant_with_many_stocks.pk}_{variant.pk}"),
+        slug=(f"variant_{variant_with_many_stocks.pk}_variant_{variant.pk}"),
         name=variant.name,
     )
     product_variant_ref_value = AttributeValue.objects.create(
         attribute=product_type_variant_reference_attribute,
         reference_variant=variant,
-        slug=f"{product.pk}_{variant.pk}",
+        slug=f"product_{product.pk}_variant_{variant.pk}",
         name=variant.name,
     )
     associate_attribute_values_to_instance(

--- a/saleor/csv/tests/export/products_data/test_handle_relations_data.py
+++ b/saleor/csv/tests/export/products_data/test_handle_relations_data.py
@@ -177,7 +177,7 @@ def test_prepare_products_relations_data(
     ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
         reference_page=page,
-        slug=f"{product_with_image.pk}_{page.pk}",
+        slug=f"product_{product_with_image.pk}_page_{page.pk}",
         name=page.title,
         date_time=None,
     )
@@ -568,7 +568,7 @@ def test_prepare_variants_relations_data(
     page_ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
         reference_page=page,
-        slug=f"{variant.pk}_{page.pk}",
+        slug=f"variant_{variant.pk}_page_{page.pk}",
         name=page.title,
     )
     associate_attribute_values_to_instance(
@@ -579,7 +579,7 @@ def test_prepare_variants_relations_data(
     product_ref_value = AttributeValue.objects.create(
         attribute=product_type_product_reference_attribute,
         reference_product=product,
-        slug=f"{variant.pk}_{product.pk}",
+        slug=f"variant_{variant.pk}_page_{product.pk}",
         name=product.name,
     )
     associate_attribute_values_to_instance(

--- a/saleor/csv/tests/export/products_data/utils.py
+++ b/saleor/csv/tests/export/products_data/utils.py
@@ -66,7 +66,7 @@ def get_attribute_value(attribute, value_instance):
     if attribute.input_type == AttributeInputType.FILE:
         value = "http://mirumee.com/media/" + value_instance.file_url
     elif attribute.input_type == AttributeInputType.REFERENCE:
-        ref_id = value_instance.slug.split("_")[1]
+        ref_id = value_instance.slug.split("_")[3]
         value = f"{attribute.entity_type}_{ref_id}"
     elif attribute.input_type == AttributeInputType.NUMERIC:
         value = f"{value_instance.name}"


### PR DESCRIPTION
I want to merge this change because it fixes a flaky test. 

In test `test_get_products_data_for_specified_warehouses_channels_and_attributes`, we could get a situation when Saleor tries to create `AttributeValue` with a duplicated slug. 

Assumptions: 
product.pk = 1
page_list[0].pk = 1
variant.pk = 1

Originally, the test tried to create `AttributeValue` for these objects. In both cases, slug is duplicated `1_1`.
```python
    product_page_ref_value = AttributeValue.objects.create(
        attribute=product_type_page_reference_attribute,
        reference_page=page_list[0],
        slug=f"{product.pk}_{page_list[0].pk}",
        name=page_list[0].title,
    )
    ...
    product_variant_ref_value = AttributeValue.objects.create(
        attribute=product_type_variant_reference_attribute,
        reference_variant=variant,
        slug=f"{product.pk}_{variant.pk}",
        name=variant.name,
    )
```

In the new solution, we add a prefix before `pk` for slug generation.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
