### PR TITLE
Add otel tests

### DIFF
--- a/saleor/asgi/tests/test_telemetry.py
+++ b/saleor/asgi/tests/test_telemetry.py
@@ -1,0 +1,90 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from asgiref.typing import ASGIReceiveCallable, ASGISendCallable
+from opentelemetry.semconv.trace import SpanAttributes
+
+from ...asgi.telemetry import get_hostname, telemetry_middleware
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected"),
+    [
+        ({"type": "http", "headers": [(b"host", b"example.com")]}, "example.com"),
+        (
+            {"type": "http", "headers": [(b"host", b"example.com:8000")]},
+            "example.com:8000",
+        ),
+        ({"type": "http", "headers": [(b"HOST", b"EXAMPLE.COM")]}, "example.com"),
+    ],
+)
+def test_get_hostname_with_http_request(scope, expected):
+    # when
+    result = get_hostname(scope)  # type: ignore[call-arg]
+
+    # then
+    assert result == expected
+
+
+def test_get_hostname_with_non_http_request():
+    # given
+    scope = {
+        "type": "websocket",
+        "headers": [
+            (b"host", b"example.com"),
+        ],
+    }
+
+    # when
+    result = get_hostname(scope)  # type: ignore[call-arg]
+
+    # then
+    assert result == ""
+
+
+def test_get_hostname_with_no_host_header():
+    # given
+    scope = {
+        "type": "http",
+        "headers": [
+            (b"content-type", b"application/json"),
+        ],
+    }
+
+    # when
+    result = get_hostname(scope)  # type: ignore[call-arg]
+
+    # then
+    assert result == ""
+
+
+@pytest.mark.asyncio
+@patch("saleor.asgi.telemetry.set_global_attributes")
+async def test_telemetry_middleware(mock_set_global_attrs):
+    # given
+    mock_set_global_attrs.return_value = MagicMock()
+    mock_app = AsyncMock(return_value=None)
+
+    scope = {
+        "type": "http",
+        "headers": [
+            (b"host", b"example.com"),
+        ],
+    }
+    receive = MagicMock(spec=ASGIReceiveCallable)
+    send = MagicMock(spec=ASGISendCallable)
+
+    # when
+    middleware = telemetry_middleware(mock_app)
+    await middleware(scope, receive, send)  # type: ignore[call-arg]
+
+    # then
+    mock_set_global_attrs.assert_called_once()
+    assert SpanAttributes.SERVER_ADDRESS in mock_set_global_attrs.call_args[0][0]
+    assert (
+        mock_set_global_attrs.call_args[0][0][SpanAttributes.SERVER_ADDRESS]
+        == "example.com"
+    )
+
+    # verify that the wrapped application was called with the same arguments
+    mock_app.assert_called_once_with(scope, receive, send)

--- a/saleor/core/telemetry/metric.py
+++ b/saleor/core/telemetry/metric.py
@@ -161,7 +161,7 @@ class MeterProxy(Meter):
 
     def initialize(self, meter_cls: type[Meter], instrumentation_version: str) -> None:
         if self._meter:
-            logger.warning("Tracer already initialized")
+            logger.warning("Meter already initialized")
         self._meter = meter_cls(instrumentation_version)
         with self._lock:
             for name, kwargs in self._metrics.items():

