### PR TITLE
Fix incorrect call of PluginsManager.get_tax_code_from_object_meta

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1727,7 +1727,9 @@ class ProductType(ModelObjectType[models.ProductType]):
     def resolve_tax_type(root: models.ProductType, info):
         def with_tax_class(data):
             tax_class, manager = data
-            tax_data = manager.get_tax_code_from_object_meta(tax_class)
+            tax_data = manager.get_tax_code_from_object_meta(
+                tax_class, channel_slug=None
+            )
             return TaxType(tax_code=tax_data.code, description=tax_data.description)
 
         if root.tax_class_id:


### PR DESCRIPTION
I want to merge this change because of the mock, we didn't discover the place with incorrect method call.
This PR fixes the method call, and changes the test to be able to catch the incorrect call.

Port of changes from: #17598

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
