### PR TITLE
Change Discord Workflow from "good first issue" to "help wanted"

### DIFF
--- a/.github/workflows/help-wanted-issues-to-discord.yml
+++ b/.github/workflows/help-wanted-issues-to-discord.yml
@@ -1,4 +1,4 @@
-name: Notify Discord on Good First Issue
+name: Notify Discord on Help Wanted Issue
 
 on:
   issues:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    if: github.event.label.name == 'good first issue'
+    if: github.event.label.name == 'help wanted'
     runs-on: ubuntu-latest
     steps:
       - name: Send notification to Discord
@@ -14,7 +14,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.DISCORD_GFI_WEBHOOK_URL }}
           message: |
-            🎉 New Issue Labeled with "Good First Issue"
+            🎉 New Issue Labeled with "Help Wanted" in Saleor Core
 
             **Issue Details:**
             - Title: ${{ github.event.issue.title }}


### PR DESCRIPTION
Change "Good First Issue" GitHub Action to notify Discord on "Help Wanted" issues instead.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
