### PR TITLE
OpenTelemetry - improve metrics wrapper

### DIFF
--- a/saleor/core/telemetry/metric.py
+++ b/saleor/core/telemetry/metric.py
@@ -114,8 +114,8 @@ class Meter:
         self,
         metric_name: str,
         amount: Amount,
+        unit: Unit,
         *,
-        unit: Unit | None = None,
         attributes: Attributes = None,
     ) -> None:
         """Record a measurement for the specified metric.
@@ -123,7 +123,7 @@ class Meter:
         Args:
             metric_name: Name of the metric to record a measurement
             amount: Value to record
-            unit: Optional unit of the measurement (converted if different from metric unit)
+            unit: Unit of the measurement (converted if different from metric unit)
             attributes: Attributes to record with the measurement
 
         """
@@ -200,8 +200,8 @@ class MeterProxy(Meter):
         self,
         metric_name: str,
         amount: Amount,
+        unit: Unit,
         *,
-        unit: Unit | None = None,
         attributes: Attributes = None,
     ) -> None:
         if self._meter:

--- a/saleor/core/telemetry/tests/test_metric.py
+++ b/saleor/core/telemetry/tests/test_metric.py
@@ -213,6 +213,7 @@ def test_meter_record():
     meter.record(
         "test_metric",
         1,
+        Unit.REQUEST,
         attributes={"attr1": "value1"},
     )
 
@@ -249,6 +250,7 @@ def test_meter_record_non_existent_metric():
         meter.record(
             "non_existent_metric",
             1,
+            Unit.REQUEST,
         )
 
 

--- a/saleor/core/telemetry/tests/test_utils.py
+++ b/saleor/core/telemetry/tests/test_utils.py
@@ -28,12 +28,6 @@ def test_convert_unit_same_unit():
     assert convert_unit(100, Unit.NANOSECOND, Unit.NANOSECOND) == 100
 
 
-def test_convert_unit_null_source():
-    # Null source unit should return the same value
-    assert convert_unit(100, None, Unit.SECOND) == 100
-    assert convert_unit(100, None, Unit.MILLISECOND) == 100
-
-
 def test_convert_unit_supported_conversions():
     # Test nanoseconds to milliseconds
     assert convert_unit(1000000, Unit.NANOSECOND, Unit.MILLISECOND) == 1
@@ -42,10 +36,17 @@ def test_convert_unit_supported_conversions():
     assert convert_unit(1000000000, Unit.NANOSECOND, Unit.SECOND) == 1
 
 
-def test_convert_unit_unsupported_conversion():
-    # Test unsupported conversion (e.g., milliseconds to requests)
+@pytest.mark.parametrize(
+    ("from_unit", "to_unit"),
+    [
+        (Unit.MILLISECOND, Unit.REQUEST),
+        (None, Unit.REQUEST),
+        (Unit.REQUEST, Unit.MILLISECOND),
+    ],
+)
+def test_convert_unit_unsupported_conversion(from_unit, to_unit):
     with pytest.raises(ValueError, match="Conversion from .* to .* not supported"):
-        convert_unit(100, Unit.MILLISECOND, Unit.REQUEST)
+        convert_unit(100, from_unit, to_unit)
 
 
 def test_convert_unit_unsupported_conversion_with_raising_disabled(settings):

--- a/saleor/core/telemetry/tests/test_utils.py
+++ b/saleor/core/telemetry/tests/test_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from opentelemetry.trace import Link, SpanContext, TraceFlags
@@ -46,6 +46,18 @@ def test_convert_unit_unsupported_conversion():
     # Test unsupported conversion (e.g., milliseconds to requests)
     with pytest.raises(ValueError, match="Conversion from .* to .* not supported"):
         convert_unit(100, Unit.MILLISECOND, Unit.REQUEST)
+
+
+def test_convert_unit_unsupported_conversion_with_raising_disabled(settings):
+    settings.TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS = False
+
+    # Test unsupported conversion (e.g., milliseconds to requests)
+    with patch("saleor.core.telemetry.utils.logger.error") as mock_error:
+        assert convert_unit(100, Unit.MILLISECOND, Unit.REQUEST) == 100
+        mock_error.assert_called_once_with(
+            "Conversion from Unit.MILLISECOND to Unit.REQUEST not supported",
+            exc_info=ANY,
+        )
 
 
 def test_global_attributes():

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from functools import wraps
 