--- a/saleor/core/telemetry/tests/test_metric.py
+++ b/saleor/core/telemetry/tests/test_metric.py
@@ -1,0 +1,416 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.metrics import Synchronous
+
+from ..metric import (
+    DuplicateMetricError,
+    Meter,
+    MeterProxy,
+    MetricType,
+    get_instrument_method,
+)
+from ..utils import Scope, Unit
+
+
+def test_get_instrument_method_add():
+    # given
+    instrument = MagicMock(spec=Synchronous)
+    instrument.add = MagicMock()
+
+    # when
+    method = get_instrument_method(instrument)
+
+    # then
+    assert method == instrument.add
+
+
+def test_get_instrument_method_record():
+    # given
+    instrument = MagicMock(spec=Synchronous)
+    instrument.record = MagicMock()
+
+    # when
+    method = get_instrument_method(instrument)
+
+    # then
+    assert method == instrument.record
+
+
+@patch("saleor.core.telemetry.metric.get_meter")
+def test_meter_initialization(mock_get_meter):
+    # given
+    instrumentation_version = "1.0.0"
+
+    # when
+    Meter(instrumentation_version)
+
+    # then
+    assert mock_get_meter.call_count == 2
+    mock_get_meter.assert_any_call(Scope.CORE.value, instrumentation_version)
+    mock_get_meter.assert_any_call(Scope.SERVICE.value, instrumentation_version)
+
+
+def test_meter_create_counter():
+    # given
+    mock_otel_meter = MagicMock()
+    mock_counter = MagicMock()
+    mock_otel_meter.create_counter.return_value = mock_counter
+
+    # when
+    instrument = Meter._create_instrument(
+        mock_otel_meter,
+        "counter_metric",
+        MetricType.COUNTER,
+        Unit.REQUEST,
+        "Counter description",
+    )
+
+    # then
+    mock_otel_meter.create_counter.assert_called_once_with(
+        "counter_metric",
+        unit=Unit.REQUEST.value,
+        description="Counter description",
+    )
+    assert instrument == mock_counter
+
+
+def test_meter_create_up_down_counter():
+    # given
+    mock_otel_meter = MagicMock()
+    mock_updown_counter = MagicMock()
+    mock_otel_meter.create_up_down_counter.return_value = mock_updown_counter
+
+    # when
+    instrument = Meter._create_instrument(
+        mock_otel_meter,
+        "updown_counter_metric",
+        MetricType.UP_DOWN_COUNTER,
+        Unit.REQUEST,
+        "UpDownCounter description",
+    )
+
+    # then
+    mock_otel_meter.create_up_down_counter.assert_called_once_with(
+        "updown_counter_metric",
+        unit=Unit.REQUEST.value,
+        description="UpDownCounter description",
+    )
+    assert instrument == mock_updown_counter
+
+
+def test_meter_create_histogram():
+    # given
+    mock_otel_meter = MagicMock()
+    mock_histogram = MagicMock()
+    mock_otel_meter.create_histogram.return_value = mock_histogram
+
+    # when
+    instrument = Meter._create_instrument(
+        mock_otel_meter,
+        "histogram_metric",
+        MetricType.HISTOGRAM,
+        Unit.SECOND,
+        "Histogram description",
+    )
+
+    # then
+    mock_otel_meter.create_histogram.assert_called_once_with(
+        "histogram_metric",
+        unit=Unit.SECOND.value,
+        description="Histogram description",
+    )
+    assert instrument == mock_histogram
+
+
+def test_meter_create_unsupported_metric_type():
+    mock_otel_meter = MagicMock()
+    with pytest.raises(AttributeError, match="Unsupported instrument type"):
+        Meter._create_instrument(
+            mock_otel_meter,
+            "invalid_metric",
+            "INVALID_TYPE",  # type: ignore[arg-type]
+            Unit.REQUEST,
+            "Invalid description",
+        )
+
+
+def test_meter_create_core_metric():
+    # given
+    meter = Meter("1.0.0")
+
+    with patch.object(meter, "_create_instrument") as mock_create_instrument:
+        mock_instrument = MagicMock()
+        mock_create_instrument.return_value = mock_instrument
+
+        # when
+        metric_name = meter.create_metric(
+            "core_metric",
+            type=MetricType.COUNTER,
+            unit=Unit.REQUEST,
+            scope=Scope.CORE,
+            description="Core metric description",
+        )
+
+        # then
+        mock_create_instrument.assert_called_once()
+        assert metric_name == "core_metric"
+        assert "core_metric" in meter._instruments
+        assert meter._instruments["core_metric"] == (Unit.REQUEST, mock_instrument)
+
+
+def test_meter_create_service_metric():
+    # given
+    meter = Meter("1.0.0")
+
+    with patch.object(meter, "_create_instrument") as mock_create_instrument:
+        mock_instrument = MagicMock()
+        mock_create_instrument.return_value = mock_instrument
+
+        # when
+        metric_name = meter.create_metric(
+            "service_metric",
+            type=MetricType.HISTOGRAM,
+            unit=Unit.SECOND,
+            scope=Scope.SERVICE,
+            description="Service metric description",
+        )
+
+        # then
+        mock_create_instrument.assert_called_once()
+        assert metric_name == "service_metric"
+        assert "service_metric" in meter._instruments
+        assert meter._instruments["service_metric"] == (Unit.SECOND, mock_instrument)
+
+
+def test_create_duplicate_metric():
+    # given
+    meter = Meter("1.0.0")
+    meter._instruments["service_metric"] = (Unit.REQUEST, MagicMock())
+
+    with patch.object(meter, "_create_instrument") as mock_create_instrument:
+        mock_instrument = MagicMock()
+        mock_create_instrument.return_value = mock_instrument
+
+        # Test duplicate metric
+        with pytest.raises(DuplicateMetricError, match="Metric .* already created"):
+            meter.create_metric(
+                "service_metric",
+                type=MetricType.COUNTER,
+                unit=Unit.REQUEST,
+                scope=Scope.SERVICE,
+            )
+
+
+def test_meter_record():
+    # given
+    meter = Meter("1.0.0")
+    mock_instrument = MagicMock(spec=Synchronous)
+    mock_instrument.add = MagicMock()
+    meter._instruments["test_metric"] = (Unit.REQUEST, mock_instrument)
+
+    # when
+    meter.record(
+        "test_metric",
+        1,
+        attributes={"attr1": "value1"},
+    )
+
+    # Verify that add was called with the correct arguments
+    mock_instrument.add.assert_called_once_with(1, {"attr1": "value1"})
+
+
+@patch("saleor.core.telemetry.metric.convert_unit")
+def test_meter_record_with_different_unit(mock_convert_unit):
+    # given
+    meter = Meter("1.0.0")
+    mock_instrument = MagicMock(spec=Synchronous)
+    mock_instrument.add = MagicMock()
+    meter._instruments["test_metric"] = (Unit.REQUEST, mock_instrument)
+
+    mock_convert_unit.return_value = 1000
+
+    # when
+    meter.record(
+        "test_metric",
+        1,
+        unit=Unit.SECOND,
+        attributes={"attr1": "value1"},
+    )
+
+    # then
+    mock_convert_unit.assert_called_once_with(1, Unit.SECOND, Unit.REQUEST)
+    mock_instrument.add.assert_called_with(1000, {"attr1": "value1"})
+
+
+def test_meter_record_non_existent_metric():
+    meter = Meter("1.0.0")
+    with pytest.raises(RuntimeError, match="Metric .* must be created first"):
+        meter.record(
+            "non_existent_metric",
+            1,
+        )
+
+
+@patch("time.monotonic_ns")
+def test_meter_record_duration(mock_monotonic_ns):
+    # given
+    meter = Meter("1.0.0")
+    mock_monotonic_ns.side_effect = [1000000, 2000000]  # 1ms difference
+    mock_instrument = MagicMock(spec=Synchronous)
+    mock_instrument.record = MagicMock()
+    meter._instruments["test_metric"] = (Unit.NANOSECOND, mock_instrument)
+
+    # when
+    with meter.record_duration("test_metric") as attrs:
+        attrs["attr1"] = "value1"
+
+    # then
+    mock_instrument.record.assert_called_once_with(1000000, {"attr1": "value1"})
+
+
+def test_meter_proxy_initialize():
+    # given
+    meter_proxy = MeterProxy()
+    mock_meter_cls = MagicMock(spec=Meter)
+    mock_meter = MagicMock(spec=Meter)
+    mock_meter_cls.return_value = mock_meter
+
+    meter_proxy.create_metric(
+        "test_metric",
+        type=MetricType.COUNTER,
+        unit=Unit.REQUEST,
+        scope=Scope.CORE,
+        description="Test metric description",
+    )
+
+    # when
+    meter_proxy.initialize(mock_meter_cls, "1.0.0")
+
+    # then
+    mock_meter_cls.assert_called_once_with("1.0.0")
+    assert meter_proxy._meter == mock_meter
+
+    mock_meter.create_metric.assert_called_once_with(
+        "test_metric",
+        type=MetricType.COUNTER,
+        unit=Unit.REQUEST,
+        scope=Scope.CORE,
+        description="Test metric description",
+    )
+
+    # Initialize again should log a warning
+    with patch("saleor.core.telemetry.metric.logger.warning") as mock_warning:
+        meter_proxy.initialize(mock_meter_cls, "1.0.0")
+        mock_warning.assert_called_once_with("Meter already initialized")
+
+
+def test_meter_proxy_create_metric_without_meter():
+    # given
+    meter_proxy = MeterProxy()
+
+    # when
+    metric_name = meter_proxy.create_metric(
+        "test_metric",
+        type=MetricType.COUNTER,
+        unit=Unit.REQUEST,
+        scope=Scope.CORE,
+        description="Test metric description",
+    )
+
+    # Verify that the metric was added to the proxy
+    assert metric_name == "test_metric"
+    assert "test_metric" in meter_proxy._metrics
+    assert meter_proxy._metrics["test_metric"]["type"] == MetricType.COUNTER
+    assert meter_proxy._metrics["test_metric"]["unit"] == Unit.REQUEST
+    assert meter_proxy._metrics["test_metric"]["scope"] == Scope.CORE
+    assert (
+        meter_proxy._metrics["test_metric"]["description"] == "Test metric description"
+    )
+
+
+def test_meter_proxy_create_duplicate_metric_without_meter():
+    # given
+    meter_proxy = MeterProxy()
+    meter_proxy.create_metric(
+        "test_metric",
+        type=MetricType.COUNTER,
+        unit=Unit.REQUEST,
+        scope=Scope.CORE,
+        description="Test metric description",
+    )
+
+    # then
+    with pytest.raises(DuplicateMetricError, match="Metric .* already created"):
+        meter_proxy.create_metric(
+            "test_metric",
+            type=MetricType.COUNTER,
+            unit=Unit.REQUEST,
+            scope=Scope.CORE,
+        )
+
+
+def test_meter_proxy_create_metric_with_meter():
+    # given
+    meter_proxy = MeterProxy()
+    mock_meter = MagicMock(spec=Meter)
+    mock_meter.create_metric.return_value = "test_metric"
+    meter_proxy._meter = mock_meter
+
+    # when
+    metric_name = meter_proxy.create_metric(
+        "test_metric",
+        type=MetricType.COUNTER,
+        unit=Unit.REQUEST,
+        scope=Scope.CORE,
+        description="Test metric description",
+    )
+
+    # then
+    mock_meter.create_metric.assert_called_once_with(
+        "test_metric",
+        type=MetricType.COUNTER,
+        unit=Unit.REQUEST,
+        scope=Scope.CORE,
+        description="Test metric description",
+    )
+    assert metric_name == "test_metric"
+
+
+def test_meter_proxy_record_without_meter():
+    # given
+    meter_proxy = MeterProxy()
+
+    # when
+    meter_proxy.record(
+        "test_metric",
+        1,
+        unit=Unit.REQUEST,
+        attributes={"attr1": "value1"},
+    )
+
+    # then
+    # should not raise an error, but do nothing
+
+
+def test_meter_proxy_record_with_meter():
+    # given
+    meter_proxy = MeterProxy()
+    mock_meter = MagicMock(spec=Meter)
+    meter_proxy._meter = mock_meter
+
+    # when
+    meter_proxy.record(
+        "test_metric",
+        1,
+        unit=Unit.REQUEST,
+        attributes={"attr1": "value1"},
+    )
+
+    # then
+    mock_meter.record.assert_called_once_with(
+        "test_metric",
+        1,
+        unit=Unit.REQUEST,
+        attributes={"attr1": "value1"},
+    )

