### PR TITLE
Remove information about specific version of removing WebhookPlugin

### DIFF
--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -160,7 +160,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an account
     # is confirmed.
     #
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     account_confirmed: Callable[["User", None], None]
 
@@ -169,7 +169,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an account
     # confirmation is requested.
     #
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     account_confirmation_requested: Callable[["User", str, str, str | None, None], None]
 
@@ -178,7 +178,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an account
     # change email is requested.
     #
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     account_change_email_requested: Callable[["User", str, str, str, str, None], None]
 
@@ -187,7 +187,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an account
     # set password is requested.
     #
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     account_set_password_requested: Callable[["User", str, str, str, None], None]
 
@@ -196,7 +196,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an account
     # delete is confirmed.
     #
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     account_deleted: Callable[["User", None], None]
 
@@ -205,7 +205,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an account
     # email is changed.
     #
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     account_email_changed: Callable[["User", None], None]
 
@@ -214,7 +214,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an account
     # delete is requested.
     #
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     account_delete_requested: Callable[["User", str, str, str, None], None]
 
@@ -223,7 +223,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an address is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     address_created: Callable[["Address", None], None]
 
@@ -231,7 +231,7 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after an address is
     # deleted.
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     address_deleted: Callable[["Address", None], None]
 
@@ -239,7 +239,7 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after an address is
     # updated.
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     address_updated: Callable[["Address", None], None]
 
@@ -248,7 +248,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an app is
     # installed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     app_installed: Callable[["App", None], None]
 
@@ -257,7 +257,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an app is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     app_deleted: Callable[["App", None], None]
 
@@ -266,7 +266,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an app is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     app_updated: Callable[["App", None], None]
 
@@ -275,7 +275,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an app
     # status is changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     app_status_changed: Callable[["App", None], None]
 
@@ -284,7 +284,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an attribute is
     # installed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_created: Callable[["Attribute", None, None], None]
 
@@ -293,7 +293,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an attribute is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_deleted: Callable[["Attribute", None, None], None]
 
@@ -302,7 +302,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an attribute is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_updated: Callable[["Attribute", None, None], None]
 
@@ -311,7 +311,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an attribute
     # value is installed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_value_created: Callable[["AttributeValue", None], None]
 
@@ -320,7 +320,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an attribute
     # value is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_value_deleted: Callable[["AttributeValue", None, None], None]
 
@@ -329,7 +329,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an attribute
     # value is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     attribute_value_updated: Callable[["AttributeValue", None], None]
 
@@ -448,7 +448,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a category is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     category_created: Callable[["Category", None], None]
 
@@ -457,7 +457,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a category is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     category_deleted: Callable[["Category", None, None], None]
 
@@ -466,7 +466,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a category is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     category_updated: Callable[["Category", None], None]
 
@@ -475,7 +475,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a channel is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     channel_created: Callable[["Channel", None], None]
 
@@ -484,7 +484,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a channel is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     channel_deleted: Callable[["Channel", None], None]
 
@@ -493,7 +493,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a channel is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     channel_updated: Callable[["Channel", None, None], None]
 
@@ -502,7 +502,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a channel
     # status is changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     channel_status_changed: Callable[["Channel", None], None]
 
@@ -511,7 +511,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a channel
     # metadata is changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     channel_metadata_updated: Callable[["Channel", None], None]
 
@@ -523,7 +523,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a checkout is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_created: Callable[["Checkout", Any, None], Any]
 
@@ -532,7 +532,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a checkout is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_updated: Callable[["Checkout", Any, None], Any]
 
@@ -541,7 +541,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a checkout is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_fully_paid: Callable[["Checkout", Any, None], Any]
 
@@ -550,7 +550,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a checkout
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_metadata_updated: Callable[["Checkout", Any, None], Any]
 
@@ -559,7 +559,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a collection is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     collection_created: Callable[["Collection", Any], Any]
 
@@ -568,7 +568,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a collection is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     collection_deleted: Callable[["Collection", Any, None], Any]
 
@@ -577,7 +577,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a collection is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     collection_updated: Callable[["Collection", Any], Any]
 
@@ -586,7 +586,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a collection
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     collection_metadata_updated: Callable[["Collection", Any], Any]
 
@@ -597,7 +597,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a user is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     customer_created: Callable[["User", Any], Any]
 
@@ -606,7 +606,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a user is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     customer_deleted: Callable[["User", Any, None], Any]
 
@@ -615,7 +615,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a user is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     customer_updated: Callable[["User", Any, None], Any]
 
@@ -624,7 +624,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a user
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     customer_metadata_updated: Callable[["User", Any, None], Any]
 
@@ -666,7 +666,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a fulfillment is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_created: Callable[["Fulfillment", bool, Any], Any]
 
@@ -675,7 +675,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a fulfillment is
     # cancelled.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_canceled: Callable[["Fulfillment", Any], Any]
 
