### PR TITLE
Integrate deferred payloads with fairness and OTEL

### DIFF
--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -571,7 +571,7 @@ def test_get_checkout_refundable_with_multiple_active_transactions(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_checkout_event_incorrect_webhook_event(
@@ -611,7 +611,7 @@ def test_call_checkout_event_incorrect_webhook_event(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -664,13 +664,9 @@ def test_call_checkout_event_triggers_sync_webhook_when_needed(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -709,7 +705,7 @@ def test_call_checkout_event_triggers_sync_webhook_when_needed(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -761,13 +757,9 @@ def test_call_checkout_event_skips_tax_webhook_when_not_expired(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -803,7 +795,7 @@ def test_call_checkout_event_skips_tax_webhook_when_not_expired(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_checkout_event_skip_sync_webhooks_when_async_missing(
@@ -841,7 +833,7 @@ def test_call_checkout_event_skip_sync_webhooks_when_async_missing(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -882,13 +874,9 @@ def test_call_checkout_event_only_async_when_sync_missing(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -899,7 +887,7 @@ def test_call_checkout_event_only_async_when_sync_missing(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_checkout_info_event_incorrect_webhook_event(
@@ -948,7 +936,7 @@ def test_call_checkout_info_event_incorrect_webhook_event(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1012,13 +1000,9 @@ def test_call_checkout_info_event_triggers_sync_webhook_when_needed(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1057,7 +1041,7 @@ def test_call_checkout_info_event_triggers_sync_webhook_when_needed(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1120,13 +1104,9 @@ def test_call_checkout_info_event_skips_tax_webhook_when_not_expired(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1162,7 +1142,7 @@ def test_call_checkout_info_event_skips_tax_webhook_when_not_expired(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1213,13 +1193,9 @@ def test_call_checkout_info_event_only_async_when_sync_missing(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -1230,7 +1206,7 @@ def test_call_checkout_info_event_only_async_when_sync_missing(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_checkout_info_event_skip_sync_webhooks_when_async_missing(
@@ -1282,7 +1258,7 @@ def test_call_checkout_info_event_skip_sync_webhooks_when_async_missing(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1342,13 +1318,9 @@ def test_transaction_amounts_for_checkout_fully_paid_triggers_sync_webhook(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_fully_paid_delivery.id,
+            "app_id": checkout_fully_paid_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1388,7 +1360,7 @@ def test_transaction_amounts_for_checkout_fully_paid_triggers_sync_webhook(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_checkout_events_incorrect_webhook_event(
@@ -1428,7 +1400,7 @@ def test_call_checkout_events_incorrect_webhook_event(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1484,13 +1456,9 @@ def test_call_checkout_events_triggers_sync_webhook_when_needed(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1534,7 +1502,7 @@ def test_call_checkout_events_triggers_sync_webhook_when_needed(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1589,13 +1557,9 @@ def test_call_checkout_events_skips_tax_webhook_when_not_expired(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1636,7 +1600,7 @@ def test_call_checkout_events_skips_tax_webhook_when_not_expired(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_checkout_events_skip_sync_webhooks_when_async_missing(
@@ -1677,7 +1641,7 @@ def test_call_checkout_events_skip_sync_webhooks_when_async_missing(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1721,13 +1685,9 @@ def test_call_checkout_events_only_async_when_sync_missing(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -833,7 +833,7 @@ def test_call_checkout_event_skip_sync_webhooks_when_async_missing(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -874,9 +874,13 @@ def test_call_checkout_event_only_async_when_sync_missing(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "app_id": checkout_create_delivery.webhook.app_id,
+            "event_delivery_id": checkout_create_delivery.id,
             "telemetry_context": ANY,
         },
+        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -1142,7 +1146,7 @@ def test_call_checkout_info_event_skips_tax_webhook_when_not_expired(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1193,9 +1197,13 @@ def test_call_checkout_info_event_only_async_when_sync_missing(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "app_id": checkout_create_delivery.webhook.app_id,
+            "event_delivery_id": checkout_create_delivery.id,
             "telemetry_context": ANY,
         },
+        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -1641,7 +1649,7 @@ def test_call_checkout_events_skip_sync_webhooks_when_async_missing(
 @freeze_time("2023-05-31 12:00:01")
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @patch(
     "saleor.checkout.actions.call_event_including_protected_events",
@@ -1685,9 +1693,13 @@ def test_call_checkout_events_only_async_when_sync_missing(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "app_id": checkout_create_delivery.webhook.app_id,
+            "event_delivery_id": checkout_create_delivery.id,
             "telemetry_context": ANY,
         },
+        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+        bind=True,
+        retry_backoff=10,
+        retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -40,6 +40,7 @@ class Unit(Enum):
 UNIT_CONVERSIONS: dict[tuple[Unit, Unit], float] = {
     (Unit.NANOSECOND, Unit.MILLISECOND): 1e-6,
     (Unit.NANOSECOND, Unit.SECOND): 1e-9,
+    (Unit.SECOND, Unit.MILLISECOND): 1e3,
 }
 
 

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from opentelemetry.trace import Link, SpanContext, TraceFlags
 from opentelemetry.util.types import Attributes, AttributeValue
 
+from .saleor_attributes import OPERATION_NAME
+
 logger = logging.getLogger(__name__)
 
 Amount = int | float
@@ -38,7 +40,6 @@ class Unit(Enum):
 UNIT_CONVERSIONS: dict[tuple[Unit, Unit], float] = {
     (Unit.NANOSECOND, Unit.MILLISECOND): 1e-6,
     (Unit.NANOSECOND, Unit.SECOND): 1e-9,
-    (Unit.SECOND, Unit.MILLISECOND): 1e3,
 }
 
 
@@ -68,8 +69,14 @@ def get_global_attributes() -> dict[str, AttributeValue]:
     return _GLOBAL_ATTRS.get({})
 
 
-def enrich_with_global_attributes(attributes: Attributes) -> Attributes:
+def enrich_with_global_attributes(attributes: Attributes) -> dict[str, AttributeValue]:
     return {**(attributes or {}), **get_global_attributes()}
+
+
+def enrich_span_with_global_attributes(
+    attributes: Attributes, span_name: str
+) -> dict[str, AttributeValue]:
+    return {OPERATION_NAME: span_name, **enrich_with_global_attributes(attributes)}
 
 
 @dataclass(frozen=True)

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -10,8 +10,6 @@ from django.conf import settings
 from opentelemetry.trace import Link, SpanContext, TraceFlags
 from opentelemetry.util.types import Attributes, AttributeValue
 
-from .saleor_attributes import OPERATION_NAME
-
 logger = logging.getLogger(__name__)
 
 Amount = int | float
@@ -40,6 +38,7 @@ class Unit(Enum):
 UNIT_CONVERSIONS: dict[tuple[Unit, Unit], float] = {
     (Unit.NANOSECOND, Unit.MILLISECOND): 1e-6,
     (Unit.NANOSECOND, Unit.SECOND): 1e-9,
+    (Unit.SECOND, Unit.MILLISECOND): 1e3,
 }
 
 
@@ -69,14 +68,8 @@ def get_global_attributes() -> dict[str, AttributeValue]:
     return _GLOBAL_ATTRS.get({})
 
 
-def enrich_with_global_attributes(attributes: Attributes) -> dict[str, AttributeValue]:
+def enrich_with_global_attributes(attributes: Attributes) -> Attributes:
     return {**(attributes or {}), **get_global_attributes()}
-
-
-def enrich_span_with_global_attributes(
-    attributes: Attributes, span_name: str
-) -> dict[str, AttributeValue]:
-    return {OPERATION_NAME: span_name, **enrich_with_global_attributes(attributes)}
 
 
 @dataclass(frozen=True)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1372,7 +1372,7 @@ def test_with_active_problems_flow(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_add_voucher_triggers_webhooks(
@@ -1421,13 +1421,9 @@ def test_checkout_add_voucher_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -662,7 +662,7 @@ def test_checkout_billing_address_skip_validation_by_app(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_billing_address_triggers_webhooks(
@@ -716,13 +716,9 @@ def test_checkout_billing_address_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -662,7 +662,7 @@ def test_checkout_billing_address_skip_validation_by_app(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_billing_address_triggers_webhooks(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -2704,7 +2704,7 @@ def test_checkout_create_skip_validation_billing_address_by_app(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_create_triggers_webhooks(
@@ -2762,13 +2762,9 @@ def test_checkout_create_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_create_delivery.id,
+            "app_id": checkout_create_delivery.webhook.app.id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -292,7 +292,7 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_customer_triggers_webhooks(
@@ -346,13 +346,9 @@ def test_checkout_customer_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -164,7 +164,7 @@ def test_with_active_problems_flow(user_api_client, checkout_with_problems):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_customer_detach_triggers_webhooks(
@@ -215,13 +215,9 @@ def test_checkout_customer_detach_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
@@ -125,7 +125,7 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_customer_note_update_triggers_webhooks(
@@ -177,13 +177,9 @@ def test_checkout_customer_note_update_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -1231,11 +1231,11 @@ def test_checkout_delivery_method_update_from_cc_to_all_warehouses_disabled_cc(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_delivery_method_update_triggers_webhooks(
-    mocked_send_webhook_request_async,
+    mocked_send_webhook_async_for_app,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
@@ -1276,15 +1276,11 @@ def test_checkout_delivery_method_update_triggers_webhooks(
     checkout_update_delivery = EventDelivery.objects.get(
         webhook_id=checkout_updated_webhook.id
     )
-    mocked_send_webhook_request_async.assert_called_once_with(
+    mocked_send_webhook_async_for_app.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1321,11 +1317,11 @@ def test_checkout_delivery_method_update_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_delivery_method_update_cc_triggers_webhooks(
-    mocked_send_webhook_request_async,
+    mocked_send_webhook_async_for_app,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
@@ -1372,15 +1368,11 @@ def test_checkout_delivery_method_update_cc_triggers_webhooks(
     checkout_update_delivery = EventDelivery.objects.get(
         webhook_id=checkout_updated_webhook.id
     )
-    mocked_send_webhook_request_async.assert_called_once_with(
+    mocked_send_webhook_async_for_app.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # Shipping sync webhooks are called twice - first call before saving the changes in
@@ -1421,7 +1413,7 @@ def test_checkout_delivery_method_update_cc_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 @patch(
@@ -1430,7 +1422,7 @@ def test_checkout_delivery_method_update_cc_triggers_webhooks(
 )
 def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
     mock_clean_delivery,
-    mocked_send_webhook_request_async,
+    mocked_send_webhook_async_for_app,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_info_event,
     setup_checkout_webhooks,
@@ -1485,15 +1477,11 @@ def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
     checkout_update_delivery = EventDelivery.objects.get(
         webhook_id=checkout_updated_webhook.id
     )
-    mocked_send_webhook_request_async.assert_called_once_with(
+    mocked_send_webhook_async_for_app.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -132,11 +132,11 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_email_update_triggers_webhooks(
-    mocked_send_webhook_request_async,
+    mocked_send_webhook_async_for_app,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event,
     setup_checkout_webhooks,
@@ -179,15 +179,11 @@ def test_checkout_email_update_triggers_webhooks(
     checkout_update_delivery = EventDelivery.objects.get(
         webhook_id=checkout_updated_webhook.id
     )
-    mocked_send_webhook_request_async.assert_called_once_with(
+    mocked_send_webhook_async_for_app.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -120,11 +120,11 @@ def test_with_active_problems_flow(api_client, checkout_with_problems):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_update_language_code_triggers_webhooks(
-    mocked_send_webhook_request_async,
+    mocked_send_webhook_async_for_app,
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_event,
     setup_checkout_webhooks,
@@ -168,15 +168,11 @@ def test_checkout_update_language_code_triggers_webhooks(
     checkout_update_delivery = EventDelivery.objects.get(
         webhook_id=checkout_updated_webhook.id
     )
-    mocked_send_webhook_request_async.assert_called_once_with(
+    mocked_send_webhook_async_for_app.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -336,7 +336,7 @@ def test_checkout_line_delete_non_removable_gift(user_api_client, checkout_line)
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_line_delete_triggers_webhooks(
@@ -397,13 +397,9 @@ def test_checkout_line_delete_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1979,7 +1979,7 @@ def test_with_active_problems_flow(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async",
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async",
     wraps=send_webhook_request_async.apply_async,
 )
 @patch(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -341,7 +341,7 @@ def test_checkout_lines_delete_not_associated_with_checkout(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_lines_delete_triggers_webhooks(
@@ -395,13 +395,9 @@ def test_checkout_lines_delete_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1499,7 +1499,7 @@ def test_checkout_lines_update_quantity_gift(user_api_client, checkout_with_item
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async",
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async",
     wraps=send_webhook_request_async.apply_async,
 )
 @patch(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -787,7 +787,7 @@ def test_with_active_problems_flow(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async",
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async",
     wraps=send_webhook_request_async.apply_async,
 )
 @patch(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -1133,7 +1133,7 @@ def test_checkout_shipping_address_skip_validation_by_app(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_shipping_address_update_triggers_webhooks(
@@ -1180,13 +1180,9 @@ def test_checkout_shipping_address_update_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -679,7 +679,7 @@ def test_with_active_problems_flow(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_shipping_method_update_triggers_webhooks(
@@ -756,7 +756,7 @@ def test_checkout_shipping_method_update_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async",
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async",
     wraps=send_webhook_request_async.apply_async,
 )
 @patch(
@@ -854,7 +854,7 @@ def test_checkout_shipping_method_update_external_shipping_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_checkout_shipping_method_update_to_none_triggers_webhooks(
@@ -902,13 +902,9 @@ def test_checkout_shipping_method_update_to_none_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -369,7 +369,7 @@ def test_update_public_metadata_for_checkout_line(api_client, checkout_line):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
@@ -420,13 +420,9 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_update_delivery.id,
+            "app_id": checkout_update_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook con was called without saving event delivery
@@ -465,7 +461,7 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
@@ -473,11 +469,9 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     mocked_send_webhook_request_sync,
     wrapped_call_checkout_events,
     setup_checkout_webhooks,
-    settings,
     api_client,
     checkout_with_item,
     address,
-    shipping_method,
 ):
     # given
 
@@ -517,13 +511,9 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": checkout_metadata_updated_delivery.id,
+            "app_id": checkout_metadata_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=None,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook con was called without saving event delivery

--- a/saleor/graphql/meta/tests/mutations/test_order.py
+++ b/saleor/graphql/meta/tests/mutations/test_order.py
@@ -619,7 +619,7 @@ def test_add_private_metadata_for_fulfillment(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_change_in_public_metadata_triggers_webhooks(
@@ -660,13 +660,9 @@ def test_change_in_public_metadata_triggers_webhooks(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": order_metadata_updated_delivery.id,
+            "app_id": order_metadata_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -698,7 +694,7 @@ def test_change_in_public_metadata_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_change_in_private_metadata_triggers_webhooks(
@@ -738,13 +734,9 @@ def test_change_in_private_metadata_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": order_metadata_updated_delivery.id,
+            "app_id": order_metadata_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1636,7 +1636,7 @@ def test_draft_order_complete_with_invalid_address_save_addresses_on(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_complete_triggers_webhooks(
@@ -1698,11 +1698,7 @@ def test_draft_order_complete_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -3703,7 +3703,7 @@ def test_draft_order_create_voucher_with_usage_limit(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_create_triggers_webhooks(
@@ -3718,7 +3718,6 @@ def test_draft_order_create_triggers_webhooks(
     product_available_in_many_channels,
     channel_PLN,
     graphql_address_data,
-    settings,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -3771,13 +3770,9 @@ def test_draft_order_create_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": draft_order_created_delivery.id,
+            "app_id": draft_order_created_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -298,7 +298,7 @@ def test_draft_order_delete_release_voucher_codes_single_use(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_delete_do_not_trigger_sync_webhooks(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -298,7 +298,7 @@ def test_draft_order_delete_release_voucher_codes_single_use(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_delete_do_not_trigger_sync_webhooks(
@@ -339,13 +339,9 @@ def test_draft_order_delete_do_not_trigger_sync_webhooks(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": draft_order_deleted_delivery.id,
+            "app_id": draft_order_deleted_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
     assert not mocked_send_webhook_request_sync.called
     assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -2487,7 +2487,7 @@ def test_draft_order_update_replace_entire_order_voucher_with_shipping_voucher(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_update_triggers_webhooks(
@@ -2547,13 +2547,9 @@ def test_draft_order_update_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": draft_order_updated_delivery.id,
+            "app_id": draft_order_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -2585,7 +2581,7 @@ def test_draft_order_update_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
@@ -2637,13 +2633,9 @@ def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": draft_order_updated_delivery.id,
+            "app_id": draft_order_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_cancel.py
+++ b/saleor/graphql/order/tests/mutations/test_order_cancel.py
@@ -138,7 +138,7 @@ def test_order_cancel_no_channel_access(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 @patch("saleor.graphql.order.mutations.order_cancel.clean_order_cancel")
@@ -205,11 +205,7 @@ def test_order_cancel_skip_trigger_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -177,7 +177,7 @@ def test_order_capture_by_app(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(
     PLUGINS=[
@@ -249,11 +249,7 @@ def test_order_capture_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -610,7 +610,7 @@ def test_order_confirm_skip_address_validation(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch("saleor.payment.gateway.capture")
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
@@ -689,11 +689,7 @@ def test_order_confirm_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -1563,7 +1563,7 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fulfill_triggers_webhooks(
@@ -1575,8 +1575,6 @@ def test_order_fulfill_triggers_webhooks(
     order_with_lines,
     permission_group_manage_orders,
     warehouse,
-    settings,
-    django_capture_on_commit_callbacks,
 ):
     # given
     mocked_send_webhook_request_sync.return_value = []
@@ -1647,11 +1645,7 @@ def test_order_fulfill_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -319,7 +319,7 @@ def test_order_line_delete_non_removable_gift(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_line_delete_triggers_webhooks(
@@ -330,7 +330,6 @@ def test_order_line_delete_triggers_webhooks(
     draft_order,
     permission_group_manage_orders,
     staff_api_client,
-    settings,
     status,
     webhook_event,
 ):
@@ -364,11 +363,7 @@ def test_order_line_delete_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_line_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_update.py
@@ -637,11 +637,11 @@ def test_order_line_update_gift_promotion(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_line_update_triggers_webhooks(
-    mocked_send_webhook_request_async,
+    mocked_send_webhook_async_for_app,
     mocked_send_webhook_request_sync,
     wrapped_call_order_event,
     setup_order_webhooks,
@@ -683,12 +683,8 @@ def test_order_line_update_triggers_webhooks(
 
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
-    mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+    mocked_send_webhook_async_for_app.assert_called_once_with(
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -1282,7 +1282,7 @@ def test_order_lines_create_no_shipping_address(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_lines_create_triggers_webhooks(
@@ -1328,11 +1328,7 @@ def test_order_lines_create_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_note_add.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_add.py
@@ -189,7 +189,7 @@ def test_order_note_add_fail_on_missing_permission(staff_api_client, order):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_note_add_user_triggers_webhooks(
@@ -232,11 +232,7 @@ def test_order_note_add_user_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_note_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_update.py
@@ -221,7 +221,7 @@ def test_order_note_remove_fail_on_missing_permission(staff_api_client, order):
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_note_update_user_triggers_webhooks(
@@ -276,11 +276,7 @@ def test_order_note_update_user_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update.py
@@ -544,7 +544,7 @@ def test_order_update_invalid_address_skip_validation(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_update_triggers_webhooks(
@@ -590,11 +590,7 @@ def test_order_update_triggers_webhooks(
     # confirm that event delivery was generated for each async webhook.
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -674,7 +674,7 @@ def test_order_shipping_update_mutation_properly_recalculate_total(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_update_shipping_triggers_webhooks(
@@ -718,11 +718,7 @@ def test_order_update_shipping_triggers_webhooks(
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -760,7 +760,7 @@ def test_order_update_shipping_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_update_shipping_triggers_proper_updated_webhook(
@@ -801,11 +801,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook(
     assert order_delivery.event_type == WebhookEventAsyncType.DRAFT_ORDER_UPDATED
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     assert wrapped_call_order_event.called
@@ -817,7 +813,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_update_shipping_triggers_proper_updated_webhook_for_null_shipping_method(
@@ -856,11 +852,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook_for_null_sh
     assert order_delivery.event_type == WebhookEventAsyncType.DRAFT_ORDER_UPDATED
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     assert wrapped_call_order_event.called
@@ -872,7 +864,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook_for_null_sh
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_editable_order_update_shipping_triggers_proper_updated_webhook_for_null_shipping_method(
@@ -913,11 +905,7 @@ def test_editable_order_update_shipping_triggers_proper_updated_webhook_for_null
     assert order_delivery.event_type == WebhookEventAsyncType.ORDER_UPDATED
 
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     assert wrapped_call_order_event.called

--- a/saleor/graphql/webhook/mutations/webhook_trigger.py
+++ b/saleor/graphql/webhook/mutations/webhook_trigger.py
@@ -1,7 +1,6 @@
 from dataclasses import asdict
 
 import graphene
-from celery.exceptions import Retry
 from django.db.models import Exists, OuterRef
 from graphene.utils.str_converters import to_camel_case
 
@@ -9,7 +8,6 @@ from ....app.models import App
 from ....core import EventDeliveryStatus
 from ....core import models as core_models
 from ....core.telemetry import get_task_context
-from ....core.utils.events import get_is_deferred_payload
 from ....discount import models as discount_models
 from ....graphql.utils import get_user_or_app_from_context
 from ....permission.auth_filters import AuthorizationFilters
@@ -17,9 +15,7 @@ from ....webhook.error_codes import WebhookTriggerErrorCode
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.models import Webhook
 from ....webhook.transport.asynchronous.transport import (
-    create_deliveries_for_subscriptions,
     generate_deferred_payloads,
-    send_webhook_request_async,
 )
 from ....webhook.transport.utils import prepare_deferred_payload_data
 from ...core import ResolveInfo
@@ -166,39 +162,22 @@ class WebhookTrigger(BaseMutation):
             ]:
                 object = [object]
 
-            is_deferred_payload = get_is_deferred_payload(event_type)
-            if is_deferred_payload:
-                delivery = core_models.EventDelivery(
-                    status=EventDeliveryStatus.PENDING,
-                    event_type=event_type,
-                    webhook=webhook,
-                )
-                delivery.save()
-                deferred_payload_data = prepare_deferred_payload_data(
-                    object, requestor, info.context.request_time
-                )
-                generate_deferred_payloads.apply_async(
-                    kwargs={
-                        "event_delivery_ids": [delivery.pk],
-                        "deferred_payload_data": asdict(deferred_payload_data),
-                        "telemetry_context": get_task_context().to_dict(),
-                    },
-                    bind=True,
-                )
-            else:
-                deliveries = create_deliveries_for_subscriptions(
-                    event_type, object, [webhook]
-                )
-                if deliveries:
-                    delivery = deliveries[0]
-                    try:
-                        send_webhook_request_async(
-                            delivery.id,
-                            telemetry_context=get_task_context().to_dict(),
-                        )
-                        return WebhookTrigger(delivery=delivery)
-                    except Retry:
-                        delivery.status = EventDeliveryStatus.FAILED
-                        delivery.save(update_fields=["status"])
+            delivery = core_models.EventDelivery(
+                status=EventDeliveryStatus.PENDING,
+                event_type=event_type,
+                webhook=webhook,
+            )
+            delivery.save()
+            deferred_payload_data = prepare_deferred_payload_data(
+                object, requestor, info.context.request_time
+            )
+            generate_deferred_payloads.apply_async(
+                kwargs={
+                    "event_delivery_ids": [delivery.pk],
+                    "deferred_payload_data": asdict(deferred_payload_data),
+                    "telemetry_context": get_task_context().to_dict(),
+                },
+                bind=True,
+            )
 
         return WebhookTrigger(delivery=delivery)

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -142,7 +142,14 @@ def generate_payload_promise_from_subscription(
             return None
 
         payload_instance = payload[0]
-        event_payload = _process_payload_instance(payload_instance)
+        payload_data_keys = payload_instance.data.keys()
+        for key in payload_data_keys:
+            extracted_payload = get_event_payload(payload_instance.data.get(key))
+            payload_instance.data[key] = extracted_payload
+        if "event" in payload_instance.data or not payload_instance.data:
+            event_payload = payload_instance.data.get("event") or {}
+        else:
+            event_payload = {"data": payload_instance.data}
 
         def check_errors(event_payload, payload_instance=payload_instance):
             if payload_instance.errors:

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
@@ -357,7 +357,7 @@ def test_webhook_trigger_for_removed_app(
 
 
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @mock.patch(
     "saleor.webhook.transport.asynchronous.transport.generate_deferred_payloads.apply_async",
@@ -405,4 +405,4 @@ def test_webhook_trigger_for_deferred_payload(
 
     assert mocked_send_webhook_request_async.called
     send_webhook_kwargs = mocked_send_webhook_request_async.call_args.kwargs["kwargs"]
-    assert send_webhook_kwargs["event_delivery_id"] == delivery_pk
+    assert send_webhook_kwargs["app_id"] == subscription_checkout_updated_webhook.app_id

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -2927,6 +2927,9 @@ def test_call_order_event_skips_when_async_webhooks_missing(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
@@ -2936,6 +2939,7 @@ def test_call_order_event_skips_when_async_webhooks_missing(
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_order_event_skips_when_sync_webhooks_missing(
     mocked_call_event_including_protected_events,
+    mocked_send_webhook_async_for_app,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
     order_with_lines,
@@ -2965,7 +2969,7 @@ def test_call_order_event_skips_when_sync_webhooks_missing(
 
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
-    mocked_send_webhook_request_async.assert_called_once_with(
+    mocked_send_webhook_async_for_app.assert_called_once_with(
         kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     assert not mocked_send_webhook_request_sync.called

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -358,7 +358,7 @@ def test_handle_fully_paid_order_for_draft_order(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_handle_fully_paid_order_triggers_webhooks(
@@ -423,11 +423,7 @@ def test_handle_fully_paid_order_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],
@@ -647,7 +643,7 @@ def test_cancel_order(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_cancel_order_dont_trigger_webhooks(
@@ -713,11 +709,7 @@ def test_cancel_order_dont_trigger_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],
@@ -810,7 +802,7 @@ def test_order_refunded_by_app(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_refunded_triggers_webhooks(
@@ -889,11 +881,7 @@ def test_order_refunded_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],
@@ -939,7 +927,7 @@ def test_order_refunded_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_voided_triggers_webhooks(
@@ -988,13 +976,9 @@ def test_order_voided_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": order_updated_delivery.id,
+            "app_id": order_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1031,7 +1015,7 @@ def test_order_voided_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fulfilled_dont_trigger_webhooks(
@@ -1100,11 +1084,7 @@ def test_order_fulfilled_dont_trigger_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],
@@ -1129,7 +1109,7 @@ def test_order_fulfilled_dont_trigger_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_awaits_fulfillment_approval_triggers_webhooks(
@@ -1185,13 +1165,9 @@ def test_order_awaits_fulfillment_approval_triggers_webhooks(
 
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": order_updated_delivery.id,
+            "app_id": order_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1228,7 +1204,7 @@ def test_order_awaits_fulfillment_approval_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_authorized_triggers_webhooks(
@@ -1281,13 +1257,9 @@ def test_order_authorized_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": order_updated_delivery.id,
+            "app_id": order_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1329,7 +1301,7 @@ def test_order_authorized_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_charged_triggers_webhooks(
@@ -1401,11 +1373,10 @@ def test_order_charged_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={
+                    "app_id": delivery.webhook.app_id,
+                    "telemetry_context": ANY,
+                },
             )
             for delivery in order_deliveries
         ],
@@ -1712,7 +1683,7 @@ def test_order_transaction_updated_order_fully_paid(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_transaction_updated_for_charged_triggers_webhooks(
@@ -1797,11 +1768,10 @@ def test_order_transaction_updated_for_charged_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={
+                    "app_id": delivery.webhook.app_id,
+                    "telemetry_context": ANY,
+                },
             )
             for delivery in order_deliveries
         ],
@@ -1849,7 +1819,7 @@ def test_order_transaction_updated_for_charged_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_transaction_updated_for_authorized_triggers_webhooks(
@@ -1913,7 +1883,7 @@ def test_order_transaction_updated_for_authorized_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": order_updated_delivery.id,
+            "app_id": order_updated_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
@@ -1957,7 +1927,7 @@ def test_order_transaction_updated_for_authorized_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_transaction_updated_for_refunded_triggers_webhooks(
@@ -2041,11 +2011,10 @@ def test_order_transaction_updated_for_refunded_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={
+                    "app_id": delivery.webhook.app_id,
+                    "telemetry_context": ANY,
+                },
             )
             for delivery in order_deliveries
         ],
@@ -2506,7 +2475,7 @@ def test_order_transaction_updated_order_fully_refunded_with_transaction_and_pay
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -2548,11 +2517,7 @@ def test_call_order_event_triggers_sync_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -2580,7 +2545,7 @@ def test_call_order_event_triggers_sync_webhook(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_order_event_incorrect_webhook_event(
@@ -2637,7 +2602,7 @@ def test_call_order_event_incorrect_webhook_event(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -2682,11 +2647,7 @@ def test_call_order_event_missing_filter_shipping_method_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     mocked_send_webhook_request_sync.assert_called_once()
@@ -2720,7 +2681,7 @@ def test_call_order_event_missing_filter_shipping_method_webhook(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -2765,11 +2726,7 @@ def test_call_order_event_skips_tax_webhook_when_prices_are_valid(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -2810,7 +2767,7 @@ def test_call_order_event_skips_tax_webhook_when_prices_are_valid(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -2855,11 +2812,7 @@ def test_call_order_event_skips_sync_webhooks_when_order_not_editable(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     assert not mocked_send_webhook_request_sync.called
     assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
@@ -2870,7 +2823,7 @@ def test_call_order_event_skips_sync_webhooks_when_order_not_editable(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -2917,11 +2870,7 @@ def test_call_order_event_skips_sync_webhooks_when_draft_order_deleted(
     assert not filter_shipping_delivery
     assert not tax_delivery
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -2931,7 +2880,7 @@ def test_call_order_event_skips_sync_webhooks_when_draft_order_deleted(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_order_event_skips_when_async_webhooks_missing(
@@ -2978,7 +2927,7 @@ def test_call_order_event_skips_when_async_webhooks_missing(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3017,11 +2966,7 @@ def test_call_order_event_skips_when_sync_webhooks_missing(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -3046,7 +2991,7 @@ def test_call_order_event_skips_when_sync_webhooks_missing(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3091,11 +3036,7 @@ def test_call_order_events_triggers_sync_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
@@ -3132,7 +3073,7 @@ def test_call_order_events_triggers_sync_webhook(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3197,7 +3138,7 @@ def test_call_order_events_incorrect_webhook_event(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3245,11 +3186,7 @@ def test_call_order_events_missing_filter_shipping_method_webhook(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -3292,7 +3229,7 @@ def test_call_order_events_missing_filter_shipping_method_webhook(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3340,11 +3277,7 @@ def test_call_order_events_skips_tax_webhook_when_prices_are_valid(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=order_webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -3393,7 +3326,7 @@ def test_call_order_events_skips_tax_webhook_when_prices_are_valid(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3448,11 +3381,7 @@ def test_call_order_events_skips_sync_webhooks_when_order_not_editable(
     assert not filter_shipping_delivery
     assert not tax_delivery
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(
@@ -3471,7 +3400,7 @@ def test_call_order_events_skips_sync_webhooks_when_order_not_editable(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3521,11 +3450,7 @@ def test_call_order_events_skips_sync_webhooks_when_draft_order_deleted(
     assert not filter_shipping_delivery
     assert not tax_delivery
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(
@@ -3544,7 +3469,7 @@ def test_call_order_events_skips_sync_webhooks_when_draft_order_deleted(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_call_order_events_skips_when_async_webhooks_missing(
@@ -3594,7 +3519,7 @@ def test_call_order_events_skips_when_async_webhooks_missing(
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @patch(
     "saleor.order.actions.call_event_including_protected_events",
@@ -3636,11 +3561,7 @@ def test_call_order_events_skips_when_sync_webhooks_missing(
     # then
     order_delivery = EventDelivery.objects.get(webhook_id=webhook.id)
     mocked_send_webhook_request_async.assert_called_once_with(
-        kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        kwargs={"app_id": order_delivery.webhook.app_id, "telemetry_context": ANY},
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(
@@ -3667,7 +3588,7 @@ def test_call_order_events_skips_when_sync_webhooks_missing(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_created_triggers_webhooks(
@@ -3750,11 +3671,7 @@ def test_order_created_triggers_webhooks(
     mocked_send_webhook_request_async.assert_has_calls(
         [
             call(
-                kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
-                queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                kwargs={"app_id": delivery.webhook.app_id, "telemetry_context": ANY},
             )
             for delivery in order_deliveries
         ],
@@ -3818,7 +3735,7 @@ def test_order_created_triggers_webhooks(
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_confirmed_triggers_webhooks(
@@ -3861,13 +3778,9 @@ def test_order_confirmed_triggers_webhooks(
     )
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={
-            "event_delivery_id": order_confirmed_delivery.id,
+            "app_id": order_confirmed_delivery.webhook.app_id,
             "telemetry_context": ANY,
         },
-        queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -982,25 +982,12 @@ def test_order_voided_triggers_webhooks(
     )
 
     # confirm each sync webhook was called without saving event delivery
-    assert mocked_send_webhook_request_sync.call_count == 2
+    assert mocked_send_webhook_request_sync.call_count == 1
     assert not EventDelivery.objects.exclude(
         webhook_id=additional_order_webhook.id
     ).exists()
 
-    tax_delivery_call, filter_shipping_call = (
-        mocked_send_webhook_request_sync.mock_calls
-    )
-
-    tax_delivery = tax_delivery_call.args[0]
-    assert tax_delivery.webhook_id == tax_webhook.id
-
-    filter_shipping_delivery = filter_shipping_call.args[0]
-    assert filter_shipping_delivery.webhook_id == shipping_filter_webhook.id
-    assert (
-        filter_shipping_delivery.event_type
-        == WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS
-    )
-    assert filter_shipping_call.kwargs["timeout"] == settings.WEBHOOK_SYNC_TIMEOUT
+    assert mocked_send_webhook_request_sync.call_args[0][0].webhook == tax_webhook
 
     wrapped_call_order_event.assert_called_once_with(
         plugins_manager,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_created.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_created.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_created(mocked_async, order_line, subscription_webhook, settings):
@@ -86,7 +86,7 @@ def test_draft_order_created(mocked_async, order_line, subscription_webhook, set
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_created_without_channels_input(
@@ -160,7 +160,7 @@ def test_draft_order_created_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_created_with_different_channel(
@@ -200,7 +200,7 @@ def test_draft_order_created_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_deleted.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_deleted.py
@@ -21,7 +21,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_deleted(mocked_async, order_line, subscription_webhook, settings):
@@ -66,7 +66,7 @@ def test_draft_order_deleted(mocked_async, order_line, subscription_webhook, set
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_deleted_without_channels_input(
@@ -120,7 +120,7 @@ def test_draft_order_deleted_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_updated_with_different_channel(
@@ -159,7 +159,7 @@ def test_draft_order_updated_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_updated.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_draft_order_updated.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_updated(mocked_async, order_line, subscription_webhook, settings):
@@ -86,7 +86,7 @@ def test_draft_order_updated(mocked_async, order_line, subscription_webhook, set
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_updated_without_channels_input(
@@ -159,7 +159,7 @@ def test_draft_order_updated_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_draft_order_updated_with_different_channel(
@@ -198,7 +198,7 @@ def test_draft_order_updated_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_cancelled.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_cancelled.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_cancelled(mocked_async, order_line, subscription_webhook, settings):
@@ -85,7 +85,7 @@ def test_order_cancelled(mocked_async, order_line, subscription_webhook, setting
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_cancelled_without_channels_input(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_confirmed.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_confirmed.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_confirmed(mocked_async, order_line, subscription_webhook, settings):
@@ -84,7 +84,7 @@ def test_order_confirmed(mocked_async, order_line, subscription_webhook, setting
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_confirmed_without_channels_input(
@@ -158,7 +158,7 @@ def test_order_confirmed_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_confirmed_with_different_channel(
@@ -196,7 +196,7 @@ def test_order_confirmed_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_created.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_created.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_created(mocked_async, order_line, subscription_webhook, settings):
@@ -84,7 +84,7 @@ def test_order_created(mocked_async, order_line, subscription_webhook, settings)
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_created_without_channels_input(
@@ -156,7 +156,7 @@ def test_order_created_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_created_with_different_channel(
@@ -194,7 +194,7 @@ def test_order_created_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_expired.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_expired.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_expired(mocked_async, order_line, subscription_webhook, settings):
@@ -85,7 +85,7 @@ def test_order_expired(mocked_async, order_line, subscription_webhook, settings)
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_expired_without_channels_input(
@@ -159,7 +159,7 @@ def test_order_expired_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_expired_with_different_channel(
@@ -197,7 +197,7 @@ def test_order_expired_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_fulfilled.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_fulfilled.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fulfilled(mocked_async, order_line, subscription_webhook, settings):
@@ -85,7 +85,7 @@ def test_order_fulfilled(mocked_async, order_line, subscription_webhook, setting
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fulfilled_without_channels_input(
@@ -159,7 +159,7 @@ def test_order_fulfilled_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fulfilled_with_different_channel(
@@ -196,7 +196,7 @@ def test_order_fulfilled_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_fully_paid.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_fully_paid.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fully_paid(mocked_async, order_line, subscription_webhook, settings):
@@ -85,7 +85,7 @@ def test_order_fully_paid(mocked_async, order_line, subscription_webhook, settin
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fully_paid_without_channels_input(
@@ -158,7 +158,7 @@ def test_order_fully_paid_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fully_paid_with_different_channel(
@@ -196,7 +196,7 @@ def test_order_fully_paid_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_fully_refunded.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_fully_refunded.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fully_refunded(mocked_async, order_line, subscription_webhook, settings):
@@ -85,7 +85,7 @@ def test_order_fully_refunded(mocked_async, order_line, subscription_webhook, se
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fully_refunded_without_channels_input(
@@ -159,7 +159,7 @@ def test_order_fully_refunded_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_fully_refunded_with_different_channel(
@@ -197,7 +197,7 @@ def test_order_fully_refunded_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_metadata_updated.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_metadata_updated.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_metadata_updated(
@@ -87,7 +87,7 @@ def test_order_metadata_updated(
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_metadata_updated_without_channels_input(
@@ -160,7 +160,7 @@ def test_order_metadata_updated_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_metadata_updated_with_different_channel(
@@ -198,7 +198,7 @@ def test_order_metadata_updated_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_paid.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_paid.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_paid(mocked_async, order_line, subscription_webhook, settings):
@@ -85,7 +85,7 @@ def test_order_paid(mocked_async, order_line, subscription_webhook, settings):
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_paid_without_channels_input(
@@ -158,7 +158,7 @@ def test_order_paid_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_paid_with_different_channel(
@@ -196,7 +196,7 @@ def test_order_paid_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_refunded.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_refunded.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_refunded(mocked_async, order_line, subscription_webhook, settings):
@@ -85,7 +85,7 @@ def test_order_refunded(mocked_async, order_line, subscription_webhook, settings
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_refunded_without_channels_input(
@@ -158,7 +158,7 @@ def test_order_refunded_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_refunded_with_different_channel(
@@ -195,7 +195,7 @@ def test_order_refunded_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_updated.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_order_updated.py
@@ -28,7 +28,7 @@ subscription {
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_updated(mocked_async, order_line, subscription_webhook, settings):
@@ -84,7 +84,7 @@ def test_order_updated(mocked_async, order_line, subscription_webhook, settings)
 
 
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_updated_without_channels_input(
@@ -156,7 +156,7 @@ def test_order_updated_without_channels_input(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_order_updated_with_different_channel(
@@ -196,7 +196,7 @@ def test_order_updated_with_different_channel(
     "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
 )
 @patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
 def test_different_event_doesnt_trigger_webhook(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -39,9 +39,6 @@ from ....discount.utils.checkout import (
 from ....graphql.discount.enums import DiscountValueTypeEnum
 from ....graphql.discount.utils import convert_migrated_sale_predicate_to_catalogue_info
 from ....graphql.order.tests.mutations.test_order_discount import ORDER_DISCOUNT_UPDATE
-from ....graphql.product.tests.mutations.test_product_create import (
-    CREATE_PRODUCT_MUTATION,
-)
 from ....payment import TransactionAction, TransactionEventType
 from ....payment.interface import TransactionActionData
 from ....payment.models import TransactionItem
@@ -2469,53 +2466,6 @@ def test_trigger_webhook_sync_with_subscription_within_mutation_use_default_db(
 
     # when
     app_api_client.post_graphql(ORDER_DISCOUNT_UPDATE, variables)
-
-    # then
-    mocked_generate_payload.assert_called_once()
-    assert not mocked_generate_payload.call_args[1]["request"].allow_replica
-
-
-@mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async"
-)
-@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
-@mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.generate_payload_from_subscription"
-)
-def test_trigger_webhook_async_with_subscription_use_main_db(
-    mocked_generate_payload,
-    mocked_get_webhooks_for_event,
-    mocked_request,
-    staff_api_client,
-    product_type,
-    category,
-    permission_manage_products,
-    subscription_product_created_webhook,
-    settings,
-):
-    # given
-    webhook = subscription_product_created_webhook
-    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    mocked_get_webhooks_for_event.return_value = [webhook]
-
-    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
-    category_id = graphene.Node.to_global_id("Category", category.pk)
-    product_name = "test name"
-    product_slug = "product-test-slug"
-
-    variables = {
-        "input": {
-            "productType": product_type_id,
-            "category": category_id,
-            "name": product_name,
-            "slug": product_slug,
-        }
-    }
-
-    # when
-    staff_api_client.post_graphql(
-        CREATE_PRODUCT_MUTATION, variables, permissions=[permission_manage_products]
-    )
 
     # then
     mocked_generate_payload.assert_called_once()

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1065,3 +1065,9 @@ patch_db()
 # Patch `Local` to remove all references that could result in reference cycles,
 # allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
 patch_local()
+
+TELEMETRY_TRACER_CLASS = "saleor.core.telemetry.trace.Tracer"
+TELEMETRY_METER_CLASS = "saleor.core.telemetry.metric.Meter"
+# Whether to raise or log exceptions for telemetry unit conversion errors
+# Disabled by default to prevent disruptions caused by unexpected unit conversion issues
+TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS = False

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1065,9 +1065,3 @@ patch_db()
 # Patch `Local` to remove all references that could result in reference cycles,
 # allowing memory to be freed immediately, without the need of a deep garbage collection cycle.
 patch_local()
-
-TELEMETRY_TRACER_CLASS = "saleor.core.telemetry.trace.Tracer"
-TELEMETRY_METER_CLASS = "saleor.core.telemetry.metric.Meter"
-# Whether to raise or log exceptions for telemetry unit conversion errors
-# Disabled by default to prevent disruptions caused by unexpected unit conversion issues
-TELEMETRY_RAISE_UNIT_CONVERSION_ERRORS = False

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -600,12 +600,10 @@ class WebhookEventAsyncType:
         CHECKOUT_CREATED: {
             "name": "Checkout created",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
-            "is_deferred_payload": True,
         },
         CHECKOUT_UPDATED: {
             "name": "Checkout updated",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
-            "is_deferred_payload": True,
         },
         CHECKOUT_FULLY_PAID: {
             "name": "Checkout fully paid",

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -204,318 +204,397 @@ class WebhookEventAsyncType:
         ACCOUNT_CONFIRMATION_REQUESTED: {
             "name": "Account confirmation requested",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ACCOUNT_CHANGE_EMAIL_REQUESTED: {
             "name": "Account change email requested",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ACCOUNT_EMAIL_CHANGED: {
             "name": "Account email changed",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ACCOUNT_SET_PASSWORD_REQUESTED: {
             "name": "Account set password requested",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ACCOUNT_CONFIRMED: {
             "name": "Account confirmed",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ACCOUNT_DELETE_REQUESTED: {
             "name": "Account delete requested",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ACCOUNT_DELETED: {
             "name": "Account delete confirmed",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": False,
         },
         ADDRESS_CREATED: {
             "name": "Address created",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ADDRESS_UPDATED: {
             "name": "Address updated",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         ADDRESS_DELETED: {
             "name": "Address deleted",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": False,
         },
         APP_INSTALLED: {
             "name": "App created",
             "permission": AppPermission.MANAGE_APPS,
+            "is_deferred_payload": True,
         },
         APP_UPDATED: {
             "name": "App updated",
             "permission": AppPermission.MANAGE_APPS,
+            "is_deferred_payload": True,
         },
         APP_DELETED: {
             "name": "App deleted",
             "permission": AppPermission.MANAGE_APPS,
+            "is_deferred_payload": False,
         },
         APP_STATUS_CHANGED: {
             "name": "App status changed",
             "permission": AppPermission.MANAGE_APPS,
+            "is_deferred_payload": True,
         },
         ATTRIBUTE_CREATED: {
             "name": "Attribute created",
             "permission": None,
+            "is_deferred_payload": True,
         },
         ATTRIBUTE_UPDATED: {
             "name": "Attribute updated",
             "permission": None,
+            "is_deferred_payload": True,
         },
         ATTRIBUTE_DELETED: {
             "name": "Attribute deleted",
             "permission": None,
+            "is_deferred_payload": False,
         },
         ATTRIBUTE_VALUE_CREATED: {
             "name": "Attribute value created",
             "permission": None,
+            "is_deferred_payload": True,
         },
         ATTRIBUTE_VALUE_UPDATED: {
             "name": "Attribute value updated",
             "permission": None,
+            "is_deferred_payload": True,
         },
         ATTRIBUTE_VALUE_DELETED: {
             "name": "Attribute value deleted",
             "permission": None,
+            "is_deferred_payload": False,
         },
         CATEGORY_CREATED: {
             "name": "Category created",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         CATEGORY_UPDATED: {
             "name": "Category updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         CATEGORY_DELETED: {
             "name": "Category deleted",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": False,
         },
         CHANNEL_CREATED: {
             "name": "Channel created",
             "permission": ChannelPermissions.MANAGE_CHANNELS,
+            "is_deferred_payload": True,
         },
         CHANNEL_UPDATED: {
             "name": "Channel updated",
             "permission": ChannelPermissions.MANAGE_CHANNELS,
+            "is_deferred_payload": True,
         },
         CHANNEL_DELETED: {
             "name": "Channel deleted",
             "permission": ChannelPermissions.MANAGE_CHANNELS,
+            "is_deferred_payload": False,
         },
         CHANNEL_STATUS_CHANGED: {
             "name": "Channel status changed",
             "permission": ChannelPermissions.MANAGE_CHANNELS,
+            "is_deferred_payload": True,
         },
         CHANNEL_METADATA_UPDATED: {
             "name": "Channel metadata updated",
             "permission": ChannelPermissions.MANAGE_CHANNELS,
+            "is_deferred_payload": True,
         },
         GIFT_CARD_CREATED: {
             "name": "Gift card created",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+            "is_deferred_payload": True,
         },
         GIFT_CARD_UPDATED: {
             "name": "Gift card updated",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+            "is_deferred_payload": True,
         },
         GIFT_CARD_DELETED: {
             "name": "Gift card deleted",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+            "is_deferred_payload": False,
         },
         GIFT_CARD_SENT: {
             "name": "Gift card sent",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+            "is_deferred_payload": True,
         },
         GIFT_CARD_STATUS_CHANGED: {
             "name": "Gift card status changed",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+            "is_deferred_payload": True,
         },
         GIFT_CARD_METADATA_UPDATED: {
             "name": "Gift card metadata updated",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+            "is_deferred_payload": True,
         },
         GIFT_CARD_EXPORT_COMPLETED: {
             "name": "Gift card export completed",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+            "is_deferred_payload": True,
         },
         MENU_CREATED: {
             "name": "Menu created",
             "permission": MenuPermissions.MANAGE_MENUS,
+            "is_deferred_payload": True,
         },
         MENU_UPDATED: {
             "name": "Menu updated",
             "permission": MenuPermissions.MANAGE_MENUS,
+            "is_deferred_payload": True,
         },
         MENU_DELETED: {
             "name": "Menu deleted",
             "permission": MenuPermissions.MANAGE_MENUS,
+            "is_deferred_payload": False,
         },
         MENU_ITEM_CREATED: {
             "name": "Menu item created",
             "permission": MenuPermissions.MANAGE_MENUS,
+            "is_deferred_payload": True,
         },
         MENU_ITEM_UPDATED: {
             "name": "Menu item updated",
             "permission": MenuPermissions.MANAGE_MENUS,
+            "is_deferred_payload": True,
         },
         MENU_ITEM_DELETED: {
             "name": "Menu item deleted",
             "permission": MenuPermissions.MANAGE_MENUS,
+            "is_deferred_payload": False,
         },
         ORDER_CREATED: {
             "name": "Order created",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_CONFIRMED: {
             "name": "Order confirmed",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_PAID: {
             "name": "Order paid",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_FULLY_PAID: {
             "name": "Order fully paid",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_REFUNDED: {
             "name": "Order refunded",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_FULLY_REFUNDED: {
             "name": "Order fully refunded",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_UPDATED: {
             "name": "Order updated",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_CANCELLED: {
             "name": "Order cancelled",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_EXPIRED: {
             "name": "Order expired",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_FULFILLED: {
             "name": "Order fulfilled",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_METADATA_UPDATED: {
             "name": "Order metadata updated",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         ORDER_BULK_CREATED: {
             "name": "Order bulk created",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         FULFILLMENT_CREATED: {
             "name": "Fulfillment created",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         FULFILLMENT_CANCELED: {
             "name": "Fulfillment cancelled",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         FULFILLMENT_APPROVED: {
             "name": "Fulfillment approved",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         FULFILLMENT_METADATA_UPDATED: {
             "name": "Fulfillment metadata updated",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         FULFILLMENT_TRACKING_NUMBER_UPDATED: {
             "name": "Fulfillment tracking number updated.",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         DRAFT_ORDER_CREATED: {
             "name": "Draft order created",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         DRAFT_ORDER_UPDATED: {
             "name": "Draft order updated",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         DRAFT_ORDER_DELETED: {
             "name": "Draft order deleted",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": False,
         },
         SALE_CREATED: {
             "name": "Sale created",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         SALE_UPDATED: {
             "name": "Sale updated",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         SALE_DELETED: {
             "name": "Sale deleted",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": False,
         },
         SALE_TOGGLE: {
             "name": "Sale toggle",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         PROMOTION_CREATED: {
             "name": "Promotion created",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         PROMOTION_UPDATED: {
             "name": "Promotion updated",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         PROMOTION_DELETED: {
             "name": "Promotion deleted",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": False,
         },
         PROMOTION_STARTED: {
             "name": "Promotion started",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         PROMOTION_ENDED: {
             "name": "Promotion ended",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         PROMOTION_RULE_CREATED: {
             "name": "Promotion rule created",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         PROMOTION_RULE_UPDATED: {
             "name": "Promotion rule updated",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         PROMOTION_RULE_DELETED: {
             "name": "Promotion rule deleted",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": False,
         },
         INVOICE_REQUESTED: {
             "name": "Invoice requested",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         INVOICE_DELETED: {
             "name": "Invoice deleted",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": False,
         },
         INVOICE_SENT: {
             "name": "Invoice sent",
             "permission": OrderPermissions.MANAGE_ORDERS,
+            "is_deferred_payload": True,
         },
         CUSTOMER_CREATED: {
             "name": "Customer created",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         CUSTOMER_UPDATED: {
             "name": "Customer updated",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         CUSTOMER_DELETED: {
             "name": "Customer deleted",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": False,
         },
         CUSTOMER_METADATA_UPDATED: {
             "name": "Customer metadata updated",
@@ -524,246 +603,307 @@ class WebhookEventAsyncType:
         COLLECTION_CREATED: {
             "name": "Collection created",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         COLLECTION_UPDATED: {
             "name": "Collection updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         COLLECTION_DELETED: {
             "name": "Collection deleted",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": False,
         },
         COLLECTION_METADATA_UPDATED: {
             "name": "Collection metadata updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_CREATED: {
             "name": "Product created",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_UPDATED: {
             "name": "Product updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_DELETED: {
             "name": "Product deleted",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": False,
         },
         PRODUCT_METADATA_UPDATED: {
             "name": "Product metadata updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_EXPORT_COMPLETED: {
             "name": "Product export completed",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_MEDIA_CREATED: {
             "name": "Product media created",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_MEDIA_UPDATED: {
             "name": "Product media updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_MEDIA_DELETED: {
             "name": "Product media deleted",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": False,
         },
         PRODUCT_VARIANT_CREATED: {
             "name": "Product variant created",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_VARIANT_UPDATED: {
             "name": "Product variant updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_VARIANT_DELETED: {
             "name": "Product variant deleted",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": False,
         },
         PRODUCT_VARIANT_METADATA_UPDATED: {
             "name": "Product variant metadata updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_VARIANT_OUT_OF_STOCK: {
             "name": "Product variant stock changed",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_VARIANT_BACK_IN_STOCK: {
             "name": "Product variant back in stock",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_VARIANT_STOCK_UPDATED: {
             "name": "Product variant stock updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         CHECKOUT_CREATED: {
             "name": "Checkout created",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
+            "is_deferred_payload": True,
         },
         CHECKOUT_UPDATED: {
             "name": "Checkout updated",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
+            "is_deferred_payload": True,
         },
         CHECKOUT_FULLY_PAID: {
             "name": "Checkout fully paid",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
+            "is_deferred_payload": True,
         },
         CHECKOUT_METADATA_UPDATED: {
             "name": "Checkout metadata updated",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
+            "is_deferred_payload": True,
         },
         NOTIFY_USER: {
             "name": "Notify user",
             "permission": AccountPermissions.MANAGE_USERS,
+            "is_deferred_payload": True,
         },
         PAGE_CREATED: {
             "name": "Page created",
             "permission": PagePermissions.MANAGE_PAGES,
+            "is_deferred_payload": True,
         },
         PAGE_UPDATED: {
             "name": "Page updated",
             "permission": PagePermissions.MANAGE_PAGES,
+            "is_deferred_payload": True,
         },
         PAGE_DELETED: {
             "name": "Page deleted",
             "permission": PagePermissions.MANAGE_PAGES,
+            "is_deferred_payload": False,
         },
         PAGE_TYPE_CREATED: {
             "name": "Page type created",
             "permission": PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+            "is_deferred_payload": True,
         },
         PAGE_TYPE_UPDATED: {
             "name": "Page type updated",
             "permission": PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+            "is_deferred_payload": True,
         },
         PAGE_TYPE_DELETED: {
             "name": "Page type deleted",
             "permission": PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+            "is_deferred_payload": False,
         },
         PERMISSION_GROUP_CREATED: {
             "name": "Permission group created",
             "permission": AccountPermissions.MANAGE_STAFF,
+            "is_deferred_payload": True,
         },
         PERMISSION_GROUP_UPDATED: {
             "name": "Permission group updated",
             "permission": AccountPermissions.MANAGE_STAFF,
+            "is_deferred_payload": True,
         },
         PERMISSION_GROUP_DELETED: {
             "name": "Permission group deleted",
             "permission": AccountPermissions.MANAGE_STAFF,
+            "is_deferred_payload": False,
         },
         SHIPPING_PRICE_CREATED: {
             "name": "Shipping price created",
             "permission": ShippingPermissions.MANAGE_SHIPPING,
+            "is_deferred_payload": True,
         },
         SHIPPING_PRICE_UPDATED: {
             "name": "Shipping price updated",
             "permission": ShippingPermissions.MANAGE_SHIPPING,
+            "is_deferred_payload": True,
         },
         SHIPPING_PRICE_DELETED: {
             "name": "Shipping price deleted",
             "permission": ShippingPermissions.MANAGE_SHIPPING,
+            "is_deferred_payload": False,
         },
         SHIPPING_ZONE_CREATED: {
             "name": "Shipping zone created",
             "permission": ShippingPermissions.MANAGE_SHIPPING,
+            "is_deferred_payload": True,
         },
         SHIPPING_ZONE_UPDATED: {
             "name": "Shipping zone updated",
             "permission": ShippingPermissions.MANAGE_SHIPPING,
+            "is_deferred_payload": True,
         },
         SHIPPING_ZONE_DELETED: {
             "name": "Shipping zone deleted",
             "permission": ShippingPermissions.MANAGE_SHIPPING,
+            "is_deferred_payload": False,
         },
         SHIPPING_ZONE_METADATA_UPDATED: {
             "name": "Shipping zone metadata updated",
             "permission": ShippingPermissions.MANAGE_SHIPPING,
+            "is_deferred_payload": True,
         },
         STAFF_CREATED: {
             "name": "Staff created",
             "permission": AccountPermissions.MANAGE_STAFF,
+            "is_deferred_payload": True,
         },
         STAFF_UPDATED: {
             "name": "Staff updated",
             "permission": AccountPermissions.MANAGE_STAFF,
+            "is_deferred_payload": True,
         },
         STAFF_DELETED: {
             "name": "Staff deleted",
             "permission": AccountPermissions.MANAGE_STAFF,
+            "is_deferred_payload": False,
         },
         STAFF_SET_PASSWORD_REQUESTED: {
             "name": "Setting a password for a staff is requested",
             "permission": AccountPermissions.MANAGE_STAFF,
+            "is_deferred_payload": True,
         },
         TRANSACTION_ITEM_METADATA_UPDATED: {
             "name": "Transaction item metadata updated",
             "permission": PaymentPermissions.HANDLE_PAYMENTS,
+            "is_deferred_payload": True,
         },
         TRANSLATION_CREATED: {
             "name": "Translation created",
             "permission": SitePermissions.MANAGE_TRANSLATIONS,
+            "is_deferred_payload": True,
         },
         TRANSLATION_UPDATED: {
             "name": "Translation updated",
             "permission": SitePermissions.MANAGE_TRANSLATIONS,
+            "is_deferred_payload": True,
         },
         WAREHOUSE_CREATED: {
             "name": "Warehouse created",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         WAREHOUSE_UPDATED: {
             "name": "Warehouse updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         WAREHOUSE_DELETED: {
             "name": "Warehouse deleted",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": False,
         },
         WAREHOUSE_METADATA_UPDATED: {
             "name": "Warehouse metadata updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         VOUCHER_CREATED: {
             "name": "Voucher created",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         VOUCHER_UPDATED: {
             "name": "Voucher updated",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         VOUCHER_DELETED: {
             "name": "Voucher deleted",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": False,
         },
         VOUCHER_CODES_CREATED: {
             "name": "Voucher codes created",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         VOUCHER_CODES_DELETED: {
             "name": "Voucher codes deleted",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": False,
         },
         VOUCHER_METADATA_UPDATED: {
             "name": "Voucher metadata updated",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         VOUCHER_CODE_EXPORT_COMPLETED: {
             "name": "Voucher code export completed",
             "permission": DiscountPermissions.MANAGE_DISCOUNTS,
+            "is_deferred_payload": True,
         },
         OBSERVABILITY: {
             "name": "Observability",
             "permission": AppPermission.MANAGE_OBSERVABILITY,
+            "is_deferred_payload": True,
         },
         THUMBNAIL_CREATED: {
             "name": "Thumbnail created",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         SHOP_METADATA_UPDATED: {
             "name": "Shop metadata updated",
             "permission": SitePermissions.MANAGE_SETTINGS,
+            "is_deferred_payload": True,
         },
     }
 

--- a/saleor/webhook/metrics.py
+++ b/saleor/webhook/metrics.py
@@ -1,0 +1,27 @@
+from datetime import UTC, datetime
+
+from ..core.models import EventDelivery
+from ..core.telemetry import MetricType, Scope, Unit, meter
+
+# Initialize metrics
+METRIC_FIRST_EVENT_DELIVERY_ATTEMPT_DELAY = meter.create_metric(
+    "saleor.webhooks.async.first_event_delivery_attempt_delay",
+    scope=Scope.CORE,
+    type=MetricType.HISTOGRAM,
+    unit=Unit.MILLISECOND,
+    description="Delay for the first attempt of delivering async webhook event after creation of EventDeliver.",
+)
+
+
+def record_first_delivery_attempt_delay(event_delivery: EventDelivery) -> None:
+    delay = (datetime.now(UTC) - event_delivery.created_at).total_seconds()
+    attributes = {
+        "app.name": event_delivery.webhook.app.name,
+        "event_type": event_delivery.event_type,
+    }
+    meter.record(
+        METRIC_FIRST_EVENT_DELIVERY_ATTEMPT_DELAY,
+        delay,
+        unit=Unit.SECOND,
+        attributes=attributes,
+    )

--- a/saleor/webhook/metrics.py
+++ b/saleor/webhook/metrics.py
@@ -20,14 +20,6 @@ METRIC_ASYNC_WEBHOOK_CALLS = meter.create_metric(
     description="Number of async webhook calls.",
 )
 
-METRICS_ASYNC_WEBHOOK_ERROR = meter.create_metric(
-    "saleor.webhooks.async.errors",
-    scope=Scope.CORE,
-    type=MetricType.COUNTER,
-    unit=Unit.REQUEST,
-    description="Number of async webhook errors.",
-)
-
 
 def record_first_delivery_attempt_delay(event_delivery: EventDelivery) -> None:
     delay = (datetime.now(UTC) - event_delivery.created_at).total_seconds()
@@ -43,17 +35,11 @@ def record_first_delivery_attempt_delay(event_delivery: EventDelivery) -> None:
     )
 
 
-def record_async_webhooks_count(event_delivery: EventDelivery, amount: int = 1) -> None:
-    attributes = {
-        "app.name": event_delivery.webhook.app.name,
-    }
-    meter.record(METRICS_ASYNC_WEBHOOK_ERROR, amount, attributes=attributes)
-
-
-def record_async_webhooks_error_count(
-    event_delivery: EventDelivery, amount: int = 1
+def record_async_webhooks_count(
+    event_delivery: EventDelivery, response_status: str, amount: int = 1
 ) -> None:
     attributes = {
         "app.name": event_delivery.webhook.app.name,
+        "response_status": response_status,
     }
-    meter.record(METRICS_ASYNC_WEBHOOK_ERROR, amount, attributes=attributes)
+    meter.record(METRIC_ASYNC_WEBHOOK_CALLS, amount, attributes=attributes)

--- a/saleor/webhook/metrics.py
+++ b/saleor/webhook/metrics.py
@@ -12,6 +12,22 @@ METRIC_FIRST_EVENT_DELIVERY_ATTEMPT_DELAY = meter.create_metric(
     description="Delay for the first attempt of delivering async webhook event after creation of EventDeliver.",
 )
 
+METRIC_ASYNC_WEBHOOK_CALLS = meter.create_metric(
+    "saleor.webhooks.async.calls",
+    scope=Scope.CORE,
+    type=MetricType.COUNTER,
+    unit=Unit.REQUEST,
+    description="Number of async webhook calls.",
+)
+
+METRICS_ASYNC_WEBHOOK_ERROR = meter.create_metric(
+    "saleor.webhooks.async.errors",
+    scope=Scope.CORE,
+    type=MetricType.COUNTER,
+    unit=Unit.REQUEST,
+    description="Number of async webhook errors.",
+)
+
 
 def record_first_delivery_attempt_delay(event_delivery: EventDelivery) -> None:
     delay = (datetime.now(UTC) - event_delivery.created_at).total_seconds()
@@ -25,3 +41,19 @@ def record_first_delivery_attempt_delay(event_delivery: EventDelivery) -> None:
         unit=Unit.SECOND,
         attributes=attributes,
     )
+
+
+def record_async_webhooks_count(event_delivery: EventDelivery, amount: int = 1) -> None:
+    attributes = {
+        "app.name": event_delivery.webhook.app.name,
+    }
+    meter.record(METRICS_ASYNC_WEBHOOK_ERROR, amount, attributes=attributes)
+
+
+def record_async_webhooks_error_count(
+    event_delivery: EventDelivery, amount: int = 1
+) -> None:
+    attributes = {
+        "app.name": event_delivery.webhook.app.name,
+    }
+    meter.record(METRICS_ASYNC_WEBHOOK_ERROR, amount, attributes=attributes)

--- a/saleor/webhook/metrics.py
+++ b/saleor/webhook/metrics.py
@@ -42,4 +42,6 @@ def record_async_webhooks_count(
         "app.name": event_delivery.webhook.app.name,
         "response_status": response_status,
     }
-    meter.record(METRIC_ASYNC_WEBHOOK_CALLS, amount, attributes=attributes)
+    meter.record(
+        METRIC_ASYNC_WEBHOOK_CALLS, amount, unit=Unit.REQUEST, attributes=attributes
+    )

--- a/saleor/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_webhook.py
@@ -16,7 +16,7 @@ from .payloads import generate_payment_payload
 
 
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 def test_trigger_webhooks_async(
     mocked_send_webhook_request,
@@ -37,13 +37,9 @@ def test_trigger_webhooks_async(
         assert (
             mock.call(
                 kwargs={
-                    "event_delivery_id": delivery.id,
+                    "app_id": delivery.webhook.app_id,
                     "telemetry_context": mock.ANY,
                 },
-                queue=None,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
             )
             in mocked_send_webhook_request.mock_calls
         )
@@ -53,7 +49,7 @@ def test_trigger_webhooks_async(
     "saleor.webhook.transport.asynchronous.transport.MAX_WEBHOOK_EVENTS_IN_DB_BULK", 2
 )
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 def test_trigger_webhooks_async_for_multiple_objects(
     mocked_send_webhook_request,
@@ -102,20 +98,16 @@ def test_trigger_webhooks_async_for_multiple_objects(
         assert (
             mock.call(
                 kwargs={
-                    "event_delivery_id": delivery.id,
+                    "app_id": delivery.webhook.app_id,
                     "telemetry_context": mock.ANY,
                 },
-                queue=None,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
             )
             in mocked_send_webhook_request.mock_calls
         )
 
 
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @mock.patch(
     "saleor.webhook.transport.asynchronous.transport.create_deliveries_for_subscriptions"

--- a/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
@@ -162,7 +162,7 @@ def test_generate_deferred_payload_model_pk_does_not_exist(
 
 
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 @mock.patch(
     "saleor.webhook.transport.asynchronous.transport.generate_deferred_payloads.apply_async",
@@ -196,8 +196,9 @@ def test_pass_queue_to_send_webhook_request_async(
     call_kwargs_generate_payloads = mocked_generate_deferred_payloads.call_args.kwargs
     assert "queue" not in call_kwargs_generate_payloads
     assert call_kwargs_generate_payloads["kwargs"]["send_webhook_queue"] == queue
-
-    call_kwargs_send_webhook_request = (
-        mocked_send_webhook_request_async.call_args.kwargs
+    mocked_send_webhook_request_async.assert_called_once_with(
+        kwargs={
+            "app_id": checkout_updated_webhook.app_id,
+            "telemetry_context": mock.ANY,
+        },
     )
-    assert call_kwargs_send_webhook_request["queue"] == queue

--- a/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
@@ -74,10 +74,10 @@ def test_call_trigger_webhook_async_deferred_payload(
 
 
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
 )
 def test_generate_deferred_payload(
-    mocked_send_webhook_request_async,
+    mocked_send_webhook_request_async_for_app,
     checkout_with_item,
     setup_checkout_webhooks,
     staff_user,
@@ -124,9 +124,9 @@ def test_generate_deferred_payload(
         data["checkout"]["totalPrice"]["gross"]["amount"] == checkout.total_gross_amount
     )
 
-    assert mocked_send_webhook_request_async.call_count == 1
-    call_kwargs = mocked_send_webhook_request_async.call_args.kwargs
-    assert call_kwargs["kwargs"]["event_delivery_id"] == delivery.pk
+    assert mocked_send_webhook_request_async_for_app.call_count == 1
+    call_kwargs = mocked_send_webhook_request_async_for_app.call_args.kwargs
+    assert call_kwargs["kwargs"]["app_id"] == delivery.webhook.app_id
 
 
 def test_generate_deferred_payload_model_pk_does_not_exist(

--- a/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
@@ -1,0 +1,216 @@
+from unittest.mock import ANY, patch
+
+from .....core.models import EventDelivery, EventDeliveryAttempt, EventDeliveryStatus
+from ..transport import (
+    WebhookResponse,
+    send_webhooks_async_for_app,
+)
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+)
+def test_send_webhooks_async_for_app(
+    mock_send_webhooks_async_for_app_apply_async,
+    mock_send_webhook_using_scheme_method,
+    app,
+    event_delivery,
+):
+    # given
+    assert EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING).exists()
+    mock_send_webhook_using_scheme_method.return_value = WebhookResponse(
+        content="", status=EventDeliveryStatus.SUCCESS
+    )
+
+    # when
+    send_webhooks_async_for_app(app_id=app.id)
+
+    # then
+    mock_send_webhook_using_scheme_method.assert_called_once()
+    mock_send_webhooks_async_for_app_apply_async.assert_called_once_with(
+        kwargs={"app_id": app.id, "telemetry_context": ANY},
+    )
+
+    # deliveries should be cleared
+    assert not EventDelivery.objects.exists()
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+def test_send_webhooks_async_for_app_no_deliveries(
+    mock_send_webhook_using_scheme_method, app
+):
+    # given
+    assert not EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING).exists()
+
+    # when
+    send_webhooks_async_for_app(app_id=app.id)
+
+    # then
+    assert mock_send_webhook_using_scheme_method.called == 0
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+def test_send_webhooks_async_for_app_doesnt_pick_failed(
+    mock_send_webhook_using_scheme_method, app, event_delivery
+):
+    # given
+    event_delivery.status = EventDeliveryStatus.FAILED
+    event_delivery.save()
+    assert not EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING).exists()
+
+    # when
+    send_webhooks_async_for_app(app_id=app.id)
+
+    # then
+    assert mock_send_webhook_using_scheme_method.called == 0
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+)
+def test_send_webhooks_async_for_app_no_payload(
+    mock_send_webhooks_async_for_app_apply_async,
+    mock_send_webhook_using_scheme_method,
+    app,
+    event_delivery,
+):
+    # given
+    event_delivery.payload = None
+    event_delivery.save()
+
+    assert EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING).exists()
+
+    # when
+    send_webhooks_async_for_app(app_id=app.id)
+
+    # then
+    mock_send_webhook_using_scheme_method.assert_not_called()
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].status == EventDeliveryStatus.PENDING
+    assert EventDeliveryAttempt.objects.filter(
+        status=EventDeliveryStatus.FAILED
+    ).exists()
+
+    mock_send_webhooks_async_for_app_apply_async.assert_called_once_with(
+        kwargs={"app_id": app.id, "telemetry_context": ANY},
+    )
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+)
+def test_send_webhooks_async_for_app_failed_status(
+    mock_send_webhooks_async_for_app_apply_async,
+    mock_send_webhook_using_scheme_method,
+    app,
+    event_delivery,
+):
+    # given
+    assert EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING).exists()
+    mock_send_webhook_using_scheme_method.return_value = WebhookResponse(
+        content="", status=EventDeliveryStatus.FAILED
+    )
+
+    # when
+    send_webhooks_async_for_app(app_id=app.id)
+
+    # then
+    mock_send_webhook_using_scheme_method.assert_called_once()
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].status == EventDeliveryStatus.PENDING
+    assert EventDeliveryAttempt.objects.filter(
+        status=EventDeliveryStatus.FAILED
+    ).exists()
+
+    mock_send_webhooks_async_for_app_apply_async.assert_called_once_with(
+        kwargs={"app_id": app.id, "telemetry_context": ANY},
+    )
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+)
+def test_send_multiple_webhooks_async_for_app(
+    mock_send_webhooks_async_for_app_apply_async,
+    mock_send_webhook_using_scheme_method,
+    app,
+    event_deliveries,
+):
+    # given
+    assert len(EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING)) == 3
+    mock_send_webhook_using_scheme_method.return_value = WebhookResponse(
+        content="", status=EventDeliveryStatus.SUCCESS
+    )
+
+    # when
+    send_webhooks_async_for_app(app_id=app.id)
+
+    # then
+    assert mock_send_webhook_using_scheme_method.call_count == 3
+    mock_send_webhooks_async_for_app_apply_async.assert_called_once_with(
+        kwargs={"app_id": app.id, "telemetry_context": ANY},
+    )
+
+    # deliveries should be cleared
+    assert not EventDelivery.objects.exists()
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhooks_async_for_app.apply_async"
+)
+def test_send_webhooks_async_for_app_last_retry_failed(
+    mock_send_webhooks_async_for_app_apply_async,
+    mock_send_webhook_using_scheme_method,
+    app,
+    event_delivery,
+):
+    # given
+    assert EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING).exists()
+    EventDeliveryAttempt.objects.bulk_create(
+        [
+            EventDeliveryAttempt(
+                delivery=event_delivery, status=EventDeliveryStatus.FAILED
+            )
+            for _ in range(5)
+        ]
+    )
+    mock_send_webhook_using_scheme_method.return_value = WebhookResponse(
+        content="", status=EventDeliveryStatus.FAILED
+    )
+
+    # when
+    send_webhooks_async_for_app(app_id=app.id)
+
+    # then
+    mock_send_webhook_using_scheme_method.assert_called_once()
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].status == EventDeliveryStatus.FAILED
+    assert (
+        len(EventDeliveryAttempt.objects.filter(status=EventDeliveryStatus.FAILED)) == 6
+    )
+
+    mock_send_webhooks_async_for_app_apply_async.assert_called_once_with(
+        kwargs={"app_id": app.id, "telemetry_context": ANY},
+    )

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -570,6 +570,7 @@ def generate_deferred_payloads(
                 EventDelivery.objects.bulk_update(
                     event_deliveries_for_bulk_update, ["payload"]
                 )
+
     for delivery in event_deliveries_for_bulk_update:
         send_webhooks_async_for_app.apply_async(
             kwargs={

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -50,13 +50,17 @@ from ..utils import (
     WebhookResponse,
     WebhookSchemes,
     attempt_update,
+    clear_successful_deliveries,
     clear_successful_delivery,
     create_attempt,
+    create_attempts_for_deliveries,
     delivery_update,
+    get_deliveries_for_app,
     get_delivery_for_webhook,
     get_multiple_deliveries_for_webhooks,
     handle_webhook_retry,
     prepare_deferred_payload_data,
+    process_failed_deliveries,
     send_webhook_using_scheme_method,
 )
 
@@ -69,6 +73,9 @@ task_logger = get_task_logger(f"{__name__}.celery")
 
 OBSERVABILITY_QUEUE_NAME = "observability"
 MAX_WEBHOOK_EVENTS_IN_DB_BULK = 100
+
+MAX_WEBHOOK_RETRIES = 5
+WEBHOOK_ASYNC_BATCH_SIZE = 100
 
 
 @dataclass
@@ -426,6 +433,8 @@ def trigger_webhooks_async_for_multiple_objects(
             bind=True,
         )
     for delivery in deliveries:
+        # TODO: switch to new `send_webhooks_async_for_app` task when we have
+        # deduplication mechanism in place.
         send_webhook_request_async.apply_async(
             kwargs={
                 "event_delivery_id": delivery.pk,
@@ -564,6 +573,8 @@ def generate_deferred_payloads(
                 )
     for delivery in event_deliveries_for_bulk_update:
         # Trigger webhook delivery task when the payload is ready.
+        # TODO: switch to new `send_webhooks_async_for_app` task when we have
+        # deduplication mechanism in place.
         send_webhook_request_async.apply_async(
             kwargs={
                 "event_delivery_id": delivery.pk,
@@ -658,6 +669,98 @@ def send_webhook_request_async(
 
     observability.report_event_delivery_attempt(attempt)
     clear_successful_delivery(delivery)
+
+
+@app.task(
+    queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
+    bind=True,
+)
+@allow_writer()
+@task_with_telemetry_context
+def send_webhooks_async_for_app(
+    self,
+    app_id,
+    telemetry_context: TelemetryTaskContext,
+) -> None:
+    domain = get_domain()
+    deliveries = get_deliveries_for_app(app_id, WEBHOOK_ASYNC_BATCH_SIZE)
+
+    if not deliveries:
+        return
+
+    attempts_for_deliveries = create_attempts_for_deliveries(
+        deliveries, self.request.id
+    )
+    failed_deliveries_attempts = []
+    successful_deliveries = []
+
+    for delivery_id, delivery_with_count in deliveries.items():
+        delivery = delivery_with_count.delivery
+        attempt_count = delivery_with_count.count
+        attempt = attempts_for_deliveries[delivery_id]
+
+        webhook = delivery.webhook
+
+        try:
+            if not delivery.payload:
+                raise ValueError(f"Event delivery id: {delivery_id} has no payload.")
+            data = delivery.payload.get_payload()
+            # Convert payload to bytes if it's not already.
+            data = data if isinstance(data, bytes) else data.encode("utf-8")
+            # Count payload size in bytes.
+            payload_size = len(data)
+
+            if attempt_count == 0:
+                record_first_delivery_attempt_delay(delivery)
+            with webhooks_otel_trace(
+                delivery.event_type,
+                domain,
+                payload_size,
+                app=webhook.app,
+                span_links=telemetry_context.links,
+            ):
+                response = send_webhook_using_scheme_method(
+                    webhook.target_url,
+                    domain,
+                    webhook.secret_key,
+                    delivery.event_type,
+                    data,
+                    webhook.custom_headers,
+                )
+
+            record_async_webhooks_count(delivery, response.status)
+            if response.status == EventDeliveryStatus.FAILED:
+                attempt_update(attempt, response, with_save=False)
+                failed_deliveries_attempts.append((delivery, attempt, attempt_count))
+            elif response.status == EventDeliveryStatus.SUCCESS:
+                task_logger.info(
+                    "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",
+                    webhook.id,
+                    sanitize_url_for_logging(webhook.target_url),
+                    delivery.event_type,
+                    delivery.id,
+                )
+                delivery.status = EventDeliveryStatus.SUCCESS
+                # update attempt without save to provide proper data in observability
+                attempt_update(attempt, response, with_save=False)
+        except ValueError as e:
+            response = WebhookResponse(
+                content=str(e), status=EventDeliveryStatus.FAILED
+            )
+            attempt_update(attempt, response, with_save=False)
+            failed_deliveries_attempts.append((delivery, attempt, attempt_count))
+
+        observability.report_event_delivery_attempt(attempt)
+        successful_deliveries.append(delivery)
+
+    process_failed_deliveries(failed_deliveries_attempts, MAX_WEBHOOK_RETRIES)
+    clear_successful_deliveries(successful_deliveries)
+
+    send_webhooks_async_for_app.apply_async(
+        kwargs={
+            "app_id": app_id,
+        },
+    )
 
 
 def send_observability_events(webhooks: list[WebhookData], events: list[bytes]):

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -36,6 +36,7 @@ from ....graphql.webhook.subscription_payload import (
 from ....graphql.webhook.subscription_types import WEBHOOK_TYPES_MAP
 from ... import observability
 from ...event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ...metrics import record_first_delivery_attempt_delay
 from ...observability import WebhookData
 from ..metrics import (
     record_external_request,
@@ -609,6 +610,8 @@ def send_webhook_request_async(
         data = data if isinstance(data, bytes) else data.encode("utf-8")
         # Count payload size in bytes.
         payload_size = len(data)
+        if self.request.retries == 0:
+            record_first_delivery_attempt_delay(delivery)
         with webhooks_otel_trace(
             delivery.event_type,
             payload_size,

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -36,7 +36,11 @@ from ....graphql.webhook.subscription_payload import (
 from ....graphql.webhook.subscription_types import WEBHOOK_TYPES_MAP
 from ... import observability
 from ...event_types import WebhookEventAsyncType, WebhookEventSyncType
-from ...metrics import record_first_delivery_attempt_delay
+from ...metrics import (
+    record_async_webhooks_count,
+    record_async_webhooks_error_count,
+    record_first_delivery_attempt_delay,
+)
 from ...observability import WebhookData
 from ..metrics import (
     record_external_request,
@@ -610,6 +614,8 @@ def send_webhook_request_async(
         data = data if isinstance(data, bytes) else data.encode("utf-8")
         # Count payload size in bytes.
         payload_size = len(data)
+
+        record_async_webhooks_count(delivery)
         if self.request.retries == 0:
             record_first_delivery_attempt_delay(delivery)
         with webhooks_otel_trace(
@@ -633,6 +639,7 @@ def send_webhook_request_async(
             attempt_update(attempt, response)
             handle_webhook_retry(self, webhook, response, delivery, attempt)
             delivery_update(delivery, EventDeliveryStatus.FAILED)
+            record_async_webhooks_error_count(delivery)
         elif response.status == EventDeliveryStatus.SUCCESS:
             task_logger.info(
                 "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -759,6 +759,7 @@ def send_webhooks_async_for_app(
     send_webhooks_async_for_app.apply_async(
         kwargs={
             "app_id": app_id,
+            "telemetry_context": telemetry_context.to_dict(),
         },
     )
 

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -38,7 +38,6 @@ from ... import observability
 from ...event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...metrics import (
     record_async_webhooks_count,
-    record_async_webhooks_error_count,
     record_first_delivery_attempt_delay,
 )
 from ...observability import WebhookData
@@ -615,7 +614,6 @@ def send_webhook_request_async(
         # Count payload size in bytes.
         payload_size = len(data)
 
-        record_async_webhooks_count(delivery)
         if self.request.retries == 0:
             record_first_delivery_attempt_delay(delivery)
         with webhooks_otel_trace(
@@ -635,11 +633,11 @@ def send_webhook_request_async(
             if response.status == EventDeliveryStatus.FAILED:
                 span.set_status(StatusCode.ERROR)
 
+        record_async_webhooks_count(delivery, response.status)
         if response.status == EventDeliveryStatus.FAILED:
             attempt_update(attempt, response)
             handle_webhook_retry(self, webhook, response, delivery, attempt)
             delivery_update(delivery, EventDeliveryStatus.FAILED)
-            record_async_webhooks_error_count(delivery)
         elif response.status == EventDeliveryStatus.SUCCESS:
             task_logger.info(
                 "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -714,7 +714,6 @@ def send_webhooks_async_for_app(
                 record_first_delivery_attempt_delay(delivery)
             with webhooks_otel_trace(
                 delivery.event_type,
-                domain,
                 payload_size,
                 app=webhook.app,
                 span_links=telemetry_context.links,

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -18,6 +18,7 @@ from celery import Task
 from celery.exceptions import MaxRetriesExceededError, Retry
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.db.models import Count
 from django.urls import reverse
 from google.cloud import pubsub_v1
 from requests import RequestException
@@ -63,6 +64,12 @@ class WebhookSchemes(str, Enum):
     HTTPS = "https"
     AWS_SQS = "awssqs"
     GOOGLE_CLOUD_PUBSUB = "gcpubsub"
+
+
+@dataclass
+class EventDeliveryWithAttemptCount:
+    delivery: "EventDelivery"
+    count: int
 
 
 @dataclass
@@ -411,6 +418,27 @@ def get_delivery_for_webhook(
     return delivery, not_found
 
 
+def get_deliveries_for_app(
+    app_id, batch_size
+) -> dict[int, "EventDeliveryWithAttemptCount"]:
+    deliveries = (
+        EventDelivery.objects.select_related("payload", "webhook__app")
+        .filter(webhook__app_id=app_id, status=EventDeliveryStatus.PENDING)
+        .order_by("created_at")
+        .annotate(
+            attempts_count=Count("attempts", distinct=True),
+        )[:batch_size]
+    )
+
+    return {
+        delivery.pk: EventDeliveryWithAttemptCount(
+            delivery=delivery,
+            count=delivery.attempts_count,
+        )
+        for delivery in deliveries
+    }
+
+
 def get_multiple_deliveries_for_webhooks(
     event_delivery_ids,
 ) -> tuple[dict[int, "EventDelivery"], set[int]]:
@@ -521,6 +549,93 @@ def clear_successful_delivery(delivery: "EventDelivery"):
         ]
         payloads_to_delete.delete()
         delete_files_from_private_storage_task(files_to_delete)
+
+
+@allow_writer()
+def clear_successful_deliveries(deliveries: list["EventDelivery"]):
+    delivery_ids_to_delete = []
+    payload_ids_to_delete = []
+    files_to_delete = []
+    for delivery in deliveries:
+        # skip deliveries that cannot be deleted
+        if not delivery.id or delivery.status != EventDeliveryStatus.SUCCESS:
+            continue
+
+        delivery_ids_to_delete.append(delivery.id)
+
+        payload_id = delivery.payload_id
+        if payload_id:
+            payload_ids_to_delete.append(payload_id)
+
+            payloads_to_delete = EventPayload.objects.filter(
+                pk=payload_id, deliveries__isnull=True
+            )
+
+            files_to_delete += [
+                event_payload.payload_file.name
+                for event_payload in payloads_to_delete.using(
+                    settings.DATABASE_CONNECTION_REPLICA_NAME
+                )
+                if event_payload.payload_file
+            ]
+
+    if payload_ids_to_delete:
+        EventPayload.objects.filter(pk__in=payload_ids_to_delete).delete()
+        delete_files_from_private_storage_task(files_to_delete)
+    if delivery_ids_to_delete:
+        EventDelivery.objects.filter(pk__in=delivery_ids_to_delete).delete()
+
+
+@allow_writer()
+def process_failed_deliveries(
+    failed_deliveries_attempts: list[tuple[EventDelivery, EventDeliveryAttempt, int]],
+    max_webhook_retries: int,
+) -> None:
+    deliveries_to_update = []
+    deliveries_attempts_to_update = []
+    for delivery, attempt, attempt_count in failed_deliveries_attempts:
+        if attempt_count >= max_webhook_retries:
+            delivery.status = EventDeliveryStatus.FAILED
+            deliveries_to_update.append(delivery)
+        deliveries_attempts_to_update.append(attempt)
+
+    if deliveries_to_update:
+        EventDelivery.objects.bulk_update(deliveries_to_update, ["status"])
+
+    update_fields = [
+        "duration",
+        "response",
+        "response_headers",
+        "response_status_code",
+        "request_headers",
+        "status",
+    ]
+    if deliveries_attempts_to_update:
+        EventDeliveryAttempt.objects.bulk_update(
+            deliveries_attempts_to_update, update_fields
+        )
+
+
+@allow_writer()
+def create_attempts_for_deliveries(
+    deliveries: dict[int, EventDeliveryWithAttemptCount],
+    task_id: str | None,
+) -> dict[int, EventDeliveryAttempt]:
+    attempt_for_deliveries = {}
+    for delivery_id, delivery_with_count in deliveries.items():
+        delivery = delivery_with_count.delivery
+
+        attempt = create_attempt(delivery, task_id, with_save=False)
+        attempt_for_deliveries[delivery_id] = attempt
+
+    if attempt_for_deliveries:
+        attempts_to_create = [
+            attempt_for_deliveries[delivery_id]
+            for delivery_id in attempt_for_deliveries
+        ]
+        EventDeliveryAttempt.objects.bulk_create(attempts_to_create)
+
+    return attempt_for_deliveries
 
 
 @allow_writer()


### PR DESCRIPTION
I want to merge this change because it integrates deferred payloads with webhook fairness and OTEL
⚠️ This is a PR to a feature branch (with fairness and OTEL)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
