### PR TITLE
Drop service.name attribute

### DIFF
--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -15,10 +15,9 @@ def traced_atomic_transaction():
 
 
 @contextmanager
-def otel_trace(span_name, component_name, service_name):
+def otel_trace(span_name, component_name):
     with tracer.start_as_current_span(span_name) as span:
         span.set_attribute("component", component_name)
-        span.set_attribute("service.name", service_name)
         yield
 
 
@@ -45,7 +44,6 @@ def webhooks_otel_trace(
             span.set_attribute("app.id", app.id)
             span.set_attribute("app.name", app.name)
         span.set_attribute("component", "webhooks")
-        span.set_attribute("service.name", "webhooks")
         span.set_attribute("webhooks.domain", domain)
         span.set_attribute("webhooks.execution_mode", "sync" if sync else "async")
         span.set_attribute("webhooks.payload_size", payload_size)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -51,7 +51,6 @@ def tracing_wrapper(execute, sql, params, many, context):
             conn.settings_dict.get("HOST"),  # type: ignore[arg-type]
         )
         span.set_attribute(SpanAttributes.SERVER_PORT, conn.settings_dict.get("PORT"))  # type: ignore[arg-type]
-        span.set_attribute("service.name", "postgres")
         span.set_attribute("span.type", "sql")
         return execute(sql, params, many, context)
 

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -261,7 +261,6 @@ class AdyenGatewayPlugin(BasePlugin):
         if path.startswith(ADDITIONAL_ACTION_PATH):
             with tracer.start_as_current_span("adyen.checkout.payment_details") as span:
                 span.set_attribute("component", "payment")
-                span.set_attribute("service.name", "adyen")
                 return handle_additional_actions(
                     request, self.adyen.checkout.payments_details, self.channel.slug
                 )
@@ -333,7 +332,6 @@ class AdyenGatewayPlugin(BasePlugin):
             )
             with tracer.start_as_current_span("adyen.checkout.payment_methods") as span:
                 span.set_attribute("component", "payment")
-                span.set_attribute("service.name", "adyen")
                 response = api_call(request, self.adyen.checkout.payment_methods)
                 adyen_payment_methods = json.dumps(response.message)
                 config.append({"field": "config", "value": adyen_payment_methods})
@@ -362,8 +360,6 @@ class AdyenGatewayPlugin(BasePlugin):
             "adyen.checkout.payment_methods_balance"
         ) as span:
             span.set_attribute("component", "payment")
-            span.set_attribute("service.name", "adyen")
-
             try:
                 result = api_call(
                     request_data,
@@ -429,7 +425,6 @@ class AdyenGatewayPlugin(BasePlugin):
         )
         with tracer.start_as_current_span("adyen.checkout.payments") as span:
             span.set_attribute("component", "payment")
-            span.set_attribute("service.name", "adyen")
             result = api_call(request_data, self.adyen.checkout.payments)
         result_code = result.message["resultCode"].strip().lower()
         is_success = result_code not in FAILED_STATUSES
@@ -514,7 +509,6 @@ class AdyenGatewayPlugin(BasePlugin):
 
         with tracer.start_as_current_span("adyen.checkout.payment_details") as span:
             span.set_attribute("component", "payment")
-            span.set_attribute("service.name", "adyen")
             result = api_call(additional_data, self.adyen.checkout.payments_details)
         result_code = result.message["resultCode"].strip().lower()
         is_success = result_code not in FAILED_STATUSES
@@ -763,7 +757,6 @@ class AdyenGatewayPlugin(BasePlugin):
         )
         with tracer.start_as_current_span("adyen.payment.cancel") as span:
             span.set_attribute("component", "payment")
