### PR TITLE
Allow to set languageCode on Orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - `CheckoutLinesAdd` now properly validates `metadata` provided in input - #17523 by @lkostrowski
 - `CheckoutCreateInput` now accepts `metadata` and `privateMetadata` fields, so `checkoutCreate` can now create checkout with metadata in a single call - #17503 by @lkostrowski
 - `orderUpdate` mutation now allows to update `metadata` and `privateMetadata` via `OrderUpdateInput` - #1508 by @lkostrowski
-- `DraftOrderInput` and `DraftOrderCreateInput` now allow to provide `languageCode` - #17553 by @lkostrowski
+- `DraftOrderInput`, `OrderUpdateInput` and `DraftOrderCreateInput` now allow to provide `languageCode` - #17553 by @lkostrowski
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Improved error handling when trying to set invalid metadata. Now, invalid metadata should properly return `error.field` containing `metadata` or `privateMetadata`, instead generic `input` - #17470 by @lkostrowski
 - `CheckoutCreateInput` now accepts `metadata` and `privateMetadata` fields, so `checkoutCreate` can now create checkout with metadata in a single call - #17503 by @lkostrowski
 - `orderUpdate` mutation now allows to update `metadata` and `privateMetadata` via `OrderUpdateInput` - #1508 by @lkostrowski
+- `DraftOrderInput` and `DraftOrderCreateInput` now allow to provide `languageCode` - #TODO by @lkostrowski
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Improved error handling when trying to set invalid metadata. Now, invalid metadata should properly return `error.field` containing `metadata` or `privateMetadata`, instead generic `input` - #17470 by @lkostrowski
 - `CheckoutCreateInput` now accepts `metadata` and `privateMetadata` fields, so `checkoutCreate` can now create checkout with metadata in a single call - #17503 by @lkostrowski
 - `orderUpdate` mutation now allows to update `metadata` and `privateMetadata` via `OrderUpdateInput` - #1508 by @lkostrowski
-- `DraftOrderInput` and `DraftOrderCreateInput` now allow to provide `languageCode` - #TODO by @lkostrowski
+- `DraftOrderInput` and `DraftOrderCreateInput` now allow to provide `languageCode` - #17553 by @lkostrowski
 
 ### Webhooks
 

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -41,6 +41,7 @@ from ...core.descriptions import (
     DEPRECATED_IN_3X_INPUT,
 )
 from ...core.doc_category import DOC_CATEGORY_ORDERS
+from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelWithRestrictedChannelAccessMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
@@ -165,6 +166,12 @@ class DraftOrderInput(BaseInputObjectType):
         description=f"Order private metadata. {ADDED_IN_321} "
         f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
+    )
+
+    language_code = graphene.Argument(
+        LanguageCodeEnum,
+        required=False,
+        description=(f"Order language code.{ADDED_IN_321}"),
     )
 
     class Meta:

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -21,6 +21,7 @@ from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_ORDERS
+from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
 from ...meta.inputs import MetadataInput, MetadataInputDescription
@@ -52,6 +53,12 @@ class OrderUpdateInput(BaseInputObjectType):
             f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
         ),
         required=False,
+    )
+
+    language_code = graphene.Argument(
+        LanguageCodeEnum,
+        required=False,
+        description=(f"Order language code.{ADDED_IN_321}"),
     )
 
     class Meta:

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -3973,3 +3973,44 @@ def test_draft_order_create_set_order_line_price_expiration_time(
     # then
     new_line = OrderLine.objects.get()
     assert new_line.draft_base_price_expire_at == expected_expire_time
+
+
+def test_draft_order_create_create_with_language_code(
+    staff_api_client,
+    permission_group_manage_orders,
+    variant,
+    channel_USD,
+    graphql_address_data,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    variant_0 = variant
+    query = DRAFT_ORDER_CREATE_MUTATION
+
+    variant_0_id = graphene.Node.to_global_id("ProductVariant", variant_0.id)
+    variant_list = [{"variantId": variant_0_id, "quantity": 2}]
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+
+    variables = {
+        "input": {
+            "lines": variant_list,
+            "billingAddress": graphql_address_data,
+            "shippingAddress": graphql_address_data,
+            "channelId": channel_id,
+            "languageCode": "PL",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["draftOrderCreate"]["errors"]
+    order_id = content["data"]["draftOrderCreate"]["order"]["id"]
+    _, order_pk = graphene.Node.from_global_id(order_id)
+
+    order = Order.objects.get(id=order_pk)
+
+    assert order.language_code == "pl"

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -3035,3 +3035,33 @@ def test_draft_order_update_with_voucher_apply_once_per_order_and_manual_line_di
     assert line_1.unit_discount_reason is None
 
     assert discounted_line.discounts.count() == 1
+
+
+def test_draft_order_update_with_language_code(
+    staff_api_client, permission_group_manage_orders, draft_order
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    query = DRAFT_ORDER_UPDATE_BY_EXTERNAL_REFERENCE
+
+    order = draft_order
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    assert not order.language_code == "pl"
+
+    variables = {
+        "id": order_id,
+        "input": {"languageCode": "PL"},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+
+    order.refresh_from_db()
+
+    assert order.language_code == "pl"

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -24180,6 +24180,13 @@ input OrderUpdateInput @doc(category: "Orders") {
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
+
+  """
+  Order language code.
+  
+  Added in Saleor 3.21.
+  """
+  languageCode: LanguageCodeEnum
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23281,6 +23281,13 @@ input DraftOrderCreateInput @doc(category: "Orders") {
   """
   privateMetadata: [MetadataInput!]
 
+  """
+  Order language code.
+  
+  Added in Saleor 3.21.
+  """
+  languageCode: LanguageCodeEnum
+
   """Variant line input consisting of variant ID and quantity of products."""
   lines: [OrderLineCreateInput!]
 }
@@ -23423,6 +23430,13 @@ input DraftOrderInput @doc(category: "Orders") {
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
+
+  """
+  Order language code.
+  
+  Added in Saleor 3.21.
+  """
+  languageCode: LanguageCodeEnum
 }
 
 """

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -410,6 +410,7 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
             "private_metadata",
             "draft_save_billing_address",
             "draft_save_shipping_address",
+            "language_code",
         ]
 
     def serialize_for_comparison(self):


### PR DESCRIPTION
I want to merge this change because there was no way to update language code for orders, despite field being available on Order.

Now OrderUpdate, DraftOrderUpdate and DraftOrderCreate will accept LanguageCode

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
