### PR TITLE
Fixes incorrect gift card balances after covering the full order total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,3 +106,4 @@ All notable, unreleased changes to this project will be documented in this file.
   certain types of data. - #17506 by @NyanKiyoshi
 - Improve status calculation for orders with waiting-for-approval fulfillments - #17471 by @delemeator
 - Allow to change Admin email plugin custom templates back to default - #17563 by @wcislo-saleor
+- Fixes incorrect gift card balances after covering the full order total - #17566 by @korycins

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -623,15 +623,11 @@ def _prepare_order_data(
 
     order_data.update(_process_voucher_data_for_order(checkout_info))
 
-    order_data["total_price_left"] = (
-        calculations.checkout_subtotal(
-            manager=manager,
-            checkout_info=checkout_info,
-            lines=lines,
-            address=address,
-        )
-        + undiscounted_base_shipping_price
-        - checkout.discount
+    order_data["total_price_left"] = calculations.checkout_total(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=address,
     ).gross
 
     try:
@@ -1419,14 +1415,13 @@ def _create_order_from_checkout(
     )
 
     # giftcards
-    total_without_giftcard = (
-        order.subtotal
-        + undiscounted_base_shipping_price
-        - checkout_info.checkout.discount
-    )
-    add_gift_cards_to_order(
-        checkout_info, order, total_without_giftcard.gross, user, app
-    )
+    total_without_giftcard = calculations.checkout_total(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=checkout_lines_info,
+        address=address,
+    ).gross
+    add_gift_cards_to_order(checkout_info, order, total_without_giftcard, user, app)
 
     # payments
     checkout_info.checkout.payments.update(order=order, checkout_id=None)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -2028,7 +2028,7 @@ def test_checkout_with_voucher_complete(
 
 
 @pytest.mark.integration
-def test_checkout_complete_with_entire_order_voucher_and_gift_card(
+def test_checkout_complete_with_entire_order_voucher_paid_with_gift_card_and_transaction(
     user_api_client,
     checkout_with_voucher_percentage,
     voucher_percentage,
@@ -2132,6 +2132,108 @@ def test_checkout_complete_with_entire_order_voucher_and_gift_card(
 
     gift_card.refresh_from_db()
     assert gift_card.current_balance == zero_money(gift_card.currency)
+    assert gift_card.last_used_on
+    assert GiftCardEvent.objects.filter(
+        gift_card=gift_card, type=GiftCardEvents.USED_IN_ORDER
+    )
+
+
+@pytest.mark.integration
+def test_checkout_complete_with_voucher_paid_with_gift_card(
+    user_api_client,
+    checkout_with_voucher_percentage,
+    voucher_percentage,
+    gift_card,
+    address,
+    shipping_method,
+    transaction_events_generator,
+    transaction_item_generator,
+):
+    # given
+    checkout = prepare_checkout_for_test(
+        checkout_with_voucher_percentage,
+        address,
+        address,
+        shipping_method,
+        transaction_item_generator,
+        transaction_events_generator,
+    )
+    checkout.gift_cards.add(gift_card)
+
+    code = voucher_percentage.codes.first()
+    voucher_used_count = code.used
+    voucher_percentage.usage_limit = voucher_used_count + 1
+    voucher_percentage.save(update_fields=["usage_limit"])
+
+    expected_voucher_discount = checkout.discount
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    total_without_gc = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
+    )
+
+    gift_card.initial_balance_amount = total_without_gc.gross.amount + Decimal("1")
+    gift_card.current_balance_amount = total_without_gc.gross.amount + Decimal("1")
+    gift_card.save()
+
+    expected_gc_balance_amount = (
+        gift_card.initial_balance_amount - total_without_gc.gross.amount
+    )
+
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    shipping_price = shipping_method.channel_listings.get(
+        channel=checkout.channel
+    ).price
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+
+    order = Order.objects.get()
+    assert order.total == total
+    subtotal = get_subtotal(order.lines.all(), order.currency)
+    assert order.subtotal.gross == subtotal.gross
+    assert (
+        order.undiscounted_total
+        == subtotal + shipping_price + expected_voucher_discount
+    )
+
+    code.refresh_from_db()
+    assert code.used == voucher_used_count + 1
+    order_discount = order.discounts.filter(type=DiscountType.VOUCHER).first()
+    assert order_discount
+    assert order_discount.amount_value == expected_voucher_discount.amount
+    assert order.voucher == voucher_percentage
+    assert order.voucher.code == code.code
+
+    assert not Checkout.objects.filter(pk=checkout.pk).exists(), (
+        "Checkout should have been deleted"
+    )
+
+    order_line = order.lines.first()
+    assert (
+        order_line.unit_discount_amount
+        == (expected_voucher_discount / order_line.quantity).amount
+    )
+    assert order_line.unit_discount_reason
+
+    gift_card.refresh_from_db()
+    assert gift_card.current_balance.amount == expected_gc_balance_amount
     assert gift_card.last_used_on
     assert GiftCardEvent.objects.filter(
         gift_card=gift_card, type=GiftCardEvents.USED_IN_ORDER


### PR DESCRIPTION
I want to merge this change because it resolves the issue of incorrect gift card balances after the entire order total is covered by the gift card.

Internal link: https://linear.app/saleor/issue/EXT-2116/bug-gift-card-balance-not-well-deducted-in-order-with-voucher
Public GH issue: https://github.com/saleor/saleor/issues/12890
<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
