### PR TITLE
Remove reference cycle in Asgiref Local

### DIFF
--- a/saleor/graphql/core/tests/garbage_collection/test_asgiref.py
+++ b/saleor/graphql/core/tests/garbage_collection/test_asgiref.py
@@ -1,0 +1,39 @@
+import gc
+
+import pytest
+from asgiref.local import Local
+
+from .utils import (
+    clean_up_after_garbage_collection_test,
+    disable_gc_for_garbage_collection_test,
+)
+
+
+# Group all tests that require garbage collection so that they do not run concurrently.
+# This is necessary to ensure that tests don't interfere with each other.
+# Without grouping we could receive false positive results.
+@pytest.mark.xdist_group(name="garbage_collection")
+def test_thread_critical_Local_remove_all_reference_cycles():
+    try:
+        # given
+        # Disable automatic garbage collection and set debugging flag.
+        disable_gc_for_garbage_collection_test()
+
+        # when
+        # Create thread critical Local object in sync context.
+        try:
+            getattr(Local(thread_critical=True), "missing")
+        except AttributeError:
+            pass
+        # Enforce garbage collection to populate the garbage list for inspection.
+        gc.collect()
+
+        # then
+        # Ensure that the garbage list is empty. The garbage list is only valid
+        # until the next collection cycle so we can only make assertions about it
+        # before re-enabling automatic collection.
+        assert gc.garbage == []
+    # Restore garbage collection settings to their original state. This should always be run to avoid interfering
+    # with other tests to ensure that code should be executed in the `finally' block.
+    finally:
+        clean_up_after_garbage_collection_test()

--- a/saleor/patch_local.py
+++ b/saleor/patch_local.py
@@ -1,0 +1,53 @@
+import asyncio
+import contextlib
+
+from asgiref.local import Local, _CVar
+
+
+@contextlib.contextmanager
+def _Local_lock_storage(self):
+    # Thread safe access to storage
+    if self._thread_critical:
+        is_async = True
+        try:
+            # this is a test for are we in a async or sync
+            # thread - will raise RuntimeError if there is
+            # no current loop
+            asyncio.get_running_loop()
+        except RuntimeError:
+            is_async = False
+        if not is_async:
+            # We are in a sync thread, the storage is
+            # just the plain thread local (i.e, "global within
+            # this thread" - it doesn't matter where you are
+            # in a call stack you see the same storage)
+            yield self._storage
+        else:
+            # We are in an async thread - storage is still
+            # local to this thread, but additionally should
+            # behave like a context var (is only visible with
+            # the same async call stack)
+
+            # Ensure context exists in the current thread
+            if not hasattr(self._storage, "cvar"):
+                self._storage.cvar = _CVar()
+
+            # self._storage is a thread local, so the members
+            # can't be accessed in another thread (we don't
+            # need any locks)
+            yield self._storage.cvar
+    else:
+        # Lock for thread_critical=False as other threads
+        # can access the exact same storage object
+        with self._thread_lock:
+            yield self._storage
+
+
+def patch_local():
+    """Patch `_lock_storage in `Local` to avoid memory leaks.
+
+    Those changes will remove the circular references inside `Local` class,
+    allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+    Issue: https://github.com/django/asgiref/issues/487
+    """
+    Local._lock_storage = _Local_lock_storage  # type: ignore[method-assign]

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -35,6 +35,7 @@ from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.executor import patch_executor
 from .graphql.promise import patch_promise
 from .patch_gzip import patch_gzip
+from .patch_local import patch_local
 
 django_stubs_ext.monkeypatch()
 
@@ -1075,3 +1076,7 @@ patch_gzip()
 # `BaseDatabaseValidation` and `DatabaseErrorWrapper` to remove all references that could result in reference cycles,
 # allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
 patch_db()
+
+# Patch `Local` to remove all references that could result in reference cycles,
+# allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
+patch_local()


### PR DESCRIPTION
Port #17293
I want to merge this change because it allows memory to be freed immediately without needing a deep garbage collection cycle.
Fix for: https://github.com/django/asgiref/issues/487

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
