### PR TITLE
fix flaky tests: Do not relay on order of returned shipping methods in tests

### DIFF
--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_checkout_resolvers.py
@@ -454,20 +454,24 @@ def test_shipping_methods_use_pregenerated_payload(
 
     # then
     assert content["data"]["checkout"]["id"] == checkout_global_id
-    assert content["data"]["checkout"]["shippingMethods"] == [
-        {
-            "id": shipping_method_global_ids[0],
-            "name": "DHL",
-            "active": True,
-            "message": "",
-        },
-        {
-            "id": shipping_method_global_ids[1],
-            "name": "DHL",
-            "active": False,
-            "message": exclude_msg,
-        },
-    ]
+
+    shipping_methods = content["data"]["checkout"]["shippingMethods"]
+    first_expected_shipping_method = {
+        "id": shipping_method_global_ids[0],
+        "name": "DHL",
+        "active": True,
+        "message": "",
+    }
+    second_expected_shipping_method = {
+        "id": shipping_method_global_ids[1],
+        "name": "DHL",
+        "active": False,
+        "message": exclude_msg,
+    }
+    assert len(shipping_methods) == 2
+    assert first_expected_shipping_method in shipping_methods
+    assert second_expected_shipping_method in shipping_methods
+
     mock_request.assert_called_once()
     mock_generate_payload.assert_not_called()
 
@@ -601,20 +605,24 @@ def test_shipping_methods_and_taxes_use_pregenerated_payload(
 
     # then
     assert content["data"]["checkout"]["id"] == checkout_global_id
-    assert content["data"]["checkout"]["shippingMethods"] == [
-        {
-            "id": shipping_method_global_ids[0],
-            "name": "DHL",
-            "active": True,
-            "message": "",
-        },
-        {
-            "id": shipping_method_global_ids[1],
-            "name": "DHL",
-            "active": False,
-            "message": exclude_msg,
-        },
-    ]
+
+    shipping_methods = content["data"]["checkout"]["shippingMethods"]
+    first_expected_shipping_method = {
+        "id": shipping_method_global_ids[0],
+        "name": "DHL",
+        "active": True,
+        "message": "",
+    }
+    second_expected_shipping_method = {
+        "id": shipping_method_global_ids[1],
+        "name": "DHL",
+        "active": False,
+        "message": exclude_msg,
+    }
+    assert len(shipping_methods) == 2
+    assert first_expected_shipping_method in shipping_methods
+    assert second_expected_shipping_method in shipping_methods
+
     assert content["data"]["checkout"]["totalPrice"]["net"]["amount"] == 16
     assert content["data"]["checkout"]["totalPrice"]["gross"]["amount"] == 20
     mock_tax_request.assert_called_once()


### PR DESCRIPTION
I want to merge this change because it caused a failure on CI. The returned shipping method objects were correct, but in different order. This caused that the CI failed.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