+from django.conf import settings
 from opentelemetry.trace import Link, SpanContext, TraceFlags
 from opentelemetry.util.types import Attributes, AttributeValue
 
@@ -44,7 +45,11 @@ def convert_unit(amount: Amount, unit: Unit | None, to_unit: Unit) -> Amount:
     try:
         return amount * UNIT_CONVERSIONS[(unit, to_unit)]
     except KeyError as e:
-        raise ValueError(f"Conversion from {unit} to {to_unit} not supported") from e
+        msg = f"Conversion from {unit} to {to_unit} not supported"
+        if settings.TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS:
+            raise ValueError(msg) from e
+        logger.error(msg, exc_info=e)
+    return amount
 
 
 @contextmanager

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -39,8 +39,8 @@ UNIT_CONVERSIONS: dict[tuple[Unit, Unit], float] = {
 }
 
 
-def convert_unit(amount: Amount, unit: Unit | None, to_unit: Unit) -> Amount:
-    if unit is None or unit == to_unit:
+def convert_unit(amount: Amount, unit: Unit, to_unit: Unit) -> Amount:
+    if unit == to_unit:
         return amount
     try:
         return amount * UNIT_CONVERSIONS[(unit, to_unit)]

--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -21,7 +21,7 @@ METRIC_GRAPHQL_QUERY_DURATION = meter.create_metric(
 
 # Helper functions
 def record_graphql_queries_count(amount: int = 1) -> None:
-    meter.record(METRIC_GRAPHQL_QUERIES, amount)
+    meter.record(METRIC_GRAPHQL_QUERIES, amount, Unit.REQUEST)
 
 
 def record_graphql_query_duration() -> AbstractContextManager[

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from ...core.telemetry import Unit
 from ..metrics import (
     METRIC_GRAPHQL_QUERIES,
     METRIC_GRAPHQL_QUERY_DURATION,
@@ -14,7 +15,7 @@ def test_record_graphql_queries_count(mock_meter):
     record_graphql_queries_count(5)
 
     # then
-    mock_meter.record.assert_called_once_with(METRIC_GRAPHQL_QUERIES, 5)
+    mock_meter.record.assert_called_once_with(METRIC_GRAPHQL_QUERIES, 5, Unit.REQUEST)
 
 
 @patch("saleor.graphql.metrics.meter")

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1038,4 +1038,5 @@ i18n_rules_override()
 TELEMETRY_TRACER_CLASS = "saleor.core.telemetry.trace.Tracer"
 TELEMETRY_METER_CLASS = "saleor.core.telemetry.metric.Meter"
 # Whether to raise or log exceptions for telemetry unit conversion errors
+# Disabled by default to prevent disruptions caused by unexpected unit conversion issues
 TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS = False

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1037,3 +1037,5 @@ i18n_rules_override()
 
 TELEMETRY_TRACER_CLASS = "saleor.core.telemetry.trace.Tracer"
 TELEMETRY_METER_CLASS = "saleor.core.telemetry.metric.Meter"
+# Whether to raise or log exceptions for telemetry unit conversion errors
+TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS = False

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -103,3 +103,5 @@ PRIVATE_FILE_STORAGE = "saleor.tests.storages.PrivateFileSystemStorage"
 PRIVATE_MEDIA_ROOT: str = os.path.join(PROJECT_ROOT, "private-media")  # noqa: F405
 
 BREAKER_BOARD_ENABLED = False
+
+TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS = True

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -104,4 +104,6 @@ PRIVATE_MEDIA_ROOT: str = os.path.join(PROJECT_ROOT, "private-media")  # noqa: F
 
 BREAKER_BOARD_ENABLED = False
 
+# Enable exception raising for telemetry unit conversion errors
+# This helps identify unit conversion issues during development and testing
 TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS = True


### PR DESCRIPTION
I want to merge this change because it fixes issues raised by @korycins during review:

- Unit conversion errors will not be raised by default (only logged). Errors will be raised during tests to catch bugs
- Providing unit will be required for meter.record method, which will help us detect hard-to-catch bugs such as unit mismatches

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
