### PR TITLE
Fix PositiveDecimal scalar (3.20)

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -38,18 +38,29 @@ class Decimal(graphene.Float):
             return None
 
 
-class PositiveDecimal(Decimal):
+class PositiveDecimal(graphene.Float):
     """Nonnegative Decimal scalar implementation.
 
     Should be used in places where value must be nonnegative (0 or greater).
     """
 
     @staticmethod
-    def parse_value(value):
-        value = super(PositiveDecimal, PositiveDecimal).parse_value(value)
-        if value and value < 0:
-            return None
-        return value
+    def parse_value(value) -> decimal.Decimal | None:
+        parsed_value = Decimal.parse_value(value)
+
+        if (parsed_value is not None) and parsed_value >= 0:
+            return parsed_value
+
+        return None
+
+    @staticmethod
+    def parse_literal(node) -> decimal.Decimal | None:
+        parsed_value = Decimal.parse_literal(node)
+
+        if (parsed_value is not None) and parsed_value >= 0:
+            return parsed_value
+
+        return None
 
 
 class JSON(GenericScalar):

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -21,19 +21,28 @@ class Decimal(graphene.Float):
     """
 
     @staticmethod
-    def parse_literal(node):
-        try:
-            return decimal.Decimal(node.value)
-        except decimal.DecimalException:
-            return None
+    def parse_literal(node) -> decimal.Decimal | None:
+        if isinstance(node, ast.FloatValue | ast.IntValue):
+            try:
+                return decimal.Decimal(node.value)
+            except decimal.DecimalException:
+                return None
+        return None
 
     @staticmethod
-    def parse_value(value):
+    def parse_value(value) -> decimal.Decimal | None:
         try:
             # Converting the float to str before parsing it to Decimal is
             # necessary to keep the decimal places as typed
             value = str(value)
-            return decimal.Decimal(value)
+            value = decimal.Decimal(value)
+            if value.is_infinite():
+                return None
+            if value.is_nan():
+                return None
+            if value.is_subnormal():
+                return None
+            return value
         except decimal.DecimalException:
             return None
 

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -1,7 +1,10 @@
+import decimal
 from unittest import mock
 
 import pytest
+from graphql.language.ast import FloatValue, IntValue, StringValue, ObjectValue
 
+from ..scalars import Decimal, PositiveDecimal
 from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
@@ -419,3 +422,89 @@ def test_correct_date_time_as_input(
 
     # then
     get_graphql_content(response)
+
+
+@pytest.mark.parametrize("invalid_value", ["NaN", "-Infinity", "1e-9999999", "-", "x"])
+def test_decimal_scalar_invalid_value(invalid_value):
+    result = Decimal.parse_value(invalid_value)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    ("valid_node", "expect"),
+    [
+        (FloatValue(value="1.0"), 1),
+        (IntValue(value="1"), 1),
+        (IntValue(value="0"), 0),
+        (IntValue(value="-5"), -5),
+    ],
+)
+def test_decimal_scalar_valid_literal(valid_node, expect):
+    result = Decimal.parse_literal(valid_node)
+    assert result == decimal.Decimal(expect)
+
+
+@pytest.mark.parametrize(
+    "invalid_node",
+    [
+        StringValue(value="1.0"),
+        ObjectValue(fields=[]),
+    ],
+)
+def test_decimal_scalar_invalid_literal(invalid_node):
+    result = Decimal.parse_literal(invalid_node)
+    assert result is None
+
+
+# PositiveDecimal
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        FloatValue(value="1.0"),
+        IntValue(value="1"),
+    ],
+)
+def test_positive_decimal_scalar_valid_literal(node):
+    result = PositiveDecimal.parse_literal(node)
+
+    assert result == decimal.Decimal(1)
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        FloatValue(value="0.0"),
+        IntValue(value="0"),
+    ],
+)
+def test_positive_decimal_scalar_valid_literal_zero(node):
+    result = PositiveDecimal.parse_literal(node)
+
+    assert result == decimal.Decimal(0)
+
+
+@pytest.mark.parametrize("invalid_value", ["NaN", "-Infinity", "1e-9999999", "-1"])
+def test_positive_decimal_scalar_invalid_value(invalid_value):
+    result = PositiveDecimal.parse_value(invalid_value)
+    assert result is None
+
+
+def test_positive_decimal_scalar_valid_value_zero():
+    result = PositiveDecimal.parse_value("0")
+
+    assert result == decimal.Decimal(0)
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        FloatValue(value="-1.0"),
+        IntValue(value="-1"),
+    ],
+)
+def test_positive_decimal_scalar_invalid_literal(node):
+    result = PositiveDecimal.parse_literal(node)
+
+    assert result is None

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -2,12 +2,12 @@ import decimal
 from unittest import mock
 
 import pytest
-from graphql.language.ast import FloatValue, IntValue, StringValue, ObjectValue
+from graphql.language.ast import FloatValue, IntValue, ObjectValue, StringValue
 
-from ..scalars import Decimal, PositiveDecimal
 from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
+from ..scalars import Decimal, PositiveDecimal
 from ..utils import to_global_id_or_none
 
 QUERY_CHECKOUT = """


### PR DESCRIPTION
I want to merge this change because it fixed DecimalScalar - orignal PR
https://github.com/saleor/saleor/pull/17593

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