--- a/saleor/core/telemetry/tests/test_trace.py
+++ b/saleor/core/telemetry/tests/test_trace.py
@@ -1,0 +1,217 @@
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.trace import INVALID_SPAN, Span, SpanKind
+
+from ..trace import Tracer, TracerProxy
+from ..utils import Scope
+
+
+@patch("saleor.core.telemetry.trace.get_tracer")
+def test_tracer_initialization(mock_get_tracer):
+    # given
+    instrumentation_version = "1.0.0"
+
+    # when
+    Tracer(instrumentation_version)
+
+    # then
+    assert mock_get_tracer.call_count == 2
+    mock_get_tracer.assert_any_call(Scope.CORE.value, instrumentation_version)
+    mock_get_tracer.assert_any_call(Scope.SERVICE.value, instrumentation_version)
+
+
+@patch("saleor.core.telemetry.trace.get_tracer")
+def test_tracer_start_as_current_span(mock_get_tracer):
+    # given
+    mock_core_tracer = MagicMock()
+    mock_service_tracer = MagicMock()
+    mock_span = MagicMock()
+    mock_core_tracer.start_as_current_span.return_value.__enter__.return_value = (
+        mock_span
+    )
+    mock_service_tracer.start_as_current_span.return_value.__enter__.return_value = (
+        mock_span
+    )
+
+    # mock get_tracer to return different tracers for different scopes
+    def mock_get_tracer_func(scope, version):
+        if scope == Scope.CORE.value:
+            return mock_core_tracer
+        return mock_service_tracer
+
+    mock_get_tracer.side_effect = mock_get_tracer_func
+
+    # when
+    tracer = Tracer("1.0.0")
+
+    # then
+    with tracer.start_as_current_span("test_span", scope=Scope.CORE) as span:
+        # verify that the core tracer was used
+        mock_core_tracer.start_as_current_span.assert_called_once()
+        assert span == mock_span
+
+    with tracer.start_as_current_span("test_span", scope=Scope.SERVICE) as span:
+        # verify that the service tracer was used
+        mock_service_tracer.start_as_current_span.assert_called_once()
+        assert span == mock_span
+
+
+@patch("saleor.core.telemetry.trace.get_tracer")
+def test_tracer_start_span(mock_get_tracer):
+    # given
+    mock_core_tracer = MagicMock()
+    mock_service_tracer = MagicMock()
+    mock_core_span = MagicMock()
+    mock_service_span = MagicMock()
+    mock_core_tracer.start_span.return_value = mock_core_span
+    mock_service_tracer.start_span.return_value = mock_service_span
+
+    # mock get_tracer to return different tracers for different scopes
+    def mock_get_tracer_func(scope, version):
+        if scope == Scope.CORE.value:
+            return mock_core_tracer
+        return mock_service_tracer
+
+    mock_get_tracer.side_effect = mock_get_tracer_func
+
+    # when
+    tracer = Tracer("1.0.0")
+    core_span = tracer.start_span("test_span", scope=Scope.CORE)
+    service_span = tracer.start_span("test_span", scope=Scope.SERVICE)
+
+    # then
+    mock_core_tracer.start_span.assert_called_once()
+    assert core_span == mock_core_span
+
+    mock_service_tracer.start_span.assert_called_once()
+    assert service_span == mock_service_span
+
+
+@patch("saleor.core.telemetry.trace.get_current_span")
+def test_tracer_get_current_span(mock_get_current_span):
+    # given
+    mock_span = MagicMock()
+    mock_get_current_span.return_value = mock_span
+
+    # when
+    tracer = Tracer("1.0.0")
+    span = tracer.get_current_span()
+
+    # then
+    mock_get_current_span.assert_called_once()
+    assert span == mock_span
+
+
+@patch("saleor.core.telemetry.trace.logger.warning")
+def test_tracer_proxy_initialize(mock_warning):
+    # given
+    tracer_proxy = TracerProxy()
+    mock_tracer_cls = MagicMock()
+
+    # when
+    tracer_proxy.initialize(mock_tracer_cls, "1.0.0")
+
+    # then
+    mock_tracer_cls.assert_called_once_with("1.0.0")
+
+    # initialize again should log a warning
+    tracer_proxy.initialize(mock_tracer_cls, "1.0.0")
+    mock_warning.assert_called_once_with("Tracer already initialized")
+
+
+def test_tracer_proxy_start_as_current_span_with_tracer():
+    # given
+    tracer_proxy = TracerProxy()
+    mock_tracer = MagicMock()
+    mock_span = MagicMock()
+    mock_tracer.start_as_current_span.return_value.__enter__.return_value = mock_span
+    tracer_proxy._tracer = mock_tracer
+
+    # when
+    with tracer_proxy.start_as_current_span("test_span") as span:
+        # then
+        mock_tracer.start_as_current_span.assert_called_once_with(
+            "test_span",
+            scope=Scope.CORE,
+            kind=SpanKind.INTERNAL,
+            attributes=None,
+            links=None,
+            start_time=None,
+            record_exception=True,
+            set_status_on_exception=True,
+            end_on_exit=True,
+        )
+        assert span == mock_span
+
+
+def test_tracer_proxy_start_span_with_tracer():
+    # given
+    tracer_proxy = TracerProxy()
+    mock_tracer = MagicMock(spec=Tracer)
+    mock_span = MagicMock(spec=Span)
+    mock_tracer.start_span.return_value = mock_span
+    tracer_proxy._tracer = mock_tracer
+
+    # when
+    span = tracer_proxy.start_span("test_span")
+
+    # then
+    mock_tracer.start_span.assert_called_once_with(
+        "test_span",
+        scope=Scope.CORE,
+        kind=SpanKind.INTERNAL,
+        attributes=None,
+        links=None,
+        start_time=None,
+        record_exception=True,
+        set_status_on_exception=True,
+    )
+    assert span == mock_span
+
+
+def test_tracer_proxy_get_current_span_with_tracer():
+    # given
+    tracer_proxy = TracerProxy()
+    mock_tracer = MagicMock(spec=Tracer)
+    mock_span = MagicMock(spec=Span)
+    mock_tracer.get_current_span.return_value = mock_span
+    tracer_proxy._tracer = mock_tracer
+
+    # when
+    span = tracer_proxy.get_current_span()
+
+    # then
+    mock_tracer.get_current_span.assert_called_once()
+    assert span == mock_span
+
+
+def test_tracer_proxy_start_as_current_span_without_tracer():
+    # given
+    tracer_proxy = TracerProxy()
+
+    # when
+    with tracer_proxy.start_as_current_span("test_span") as span:
+        # then
+        assert span == INVALID_SPAN
+
+
+def test_tracer_proxy_start_span_without_tracer():
+    # given
+    tracer_proxy = TracerProxy()
+
+    # when
+    span = tracer_proxy.start_span("test_span")
+
+    # then
+    assert span == INVALID_SPAN
+
+
+def test_tracer_proxy_get_current_span_without_tracer():
+    # given
+    tracer_proxy = TracerProxy()
+
+    # when
+    span = tracer_proxy.get_current_span()
+
+    # then
+    assert span == INVALID_SPAN

