### PR TITLE
Optimise update events for `ProductVariantUpdate` and `DraftOrderUpdate`

### DIFF
--- a/saleor/core/utils/update_mutation_manager.py
+++ b/saleor/core/utils/update_mutation_manager.py
@@ -1,3 +1,8 @@
+from typing import Any, TypeVar
+
+from django.db.models import Model
+
+
 def get_editable_values_from_instance(instance):
     field_names = [
         field.name for field in instance._meta.model._meta.fields if field.editable
@@ -14,3 +19,48 @@ def get_edited_fields(old_values: dict, new_values: dict):
         for field in old_values.keys()
         if old_values.get(field) != new_values.get(field)
     ]
+
+
+N = TypeVar("N", bound=Model)
+
+
+class InstanceTracker:
+    """Instance with modifications tracker."""
+
+    def __init__(
+        self,
+        instance: N,
+        instance_editable_fields: list[str],
+    ):
+        self.instance = instance
+        self.instance_editable_fields = instance_editable_fields
+        self.initial_instance_values: dict[str, Any] = self.get_field_values()
+
+    def get_field_values(self) -> dict[str, Any]:
+        return {
+            field: getattr(self.instance, field, None)
+            for field in self.instance_editable_fields
+        }
+
+    def get_modified_fields(self) -> list[str]:
+        modified_instance_values: dict[str, Any] = self.get_field_values()
+        return [
+            field
+            for field in self.initial_instance_values.keys()
+            if self.initial_instance_values.get(field)
+            != modified_instance_values.get(field)
+        ]
+
+    def save_instance(self) -> bool:
+        if modified_fields := self.get_modified_fields():
+            modified_fields.append("updated_at")
+            self.instance.save(update_fields=modified_fields)
+            return True
+        return False
+
+    def metadata_modified(self) -> bool:
+        if modified_fields := self.get_modified_fields():
+            return (
+                "metadata" in modified_fields or "private_metadata" in modified_fields
+            )
+        return False

