### PR TITLE
Allow to change Admin email plugin custom templates back to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,4 @@ All notable, unreleased changes to this project will be documented in this file.
   This ensures user awareness of potential security policy violations and compliance risks of storing
   certain types of data. - #17506 by @NyanKiyoshi
 - Improve status calculation for orders with waiting-for-approval fulfillments - #17471 by @delemeator
+- Allow to change Admin email plugin custom templates back to default - #17563 by @wcislo-saleor

--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -308,6 +308,10 @@ class AdminEmailPlugin(BasePlugin):
                     plugin_configuration=plugin_configuration,
                     defaults={"value": et_data["value"]},
                 )
+            else:
+                EmailTemplate.objects.filter(
+                    plugin_configuration=plugin_configuration, name=et_data["name"]
+                ).delete()
 
         if plugin_configuration.configuration:
             # Let's add a translated descriptions and labels

--- a/saleor/plugins/admin_email/tests/test_plugin.py
+++ b/saleor/plugins/admin_email/tests/test_plugin.py
@@ -15,12 +15,13 @@ from ...email_common import (
     get_email_template,
 )
 from ...manager import get_plugins_manager
-from ...models import PluginConfiguration
+from ...models import EmailTemplate, PluginConfiguration
 from ..constants import (
     CSV_EXPORT_FAILED_TEMPLATE_FIELD,
     CSV_EXPORT_SUCCESS_TEMPLATE_FIELD,
     SET_STAFF_PASSWORD_TEMPLATE_FIELD,
     STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD,
+    STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
 )
 from ..notify_events import (
     send_csv_export_failed,
@@ -203,14 +204,23 @@ def test_save_plugin_configuration_incorrect_template(mocked_open, admin_email_p
     mocked_open.assert_called_with()
 
 
-def test_get_email_template(admin_email_plugin, admin_email_template):
-    plugin = admin_email_plugin()
-    default = "Default template"
-    template = get_email_template(plugin, admin_email_template.name, default)
-    assert template == admin_email_template.value
+def test_get_email_template(admin_email_plugin):
+    assert EmailTemplate.objects.exists() is False
 
-    admin_email_template.delete()
-    template = get_email_template(plugin, admin_email_template.name, default)
+    staff_password_reset_template = "Custom staff reset password email template"
+    plugin = admin_email_plugin(
+        staff_password_reset_template=staff_password_reset_template
+    )
+
+    assert EmailTemplate.objects.exists() is True
+
+    default = "Default template"
+    template = get_email_template(plugin, STAFF_PASSWORD_RESET_TEMPLATE_FIELD, default)
+    assert template == staff_password_reset_template
+
+    EmailTemplate.objects.all().delete()
+
+    template = get_email_template(plugin, STAFF_PASSWORD_RESET_TEMPLATE_FIELD, default)
     assert template == default
 
 
@@ -260,10 +270,12 @@ QUERY_GET_PLUGIN = """
 def test_configuration_resolver_returns_email_template_value(
     staff_api_client,
     admin_email_plugin,
-    admin_email_template,
     permission_manage_plugins,
 ):
-    plugin = admin_email_plugin()
+    staff_password_reset_template = "Custom staff reset password email template"
+    plugin = admin_email_plugin(
+        staff_password_reset_template=staff_password_reset_template
+    )
     response = staff_api_client.post_graphql(
         QUERY_GET_PLUGIN,
         {"id": plugin.PLUGIN_ID},
@@ -274,11 +286,11 @@ def test_configuration_resolver_returns_email_template_value(
 
     email_config_item = None
     for config_item in data["globalConfiguration"]["configuration"]:
-        if config_item["name"] == admin_email_template.name:
+        if config_item["name"] == STAFF_PASSWORD_RESET_TEMPLATE_FIELD:
             email_config_item = config_item
 
     assert email_config_item
-    assert email_config_item["value"] == admin_email_template.value
+    assert email_config_item["value"] == staff_password_reset_template
 
 
 def test_plugin_manager_doesnt_load_email_templates_from_db(
@@ -288,6 +300,7 @@ def test_plugin_manager_doesnt_load_email_templates_from_db(
     manager = get_plugins_manager(allow_replica=False)
     manager.get_all_plugins()
     plugin = manager.all_plugins[0]
+    assert EmailTemplate.objects.exists() is True
 
     email_config_item = None
     for config_item in plugin.configuration:
@@ -393,3 +406,41 @@ def test_override_default_config(
     )
     assert not email_backed.username
     assert not email_backed.password
+
+
+@patch("saleor.plugins.email_common.validate_email_config")
+def test_set_and_unset_custom_email_template(
+    mocked_validate_email_config, admin_email_plugin
+):
+    # Set custom email template
+    plugin = admin_email_plugin()
+    configuration = PluginConfiguration.objects.get()
+    data_to_save = {
+        "configuration": [
+            {
+                "name": STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD,
+                "value": "custom template",
+            },
+        ]
+    }
+    assert EmailTemplate.objects.exists() is False
+
+    plugin.save_plugin_configuration(configuration, data_to_save)
+
+    email_template = EmailTemplate.objects.get()
+    assert email_template.name == STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD
+    assert email_template.value == "custom template"
+
+    # Unset custom email template
+    data_to_save = {
+        "configuration": [
+            {
+                "name": STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD,
+                "value": DEFAULT_EMAIL_VALUE,
+            },
+        ]
+    }
+
+    plugin.save_plugin_configuration(configuration, data_to_save)
+
+    assert EmailTemplate.objects.exists() is False


### PR DESCRIPTION
It has to be backported to previous versions.

Changes in unrelated tests were necessary due to the way fixtures are written and used (`admin_email_plugin` fixture upon its use deletes template created by `admin_email_template` fixture).