--- a/saleor/core/telemetry/tests/test_utils.py
+++ b/saleor/core/telemetry/tests/test_utils.py
@@ -1,0 +1,247 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.trace import Link, SpanContext, TraceFlags
+from opentelemetry.util.types import AttributeValue
+
+from ..utils import (
+    Scope,
+    TelemetryTaskContext,
+    Unit,
+    convert_unit,
+    enrich_with_global_attributes,
+    get_global_attributes,
+    set_global_attributes,
+    task_with_telemetry_context,
+)
+
+
+def test_scope_is_service():
+    assert Scope.SERVICE.is_service is True
+    assert Scope.CORE.is_service is False
+
+
+def test_convert_unit_same_unit():
+    # Same unit should return the same value
+    assert convert_unit(100, Unit.SECOND, Unit.SECOND) == 100
+    assert convert_unit(100, Unit.MILLISECOND, Unit.MILLISECOND) == 100
+    assert convert_unit(100, Unit.NANOSECOND, Unit.NANOSECOND) == 100
+
+
+def test_convert_unit_null_source():
+    # Null source unit should return the same value
+    assert convert_unit(100, None, Unit.SECOND) == 100
+    assert convert_unit(100, None, Unit.MILLISECOND) == 100
+
+
+def test_convert_unit_supported_conversions():
+    # Test nanoseconds to milliseconds
+    assert convert_unit(1000000, Unit.NANOSECOND, Unit.MILLISECOND) == 1
+
+    # Test nanoseconds to seconds
+    assert convert_unit(1000000000, Unit.NANOSECOND, Unit.SECOND) == 1
+
+
+def test_convert_unit_unsupported_conversion():
+    # Test unsupported conversion (e.g., milliseconds to requests)
+    with pytest.raises(ValueError, match="Conversion from .* to .* not supported"):
+        convert_unit(100, Unit.MILLISECOND, Unit.REQUEST)
+
+
+def test_global_attributes():
+    # Test setting and getting global attributes
+    test_attrs: dict[str, AttributeValue] = {"test_key": "test_value"}
+
+    # Initial global attributes should be empty
+    assert get_global_attributes() == {}
+
+    # Set global attributes
+    with set_global_attributes(test_attrs):
+        # Get global attributes
+        assert get_global_attributes() == test_attrs
+
+        # Nested attributes should work
+        nested_attrs: dict[str, AttributeValue] = {"nested_key": "nested_value"}
+        with set_global_attributes(nested_attrs):
+            assert get_global_attributes() == nested_attrs
+
+        # After exiting nested context, should return to original attributes
+        assert get_global_attributes() == test_attrs
+
+    # After exiting context, should be empty again
+    assert get_global_attributes() == {}
+
+
+def test_enrich_with_global_attributes():
+    # given
+    global_attrs: dict[str, AttributeValue] = {"global_key": "global_value"}
+    local_attrs: dict[str, AttributeValue] = {"local_key": "local_value"}
+
+    with set_global_attributes(global_attrs):
+        # when
+        enriched = enrich_with_global_attributes(local_attrs)
+
+        # then
+        assert enriched is not None
+        assert "global_key" in enriched
+        assert "local_key" in enriched
+        assert enriched["global_key"] == "global_value"
+        assert enriched["local_key"] == "local_value"
+
+
+def test_enrich_with_global_attributes_none():
+    # given
+    global_attrs: dict[str, AttributeValue] = {"global_key": "global_value"}
+
+    with set_global_attributes(global_attrs):
+        # when
+        enriched = enrich_with_global_attributes(None)
+
+        # then
+        assert enriched == global_attrs
+
+
+def test_telemetry_task_context_to_dict():
+    # given
+    span_context = SpanContext(
+        trace_id=12345, span_id=67890, is_remote=True, trace_flags=TraceFlags(1)
+    )
+    link = Link(context=span_context, attributes={"link_attr": "link_value"})
+
+    # when
+    global_attrs: dict[str, AttributeValue] = {"global_key": "global_value"}
+    context = TelemetryTaskContext(links=[link], global_attributes=global_attrs)
+
+    # then
+    data = context.to_dict()
+    assert "links" in data
+    assert "global_attributes" in data
+    assert len(data["links"]) == 1
+    assert "context" in data["links"][0]
+    assert "attributes" in data["links"][0]
+    assert data["links"][0]["context"]["trace_id"] == 12345
+    assert data["links"][0]["context"]["span_id"] == 67890
+    assert data["links"][0]["context"]["trace_flags"] == 1
+    assert data["links"][0]["attributes"] == {"link_attr": "link_value"}
+    assert data["global_attributes"] == global_attrs
+
+
+def test_telemetry_task_context_from_dict():
+    # given
+    data = {
+        "links": [
+            {
+                "context": {
+                    "trace_id": 12345,
+                    "span_id": 67890,
+                    "trace_flags": 1,
+                },
+                "attributes": {"link_attr": "link_value"},
+            }
+        ],
+        "global_attributes": {"global_key": "global_value"},
+    }
+
+    # when
+    context = TelemetryTaskContext.from_dict(data)
+
+    # then
+    assert context.links is not None
+    assert len(context.links) == 1
+    assert context.links[0].context.trace_id == 12345
+    assert context.links[0].context.span_id == 67890
+    assert context.links[0].context.trace_flags == TraceFlags(1)
+    assert context.links[0].attributes == {"link_attr": "link_value"}
+    assert context.global_attributes == {"global_key": "global_value"}
+
+
+def test_telemetry_task_context_from_dict_invalid():
+    invalid_data = {
+        "links": [
+            {
+                "invalid_key": "invalid_value",
+            }
+        ],
+    }
+
+    # should raise ValueError
+    with pytest.raises(ValueError, match="Invalid telemetry context data"):
+        TelemetryTaskContext.from_dict(invalid_data)
+
+
+def test_telemetry_task_context_from_dict_empty():
+    # when
+    context = TelemetryTaskContext.from_dict(None)
+
+    # then
+    assert context.links is None
+    assert context.global_attributes == {}
+
+
+@patch("saleor.core.telemetry.utils.set_global_attributes")
+def test_task_with_telemetry_context_decorator(mock_set_global_attrs):
+    # given
+    mock_func = MagicMock()
+    decorated_func = task_with_telemetry_context(mock_func)
+    context = TelemetryTaskContext(global_attributes={"test": "value"})
+
+    # when
+    decorated_func(telemetry_context=context.to_dict())
+
+    # then
+    mock_set_global_attrs.assert_called_once_with({"test": "value"})
+    mock_func.assert_called_once()
+    assert "telemetry_context" in mock_func.call_args.kwargs
+    assert isinstance(
+        mock_func.call_args.kwargs["telemetry_context"], TelemetryTaskContext
+    )
+
+
+@patch("saleor.core.telemetry.utils.set_global_attributes")
+@patch("saleor.core.telemetry.utils.logger.warning")
+def test_task_with_telemetry_context_decorator_no_context(
+    mock_warning, mock_set_global_attrs
+):
+    # given
+    mock_func = MagicMock()
+    decorated_func = task_with_telemetry_context(mock_func)
+
+    # when
+    decorated_func()
+
+    # then
+    mock_warning.assert_called_once_with("No telemetry_context provided for the task")
+    mock_set_global_attrs.assert_called_once_with({})
+    mock_func.assert_called_once()
+
+
+@patch("saleor.core.telemetry.utils.set_global_attributes")
+@patch("saleor.core.telemetry.utils.logger.exception")
+def test_task_with_telemetry_context_decorator_invalid_links_context(
+    mock_logger, mock_set_global_attrs
+):
+    # given
+    mock_func = MagicMock()
+    decorated_func = task_with_telemetry_context(mock_func)
+
+    # when
+    decorated_func(telemetry_context={"links": [{"invalid": "context"}]})
+
+    # then
+    mock_logger.assert_called_once_with("Failed to parse telemetry context")
+    mock_set_global_attrs.assert_called_once_with({})
+    mock_func.assert_called_once()
+
+
+@patch("saleor.core.telemetry.utils.set_global_attributes")
+def test_task_with_telemetry_context_decorator_invalid_context(mock_set_global_attrs):
+    # given
+    mock_func = MagicMock()
+    decorated_func = task_with_telemetry_context(mock_func)
+
+    # when
+    decorated_func(telemetry_context={"invalid": "context"})
+
+    # then
+    mock_set_global_attrs.assert_called_once_with({})
+    mock_func.assert_called_once()

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from ..metrics import (
+    METRIC_GRAPHQL_QUERIES,
+    METRIC_GRAPHQL_QUERY_DURATION,
+    record_graphql_queries_count,
+    record_graphql_query_duration,
+)
+
+
+@patch("saleor.graphql.metrics.meter")
+def test_record_graphql_queries_count(mock_meter):
+    # when
+    record_graphql_queries_count(5)
+
+    # then
+    mock_meter.record.assert_called_once_with(METRIC_GRAPHQL_QUERIES, 5)
+
+
+@patch("saleor.graphql.metrics.meter")
+def test_record_graphql_query_duration(mock_meter):
+    # given
+    mock_context_manager = object()
+    mock_meter.record_duration.return_value = mock_context_manager
+
+    # when
+    result = record_graphql_query_duration()
+
+    # then
+    mock_meter.record_duration.assert_called_once_with(METRIC_GRAPHQL_QUERY_DURATION)
+    assert result == mock_context_manager


### PR DESCRIPTION
Add tests for OpenTelemetry utilities and logic.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