--- a/saleor/core/utils/update_mutation_manager.py
+++ b/saleor/core/utils/update_mutation_manager.py
@@ -1,0 +1,16 @@
+def get_editable_values_from_instance(instance):
+    field_names = [
+        field.name for field in instance._meta.model._meta.fields if field.editable
+    ]
+    instance_values = {
+        field_name: getattr(instance, field_name) for field_name in field_names
+    }
+    return instance_values
+
+
+def get_edited_fields(old_values: dict, new_values: dict):
+    return [
+        field
+        for field in old_values.keys()
+        if old_values.get(field) != new_values.get(field)
+    ]

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -1611,7 +1611,7 @@ def prepare_error_list_from_error_attribute_mapping(
     return errors
 
 
-def has_input_new_attribute_values(
+def has_input_modified_attribute_values(
     variant: ProductVariant, attributes_data: list[tuple[Attribute, AttrValuesInput]]
 ) -> bool:
     """Compare already assigned attribute values with values from AttrValuesInput.
@@ -1631,7 +1631,7 @@ def has_input_new_attribute_values(
                     else []
                 )
             else:
-                values = attr_data.values
+                values = attr_data.values  # type: ignore[assignment]
             input_attribute_values[attr_data.global_id].extend(values)
         if input_attribute_values != assigned_attributes:
             return True

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -212,7 +212,7 @@ class DraftOrderUpdate(
     def _save(
         cls,
         info: ResolveInfo,
-        instance,
+        instance: models.Order,
         cleaned_input,
         old_voucher,
         old_voucher_code,
@@ -225,7 +225,11 @@ class DraftOrderUpdate(
             address_fields = save_addresses(instance, cleaned_input)
             updated_fields.extend(address_fields)
 
-            if "shipping_method" in cleaned_input:
+            is_shipping_method_update_required = (
+                "shipping_method" in cleaned_input
+                and cleaned_input["shipping_method"] != instance.shipping_method
+            )
+            if is_shipping_method_update_required:
                 method = cleaned_input["shipping_method"]
                 if method is None:
                     ShippingMethodUpdateMixin.clear_shipping_method_from_order(instance)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -3342,3 +3342,94 @@ def test_draft_order_update_nothing_change(
     order.refresh_from_db()
     save_order_mock.assert_not_called()
     call_event_mock.assert_not_called()
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
+    wraps=call_order_event,
+)
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.DraftOrderUpdate._save_order_instance"
+)
+def test_draft_order_update_emit_events(
+    save_order_mock,
+    call_event_mock,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    graphql_address_data,
+    voucher,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order.save(update_fields=["status"])
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    key = "some_key"
+    value = "some_value"
+    order.metadata = {key: value}
+    order.private_metadata = {key: value}
+    order.draft_save_billing_address = True
+    order.draft_save_shipping_address = True
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    order.customer_note = "some note"
+    order.redirect_url = "https://www.example.com"
+    order.external_reference = "some_reference_string"
+    order.language_code = "pl"
+    order.save()
+
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethod", order.shipping_method_id
+    )
+    user_id = graphene.Node.to_global_id("User", order.user_id)
+
+    input_fields = [
+        snake_to_camel_case(key) for key in DraftOrderInput._meta.fields.keys()
+    ]
+
+    # `discount` field is unused and deprecated
+    input_fields.remove("discount")
+    # `voucher` and `voucherCode` fields can't be combined
+    input_fields.remove("voucher")
+    # `channel` can't be updated when is not None
+    input_fields.remove("channelId")
+
+    input = {
+        "billingAddress": graphql_address_data,
+        "saveBillingAddress": True,
+        "shippingAddress": graphql_address_data,
+        "saveShippingAddress": True,
+        "shippingMethod": shipping_method_id,
+        "user": user_id,
+        "userEmail": order.user_email,
+        "voucherCode": order.voucher_code,
+        "customerNote": order.customer_note,
+        "redirectUrl": order.redirect_url,
+        "externalReference": order.external_reference,
+        "metadata": [{"key": key, "value": value}],
+        "privateMetadata": [{"key": key, "value": value}],
+        "languageCode": "PL",
+    }
+    assert set(input_fields) == set(input.keys())
+
+    # fields making changes to related models (other than order)
+    non_base_model_fields = ["billingAddress", "shippingAddress"]
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    for key, value in input.items():
+        variables = {"id": order_id, "input": {key: value}}
+
+        # when
+        response = staff_api_client.post_graphql(
+            DRAFT_ORDER_UPDATE_MUTATION,
+            variables,
+        )
+        content = get_graphql_content(response)
+
+        # then
+        assert not content["data"]["draftOrderUpdate"]["errors"]
+        if key not in non_base_model_fields:
+            save_order_mock.assert_called()
+        call_event_mock.assert_called()

--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -231,7 +231,7 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
             info, id=id, sku=sku, external_reference=external_reference, input=input
         )
         instance = cast(ProductVariant, instance)
-        instance_values_before_update = cls.get_editable_values_from_instance(
+        instance_values_before_update = get_editable_values_from_instance(
             deepcopy(instance)
         )
         cleaned_input = cls.clean_input(info, instance, input)
@@ -252,13 +252,13 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
             new_instance, metadata_collection, private_metadata_collection
         )
         cls.clean_instance(info, new_instance)
-        instance_values_after_update = get_editable_values_from_instance(new_instance)
 
+        instance_values_after_update = get_editable_values_from_instance(new_instance)
         changed_fields = get_edited_fields(
             instance_values_before_update, instance_values_after_update
         )
 
-        # TODO zedzior: refactor clean_input function to not call the attribute logic twice
+        # TODO zedzior: attribute logic refactor PR:
         has_new_attribute_values = False
         if attributes_data := cleaned_input.get("attributes"):
             has_new_attribute_values = has_input_new_attribute_values(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -249,11 +249,7 @@ QUERY_UPDATE_VARIANT_CHANGING_FIELDS = """
 @patch(
     "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate.call_event"
 )
-@patch(
-    "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate._save_variant_instance"
-)
 def test_update_product_variant_update_fields_when_necessary(
-    save_variant_mock,
     call_event_mock,
     staff_api_client,
     product,
@@ -304,7 +300,6 @@ def test_update_product_variant_update_fields_when_necessary(
     # then
     variant.refresh_from_db()
     get_graphql_content(response)
-    save_variant_mock.assert_called_once_with(variant, changed_fields)
     call_event_mock.assert_has_calls(
         [
             call(ANY, variant),
@@ -327,11 +322,7 @@ def test_update_product_variant_update_fields_when_necessary(
 @patch(
     "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate.call_event"
 )
-@patch(
-    "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate._save_variant_instance"
-)
 def test_update_product_variant_skip_updating_fields_when_unchanged(
-    save_variant_mock,
     call_event_mock,
     staff_api_client,
     product,
@@ -381,7 +372,6 @@ def test_update_product_variant_skip_updating_fields_when_unchanged(
     # then
     variant.refresh_from_db()
     get_graphql_content(response)
-    save_variant_mock.assert_not_called()
     call_event_mock.assert_not_called()
 
 
@@ -410,11 +400,7 @@ mutation ProductVariantUpdate($id: ID!, $input: ProductVariantInput!) {
 @patch(
     "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate.call_event"
 )
-@patch(
-    "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate._save_variant_instance"
-)
 def test_update_product_variant_nothing_changed(
-    save_variant_mock,
     call_event_mock,
     staff_api_client,
     product_with_variant_with_two_attributes,
@@ -485,18 +471,13 @@ def test_update_product_variant_nothing_changed(
     # then
     assert not content["data"]["productVariantUpdate"]["errors"]
     variant.refresh_from_db()
-    save_variant_mock.assert_not_called()
     call_event_mock.assert_not_called()
 
 
 @patch(
     "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate.call_event"
 )
-@patch(
-    "saleor.graphql.product.mutations.product_variant.ProductVariantUpdate._save_variant_instance"
-)
 def test_update_product_variant_emit_event(
-    save_variant_mock,
     call_event_mock,
     staff_api_client,
     product_with_variant_with_two_attributes,
@@ -551,8 +532,6 @@ def test_update_product_variant_emit_event(
     }
     assert set(input_fields) == set(input.keys())
 
-    # fields making changes to related models (other than variant)
-    non_base_model_fields = ["attributes"]
     staff_api_client.user.user_permissions.add(permission_manage_products)
 
     for key, value in input.items():
@@ -567,8 +546,6 @@ def test_update_product_variant_emit_event(
 
         # then
         assert not content["data"]["productVariantUpdate"]["errors"]
-        if key not in non_base_model_fields:
-            save_variant_mock.assert_called()
         call_event_mock.assert_called()
 
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -476,10 +476,11 @@ def test_update_product_variant_nothing_changed(
         variables,
         permissions=[permission_manage_products],
     )
+    content = get_graphql_content(response)
 
     # then
+    assert not content["data"]["productVariantUpdate"]["errors"]
     variant.refresh_from_db()
-    get_graphql_content(response)
     save_variant_mock.assert_not_called()
     call_event_mock.assert_not_called()
 

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -1,4 +1,3 @@
-import copy
 from decimal import Decimal
 from operator import attrgetter
 from re import match
@@ -12,7 +11,6 @@ from django.core.validators import MinValueValidator
 from django.db import connection, models
 from django.db.models import F, JSONField, Max
 from django.db.models.expressions import Exists, OuterRef
-from django.forms.models import model_to_dict
 from django.utils.timezone import now
 from django_measurement.models import MeasurementField
 from measurement.measures import Weight
@@ -396,28 +394,6 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
             ),
             BTreeIndex(fields=["checkout_token"], name="checkout_token_btree_idx"),
         ]
-
-    @property
-    def comparison_fields(self):
-        return [
-            "discount",
-            "voucher",
-            "voucher_code",
-            "customer_note",
-            "redirect_url",
-            "external_reference",
-            "user",
-            "user_email",
-            "channel",
-            "metadata",
-            "private_metadata",
-            "draft_save_billing_address",
-            "draft_save_shipping_address",
-            "language_code",
-        ]
-
-    def serialize_for_comparison(self):
-        return copy.deepcopy(model_to_dict(self, fields=self.comparison_fields))
 
     def is_fully_paid(self):
         return self.total_charged >= self.total.gross

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
@@ -12,7 +11,6 @@ from django.contrib.postgres.search import SearchVectorField
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
 from django.db.models import JSONField, TextField
-from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
 from django_measurement.models import MeasurementField
@@ -458,25 +456,6 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
         return self.is_preorder and (
             self.preorder_end_date is None or timezone.now() <= self.preorder_end_date
         )
-
-    @property
-    def comparison_fields(self):
-        return [
-            "sku",
-            "name",
-            "track_inventory",
-            "is_preorder",
-            "quantity_limit_per_customer",
-            "weight",
-            "external_reference",
-            "metadata",
-            "private_metadata",
-            "preorder_end_date",
-            "preorder_global_threshold",
-        ]
-
-    def serialize_for_comparison(self):
-        return copy.deepcopy(model_to_dict(self, fields=self.comparison_fields))
 
 
 class ProductVariantTranslation(Translation):


### PR DESCRIPTION
This PR presents a proposal approach how to optimise `*Update` mutations to not perform `save` and not emit events in case of nothing has been updated.

1. It removes `comparison_fields` on models in favour of dedicated function `get_editable_values_from_instance`
2. It distinguish logic for updating base model fields and related models fields:
   - base model fields are handled by comparing instance values before an after update
   - related model fields are handled with custom logic per mutation 
3. Add 2 tests:
   - to ensure no save and event emitted in case of nothing has changed 
   - iterate over all input fields and check if save was call and event emitted in case of new value    
   - the tests should fail if new input field will be added to the mutation
   - the test should fail if we omit any input field

If we approve proposal solution, I will apply it to all update mutations in separate PRs (PR / mutation)