### PR TITLE
Fix `product.productVariants` resolver - do not require providing channel anymore

### DIFF
--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -44,6 +44,14 @@ MUTATION_UPDATE_PRODUCT = """
                     variants {
                         name
                     }
+                    productVariants(first: 10) {
+                        edges {
+                            node {
+                                id
+                                name
+                            }
+                        }
+                    }
                     taxType {
                         taxCode
                         description

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -495,6 +495,70 @@ def test_product_only_with_variants_without_sku_query_by_anonymous(
     assert product_data["variants"] == [{"id": variant_id}]
 
 
+def test_product_variants_query_by_staff_no_channel_provided(
+    staff_api_client, product, permission_manage_products, channel_USD, channel_PLN
+):
+    # given
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    variables = {
+        "id": product_id,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PRODUCT_BY_ID,
+        variables=variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_data = content["data"]["product"]
+
+    assert product_data is not None
+    assert product_data["id"] == product_id
+
+    variant = product.variants.first()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    assert product_data["productVariants"]["edges"] == [{"node": {"id": variant_id}}]
+    # deprecated field test
+    assert product_data["variants"] == [{"id": variant_id}]
+
+
+def test_product_variants_query_by_app_no_channel_provided(
+    app_api_client, product, permission_manage_products, channel_USD, channel_PLN
+):
+    # given
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    app_api_client.app.permissions.add(permission_manage_products)
+
+    variables = {
+        "id": product_id,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_PRODUCT_BY_ID,
+        variables=variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_data = content["data"]["product"]
+
+    assert product_data is not None
+    assert product_data["id"] == product_id
+
+    variant = product.variants.first()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    assert product_data["productVariants"]["edges"] == [{"node": {"id": variant_id}}]
+    # deprecated field test
+    assert product_data["variants"] == [{"id": variant_id}]
+
+
 QUERY_PRODUCT_BY_ID_WITH_MEDIA = """
     query ($id: ID, $channel: String, $size: Int, $format: ThumbnailFormatEnum){
         product(id: $id, channel: $channel) {


### PR DESCRIPTION
Fix the `product.productVariants` resolver, previously the following query:
```
mutation productUpdate($id: ID, $input: ProductInput!) {
  productUpdate(id: $id, input: $input){
    product {
      id
      productVariants(first: 10){
        edges {
          node{
            id
          }
        }
      }
    }
  }
}
```
failed with the following response
```
{
  "errors": [
    {
      "message": "The loader.load() function must be called with a value,but got: None.",
      "locations": [
        {
```
as the `product_variants` resolver required the channel.
Currently in case the query is provided by the user with proper permissions, the variants are properly resolved.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