@@ -684,7 +684,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a fulfillment is
     # approved.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_approved: Callable[["Fulfillment", Any], Any]
 
@@ -693,7 +693,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a fulfillment
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     fulfillment_metadata_updated: Callable[["Fulfillment", Any], Any]
 
@@ -718,14 +718,14 @@ class BasePlugin:
         Any,
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     get_taxes_for_checkout: Callable[
         ["CheckoutInfo", list["CheckoutLineInfo"], str, Any, dict | None],
         Optional["TaxData"],
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     get_taxes_for_order: Callable[["Order", str, Any], Optional["TaxData"]]
 
@@ -739,7 +739,7 @@ class BasePlugin:
     get_order_shipping_tax_rate: Callable[["Order", Any], Any]
     get_payment_config: Callable[[Any], Any]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     get_shipping_methods_for_checkout: Callable[
         ["Checkout", Any], list["ShippingMethodData"]
@@ -769,7 +769,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a gift card is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_created: Callable[["GiftCard", None, None], None]
 
@@ -778,7 +778,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a gift card is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_deleted: Callable[["GiftCard", None, None], None]
 
@@ -787,7 +787,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a gift card is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_updated: Callable[["GiftCard", None], None]
 
@@ -796,7 +796,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a gift card
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_metadata_updated: Callable[["GiftCard", None], None]
 
@@ -805,7 +805,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a gift card
     # status is changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_status_changed: Callable[["GiftCard", None, None], None]
 
@@ -814,7 +814,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a gift cards
     # export is completed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     gift_card_export_completed: Callable[["ExportFile", None], None]
 
@@ -823,7 +823,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an order is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     draft_order_created: Callable[["Order", Any, None], Any]
 
@@ -832,7 +832,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     draft_order_updated: Callable[["Order", Any, None], Any]
 
@@ -841,7 +841,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     draft_order_deleted: Callable[["Order", Any, None], Any]
 
@@ -854,7 +854,7 @@ class BasePlugin:
     # Perform any extra logic before the invoice gets deleted.
     # Note there is no need to run invoice.delete() as it will happen in mutation.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     invoice_delete: Callable[["Invoice", Any], Any]
 
@@ -867,20 +867,20 @@ class BasePlugin:
 
     # Trigger after invoice is sent.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     invoice_sent: Callable[["Invoice", str, Any], Any]
 
     list_payment_sources: Callable[[str, Any], list["CustomerSource"]]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     list_stored_payment_methods: Callable[
         ["ListStoredPaymentMethodsRequestData", list["PaymentMethodData"]],
         list["PaymentMethodData"],
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     stored_payment_method_request_delete: Callable[
         [
@@ -890,7 +890,7 @@ class BasePlugin:
         "StoredPaymentMethodRequestDeleteResponseData",
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     payment_gateway_initialize_tokenization: Callable[
         [
@@ -900,7 +900,7 @@ class BasePlugin:
         "PaymentGatewayInitializeTokenizationResponseData",
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     payment_method_initialize_tokenization: Callable[
         [
@@ -910,7 +910,7 @@ class BasePlugin:
         "PaymentMethodTokenizationResponseData",
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     payment_method_process_tokenization: Callable[
         [
@@ -925,7 +925,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a menu is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     menu_created: Callable[["Menu", None], None]
 
@@ -934,7 +934,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a menu is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     menu_deleted: Callable[["Menu", None, None], None]
 
@@ -943,7 +943,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a menu is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     menu_updated: Callable[["Menu", None], None]
 
@@ -952,7 +952,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a menu item is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     menu_item_created: Callable[["MenuItem", None], None]
 
@@ -961,7 +961,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a menu item is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     menu_item_deleted: Callable[["MenuItem", None, None], None]
 
@@ -970,7 +970,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a menu item is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     menu_item_updated: Callable[["MenuItem", None], None]
 
@@ -984,7 +984,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # canceled.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_cancelled: Callable[["Order", Any, None], Any]
 
@@ -993,7 +993,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # expired.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_expired: Callable[["Order", Any, None], Any]
 
@@ -1008,7 +1008,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after an order is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_created: Callable[["Order", Any, None], Any]
 
@@ -1017,7 +1017,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # fulfilled.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_fulfilled: Callable[["Order", Any, None], Any]
 
@@ -1026,7 +1026,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # fully paid.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_fully_paid: Callable[["Order", Any, None], Any]
 
@@ -1035,7 +1035,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # received the payment.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_paid: Callable[["Order", Any, None], Any]
 
@@ -1044,7 +1044,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # refunded.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_refunded: Callable[["Order", Any, None], Any]
 
@@ -1053,7 +1053,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # fully refunded.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_fully_refunded: Callable[["Order", Any, None], Any]
 
@@ -1062,7 +1062,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order is
     # changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_updated: Callable[["Order", Any, None], Any]
 
@@ -1071,7 +1071,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order
     # metadata is changed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_metadata_updated: Callable[["Order", Any, None], Any]
 
@@ -1080,7 +1080,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when an order
     # is imported.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     order_bulk_created: Callable[[list["Order"], Any], Any]
 
@@ -1089,7 +1089,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a page is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     page_created: Callable[["Page", Any], Any]
 
@@ -1098,7 +1098,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a page is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     page_deleted: Callable[["Page", Any], Any]
 
@@ -1107,7 +1107,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a page is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     page_updated: Callable[["Page", Any], Any]
 
@@ -1116,7 +1116,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a page type is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     page_type_created: Callable[["PageType", Any], Any]
 
@@ -1125,7 +1125,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a page type is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     page_type_deleted: Callable[["PageType", Any, None], Any]
 
@@ -1134,7 +1134,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a page type is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     page_type_updated: Callable[["PageType", Any], Any]
 
@@ -1143,7 +1143,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a permission
     # group is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     permission_group_created: Callable[["Group", Any], Any]
 
@@ -1152,7 +1152,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a permission
     # group is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     permission_group_deleted: Callable[["Group", Any], Any]
 
@@ -1161,7 +1161,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a permission
     # group is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     permission_group_updated: Callable[["Group", Any], Any]
 
@@ -1180,19 +1180,19 @@ class BasePlugin:
 
     process_payment: Callable[["PaymentData", Any], Any]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_charge_requested: Callable[["TransactionActionData", None], None]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_cancelation_requested: Callable[["TransactionActionData", None], None]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_refund_requested: Callable[["TransactionActionData", None], None]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     payment_gateway_initialize_session: Callable[
         [
@@ -1204,13 +1204,13 @@ class BasePlugin:
         list["PaymentGatewayData"],
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_initialize_session: Callable[
         ["TransactionSessionData", None], "TransactionSessionResult"
     ]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_process_session: Callable[
         ["TransactionSessionData", None], "TransactionSessionResult"
@@ -1221,7 +1221,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a transaction
     # item metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_item_metadata_updated: Callable[["TransactionItem", Any], Any]
 
@@ -1230,7 +1230,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a transaction
     # item metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     translations_created: Callable[[list["Translation"], None, None], Any]
 
@@ -1239,7 +1239,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic when a transaction
     # item metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     translations_updated: Callable[[list["Translation"], None, None], Any]
 
@@ -1248,7 +1248,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_created: Callable[["Product", Any, None], Any]
 
@@ -1257,7 +1257,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_deleted: Callable[["Product", list[int], Any, None], Any]
 
@@ -1266,7 +1266,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_updated: Callable[["Product", Any, None], Any]
 
@@ -1275,7 +1275,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product media
     # is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_media_created: Callable[["ProductMedia", Any], Any]
 
@@ -1284,7 +1284,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product media
     # is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_media_updated: Callable[["ProductMedia", Any], Any]
 
@@ -1293,7 +1293,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product media
     # is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_media_deleted: Callable[["ProductMedia", Any], Any]
 
@@ -1302,7 +1302,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_metadata_updated: Callable[["Product", Any], Any]
 
@@ -1311,7 +1311,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_created: Callable[["ProductVariant", Any, None], Any]
 
@@ -1320,7 +1320,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_deleted: Callable[["ProductVariant", Any, None], Any]
 
@@ -1329,7 +1329,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_updated: Callable[["ProductVariant", Any, None], Any]
 
@@ -1338,7 +1338,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # variant metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_metadata_updated: Callable[["ProductVariant", Any], Any]
 
@@ -1347,7 +1347,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is out of stock.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_out_of_stock: Callable[["Stock", None, None], Any]
 
@@ -1356,7 +1356,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # variant is back in stock.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_back_in_stock: Callable[["Stock", None, None], Any]
 
@@ -1365,7 +1365,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # variant stock is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_variant_stocks_updated: Callable[[list["Stock"], None, None], Any]
 
@@ -1374,7 +1374,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a product
     # export is completed.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     product_export_completed: Callable[["ExportFile", None], None]
 
@@ -1384,7 +1384,7 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after sale is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     sale_created: Callable[["Promotion", defaultdict[str, set[str]], Any], Any]
 
@@ -1393,7 +1393,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a sale is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     sale_deleted: Callable[["Promotion", defaultdict[str, set[str]], Any], Any]
 
@@ -1402,7 +1402,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a sale is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     sale_updated: Callable[
         ["Promotion", defaultdict[str, set[str]], defaultdict[str, set[str]], Any], Any
@@ -1413,7 +1413,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after promotion
     # is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_created: Callable[["Promotion", Any], Any]
 
@@ -1422,7 +1422,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_deleted: Callable[["Promotion", Any, None], Any]
 
@@ -1431,7 +1431,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_updated: Callable[["Promotion", Any], Any]
 
@@ -1440,7 +1440,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is started.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_started: Callable[["Promotion", Any], Any]
 
@@ -1449,7 +1449,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a promotion is ended.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_ended: Callable[["Promotion", Any], Any]
 
@@ -1458,7 +1458,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a promotion rule is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_rule_created: Callable[["PromotionRule", Any], Any]
 
@@ -1467,7 +1467,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a promotion rule is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_rule_deleted: Callable[["PromotionRule", Any], Any]
 
@@ -1476,7 +1476,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a promotion rule is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     promotion_rule_updated: Callable[["PromotionRule", Any], Any]
 
@@ -1485,7 +1485,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shipping
     # price is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_price_created: Callable[["ShippingMethod", None], None]
 
@@ -1494,7 +1494,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shipping
     # price is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_price_deleted: Callable[["ShippingMethod", None, None], None]
 
@@ -1503,7 +1503,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shipping
     # price is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_price_updated: Callable[["ShippingMethod", None], None]
 
@@ -1512,7 +1512,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # is created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_created: Callable[["ShippingZone", None], None]
 
@@ -1521,7 +1521,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # is deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_deleted: Callable[["ShippingZone", None, None], None]
 
@@ -1530,7 +1530,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_updated: Callable[["ShippingZone", None], None]
 
@@ -1539,7 +1539,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shipping zone
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shipping_zone_metadata_updated: Callable[["ShippingZone", None], None]
 
@@ -1548,7 +1548,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a staff user is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     staff_created: Callable[["User", Any], Any]
 
@@ -1557,7 +1557,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a staff user is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     staff_updated: Callable[["User", Any], Any]
 
@@ -1566,7 +1566,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a staff user is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     staff_deleted: Callable[["User", Any, None], Any]
 
@@ -1575,13 +1575,13 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after set
     # password for staff is requested.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     staff_set_password_requested: Callable[["User", str, str, str, None], None]
 
     # Trigger when thumbnail is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     thumbnail_created: Callable[["Thumbnail", Any], Any]
 
@@ -1595,7 +1595,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a warehouse is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_created: Callable[["Warehouse", None], None]
 
@@ -1604,7 +1604,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a warehouse is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_deleted: Callable[["Warehouse", None], None]
 
@@ -1613,7 +1613,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a warehouse is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_updated: Callable[["Warehouse", None], None]
 
@@ -1622,7 +1622,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a warehouse
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     warehouse_metadata_updated: Callable[["Warehouse", None], None]
 
@@ -1631,7 +1631,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a voucher is
     # created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_created: Callable[["Voucher", str, None], None]
 
@@ -1640,7 +1640,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a voucher is
     # deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_deleted: Callable[["Voucher", str, None, None], None]
 
@@ -1649,7 +1649,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a voucher is
     # updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_updated: Callable[["Voucher", str, None], None]
 
@@ -1658,7 +1658,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after voucher codes
     # are created.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_codes_created: Callable[[list["VoucherCode"], None, None], None]
 
@@ -1667,7 +1667,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after voucher codes
     # are deleted.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_codes_deleted: Callable[[list["VoucherCode"], None, None], None]
 
@@ -1676,11 +1676,11 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a voucher
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_metadata_updated: Callable[["Voucher", None], None]
 
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     voucher_code_export_completed: Callable[["ExportFile", None], None]
 
@@ -1689,7 +1689,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a shop
     # metadata is updated.
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     shop_metadata_updated: Callable[["SiteSettings", None], None]
 
@@ -1700,7 +1700,7 @@ class BasePlugin:
 
     # Triggers retry mechanism for event delivery
     #
-    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     event_delivery_retry: Callable[[EventDelivery, None], None]
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -628,7 +628,7 @@ class PluginsManager(PaymentInterface):
             or default_value
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def get_taxes_for_checkout(
         self,
@@ -648,7 +648,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=checkout_info.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def get_taxes_for_order(self, order: "Order", app_identifier) -> TaxData | None:
         return self.__run_plugin_method_until_first_success(
@@ -672,7 +672,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=checkout_info.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def customer_created(self, customer: "User"):
         default_value = None
@@ -680,7 +680,7 @@ class PluginsManager(PaymentInterface):
             "customer_created", default_value, customer, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def customer_deleted(self, customer: "User", webhooks=None):
         default_value = None
@@ -692,7 +692,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def customer_updated(self, customer: "User", webhooks=None):
         default_value = None
@@ -704,7 +704,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def customer_metadata_updated(self, customer: "User", webhooks=None):
         default_value = None
@@ -716,7 +716,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def collection_created(self, collection: "Collection"):
         default_value = None
@@ -724,7 +724,7 @@ class PluginsManager(PaymentInterface):
             "collection_created", default_value, collection, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def collection_updated(self, collection: "Collection"):
         default_value = None
@@ -732,7 +732,7 @@ class PluginsManager(PaymentInterface):
             "collection_updated", default_value, collection, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def collection_deleted(self, collection: "Collection", webhooks=None):
         default_value = None
@@ -744,7 +744,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def collection_metadata_updated(self, collection: "Collection"):
         default_value = None
@@ -752,7 +752,7 @@ class PluginsManager(PaymentInterface):
             "collection_metadata_updated", default_value, collection, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_created(self, product: "Product", webhooks=None):
         default_value = None
@@ -764,7 +764,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_updated(self, product: "Product", webhooks=None):
         default_value = None
@@ -776,7 +776,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_deleted(self, product: "Product", variants: list[int], webhooks=None):
         default_value = None
@@ -789,7 +789,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_media_created(self, media: "ProductMedia"):
         default_value = None
@@ -797,7 +797,7 @@ class PluginsManager(PaymentInterface):
             "product_media_created", default_value, media, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_media_updated(self, media: "ProductMedia"):
         default_value = None
@@ -805,7 +805,7 @@ class PluginsManager(PaymentInterface):
             "product_media_updated", default_value, media, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_media_deleted(self, media: "ProductMedia"):
         default_value = None
@@ -813,7 +813,7 @@ class PluginsManager(PaymentInterface):
             "product_media_deleted", default_value, media, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_metadata_updated(self, product: "Product"):
         default_value = None
@@ -821,7 +821,7 @@ class PluginsManager(PaymentInterface):
             "product_metadata_updated", default_value, product, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_created(self, product_variant: "ProductVariant", webhooks=None):
         default_value = None
@@ -833,7 +833,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_updated(
         self, product_variant: "ProductVariant", webhooks=None, **kwargs
@@ -848,7 +848,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_deleted(self, product_variant: "ProductVariant", webhooks=None):
         default_value = None
@@ -860,7 +860,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_out_of_stock(self, stock: "Stock", webhooks=None):
         default_value = None
@@ -872,7 +872,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_back_in_stock(self, stock: "Stock", webhooks=None):
         default_value = None
@@ -884,7 +884,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_stocks_updated(self, stocks: list["Stock"], webhooks=None):
         default_value = None
@@ -896,7 +896,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_variant_metadata_updated(self, product_variant: "ProductVariant"):
         default_value = None
@@ -907,7 +907,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def product_export_completed(self, export: "ExportFile"):
         default_value = None
@@ -915,7 +915,7 @@ class PluginsManager(PaymentInterface):
             "product_export_completed", default_value, export, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_created(self, order: "Order", webhooks=None):
         default_value = None
@@ -927,7 +927,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def event_delivery_retry(self, event_delivery: "EventDelivery"):
         default_value = None
@@ -945,7 +945,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def draft_order_created(self, order: "Order", webhooks=None):
         default_value = None
@@ -957,7 +957,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def draft_order_updated(self, order: "Order", webhooks=None):
         default_value = None
@@ -969,7 +969,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def draft_order_deleted(self, order: "Order", webhooks=None):
         default_value = None
@@ -981,7 +981,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def sale_created(self, sale: "Promotion", current_catalogue):
         default_value = None
@@ -989,7 +989,7 @@ class PluginsManager(PaymentInterface):
             "sale_created", default_value, sale, current_catalogue, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def sale_deleted(self, sale: "Promotion", previous_catalogue, webhooks=None):
         default_value = None
@@ -1002,7 +1002,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def sale_updated(self, sale: "Promotion", previous_catalogue, current_catalogue):
         default_value = None
@@ -1026,7 +1026,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_created(self, promotion: "Promotion"):
         default_value = None
@@ -1034,7 +1034,7 @@ class PluginsManager(PaymentInterface):
             "promotion_created", default_value, promotion, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_updated(self, promotion: "Promotion"):
         default_value = None
@@ -1042,7 +1042,7 @@ class PluginsManager(PaymentInterface):
             "promotion_updated", default_value, promotion, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_deleted(self, promotion: "Promotion", webhooks=None):
         default_value = None
@@ -1054,7 +1054,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_started(self, promotion: "Promotion", webhooks=None):
         default_value = None
@@ -1066,7 +1066,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_ended(self, promotion: "Promotion", webhooks=None):
         default_value = None
@@ -1078,7 +1078,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_rule_created(self, promotion_rule: "PromotionRule"):
         default_value = None
@@ -1086,7 +1086,7 @@ class PluginsManager(PaymentInterface):
             "promotion_rule_created", default_value, promotion_rule, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_rule_updated(self, promotion_rule: "PromotionRule"):
         default_value = None
@@ -1094,7 +1094,7 @@ class PluginsManager(PaymentInterface):
             "promotion_rule_updated", default_value, promotion_rule, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def promotion_rule_deleted(self, promotion_rule: "PromotionRule"):
         default_value = None
@@ -1113,7 +1113,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=order.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def invoice_delete(self, invoice: "Invoice"):
         default_value = None
@@ -1125,7 +1125,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def invoice_sent(self, invoice: "Invoice", email: str):
         default_value = None
@@ -1138,7 +1138,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_fully_paid(self, order: "Order", webhooks=None):
         default_value = None
@@ -1150,7 +1150,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_paid(self, order: "Order", webhooks=None):
         default_value = None
@@ -1162,7 +1162,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_fully_refunded(self, order: "Order", webhooks=None):
         default_value = None
@@ -1174,7 +1174,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_refunded(self, order: "Order", webhooks=None):
         default_value = None
@@ -1186,7 +1186,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_updated(self, order: "Order", webhooks=None):
         default_value = None
@@ -1198,7 +1198,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_cancelled(self, order: "Order", webhooks=None):
         default_value = None
@@ -1210,7 +1210,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_expired(self, order: "Order", webhooks=None):
         default_value = None
@@ -1222,7 +1222,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_fulfilled(self, order: "Order", webhooks=None):
         default_value = None
@@ -1234,7 +1234,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_metadata_updated(self, order: "Order", webhooks=None):
         default_value = None
@@ -1246,7 +1246,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def order_bulk_created(self, orders: list["Order"]):
         default_value = None
@@ -1254,7 +1254,7 @@ class PluginsManager(PaymentInterface):
             "order_bulk_created", default_value, orders, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_created(
         self, fulfillment: "Fulfillment", notify_customer: bool | None = True
@@ -1268,7 +1268,7 @@ class PluginsManager(PaymentInterface):
             notify_customer=notify_customer,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_canceled(self, fulfillment: "Fulfillment"):
         default_value = None
@@ -1279,7 +1279,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=fulfillment.order.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_approved(
         self, fulfillment: "Fulfillment", notify_customer: bool | None = True
@@ -1293,7 +1293,7 @@ class PluginsManager(PaymentInterface):
             notify_customer=notify_customer,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def fulfillment_metadata_updated(self, fulfillment: "Fulfillment"):
         default_value = None
@@ -1313,7 +1313,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=fulfillment.order.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_created(self, checkout: "Checkout", webhooks=None):
         default_value = None
@@ -1325,7 +1325,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_updated(self, checkout: "Checkout", webhooks=None):
         default_value = None
@@ -1337,7 +1337,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_fully_paid(self, checkout: "Checkout", webhooks=None):
         default_value = None
@@ -1349,7 +1349,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_metadata_updated(self, checkout: "Checkout", webhooks=None):
         default_value = None
@@ -1361,7 +1361,7 @@ class PluginsManager(PaymentInterface):
             webhooks=webhooks,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def page_created(self, page: "Page"):
         default_value = None
@@ -1369,7 +1369,7 @@ class PluginsManager(PaymentInterface):
             "page_created", default_value, page, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def page_updated(self, page: "Page"):
         default_value = None
@@ -1377,7 +1377,7 @@ class PluginsManager(PaymentInterface):
             "page_updated", default_value, page, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def page_deleted(self, page: "Page"):
         default_value = None
@@ -1385,7 +1385,7 @@ class PluginsManager(PaymentInterface):
             "page_deleted", default_value, page, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def page_type_created(self, page_type: "PageType"):
         default_value = None
@@ -1393,7 +1393,7 @@ class PluginsManager(PaymentInterface):
             "page_type_created", default_value, page_type, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def page_type_updated(self, page_type: "PageType"):
         default_value = None
@@ -1401,7 +1401,7 @@ class PluginsManager(PaymentInterface):
             "page_type_updated", default_value, page_type, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def page_type_deleted(self, page_type: "PageType", webhooks=None):
         default_value = None
@@ -1413,7 +1413,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def permission_group_created(self, group: "Group"):
         default_value = None
@@ -1421,7 +1421,7 @@ class PluginsManager(PaymentInterface):
             "permission_group_created", default_value, group, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def permission_group_updated(self, group: "Group"):
         default_value = None
@@ -1429,7 +1429,7 @@ class PluginsManager(PaymentInterface):
             "permission_group_updated", default_value, group, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def permission_group_deleted(self, group: "Group"):
         default_value = None
@@ -1437,7 +1437,7 @@ class PluginsManager(PaymentInterface):
             "permission_group_deleted", default_value, group, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_charge_requested(
         self, payment_data: "TransactionActionData", channel_slug: str
@@ -1450,7 +1450,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_refund_requested(
         self, payment_data: "TransactionActionData", channel_slug: str
@@ -1463,7 +1463,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_cancelation_requested(
         self, payment_data: "TransactionActionData", channel_slug: str
@@ -1476,7 +1476,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def payment_gateway_initialize_session(
         self,
@@ -1494,7 +1494,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=source_object.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_initialize_session(
         self,
@@ -1508,7 +1508,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=transaction_session_data.source_object.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_process_session(
         self,
@@ -1522,7 +1522,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=transaction_session_data.source_object.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def transaction_item_metadata_updated(self, transaction_item: "TransactionItem"):
         default_value = None
@@ -1533,7 +1533,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def account_confirmed(self, user: "User"):
         default_value = None
@@ -1541,7 +1541,7 @@ class PluginsManager(PaymentInterface):
             "account_confirmed", default_value, user, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def account_confirmation_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: str | None
@@ -1557,7 +1557,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def account_change_email_requested(
         self,
@@ -1579,7 +1579,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def account_email_changed(
         self,
@@ -1593,7 +1593,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def account_set_password_requested(
         self,
@@ -1613,7 +1613,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def account_delete_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: str
@@ -1629,7 +1629,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def account_deleted(self, user: "User"):
         default_value = None
@@ -1637,7 +1637,7 @@ class PluginsManager(PaymentInterface):
             "account_deleted", default_value, user, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def address_created(self, address: "Address"):
         default_value = None
@@ -1645,7 +1645,7 @@ class PluginsManager(PaymentInterface):
             "address_created", default_value, address, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def address_updated(self, address: "Address"):
         default_value = None
@@ -1653,7 +1653,7 @@ class PluginsManager(PaymentInterface):
             "address_updated", default_value, address, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def address_deleted(self, address: "Address"):
         default_value = None
@@ -1661,7 +1661,7 @@ class PluginsManager(PaymentInterface):
             "address_deleted", default_value, address, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def app_installed(self, app: "App"):
         default_value = None
@@ -1669,7 +1669,7 @@ class PluginsManager(PaymentInterface):
             "app_installed", default_value, app, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def app_updated(self, app: "App"):
         default_value = None
@@ -1677,7 +1677,7 @@ class PluginsManager(PaymentInterface):
             "app_updated", default_value, app, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def app_deleted(self, app: "App"):
         default_value = None
@@ -1685,7 +1685,7 @@ class PluginsManager(PaymentInterface):
             "app_deleted", default_value, app, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def app_status_changed(self, app: "App"):
         default_value = None
@@ -1693,7 +1693,7 @@ class PluginsManager(PaymentInterface):
             "app_status_changed", default_value, app, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_created(self, attribute: "Attribute", webhooks=None):
         default_value = None
@@ -1705,7 +1705,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_updated(self, attribute: "Attribute", webhooks=None):
         default_value = None
@@ -1717,7 +1717,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_deleted(self, attribute: "Attribute", webhooks=None):
         default_value = None
@@ -1729,7 +1729,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_value_created(self, attribute_value: "AttributeValue", webhooks=None):
         default_value = None
@@ -1741,7 +1741,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_value_updated(self, attribute_value: "AttributeValue"):
         default_value = None
@@ -1749,7 +1749,7 @@ class PluginsManager(PaymentInterface):
             "attribute_value_updated", default_value, attribute_value, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def attribute_value_deleted(self, attribute_value: "AttributeValue", webhooks=None):
         default_value = None
@@ -1761,7 +1761,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def category_created(self, category: "Category"):
         default_value = None
@@ -1769,7 +1769,7 @@ class PluginsManager(PaymentInterface):
             "category_created", default_value, category, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def category_updated(self, category: "Category"):
         default_value = None
@@ -1777,7 +1777,7 @@ class PluginsManager(PaymentInterface):
             "category_updated", default_value, category, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def category_deleted(self, category: "Category", webhooks=None):
         default_value = None
@@ -1789,7 +1789,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def channel_created(self, channel: "Channel"):
         default_value = None
@@ -1797,7 +1797,7 @@ class PluginsManager(PaymentInterface):
             "channel_created", default_value, channel, channel_slug=channel.slug
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def channel_updated(self, channel: "Channel", webhooks=None):
         default_value = None
@@ -1809,7 +1809,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def channel_deleted(self, channel: "Channel"):
         default_value = None
@@ -1817,7 +1817,7 @@ class PluginsManager(PaymentInterface):
             "channel_deleted", default_value, channel, channel_slug=None
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def channel_status_changed(self, channel: "Channel"):
         default_value = None
@@ -1825,7 +1825,7 @@ class PluginsManager(PaymentInterface):
             "channel_status_changed", default_value, channel, channel_slug=channel.slug
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def channel_metadata_updated(self, channel: "Channel"):
         default_value = None
@@ -1836,7 +1836,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_created(self, gift_card: "GiftCard", webhooks=None):
         default_value = None
@@ -1848,7 +1848,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_updated(self, gift_card: "GiftCard"):
         default_value = None
@@ -1859,7 +1859,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_deleted(self, gift_card: "GiftCard", webhooks=None):
         default_value = None
@@ -1882,7 +1882,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_status_changed(self, gift_card: "GiftCard", webhooks=None):
         default_value = None
@@ -1894,7 +1894,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_metadata_updated(self, gift_card: "GiftCard"):
         default_value = None
@@ -1905,7 +1905,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def gift_card_export_completed(self, export: "ExportFile"):
         default_value = None
@@ -1916,7 +1916,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def menu_created(self, menu: "Menu"):
         default_value = None
@@ -1927,7 +1927,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def menu_updated(self, menu: "Menu"):
         default_value = None
@@ -1938,7 +1938,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def menu_deleted(self, menu: "Menu", webhooks=None):
         default_value = None
@@ -1950,7 +1950,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def menu_item_created(self, menu_item: "MenuItem"):
         default_value = None
@@ -1961,7 +1961,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def menu_item_updated(self, menu_item: "MenuItem"):
         default_value = None
@@ -1972,7 +1972,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def menu_item_deleted(self, menu_item: "MenuItem", webhooks=None):
         default_value = None
@@ -1984,7 +1984,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_price_created(self, shipping_method: "ShippingMethod"):
         default_value = None
@@ -1995,7 +1995,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_price_updated(self, shipping_method: "ShippingMethod"):
         default_value = None
@@ -2006,7 +2006,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_price_deleted(self, shipping_method: "ShippingMethod", webhooks=None):
         default_value = None
@@ -2018,7 +2018,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_created(self, shipping_zone: "ShippingZone"):
         default_value = None
@@ -2029,7 +2029,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_updated(self, shipping_zone: "ShippingZone"):
         default_value = None
@@ -2040,7 +2040,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_deleted(self, shipping_zone: "ShippingZone", webhooks=None):
         default_value = None
@@ -2052,7 +2052,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shipping_zone_metadata_updated(self, shipping_zone: "ShippingZone"):
         default_value = None
@@ -2063,7 +2063,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def staff_created(self, staff_user: "User"):
         default_value = None
@@ -2074,7 +2074,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def staff_updated(self, staff_user: "User"):
         default_value = None
@@ -2085,7 +2085,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def staff_deleted(self, staff_user: "User", webhooks=None):
         default_value = None
@@ -2097,7 +2097,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def staff_set_password_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: str
@@ -2113,7 +2113,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def thumbnail_created(
         self,
@@ -2127,7 +2127,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_created(self, warehouse: "Warehouse"):
         default_value = None
@@ -2138,7 +2138,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_updated(self, warehouse: "Warehouse"):
         default_value = None
@@ -2149,7 +2149,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_deleted(self, warehouse: "Warehouse"):
         default_value = None
@@ -2160,7 +2160,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def warehouse_metadata_updated(self, warehouse: "Warehouse"):
         default_value = None
@@ -2171,7 +2171,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_created(self, voucher: "Voucher", code: str):
         default_value = None
@@ -2183,7 +2183,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_updated(self, voucher: "Voucher", code: str):
         default_value = None
@@ -2195,7 +2195,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_deleted(self, voucher: "Voucher", code: str, webhooks=None):
         default_value = None
@@ -2208,7 +2208,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_codes_created(self, voucher_codes: list["VoucherCode"], webhooks=None):
         default_value = None
@@ -2220,7 +2220,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_codes_deleted(self, voucher_codes: list["VoucherCode"], webhooks=None):
         default_value = None
@@ -2232,7 +2232,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_metadata_updated(self, voucher: "Voucher"):
         default_value = None
@@ -2243,7 +2243,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def voucher_code_export_completed(self, export: "ExportFile"):
         default_value = None
@@ -2254,7 +2254,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=None,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def shop_metadata_updated(self, shop: "SiteSettings"):
         default_value = None
@@ -2365,7 +2365,7 @@ class PluginsManager(PaymentInterface):
             )
         raise Exception(f"Payment plugin {gateway} is inaccessible!")
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def list_stored_payment_methods(
         self,
@@ -2379,7 +2379,7 @@ class PluginsManager(PaymentInterface):
             channel_slug=list_stored_payment_methods_data.channel.slug,
         )
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def stored_payment_method_request_delete(
         self,
@@ -2397,7 +2397,7 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def payment_gateway_initialize_tokenization(
         self,
@@ -2417,7 +2417,7 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
     def payment_method_initialize_tokenization(
         self,
@@ -2437,7 +2437,7 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
-    # Note: this method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules..
     # Any webhook-related functionality will be moved from plugin to core modules.
     def payment_method_process_tokenization(


### PR DESCRIPTION
I want to merge this change because we are planning to remove WebhookPlugin, and move the whole functionality to the core. Right now, the comments suggest that this will happen in 3.21 (which will not happen). 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1514

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
