### PR TITLE
Allow proper price calculations for draft orders created in OrderBulkCreate mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,3 +108,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Allow to change Admin email plugin custom templates back to default - #17563 by @wcislo-saleor
 - Fixes incorrect gift card balances after covering the full order total - #17566 by @korycins
 - Fixes tax class not clearing when selecting a shipping method without a tax class - #17560 by @korycins
+- The prices for draft orders created in `OrderBulkCreate` now are properly calculated - #17583 by @IKarbowiak

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -1783,7 +1783,8 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
                 line=order_line,
                 unique_type=DiscountType.MANUAL,
                 type=DiscountType.MANUAL,
-                value_type=line_amounts.unit_discount_type,
+                value_type=line_amounts.unit_discount_type
+                or DiscountValueTypeEnum.FIXED.name,  # type: ignore[attr-defined]
                 value=line_amounts.unit_discount_value,
                 amount_value=discount_amount,
                 currency=order_line.currency,

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -110,6 +110,14 @@ ORDER_BULK_CREATE = """
                                 amount
                             }
                         }
+                        undiscountedTotalPrice{
+                            gross {
+                                amount
+                            }
+                            net {
+                                amount
+                            }
+                        }
                         metadata {
                             key
                             value

--- a/saleor/tests/e2e/orders/test_able_to_update_draft_order_after_bulk_order_creation_with_line_discount.py
+++ b/saleor/tests/e2e/orders/test_able_to_update_draft_order_after_bulk_order_creation_with_line_discount.py
@@ -1,0 +1,231 @@
+import graphene
+from django.utils import timezone
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..taxes.utils import update_country_tax_rates
+from ..utils import assert_address_data, assign_permissions
+from .utils import draft_order_update, order_bulk_create, order_query
+
+
+def prepare_order_bulk_create_input(
+    customer_user,
+    product_variant_id,
+    warehouse_id,
+    shipping_method_id,
+    channel_slug,
+    currency,
+    tax_class_id,
+    line_discount_data,
+):
+    user = {
+        "id": graphene.Node.to_global_id("User", customer_user.id),
+        "email": None,
+    }
+    delivery_method = {
+        "shippingMethodId": shipping_method_id,
+        "shippingMethodName": "Denormalized name",
+        "shippingPrice": {
+            "gross": 60,
+            "net": 50,
+        },
+        "shippingTaxRate": 0.2,
+        "shippingTaxClassId": tax_class_id,
+        "shippingTaxClassName": "Denormalized name",
+    }
+    line = {
+        "variantId": product_variant_id,
+        "createdAt": timezone.now(),
+        "productName": "Product Name",
+        "variantName": "Variant Name",
+        "translatedProductName": "Nazwa Produktu",
+        "translatedVariantName": "Nazwa Wariantu",
+        "isShippingRequired": True,
+        "isGiftCard": False,
+        "quantity": 5,
+        "totalPrice": {
+            "gross": 120,
+            "net": 100,
+        },
+        "undiscountedTotalPrice": {
+            "gross": 120,
+            "net": 100,
+        },
+        "taxRate": 0.2,
+        "taxClassId": tax_class_id,
+        "warehouse": warehouse_id,
+        "metadata": [{"key": "md key", "value": "md value"}],
+        "privateMetadata": [{"key": "pmd key", "value": "pmd value"}],
+        **line_discount_data,
+    }
+    return {
+        "channel": channel_slug,
+        "createdAt": timezone.now(),
+        "status": "DRAFT",
+        "user": user,
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "currency": currency,
+        "languageCode": "PL",
+        "deliveryMethod": delivery_method,
+        "lines": [line],
+        "weight": "10.15",
+        "redirectUrl": "https://www.example.com",
+        "metadata": [{"key": "md key", "value": "md value"}],
+        "privateMetadata": [{"key": "pmd key", "value": "pmd value"}],
+    }
+
+
+def test_able_to_update_draft_order_after_bulk_order_creation_with_line_discount_CORE_0258(
+    e2e_staff_api_client,
+    e2e_logged_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_orders_import,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_orders_import,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_country = "US"
+    shipping_class_tax_rate = 8
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+        "tax_rates": [
+            {
+                "type": "shipping_country",
+                "name": "Shipping Country Tax Rate",
+                "country_code": shipping_country,
+                "rate": shipping_class_tax_rate,
+            },
+        ],
+    }
+    price = 10
+
+    shop_data, tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {
+                                "add_channels": {},
+                            },
+                            {
+                                "name": "Another shipping method",
+                                "add_channels": {},
+                            },
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            },
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_data = shop_data[0]
+    channel_id = channel_data["id"]
+    channel_slug = channel_data["slug"]
+    currency = channel_data["currency"]
+    warehouse_id = channel_data["warehouse_id"]
+    shipping_method_id = channel_data["shipping_zones"][0]["shipping_methods"][0]["id"]
+    shipping_method_id_2 = channel_data["shipping_zones"][0]["shipping_methods"][1][
+        "id"
+    ]
+    tax_class_id = tax_config[0]["shipping_country_tax_class_id"]
+
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        shipping_country,
+        [{"rate": shipping_class_tax_rate}],
+    )
+
+    _product_id, product_variant_id, _product_variant_price = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    line_discount_data = {
+        "unitDiscountValue": 10,
+        "unitDiscountType": "FIXED",
+        "unitDiscountReason": "Test discount",
+        "totalPrice": {
+            "net": 50,
+            "gross": 60,
+        },
+    }
+    order_input = prepare_order_bulk_create_input(
+        e2e_logged_api_client.user,
+        product_variant_id,
+        warehouse_id,
+        shipping_method_id,
+        channel_slug,
+        currency,
+        tax_class_id,
+        line_discount_data,
+    )
+
+    # Step 1 - Create order with order bulk create
+    create_order_response = order_bulk_create(e2e_staff_api_client, [order_input])
+
+    assert create_order_response["count"] == 1
+
+    draft_order = create_order_response["results"][0]["order"]
+    assert draft_order
+    order_id = draft_order["id"]
+    assert len(draft_order["lines"]) == 1
+    line = draft_order["lines"][0]
+    assert line["unitDiscountValue"] == line_discount_data["unitDiscountValue"]
+    assert line["unitDiscountType"] == line_discount_data["unitDiscountType"]
+    assert line["unitDiscountReason"] == line_discount_data["unitDiscountReason"]
+    assert line["unitDiscount"]["amount"] == line_discount_data["unitDiscountValue"]
+
+    # Step 2 - Update delivery method
+    address = DEFAULT_ADDRESS
+    address["firstName"] = "New name"
+    input = {
+        "shippingMethod": shipping_method_id_2,
+        "billingAddress": DEFAULT_ADDRESS,  # force the price recalculation
+    }
+    draft_order = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id == shipping_method_id_2
+    order_billing_address = draft_order["order"]["billingAddress"]
+    assert_address_data(order_billing_address, address)
+
+    # Step 3 - Ensure that the line discount is still applied
+    draft_order = order_query(e2e_staff_api_client, order_id)
+
+    assert draft_order
+    assert len(draft_order["lines"]) == 1
+    line = draft_order["lines"][0]
+    assert line["unitDiscountValue"] == line_discount_data["unitDiscountValue"]
+    assert line["unitDiscountType"] == line_discount_data["unitDiscountType"]
+    assert line["unitDiscountReason"] == line_discount_data["unitDiscountReason"]
+    assert line["unitDiscount"]["amount"] == line_discount_data["unitDiscountValue"]
+    assert (
+        line["undiscountedUnitPrice"]["gross"]["amount"] * line["quantity"]
+        - line["totalPrice"]["gross"]["amount"]
+    ) / 5 == line["unitDiscount"]["amount"]
+    assert (
+        draft_order["subtotal"]["gross"]["amount"]
+        == line["totalPrice"]["gross"]["amount"]
+    )

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -3,6 +3,7 @@ from .draft_order_complete import draft_order_complete, raw_draft_order_complete
 from .draft_order_create import draft_order_create
 from .draft_order_delete import draft_order_delete
 from .draft_order_update import draft_order_update, raw_draft_order_update
+from .order_bulk_create import order_bulk_create
 from .order_by_checkout_id_query import order_by_checkout_id_query
 from .order_cancel import order_cancel
 from .order_create_from_checkout import (
@@ -25,6 +26,7 @@ from .order_update_shipping import order_update_shipping
 from .order_void import order_void, raw_order_void
 
 __all__ = [
+    "order_bulk_create",
     "raw_draft_order_complete",
     "draft_order_create",
     "order_lines_create",

--- a/saleor/tests/e2e/orders/utils/fragments.py
+++ b/saleor/tests/e2e/orders/utils/fragments.py
@@ -1,0 +1,75 @@
+ORDER_LINE_FRAGMENT = """
+fragment OrderLine on OrderLine {
+    id
+    variant {
+        id
+    }
+    productName
+    productSku
+    variantName
+    translatedVariantName
+    translatedProductName
+    productVariantId
+    isShippingRequired
+    quantity
+    quantityFulfilled
+    unitPrice {
+        gross {
+            amount
+        }
+        net {
+            amount
+        }
+    }
+    unitDiscount {
+        amount
+    }
+    unitDiscountValue
+    unitDiscountReason
+    unitDiscountType
+    totalPrice {
+        gross {
+            amount
+        }
+        net {
+            amount
+        }
+    }
+    undiscountedUnitPrice{
+        gross {
+            amount
+        }
+        net {
+            amount
+        }
+    }
+    undiscountedTotalPrice{
+        gross {
+            amount
+        }
+        net {
+            amount
+        }
+    }
+    metadata {
+        key
+        value
+    }
+    privateMetadata {
+        key
+        value
+    }
+    taxClass {
+        id
+    }
+    taxClassName
+    taxRate
+    taxClassMetadata {
+        key
+        value
+    }
+    taxClassPrivateMetadata {
+        key
+        value
+    }
+}"""

--- a/saleor/tests/e2e/orders/utils/order_bulk_create.py
+++ b/saleor/tests/e2e/orders/utils/order_bulk_create.py
@@ -1,0 +1,203 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+from .fragments import ORDER_LINE_FRAGMENT
+
+ORDER_BULK_CREATE_MUTATION = (
+    """
+ mutation OrderBulkCreate(
+    $orders: [OrderBulkCreateInput!]!,
+    $errorPolicy: ErrorPolicyEnum,
+    $stockUpdatePolicy: StockUpdatePolicyEnum
+) {
+    orderBulkCreate(
+        orders: $orders,
+        errorPolicy: $errorPolicy,
+        stockUpdatePolicy: $stockUpdatePolicy
+    ) {
+        count
+        results {
+            order {
+                id
+                user {
+                    id
+                    email
+                }
+                metadata {
+                    key
+                    value
+                }
+                privateMetadata {
+                    key
+                    value
+                }
+                lines {
+                    ...OrderLine
+                }
+                billingAddress{
+                    postalCode
+                    metadata{
+                        key
+                        value
+                    }
+                }
+                shippingAddress{
+                    postalCode
+                    metadata{
+                        key
+                        value
+                    }
+                }
+                shippingMethodName
+                shippingTaxClass{
+                    name
+                }
+                shippingTaxClassName
+                shippingTaxClassMetadata {
+                    key
+                    value
+                }
+                shippingTaxClassPrivateMetadata {
+                    key
+                    value
+                }
+                shippingPrice {
+                    gross {
+                        amount
+                    }
+                    net {
+                        amount
+                    }
+                }
+                subtotal{
+                    gross {
+                        amount
+                    }
+                    net {
+                        amount
+                    }
+                }
+                total{
+                    gross {
+                        amount
+                    }
+                    net {
+                        amount
+                    }
+                }
+                undiscountedTotal{
+                    gross {
+                        amount
+                    }
+                    net {
+                        amount
+                    }
+                }
+                events {
+                    message
+                    user {
+                        id
+                    }
+                    app {
+                        id
+                    }
+                }
+                weight {
+                    value
+                }
+                externalReference
+                trackingClientId
+                displayGrossPrices
+                channel {
+                    slug
+                }
+                status
+                created
+                languageCode
+                collectionPointName
+                redirectUrl
+                origin
+                fulfillments {
+                    lines {
+                        id
+                        quantity
+                        orderLine {
+                            id
+                        }
+                    }
+                    trackingNumber
+                    fulfillmentOrder
+                    status
+                }
+                transactions {
+                    id
+                    pspReference
+                    message
+                    name
+                    authorizedAmount {
+                        amount
+                        currency
+                    }
+                    canceledAmount{
+                        currency
+                        amount
+                    }
+                    chargedAmount{
+                        currency
+                        amount
+                    }
+                    refundedAmount{
+                        currency
+                        amount
+                    }
+                    events {
+                        amount {
+                            amount
+                        }
+                        type
+                    }
+                }
+                invoices {
+                    number
+                    url
+                }
+                discounts {
+                    type
+                    valueType
+                    value
+                    reason
+                }
+                voucher {
+                    id
+                    code
+                }
+                voucherCode
+            }
+            errors {
+                path
+                message
+                code
+            }
+        }
+        errors {
+            message
+            code
+        }
+    }
+}
+"""
+    + ORDER_LINE_FRAGMENT
+)
+
+
+def order_bulk_create(api_client, orders):
+    variables = {"orders": orders}
+
+    response = api_client.post_graphql(
+        ORDER_BULK_CREATE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["orderBulkCreate"]
+
+    return data

--- a/saleor/tests/e2e/orders/utils/order_query.py
+++ b/saleor/tests/e2e/orders/utils/order_query.py
@@ -1,5 +1,6 @@
 from ...account.utils.fragments import ADDRESS_FRAGMENT
 from ...utils import get_graphql_content
+from .fragments import ORDER_LINE_FRAGMENT
 
 ORDER_QUERY = (
     """
