### PR TITLE
Set error status on failed spans

### DIFF
--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -47,4 +47,4 @@ def webhooks_otel_trace(
         span.set_attribute("webhooks.domain", domain)
         span.set_attribute("webhooks.execution_mode", "sync" if sync else "async")
         span.set_attribute("webhooks.payload_size", payload_size)
-        yield
+        yield span

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -16,6 +16,7 @@ from graphql import GraphQLBackend, GraphQLDocument, GraphQLSchema
 from graphql.error import GraphQLError, GraphQLSyntaxError
 from graphql.execution import ExecutionResult
 from jwt.exceptions import PyJWTError
+from opentelemetry.trace import StatusCode
 from requests_hardened.ip_filter import InvalidIPAddress
 
 from .. import __version__ as saleor_version
@@ -354,7 +355,7 @@ class GraphQLView(View):
 
                     return set_query_cost_on_result(response, query_cost)
             except Exception as e:
-                span.set_attribute("error", True)
+                span.set_status(StatusCode.ERROR)
 
                 # In the graphql-core version that we are using,
                 # the Exception is raised for too big integers value.

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -281,19 +281,29 @@ class GraphQLView(View):
 
             query, variables, operation_name = self.get_graphql_params(request, data)
             document, error = self.parse_query(query)
+
             with observability.report_gql_operation() as operation:
                 operation.query = document
                 operation.name = operation_name
                 operation.variables = variables
+
             if error or document is None:
+                error_description = self.format_span_error_description(error)
+                span.set_status(status=StatusCode.ERROR, description=error_description)
                 return error
+
+            try:
+                query_contains_schema = check_if_query_contains_only_schema(document)
+            except GraphQLError as e:
+                span.set_status(status=StatusCode.ERROR, description=str(e))
+                return ExecutionResult(errors=[e], invalid=True)
 
             _query_identifier = query_identifier(document)
             self._query = _query_identifier
             raw_query_string = document.document_string
             span.set_attribute("resource.name", raw_query_string)
             span.set_attribute("graphql.query", raw_query_string)
-            span.set_attribute("graphql.query_identifier", query_identifier(document))
+            span.set_attribute("graphql.query_identifier", _query_identifier)
             span.set_attribute("graphql.query_fingerprint", query_fingerprint(document))
 
             source_service_name = get_source_service_name_value(
@@ -301,11 +311,6 @@ class GraphQLView(View):
             )
             if source_service_name:
                 span.set_attribute("source.service.name", source_service_name)
-
-            try:
-                query_contains_schema = check_if_query_contains_only_schema(document)
-            except GraphQLError as e:
-                return ExecutionResult(errors=[e], invalid=True)
 
             query_cost, cost_errors = validate_query_cost(
                 schema,
@@ -315,8 +320,11 @@ class GraphQLView(View):
                 settings.GRAPHQL_QUERY_MAX_COMPLEXITY,
             )
             span.set_attribute("graphql.query_cost", query_cost)
+
             if settings.GRAPHQL_QUERY_MAX_COMPLEXITY and cost_errors:
                 result = ExecutionResult(errors=cost_errors, invalid=True)
+                error_description = self.format_span_error_description(result)
+                span.set_status(status=StatusCode.ERROR, description=error_description)
                 return set_query_cost_on_result(result, query_cost)
 
             extra_options: dict[str, Any | None] = {}
@@ -350,12 +358,20 @@ class GraphQLView(View):
                             middleware=self.middleware,
                             **extra_options,
                         )
+                        if response.errors:
+                            error_description = self.format_span_error_description(
+                                response
+                            )
+                            span.set_status(
+                                status=StatusCode.ERROR, description=error_description
+                            )
+
                         if should_use_cache_for_scheme:
                             cache.set(key, response)
 
                     return set_query_cost_on_result(response, query_cost)
             except Exception as e:
-                span.set_status(StatusCode.ERROR)
+                span.set_status(status=StatusCode.ERROR, description=str(e))
 
                 # In the graphql-core version that we are using,
                 # the Exception is raised for too big integers value.
@@ -400,6 +416,13 @@ class GraphQLView(View):
 
     def format_error(self, error):
         return format_error(error, self.HANDLED_EXCEPTIONS, self._query)
+
+    def format_span_error_description(
+        self, execution_result: ExecutionResult | None
+    ) -> str | None:
+        if execution_result and execution_result.errors:
+            return "".join([str(error) for error in execution_result.errors])
+        return None
 
 
 def get_key(key):

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -421,7 +421,7 @@ class GraphQLView(View):
         self, execution_result: ExecutionResult | None
     ) -> str | None:
         if execution_result and execution_result.errors:
