### PR TITLE
Remove reference cycle in Saleor context

### DIFF
--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -28,6 +28,7 @@ def get_context_value(request: HttpRequest) -> SaleorContext:
 
 def clear_context(context: SaleorContext):
     context.dataloaders.clear()
+    del context.user
 
 
 class RequestWithUser(HttpRequest):

--- a/saleor/graphql/core/tests/garbage_collection/test_saleor_context.py
+++ b/saleor/graphql/core/tests/garbage_collection/test_saleor_context.py
@@ -1,0 +1,65 @@
+import gc
+import json
+
+import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+
+from .....core.jwt import create_access_token
+from ....api import backend, schema
+from ....tests.utils import get_graphql_content
+from ....views import GraphQLView
+from .utils import (
+    clean_up_after_garbage_collection_test,
+    disable_gc_for_garbage_collection_test,
+)
+
+PRODUCTS_QUERY = """
+{
+    me {
+        email
+    }
+}
+"""
+
+
+# Group all tests that require garbage collection so that they do not run concurrently.
+# This is necessary to ensure that tests don't interfere with each other.
+# Without grouping we could receive false positive results.
+@pytest.mark.xdist_group(name="garbage_collection")
+def test_query_remove_SaleorContext_memory_cycles(rf, staff_user):
+    try:
+        # given
+        # Disable automatic garbage collection and set debugging flag.
+        disable_gc_for_garbage_collection_test()
+        # Prepare request body with GraphQL query.
+        data = {"query": PRODUCTS_QUERY}
+        data = json.dumps(data, cls=DjangoJSONEncoder)
+        jwt_token = create_access_token(staff_user)
+
+        # when
+        # Execute the query as staff user.
+        content = get_graphql_content(
+            GraphQLView(backend=backend, schema=schema).handle_query(
+                rf.post(
+                    path="/graphql/",
+                    data=data,
+                    content_type="application/json",
+                    headers={"authorization": f"JWT {jwt_token}"},
+                )
+            ),
+            ignore_errors=True,
+        )
+        # Enforce garbage collection to populate the garbage list for inspection.
+        gc.collect()
+
+        # then
+        # Ensure that the garbage list is empty. The garbage list is only valid
+        # until the next collection cycle so we can only make assertions about it
+        # before re-enabling automatic collection.
+        assert gc.garbage == []
+        # Ensure that the query returned the expected data.
+        assert content["data"]["me"]["email"] == staff_user.email
+    # Restore garbage collection settings to their original state. This should always be run to avoid interfering
+    # with other tests to ensure that code should be executed in the `finally' block.
+    finally:
+        clean_up_after_garbage_collection_test()

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_create.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_create.py
@@ -91,8 +91,9 @@ class GiftCardBulkCreate(BaseMutation):
         instances = cls.create_instances(input, info)
         if tags:
             cls.assign_gift_card_tags(instances, tags)
+        manager = get_plugin_manager_promise(info.context).get()
         transaction.on_commit(
-            lambda: cls.call_gift_card_created_on_plugins(instances, info.context)
+            lambda: cls.call_gift_card_created_on_plugins(instances, manager)
         )
         return cls(count=len(instances), gift_cards=instances)
 
@@ -172,8 +173,7 @@ class GiftCardBulkCreate(BaseMutation):
             tag_instance.gift_cards.set(instances)
 
     @classmethod
-    def call_gift_card_created_on_plugins(cls, instances, context):
+    def call_gift_card_created_on_plugins(cls, instances, manager):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.GIFT_CARD_CREATED)
-        manager = get_plugin_manager_promise(context).get()
         for instance in instances:
             cls.call_event(manager.gift_card_created, instance, webhooks=webhooks)

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -92,7 +92,7 @@ class OrderConfirm(DeprecatedModelMutation):
                 transaction.on_commit(
                     lambda: order_charged(
                         order_info,
-                        info.context.user,
+                        user,
                         app,
                         authorized_payment.total,
                         authorized_payment,


### PR DESCRIPTION
Port #17309
I want to merge this change because:
- allows memory to be freed immediately without needing a deep garbage collection cycle.
- Drop usage of SaleorContext in transaction.on_commit.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
