### PR TITLE
Raise logger.error when sync webhook is called inside db.transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ env.bak/
 venv.bak/
 Pipfile
 !.env.example
+logoutput/
 
 # Exported results file
 django-queries-results.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixes incorrect gift card balances after covering the full order total - #17566 by @korycins
 - Fixes tax class not clearing when selecting a shipping method without a tax class - #17560 by @korycins
 - The prices for draft orders created in `OrderBulkCreate` now are properly calculated - #17583 by @IKarbowiak
+- Raises logger.error when sync webhook is called inside db.transaction - #15138 by @robfleur


### PR DESCRIPTION
I want to merge this change because sync webhooks are called inside of some db.transaction. We want to document if/where it happens. This corresponds to issue 15138.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

- [ ] Link to documentation:

# Pull Request Checklist

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
