### PR TITLE
OpenTelemetry - Introduce Saleor custom span attributes

### DIFF
--- a/saleor/asgi/telemetry.py
+++ b/saleor/asgi/telemetry.py
@@ -4,9 +4,9 @@ from asgiref.typing import (
     ASGISendCallable,
     Scope,
 )
-from opentelemetry.semconv.trace import SpanAttributes
 
 from ..core.telemetry import set_global_attributes
+from ..core.telemetry.attributes import SALEOR_ENVIRONMENT_DOMAIN
 
 
 def get_hostname(scope: Scope) -> str:
@@ -21,9 +21,7 @@ def telemetry_middleware(application: ASGI3Application) -> ASGI3Application:
     async def telemetry_wrapper(
         scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:
-        with set_global_attributes(
-            {SpanAttributes.SERVER_ADDRESS: get_hostname(scope)}
-        ):
+        with set_global_attributes({SALEOR_ENVIRONMENT_DOMAIN: get_hostname(scope)}):
             return await application(scope, receive, send)
 
     return telemetry_wrapper

--- a/saleor/asgi/tests/test_telemetry.py
+++ b/saleor/asgi/tests/test_telemetry.py
@@ -2,9 +2,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from asgiref.typing import ASGIReceiveCallable, ASGISendCallable
-from opentelemetry.semconv.trace import SpanAttributes
 
 from ...asgi.telemetry import get_hostname, telemetry_middleware
+from ...core.telemetry.attributes import SALEOR_ENVIRONMENT_DOMAIN
 
 
 @pytest.mark.parametrize(
@@ -80,9 +80,9 @@ async def test_telemetry_middleware(mock_set_global_attrs):
 
     # then
     mock_set_global_attrs.assert_called_once()
-    assert SpanAttributes.SERVER_ADDRESS in mock_set_global_attrs.call_args[0][0]
+    assert SALEOR_ENVIRONMENT_DOMAIN in mock_set_global_attrs.call_args[0][0]
     assert (
-        mock_set_global_attrs.call_args[0][0][SpanAttributes.SERVER_ADDRESS]
+        mock_set_global_attrs.call_args[0][0][SALEOR_ENVIRONMENT_DOMAIN]
         == "example.com"
     )
 

--- a/saleor/core/telemetry/attributes.py
+++ b/saleor/core/telemetry/attributes.py
@@ -1,0 +1,3 @@
+from typing import Final
+
+SALEOR_ENVIRONMENT_DOMAIN: Final = "saleor.environment_domain"


### PR DESCRIPTION
I want to merge this change because this PR introduces a set for custom Saleor OTEL attributes, including one specifically designed to identify the Saleor environment in spans

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
