### PR TITLE
Add migration for orders with `awaiting_for_approval` fulfillment

### DIFF
--- a/saleor/order/migrations/0200_order_with_waiting_for_approval_fulfillments.py
+++ b/saleor/order/migrations/0200_order_with_waiting_for_approval_fulfillments.py
@@ -1,0 +1,26 @@
+from django.apps import apps as registry
+from django.db import migrations
+from django.db.models.signals import post_migrate
+
+from .tasks.saleor3_21 import migrate_orders_with_waiting_for_approval_fulfillment_task
+
+
+def migrate_orders_with_waiting_for_approval_fulfillment(apps, _schema_editor):
+    def on_migrations_complete(sender=None, **kwargs):
+        migrate_orders_with_waiting_for_approval_fulfillment_task.delay()
+
+    sender = registry.get_app_config("order")
+    post_migrate.connect(on_migrations_complete, weak=False, sender=sender)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("order", "0199_set_draft_base_price_expire_at"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_orders_with_waiting_for_approval_fulfillment,
+            reverse_code=migrations.RunPython.noop,
+        )
+    ]

--- a/saleor/order/migrations/tasks/saleor3_21.py
+++ b/saleor/order/migrations/tasks/saleor3_21.py
@@ -6,11 +6,15 @@ from django.utils import timezone
 
 from ....celeryconf import app
 from ....core.db.connection import allow_writer
-from ...models import Order, OrderLine
+from ... import FulfillmentStatus, OrderStatus
+from ...models import Fulfillment, Order, OrderLine
 
 # The batch of size 250 takes ~0.2 second and consumes ~20MB memory at peak
 BATCH_SIZE = 250
 DEFAULT_EXPIRE_TIME = 24
+
+# The batch of size 250 takes ~0.2 second and consumes ~15MB memory at peak
+ORDER_BATCH_SIZE = 250
 
 
 @app.task
@@ -32,3 +36,33 @@ def set_base_price_expire_time_task():
             order_lines.update(draft_base_price_expire_at=expire_time)
 
         set_base_price_expire_time_task.delay()
+
+
+@app.task
+@allow_writer()
+def migrate_orders_with_waiting_for_approval_fulfillment_task():
+    """Migrate order with waiting for approval fulfillment to unfulfilled status.
+
+    If the order has a fulfillment with waiting for approval status, it will be set to unfulfilled,
+    instead of `partially_fulfilled` status.
+    """
+    waiting_for_approval_fulfillments = Fulfillment.objects.filter(
+        status=FulfillmentStatus.WAITING_FOR_APPROVAL
+    )
+    fulfilled_fulfillments = Fulfillment.objects.filter(
+        status=FulfillmentStatus.FULFILLED
+    )
+    # get orders that has at least one waiting for approval fulfillment and not
+    # fulfilled fulfillment
+    orders = Order.objects.filter(
+        Exists(waiting_for_approval_fulfillments.filter(order_id=OuterRef("id"))),
+        ~Exists(fulfilled_fulfillments.filter(order_id=OuterRef("id"))),
+        status=OrderStatus.PARTIALLY_FULFILLED,
+    ).order_by("pk")
+    ids = orders.values_list("pk", flat=True)[:ORDER_BATCH_SIZE]
+    if ids:
+        orders = Order.objects.filter(id__in=ids).order_by("pk")
+        with transaction.atomic():
+            _orders_lock = list(orders.select_for_update(of=(["self"])))
+            orders.update(status=OrderStatus.UNFULFILLED)
+        migrate_orders_with_waiting_for_approval_fulfillment_task.delay()


### PR DESCRIPTION
Add migration that will change `PARTIALLY_FULLFILLED` order status to `UNFULFILLED` for orders that has only fulfilments in awaiting approval status.

Migration for the following changes: https://github.com/saleor/saleor/pull/17471

Related PR for 3.22:https://github.com/saleor/saleor/pull/17591

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
