### PR TITLE
Return shipping app id in ShippingMethodSchema.id

### DIFF
--- a/saleor/webhook/response_schemas/shipping.py
+++ b/saleor/webhook/response_schemas/shipping.py
@@ -9,15 +9,18 @@ from pydantic import (
     Field,
     RootModel,
     ValidationError,
+    ValidationInfo,
     ValidatorFunctionWrapHandler,
     WrapValidator,
     field_validator,
 )
 from pydantic_core import PydanticOmit
 
+from ...app.models import App
 from ...graphql.core.utils import from_global_id_or_error
 from ...shipping.models import ShippingMethod
 from ..const import APP_ID_PREFIX
+from ..transport.shipping_helpers import to_shipping_app_id
 from .annotations import DefaultIfNone, Metadata
 
 logger = logging.getLogger(__name__)
@@ -53,6 +56,14 @@ class ShippingMethodSchema(BaseModel):
     @property
     def price(self) -> Money:
         return Money(self.amount, self.currency)
+
+    @field_validator("id", mode="after")
+    @classmethod
+    def clean_id(cls, shipping_method_id: str, info: ValidationInfo) -> str:
+        app: App | None = info.context.get("app", None) if info.context else None
+        if not app:
+            raise RuntimeError("Missing app in context")
+        return to_shipping_app_id(app, shipping_method_id)
 
 
 class ListShippingMethodsSchema(RootModel):

--- a/saleor/webhook/transport/shipping.py
+++ b/saleor/webhook/transport/shipping.py
@@ -22,7 +22,6 @@ from ..response_schemas.shipping import (
     FilterShippingMethodsSchema,
     ListShippingMethodsSchema,
 )
-from .shipping_helpers import to_shipping_app_id
 from .synchronous.transport import trigger_webhook_sync_if_not_cached
 
 logger = logging.getLogger(__name__)
@@ -33,14 +32,14 @@ def parse_list_shipping_methods_response(
 ) -> list["ShippingMethodData"]:
     try:
         list_shipping_method_model = ListShippingMethodsSchema.model_validate(
-            response_data
+            response_data, context={"app": app}
         )
     except ValidationError:
         logger.warning("Skipping invalid shipping method response: %s", response_data)
         return []
     return [
         ShippingMethodData(
-            id=to_shipping_app_id(app, str(shipping_method.id)),
+            id=shipping_method.id,
             name=shipping_method.name,
             price=shipping_method.price,
             maximum_delivery_days=shipping_method.maximum_delivery_days,


### PR DESCRIPTION
Adjust `ShippingMethodSchema`, return `shipping_app_id` in `ShippingMethodSchema.id`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