-            span.set_attribute("service.name", "adyen")
             result = api_call(request, self.adyen.payment.cancel)
 
         return GatewayResponse(

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -446,7 +446,6 @@ def call_refund(
     )
     with tracer.start_as_current_span("adyen.payment.refund") as span:
         span.set_attribute("component", "payment")
-        span.set_attribute("service.name", "adyen")
         return api_call(request, adyen_client.payment.refund)
 
 
@@ -465,7 +464,6 @@ def call_capture(
     )
     with tracer.start_as_current_span("adyen.payment.capture") as span:
         span.set_attribute("component", "payment")
-        span.set_attribute("service.name", "adyen")
         return api_call(request, adyen_client.payment.capture)
 
 

--- a/saleor/payment/gateways/braintree/__init__.py
+++ b/saleor/payment/gateways/braintree/__init__.py
@@ -111,7 +111,6 @@ def get_client_token(
     gateway = get_braintree_gateway(**config.connection_params)
     with tracer.start_as_current_span("braintree.client_token.generate") as span:
         span.set_attribute("component", "payment")
-        span.set_attribute("service.name", "braintree")
         parameters = create_token_params(config, token_config)
         return gateway.client_token.generate(parameters)
 
@@ -180,7 +179,6 @@ def transaction_for_new_customer(
 
     with tracer.start_as_current_span("braintree.transaction.sale") as span:
         span.set_attribute("component", "payment")
-        span.set_attribute("service.name", "braintree")
         params = get_customer_data(payment_information)
         merchant_account_id = config.connection_params["merchant_account_id"]
         if merchant_account_id:
@@ -209,7 +207,6 @@ def transaction_for_existing_customer(
     gateway = get_braintree_gateway(**config.connection_params)
     with tracer.start_as_current_span("braintree.transaction.sale") as span:
         span.set_attribute("component", "payment")
-        span.set_attribute("service.name", "braintree")
         params = get_customer_data(payment_information)
         merchant_account_id = config.connection_params["merchant_account_id"]
         if merchant_account_id:
@@ -236,7 +233,6 @@ def capture(payment_information: PaymentData, config: GatewayConfig) -> GatewayR
             "braintree.transaction.submit_for_settlement"
         ) as span:
             span.set_attribute("component", "payment")
-            span.set_attribute("service.name", "braintree")
             result = gateway.transaction.submit_for_settlement(
                 transaction_id=payment_information.token,
                 amount=str(payment_information.amount),
@@ -267,7 +263,6 @@ def void(payment_information: PaymentData, config: GatewayConfig) -> GatewayResp
     try:
         with tracer.start_as_current_span("braintree.transaction.void") as span:
             span.set_attribute("component", "payment")
-            span.set_attribute("service.name", "braintree")
             result = gateway.transaction.void(transaction_id=payment_information.token)
     except BraintreeError as exc:
         handle_braintree_error(exc)
@@ -295,7 +290,6 @@ def refund(payment_information: PaymentData, config: GatewayConfig) -> GatewayRe
     try:
         with tracer.start_as_current_span("braintree.transaction.refund") as span:
             span.set_attribute("component", "payment")
-            span.set_attribute("service.name", "braintree")
             result = gateway.transaction.refund(
                 transaction_id=payment_information.token,
                 amount_or_options=str(payment_information.amount),
@@ -333,7 +327,6 @@ def list_client_sources(
     gateway = get_braintree_gateway(**config.connection_params)
     with tracer.start_as_current_span("braintree.customer.find") as span:
         span.set_attribute("component", "payment")
-        span.set_attribute("service.name", "braintree")
         customer = gateway.customer.find(customer_id)
     if not customer:
         return []

--- a/saleor/payment/gateways/np_atobarai/utils.py
+++ b/saleor/payment/gateways/np_atobarai/utils.py
@@ -60,11 +60,7 @@ def get_fulfillment_for_order(order: Order) -> Fulfillment:
 
 @contextmanager
 def np_atobarai_otel_trace(span_name: str):
-    with otel_trace(
-        span_name=span_name,
-        component_name="payment",
-        service_name="np-atobarai",
-    ):
+    with otel_trace(span_name=span_name, component_name="payment"):
         yield
 
 

--- a/saleor/payment/gateways/razorpay/__init__.py
+++ b/saleor/payment/gateways/razorpay/__init__.py
@@ -98,7 +98,6 @@ def capture(payment_information: PaymentData, config: GatewayConfig) -> GatewayR
         try:
             with tracer.start_as_current_span("razorpay.payment.capture") as span:
                 span.set_attribute("component", "payment")
-                span.set_attribute("service.name", "razorpay")
                 response = razorpay_client.payment.capture(
                     payment_information.token, razorpay_amount
                 )
@@ -141,7 +140,6 @@ def refund(payment_information: PaymentData, config: GatewayConfig) -> GatewayRe
         try:
             with tracer.start_as_current_span("razorpay.payment.refund") as span:
                 span.set_attribute("component", "payment")
-                span.set_attribute("service.name", "razorpay")
                 response = razorpay_client.payment.refund(
                     payment_information.token, razorpay_amount
                 )

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -30,9 +30,7 @@ stripe.api_version = STRIPE_API_VERSION
 
 @contextmanager
 def stripe_otel_trace(span_name):
-    with otel_trace(
-        span_name=span_name, component_name="payment", service_name="stripe"
-    ):
+    with otel_trace(span_name=span_name, component_name="payment"):
         yield
 
 

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -566,7 +566,6 @@ def _fetch_new_taxes_data(
     )
     with tracer.start_as_current_span("avatax.transactions.crateoradjust") as span:
         span.set_attribute("component", "tax")
-        span.set_attribute("service.name", "avatax")
         response = api_post_request(transaction_url, data, config)
     if response and "error" not in response:
         cache.set(data_cache_key, (data, response), CACHE_TIME)
@@ -674,7 +673,6 @@ def get_cached_tax_codes_or_fetch(
         tax_codes_url = urljoin(get_api_url(config.use_sandbox), "definitions/taxcodes")
         with tracer.start_as_current_span("avatax.definitions.taxcodes") as span:
             span.set_attribute("component", "tax")
-            span.set_attribute("service.name", "avatax")
             response = api_get_request(
                 tax_codes_url, config.username_or_account, config.password_or_license
             )

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -346,7 +346,6 @@ class AvataxPlugin(BasePlugin):
         )
         with tracer.start_as_current_span("avatax.transactions.crateoradjust") as span:
             span.set_attribute("component", "tax")
-            span.set_attribute("service.name", "avatax")
             response = api_post_request(transaction_url, data, self.config)
         if not response or "error" in response:
             msg = response.get("error", {}).get("message", "")
@@ -907,7 +906,6 @@ class AvataxPlugin(BasePlugin):
         url = urljoin(get_api_url(conf["Use sandbox"]), "utilities/ping")
         with tracer.start_as_current_span("avatax.utilities.ping") as span:
             span.set_attribute("component", "tax")
-            span.set_attribute("service.name", "avatax")
             response = api_get_request(
                 url,
                 username_or_account=conf["Username or account"],

--- a/saleor/plugins/avatax/tasks.py
+++ b/saleor/plugins/avatax/tasks.py
@@ -39,7 +39,6 @@ def api_post_request_task(transaction_url, data, config, order_id):
 
     with tracer.start_as_current_span("avatax.transactions.crateoradjust") as span:
         span.set_attribute("component", "tax")
-        span.set_attribute("service.name", "avatax")
         response = api_post_request(transaction_url, data, config)
     msg = f"Order sent to Avatax. Order ID: {order.id}"
     if not response or "error" in response:

--- a/saleor/webhook/observability/tracing.py
+++ b/saleor/webhook/observability/tracing.py
@@ -6,6 +6,5 @@ from ...core.telemetry import tracer
 @contextmanager
 def otel_trace(span_name, component):
     with tracer.start_as_current_span(f"observability.{span_name}") as span:
-        span.set_attribute("service.name", "observability")
         span.set_attribute("component", component)
         yield


### PR DESCRIPTION
This PR removes the `service.name` attribute from spans. The attribute indicates that a span comes from another service, while in the case of core spans, they are all part of the "core" service.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
