### PR TITLE
Make sure that adding manual order discount always use correct prices

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -9,7 +9,7 @@ import graphene
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import prefetch_related_objects
+from django.db.models import QuerySet, prefetch_related_objects
 from django.utils import timezone
 from prices import Money
 
@@ -118,7 +118,7 @@ def invalidate_checkout_prices(
     return updated_fields
 
 
-def checkout_lines_qs_select_for_update():
+def checkout_lines_qs_select_for_update() -> QuerySet[CheckoutLine]:
     return CheckoutLine.objects.order_by("id").select_for_update(of=(["self"]))
 
 

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -22,10 +22,7 @@ from ....graphql.core.utils import to_global_id_or_none
 from ....order import OrderStatus
 from ....order.calculations import fetch_order_prices_if_expired
 from ....order.models import Order
-from ....order.utils import (
-    create_order_discount_for_order,
-    update_discount_for_order_line,
-)
+from ....order.utils import create_manual_order_discount, update_discount_for_order_line
 from ....plugins.manager import get_plugins_manager
 from ....tax import TaxableObjectDiscountType
 from ...event_types import WebhookEventSyncType
@@ -1270,12 +1267,11 @@ def test_order_calculate_taxes_order_voucher_and_manual_discount(
     order.save(update_fields=["voucher_id"])
 
     manual_reward = Decimal(10)
-    create_order_discount_for_order(
+    create_manual_order_discount(
         order=order,
         reason="Manual discount",
         value_type=DiscountValueType.FIXED,
         value=manual_reward,
-        type=DiscountType.MANUAL,
     )
 
     subtotal_manual_reward_portion = (subtotal_amount / total_amount) * manual_reward
@@ -1375,12 +1371,11 @@ def test_order_calculate_taxes_order_promotion_and_manual_discount(
     assert rule.reward_type == RewardType.SUBTOTAL_DISCOUNT
 
     manual_reward = Decimal(10)
-    create_order_discount_for_order(
+    create_manual_order_discount(
         order=order,
         reason="Manual discount",
         value_type=DiscountValueType.FIXED,
         value=manual_reward,
-        type=DiscountType.MANUAL,
     )
 
     subtotal_manual_reward_portion = (subtotal_amount / total_amount) * manual_reward
@@ -1474,12 +1469,11 @@ def test_order_calculate_taxes_free_shipping_voucher_and_manual_discount_fixed(
     create_or_update_voucher_discount_objects_for_order(order)
 
     manual_reward = Decimal(10)
-    create_order_discount_for_order(
+    create_manual_order_discount(
         order=order,
         reason="Manual discount",
         value_type=DiscountValueType.FIXED,
         value=manual_reward,
-        type=DiscountType.MANUAL,
     )
 
     # Since shipping is free, whole manual discount should be applied to subtotal
@@ -1576,12 +1570,11 @@ def test_order_calculate_taxes_free_shipping_voucher_and_manual_discount_percent
     total_amount -= shipping_price_amount
 
     manual_reward = Decimal(10)
-    create_order_discount_for_order(
+    create_manual_order_discount(
         order=order,
         reason="Manual discount",
         value_type=DiscountValueType.PERCENTAGE,
         value=manual_reward,
-        type=DiscountType.MANUAL,
     )
 
     # Since shipping is free, whole manual discount should be applied to subtotal


### PR DESCRIPTION
I want to merge this change because it fixes the logic responsible for creating the order-discount. 

Previously, the amounts stored in the `OrderDiscount` object were not correct. It was immediately fixed by forcing price refresh. So, when ending the mutation, everything was correct. I've changed the logic to create the OrderDiscount with correct amounts, and instead of forcing the price recalculation, it only marks the prices as expired.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
