### PR TITLE
Improve checkout lines metadata overwriting conditions

### DIFF
--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 from collections import defaultdict
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, cast
 
@@ -68,7 +68,7 @@ class CheckoutLineData:
     quantity_to_update: bool = False
     custom_price: Decimal | None = None
     custom_price_to_update: bool = False
-    metadata_list: list | None = None
+    metadata_list: list = field(default_factory=list)
 
 
 def clean_delivery_method(
@@ -376,7 +376,7 @@ def group_lines_input_on_add(
     for line in lines:
         variant_id = cast(str, line.get("variant_id"))
         force_new_line = line.get("force_new_line")
-        metadata_list_from_input = line.get("metadata")
+        metadata_list_from_input = line.get("metadata", [])
 
         _, variant_db_id = graphene.Node.from_global_id(variant_id)
 
@@ -395,19 +395,17 @@ def group_lines_input_on_add(
 
                 if not line_db_id:
                     line_data = checkout_lines_data_map[variant_db_id]
+
                     line_data.variant_id = variant_db_id
-                    line_data.metadata_list = metadata_list_from_input
                 else:
                     line_data = checkout_lines_data_map[line_db_id]
+
                     line_data.line_id = line_db_id
                     line_data.variant_id = find_variant_id_when_line_parameter_used(
                         line_db_id, existing_lines_info
                     )
 
-                    if metadata_list_from_input:
-                        line_data.metadata_list = line_data.metadata_list or []
-
-                        line_data.metadata_list += metadata_list_from_input
+                line_data.metadata_list += metadata_list_from_input
 
             # when variant already exist in multiple lines then create a new line
             except ValidationError:
@@ -443,7 +441,7 @@ def group_lines_input_data_on_update(
     for line in lines:
         variant_id = cast(str, line.get("variant_id"))
         line_id = cast(str, line.get("line_id"))
-        metadata_list_from_input = line.get("metadata")
+        metadata_list_from_input = line.get("metadata", [])
 
         line_db_id, variant_db_id = None, None
         if line_id:
@@ -473,8 +471,7 @@ def group_lines_input_data_on_update(
             line_data.custom_price = line["price"]
             line_data.custom_price_to_update = True
 
-        if metadata_list_from_input:
-            line_data.metadata_list = metadata_list_from_input
+        line_data.metadata_list += metadata_list_from_input
 
     grouped_checkout_lines_data += list(checkout_lines_data_map.values())
     return grouped_checkout_lines_data

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -404,10 +404,10 @@ def group_lines_input_on_add(
                         line_db_id, existing_lines_info
                     )
 
-                    if line_data.metadata_list and metadata_list_from_input:
+                    if metadata_list_from_input:
+                        line_data.metadata_list = line_data.metadata_list or []
+
                         line_data.metadata_list += metadata_list_from_input
-                    elif metadata_list_from_input and not line_data.metadata_list:
-                        line_data.metadata_list = metadata_list_from_input
 
             # when variant already exist in multiple lines then create a new line
             except ValidationError:

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -473,9 +473,7 @@ def group_lines_input_data_on_update(
             line_data.custom_price = line["price"]
             line_data.custom_price_to_update = True
 
-        if line_data.metadata_list and metadata_list_from_input:
-            line_data.metadata_list += metadata_list_from_input
-        elif metadata_list_from_input and not line_data.metadata_list:
+        if metadata_list_from_input:
             line_data.metadata_list = metadata_list_from_input
 
     grouped_checkout_lines_data += list(checkout_lines_data_map.values())

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -376,13 +376,13 @@ def group_lines_input_on_add(
     for line in lines:
         variant_id = cast(str, line.get("variant_id"))
         force_new_line = line.get("force_new_line")
-        metadata_list = line.get("metadata")
+        metadata_list_from_input = line.get("metadata")
 
         _, variant_db_id = graphene.Node.from_global_id(variant_id)
 
         if force_new_line:
             line_data = CheckoutLineData(
-                variant_id=variant_db_id, metadata_list=metadata_list
+                variant_id=variant_db_id, metadata_list=metadata_list_from_input
             )
             grouped_checkout_lines_data.append(line_data)
         else:
@@ -396,7 +396,7 @@ def group_lines_input_on_add(
                 if not line_db_id:
                     line_data = checkout_lines_data_map[variant_db_id]
                     line_data.variant_id = variant_db_id
-                    line_data.metadata_list = metadata_list
+                    line_data.metadata_list = metadata_list_from_input
                 else:
                     line_data = checkout_lines_data_map[line_db_id]
                     line_data.line_id = line_db_id
@@ -404,15 +404,15 @@ def group_lines_input_on_add(
                         line_db_id, existing_lines_info
                     )
 
-                    if line_data.metadata_list and metadata_list:
-                        line_data.metadata_list += metadata_list
-                    else:
-                        line_data.metadata_list = metadata_list
+                    if line_data.metadata_list and metadata_list_from_input:
+                        line_data.metadata_list += metadata_list_from_input
+                    elif metadata_list_from_input and not line_data.metadata_list:
+                        line_data.metadata_list = metadata_list_from_input
 
             # when variant already exist in multiple lines then create a new line
             except ValidationError:
                 line_data = CheckoutLineData(
-                    variant_id=variant_db_id, metadata_list=metadata_list
+                    variant_id=variant_db_id, metadata_list=metadata_list_from_input
                 )
                 grouped_checkout_lines_data.append(line_data)
 
@@ -443,7 +443,7 @@ def group_lines_input_data_on_update(
     for line in lines:
         variant_id = cast(str, line.get("variant_id"))
         line_id = cast(str, line.get("line_id"))
-        metadata_list = line.get("metadata")
+        metadata_list_from_input = line.get("metadata")
 
         line_db_id, variant_db_id = None, None
         if line_id:
@@ -473,10 +473,10 @@ def group_lines_input_data_on_update(
             line_data.custom_price = line["price"]
             line_data.custom_price_to_update = True
 
-        if line_data.metadata_list and metadata_list:
-            line_data.metadata_list += metadata_list
-        else:
-            line_data.metadata_list = metadata_list
+        if line_data.metadata_list and metadata_list_from_input:
+            line_data.metadata_list += metadata_list_from_input
+        elif metadata_list_from_input and not line_data.metadata_list:
+            line_data.metadata_list = metadata_list_from_input
 
     grouped_checkout_lines_data += list(checkout_lines_data_map.values())
     return grouped_checkout_lines_data

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1859,3 +1859,59 @@ def test_checkout_lines_update_with_empy_metadata_preserve_old(
     assert line.metadata["test_key"] == "old_value"
 
     assert line.variant == variant
+
+
+def test_checkout_lines_update_with_empy_metadata_merge_old(
+    user_api_client,
+    checkout_with_item,
+):
+    # given
+    checkout = checkout_with_item
+
+    assert checkout.lines.count() == 1
+
+    line = checkout.lines.first()
+
+    line.metadata["test_key"] = "old_value"
+    line.save(update_fields=["metadata"])
+
+    variant = line.variant
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    # when
+    variables = {
+        "id": to_global_id_or_none(checkout_with_item),
+        "lines": [
+            {
+                "variantId": variant_id,
+                "quantity": 1,
+                # Leave input empty to ensure it will not affect existing entries
+                "metadata": [
+                    {
+                        "key": "new_key",
+                        "value": "new_value",
+                    }
+                ],
+            }
+        ],
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+
+    assert not data["errors"]
+
+    checkout.refresh_from_db()
+
+    assert checkout.lines.count() == 1
+
+    line = checkout.lines.first()
+
+    assert line.metadata["test_key"] == "old_value"
+    assert line.metadata["new_key"] == "new_value"
+
+    assert line.variant == variant

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1861,7 +1861,7 @@ def test_checkout_lines_update_with_empy_metadata_preserve_old(
     assert line.variant == variant
 
 
-def test_checkout_lines_update_with_empy_metadata_merge_old(
+def test_checkout_lines_update_with_new_metadata_merge_old(
     user_api_client,
     checkout_with_item,
 ):
@@ -1886,7 +1886,6 @@ def test_checkout_lines_update_with_empy_metadata_merge_old(
             {
                 "variantId": variant_id,
                 "quantity": 1,
-                # Leave input empty to ensure it will not affect existing entries
                 "metadata": [
                     {
                         "key": "new_key",

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1811,7 +1811,7 @@ def test_checkout_lines_update_with_invalid_metadata(
     assert expected_error["code"] == "REQUIRED"
 
 
-def test_checkout_lines_update_with_empy_metadata_preserve_old(
+def test_checkout_lines_update_with_empty_metadata_preserve_old(
     user_api_client,
     checkout_with_item,
 ):


### PR DESCRIPTION
I want to merge this change because 
- it fixes invalid condition that would overwrite metadata in some cases
- adds extra tests for that

This behavior didn't really trigger the issue, because in another part of code it was "healed"

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
