### PR TITLE
Drop the log indicating the mismatch of code usage

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -78,15 +78,6 @@ def _bulk_release_voucher_usage(order_ids):
         Exists(vouchers.filter(id=OuterRef("voucher_id"))),
     ).annotate(order_count=Subquery(count_orders))
 
-    # We observed mismatch between code.used and number of orders which utilize the code
-    # In some cases it is expected, but we want to further investigate the issue
-    suspected_codes = [code.code for code in codes if code.used < code.order_count]
-    if suspected_codes:
-        logger.error(
-            "Voucher codes: [%s] have been used more times than indicated by `code.used` field.",
-            ",".join(suspected_codes),
-        )
-
     codes.update(used=Greatest(F("used") - F("order_count"), 0))
 
     orders = Order.objects.filter(id__in=order_ids)

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 from unittest import mock
 from unittest.mock import call, patch
 
@@ -707,7 +706,7 @@ def test_delete_expired_orders_task_schedule_itself(
 
 
 def test_bulk_release_voucher_usage_voucher_usage_mismatch(
-    order_list, allocations, channel_USD, voucher_customer, caplog
+    order_list, allocations, channel_USD, voucher_customer
 ):
     # We can have mismatch between `voucher.used` and number of order utilizing
     # the voucher. It can happen in following cases:
@@ -744,7 +743,6 @@ def test_bulk_release_voucher_usage_voucher_usage_mismatch(
     channel_USD.save()
 
     now = timezone.now()
-    caplog.set_level(logging.ERROR)
     code = voucher_customer.voucher_code
     voucher = code.voucher
     code.used = 1
@@ -770,7 +768,6 @@ def test_bulk_release_voucher_usage_voucher_usage_mismatch(
     # then
     code.refresh_from_db()
     assert code.used == 0
-    assert code.code in caplog.text
 
 
 @patch(


### PR DESCRIPTION
Drop the log indicating the mismatch of code usage.
According the description of this [PR](https://github.com/saleor/saleor/pull/16291), there are two cases when this situation is valid, and the log is useless. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