@@ -59,10 +60,38 @@ query OrderDetails($id: ID!) {
       key
       value
     }
+    lines {
+      ...OrderLine
+    }
+    subtotal{
+      gross {
+          amount
+      }
+      net {
+          amount
+      }
+    }
+    total{
+      gross {
+          amount
+      }
+      net {
+          amount
+      }
+    }
+    undiscountedTotal{
+      gross {
+          amount
+      }
+      net {
+          amount
+      }
+    }
   }
 }
 """
     + ADDRESS_FRAGMENT
+    + ORDER_LINE_FRAGMENT
 )
 
 

--- a/saleor/tests/e2e/shop/utils/preparing_shop.py
+++ b/saleor/tests/e2e/shop/utils/preparing_shop.py
@@ -75,6 +75,7 @@ def prepare_shop(
                 "id": channel_id,
                 "warehouse_id": warehouse_id,
                 "slug": created_channel["slug"],
+                "currency": created_channel["currencyCode"],
                 "shipping_zones": [],
                 "order_settings": created_channel["orderSettings"],
                 "checkout_settings": created_channel["checkoutSettings"],


### PR DESCRIPTION
The recalculations of draft orders created in `OrderBulkCreate` previously clears the provided unit discounts and set prices to 0.
The PR adds `OrderLineDiscount` creation and sets the line `base_prices` that allows to properly calculate the prices.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