-            return "".join([str(error) for error in execution_result.errors])
+            return "\n".join([str(error) for error in execution_result.errors])
         return None
 
 

--- a/saleor/webhook/transport/asynchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_transport.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.trace import StatusCode
+
+from .....core.models import EventDeliveryStatus
+from ...utils import WebhookResponse
+from ..transport import send_webhook_request_async
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+@patch("saleor.webhook.transport.asynchronous.transport.webhooks_otel_trace")
+@patch("saleor.webhook.transport.asynchronous.transport.attempt_update")
+@patch("saleor.webhook.transport.asynchronous.transport.handle_webhook_retry")
+def test_send_webhook_request_async_set_span_status_failed(
+    mock_handle_webhook_retry,
+    mock_attempt_update,
+    mock_webhooks_otel_trace,
+    mock_send_webhook_using_scheme_method,
+    event_delivery_payload_in_database,
+):
+    # given
+    event_delivery_id = event_delivery_payload_in_database.id
+    mock_span = MagicMock()
+    mock_webhooks_otel_trace.return_value.__enter__.return_value = mock_span
+
+    mock_response = MagicMock(spec=WebhookResponse)
+    mock_response.response_status_code = 500
+    mock_response.status = EventDeliveryStatus.FAILED
+    mock_response.content = ""
+    mock_send_webhook_using_scheme_method.return_value = mock_response
+
+    # when
+    send_webhook_request_async(
+        event_delivery_id=event_delivery_id, telemetry_context={}
+    )
+
+    # then
+    mock_span.set_status.assert_called_once_with(
+        StatusCode.ERROR,
+    )

--- a/saleor/webhook/transport/synchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/synchronous/tests/test_transport.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.trace import StatusCode
+
+from .....core.models import EventDeliveryStatus
+from ...utils import WebhookResponse
+from ..transport import _send_webhook_request_sync
+
+
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_using_http")
+@patch("saleor.webhook.transport.synchronous.transport.webhooks_otel_trace")
+@patch("saleor.webhook.transport.synchronous.transport.attempt_update")
+def test_send_webhook_request_sync_set_span_status_failed_invalid_json(
+    mock_attempt_update,
+    mock_webhooks_otel_trace,
+    mock_send_webhook_using_http,
+    event_delivery_payload_in_database,
+):
+    # given
+    mock_span = MagicMock()
+    mock_webhooks_otel_trace.return_value.__enter__.return_value = mock_span
+
+    mock_response = MagicMock(spec=WebhookResponse)
+    mock_response.response_status_code = 200
+    mock_response.status = EventDeliveryStatus.SUCCESS
+    mock_response.content = ""  # Simulating invalid JSON
+    mock_send_webhook_using_http.return_value = mock_response
+
+    # when
+    _send_webhook_request_sync(event_delivery_payload_in_database)
+
+    # then
+    mock_span.set_status.assert_called_once_with(
+        StatusCode.ERROR,
+    )
+
+
+@patch("saleor.webhook.transport.synchronous.transport.send_webhook_using_http")
+@patch("saleor.webhook.transport.synchronous.transport.webhooks_otel_trace")
+@patch("saleor.webhook.transport.synchronous.transport.attempt_update")
+def test_send_webhook_request_sync_set_span_status_failed_error_response(
+    mock_attempt_update,
+    mock_webhooks_otel_trace,
+    mock_send_webhook_using_http,
+    event_delivery_payload_in_database,
+):
+    # given
+    mock_span = MagicMock()
+    mock_webhooks_otel_trace.return_value.__enter__.return_value = mock_span
+
+    mock_response = MagicMock(spec=WebhookResponse)
+    mock_response.response_status_code = 500
+    mock_response.status = EventDeliveryStatus.FAILED
+    mock_response.content = "{}"
+    mock_send_webhook_using_http.return_value = mock_response
+
+    # when
+    _send_webhook_request_sync(event_delivery_payload_in_database)
+
+    # then
+    mock_span.set_status.assert_called_once_with(
+        StatusCode.ERROR,
+    )


### PR DESCRIPTION
Set an error status for failed GraphQL and HTTP webhooks spans.

For the GraphQL spans, there are a couple of paths when the execution can fail, and the span should be marked as failed:
- invalid GraphQL query, failed GraphQL parsing
- GraphQL errors raised during execution, caused by exceptions raised from resolvers
- permission errors
- exceeded query cost
- mixing GraphQL query with introspection query

For webhook HTTP spans, a failed span is considered when the event delivery returns the `EventDeliveryStatus.FAILED` status.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
