### PR TITLE
Remove reference cycle in Gzip

### DIFF
--- a/saleor/asgi/gzip_compression.py
+++ b/saleor/asgi/gzip_compression.py
@@ -139,6 +139,8 @@ def gzip_compression(
                         await send(message)
 
                 await app(scope, receive, send_compressed)
+                gzip_file.close()
+                gzip_buffer.close()
                 return
         await app(scope, receive, send)
 

--- a/saleor/graphql/core/tests/garbage_collection/test_gzip.py
+++ b/saleor/graphql/core/tests/garbage_collection/test_gzip.py
@@ -1,0 +1,40 @@
+import gc
+import gzip
+import io
+
+import pytest
+
+from .utils import (
+    clean_up_after_garbage_collection_test,
+    disable_gc_for_garbage_collection_test,
+)
+
+
+# Group all tests that require garbage collection so that they do not run concurrently.
+# This is necessary to ensure that tests don't interfere with each other.
+# Without grouping we could receive false positive results.
+@pytest.mark.xdist_group(name="garbage_collection")
+def test_GzipFile_with_BytesIO_buffer_remove_all_reference_cycles():
+    try:
+        # given
+        # Disable automatic garbage collection and set debugging flag.
+        disable_gc_for_garbage_collection_test()
+
+        # when
+        # Create GzipFile object with BytesIO buffer and close it to free resources.
+        with io.BytesIO() as buffer:
+            with gzip.GzipFile(mode="wb", fileobj=buffer):
+                pass
+
+        # Enforce garbage collection to populate the garbage list for inspection.
+        gc.collect()
+
+        # then
+        # Ensure that the garbage list is empty. The garbage list is only valid
+        # until the next collection cycle so we can only make assertions about it
+        # before re-enabling automatic collection.
+        assert gc.garbage == []
+    # Restore garbage collection settings to their original state. This should always be run to avoid interfering
+    # with other tests to ensure that code should be executed in the `finally' block.
+    finally:
+        clean_up_after_garbage_collection_test()

--- a/saleor/patch_gzip.py
+++ b/saleor/patch_gzip.py
@@ -1,0 +1,16 @@
+from gzip import _WriteBufferStream  # type: ignore[attr-defined]
+
+
+def __del_tmp__(self):
+    del self.gzip_file
+
+
+def patch_gzip():
+    """Patch `__del__` in `_WriteBufferStream` from `gzip` to avoid memory leaks.
+
+    Those changes will remove the circular references in `GzipFile`,  allowing memory to be freed immediately,
+    without the need of a deep garbage collection cycle.
+    Cycle: `GzipFile._buffer` -> `BufferedWriter._raw` -> `_WriteBufferStream.gzip_file` -> `GzipFile`.
+    Issue: https://github.com/python/cpython/issues/129640
+    """
+    _WriteBufferStream.__del__ = __del_tmp__

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -33,6 +33,7 @@ from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
 from .graphql.promise import patch_promise
+from .patch_gzip import patch_gzip
 
 django_stubs_ext.monkeypatch()
 
@@ -1064,3 +1065,7 @@ i18n_rules_override()
 # Patch Promise to remove all references that could result in reference cycles, allowing memory to be freed
 # immediately, without the need of a deep garbage collection cycle.
 patch_promise()
+
+# Patch `_WriteBufferStream` from `gizip` to remove all references that could result in reference cycles,
+# allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+patch_gzip()


### PR DESCRIPTION
Port #17564
I want to merge this change because it allows memory to be freed immediately without needing a deep garbage collection cycle.
Fix for: https://github.com/python/cpython/issues/129640

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
