### PR TITLE
Improve the way of handling tax-class

### DIFF
--- a/saleor/graphql/product/tests/test_product_channel_listings_queries.py
+++ b/saleor/graphql/product/tests/test_product_channel_listings_queries.py
@@ -155,9 +155,9 @@ query FetchProduct($id: ID, $channel: String) {
 """
 
 
-@mock.patch("saleor.graphql.product.types.products.get_tax_rate_for_tax_class")
+@mock.patch("saleor.graphql.product.types.products.get_tax_rate_for_country")
 def test_product_channel_listing_pricing_field_no_address(
-    mock_get_tax_rate_for_tax_class,
+    mock_get_tax_rate_for_country,
     staff_api_client,
     permission_manage_products,
     channel_USD,
@@ -181,9 +181,7 @@ def test_product_channel_listing_pricing_field_no_address(
     )
 
     # then
-    assert (
-        mock_get_tax_rate_for_tax_class.call_args[0][3] == channel_USD.default_country
-    )
+    assert mock_get_tax_rate_for_country.call_args[0][2] == channel_USD.default_country
 
 
 FRAGMENT_PRICE = """

--- a/saleor/graphql/product/tests/test_variant_pricing.py
+++ b/saleor/graphql/product/tests/test_variant_pricing.py
@@ -384,10 +384,10 @@ QUERY_GET_PRODUCT_VARIANTS_PRICING_NO_ADDRESS = """
 
 
 @patch(
-    "saleor.graphql.product.types.products.get_tax_rate_for_tax_class",
+    "saleor.graphql.product.types.products.get_tax_rate_for_country",
 )
 def test_product_variant_price_no_address(
-    mock_get_tax_rate_for_tax_class, user_api_client, variant, stock, channel_USD
+    mock_get_tax_rate_for_country, user_api_client, variant, stock, channel_USD
 ):
     channel_USD.default_country = "FR"
     channel_USD.save()
@@ -396,9 +396,7 @@ def test_product_variant_price_no_address(
     user_api_client.post_graphql(
         QUERY_GET_PRODUCT_VARIANTS_PRICING_NO_ADDRESS, variables
     )
-    assert (
-        mock_get_tax_rate_for_tax_class.call_args[0][3] == channel_USD.default_country
-    )
+    assert mock_get_tax_rate_for_country.call_args[0][2] == channel_USD.default_country
 
 
 FRAGMENT_PRICE = """

--- a/saleor/graphql/tax/dataloaders.py
+++ b/saleor/graphql/tax/dataloaders.py
@@ -80,8 +80,8 @@ class TaxClassByIdLoader(DataLoader):
         return [tax_class_map.get(obj_id) for obj_id in keys]
 
 
-class TaxClassByProductIdLoader(DataLoader):
-    context_key = "tax_class_by_product_id"
+class TaxClassIdByProductIdLoader(DataLoader):
+    context_key = "tax_class_id_by_product_id"
 
     def batch_load(self, keys):
         products = ProductByIdLoader(self.context).load_many(keys)
@@ -99,12 +99,7 @@ class TaxClassByProductIdLoader(DataLoader):
                 tax_class_id = product.tax_class_id or product_type.tax_class_id
                 tax_class_ids_map[product_id] = tax_class_id
 
-            return [
-                TaxClassByIdLoader(self.context).load(tax_class_ids_map[product_id])
-                if tax_class_ids_map[product_id]
-                else None
-                for product_id in keys
-            ]
+            return [tax_class_ids_map[product_id] for product_id in keys]
 
         return Promise.all([products, product_types]).then(load_tax_classes)
 
@@ -129,9 +124,11 @@ class TaxClassByVariantIdLoader(DataLoader):
                 tax_class_ids_map[variant_pk] = tax_class_id
 
             return [
-                TaxClassByIdLoader(self.context).load(tax_class_ids_map[variant_id])
-                if tax_class_ids_map[variant_id]
-                else None
+                (
+                    TaxClassByIdLoader(self.context).load(tax_class_ids_map[variant_id])
+                    if tax_class_ids_map[variant_id]
+                    else None
+                )
                 for variant_id in keys
             ]
 
@@ -157,8 +154,10 @@ class ProductChargeTaxesByTaxClassIdLoader(DataLoader):
             .in_bulk(keys)
         )
         return [
-            tax_class_map[tax_class_id].charge_taxes
-            if tax_class_map.get(tax_class_id)
-            else False
+            (
+                tax_class_map[tax_class_id].charge_taxes
+                if tax_class_map.get(tax_class_id)
+                else False
+            )
             for tax_class_id in keys
         ]

--- a/saleor/order/tests/benchmark/test_fetch_order_prices.py
+++ b/saleor/order/tests/benchmark/test_fetch_order_prices.py
@@ -18,5 +18,5 @@ def test_fetch_order_prices(
     order.status = OrderStatus.UNCONFIRMED
 
     # when & then
-    with django_assert_num_queries(32):
+    with django_assert_num_queries(28):
         fetch_order_prices_if_expired(order, plugins_manager, None, True)

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -218,17 +218,22 @@ def calculate_tax_rate(price: TaxedMoney) -> Decimal:
     return tax_rate
 
 
-def get_tax_rate_for_tax_class(
-    tax_class: Optional["TaxClass"],
+def get_tax_rate_for_country(
     tax_class_country_rates: Iterable["TaxClassCountryRate"],
     default_tax_rate: Decimal,
     country_code: str,
 ) -> Decimal:
+    """Get tax rate for provided country code.
+
+    Function returns the tax rate for provided country code. If not found, the default
+    one will be returned.
+    `tax_class_country_rates` is the iterable set of rates assigned to single
+    `TaxClass`.
+    """
     tax_rate = default_tax_rate
-    if tax_class:
-        for country_rate in tax_class_country_rates:
-            if country_rate.country == country_code:
-                tax_rate = country_rate.rate
+    for country_rate in tax_class_country_rates:
+        if country_rate.country == country_code:
+            tax_rate = country_rate.rate
     return tax_rate
 
 


### PR DESCRIPTION
I want to merge this change because: 
- it makes a const value of DB queries when re-calculating order-prices
- it reduces the DB queries when re-calculating order-prices (from 32 to 28)
- it drops unneeded `allow_writer` context


Note: Didn't add any tests, as I didn't change anything in the logic - just some ways of fetching tax_class_ids. It should work in the same way as previously, but with a reduced amount of db queries 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
