### PR TITLE
Use use_legacy_line_voucher_propagation_for_order to control entire-order propagation

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -2047,6 +2047,98 @@ def test_checkout_with_voucher_complete(
     assert order_line.unit_discount_reason == expected_unit_discount_reason
 
 
+@pytest.mark.parametrize(
+    (
+        "legacy_propagation",
+        "expected_unit_discount_amount",
+    ),
+    [
+        (True, Decimal("1.67")),
+        (
+            False,
+            Decimal(0),
+        ),
+    ],
+)
+@pytest.mark.integration
+def test_checkout_with_order_promotion_complete(
+    legacy_propagation,
+    expected_unit_discount_amount,
+    user_api_client,
+    checkout_with_item_and_order_discount,
+    address,
+    shipping_method,
+    transaction_events_generator,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_with_item_and_order_discount
+
+    channel = checkout.channel
+    channel.use_legacy_line_voucher_propagation_for_order = legacy_propagation
+    channel.save()
+
+    checkout = prepare_checkout_for_test(
+        checkout,
+        address,
+        address,
+        shipping_method,
+        transaction_item_generator,
+        transaction_events_generator,
+    )
+
+    discount_amount = checkout.discount
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    total = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
+    )
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+
+    order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
+    assert Order.objects.count() == 1
+    order = Order.objects.first()
+    assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
+    assert order.metadata == checkout.metadata_storage.metadata
+    assert order.private_metadata == checkout.metadata_storage.private_metadata
+
+    assert order.total == total
+    assert order.subtotal.gross == get_subtotal(order.lines.all(), order.currency).gross
+    assert order.undiscounted_total == total + discount_amount
+
+    assert not Checkout.objects.filter(pk=checkout.pk).exists(), (
+        "Checkout should have been deleted"
+    )
+
+    order_line = order.lines.first()
+    assert order_line.unit_discount_amount == expected_unit_discount_amount
+    assert order_line.unit_discount_reason is None
+
+    order_discount = order.discounts.filter(type=DiscountType.ORDER_PROMOTION).first()
+    assert order_discount
+    assert (
+        order_discount.amount_value
+        == (order.undiscounted_total - order.total).gross.amount
+    )
+
+
 @pytest.mark.integration
 def test_checkout_complete_with_entire_order_voucher_paid_with_gift_card_and_transaction(
     user_api_client,

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
@@ -115,20 +115,15 @@ def prepare_voucher(
         "voucher_discount_type",
         "expected_voucher_discount",
         "expected_unit_price",
-        "legacy_voucher_propagation",
     ),
     [
-        ("19.99", 13, "PERCENTAGE", 2.60, 13, "PERCENTAGE", 2.26, 15.13, True),
-        ("30", 10, "FIXED", 10, 5, "FIXED", 5, 17.5, True),
-        ("56.50", 19.99, "FIXED", 19.99, 33, "PERCENTAGE", 12.05, 24.46, True),
-        ("77.77", 17.5, "PERCENTAGE", 13.61, 25, "FIXED", 25, 51.66, True),
-        ("19.99", 13, "PERCENTAGE", 2.60, 13, "PERCENTAGE", 2.26, 15.13, False),
-        ("30", 10, "FIXED", 10, 5, "FIXED", 5, 17.5, False),
-        ("56.50", 19.99, "FIXED", 19.99, 33, "PERCENTAGE", 12.05, 24.46, False),
-        ("77.77", 17.5, "PERCENTAGE", 13.61, 25, "FIXED", 25, 51.66, False),
+        ("19.99", 13, "PERCENTAGE", 2.60, 13, "PERCENTAGE", 2.26, 15.13),
+        ("30", 10, "FIXED", 10, 5, "FIXED", 5, 17.5),
+        ("56.50", 19.99, "FIXED", 19.99, 33, "PERCENTAGE", 12.05, 24.46),
+        ("77.77", 17.5, "PERCENTAGE", 13.61, 25, "FIXED", 25, 51.66),
     ],
 )
-def test_checkout_with_promotion_and_voucher_CORE_2107(
+def test_checkout_with_promotion_and_voucher_legacy_propagation_CORE_2107(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
     shop_permissions,
@@ -142,7 +137,6 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
     voucher_discount_type,
     expected_voucher_discount,
     expected_unit_price,
-    legacy_voucher_propagation,
 ):
     # Before
     permissions = [
@@ -154,9 +148,7 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
 
     shop_data = prepare_default_shop(
         e2e_staff_api_client,
-        channel_order_settings={
-            "useLegacyLineVoucherPropagation": legacy_voucher_propagation
-        },
+        channel_order_settings={"useLegacyLineVoucherPropagation": True},
     )
     channel_id = shop_data["channel"]["id"]
     channel_slug = shop_data["channel"]["slug"]
@@ -272,9 +264,172 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
         product_variant_price
     )
     assert f"Promotion: {promotion_id}" in order_line["unitDiscountReason"]
+    assert (
+        f"Entire order voucher code: {voucher_code}" in order_line["unitDiscountReason"]
+    )
 
-    if legacy_voucher_propagation:
-        assert (
-            f"Entire order voucher code: {voucher_code}"
-            in order_line["unitDiscountReason"]
-        )
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    (
+        "variant_price",
+        "promotion_value",
+        "promotion_value_type",
+        "expected_promotion_discount",
+        "voucher_discount_value",
+        "voucher_discount_type",
+        "expected_voucher_discount",
+        "expected_unit_price",
+    ),
+    [
+        ("19.99", 13, "PERCENTAGE", 2.60, 13, "PERCENTAGE", 2.26, 15.13),
+        ("30", 10, "FIXED", 10, 5, "FIXED", 5, 17.5),
+        ("56.50", 19.99, "FIXED", 19.99, 33, "PERCENTAGE", 12.05, 24.46),
+        ("77.77", 17.5, "PERCENTAGE", 13.61, 25, "FIXED", 25, 51.66),
+    ],
+)
+def test_checkout_with_promotion_and_voucher_CORE_2107(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    variant_price,
+    promotion_value_type,
+    promotion_value,
+    expected_promotion_discount,
+    voucher_discount_value,
+    voucher_discount_type,
+    expected_voucher_discount,
+    expected_unit_price,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shop_data = prepare_default_shop(
+        e2e_staff_api_client,
+        channel_order_settings={"useLegacyLineVoucherPropagation": False},
+    )
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+
+    promotion_id, promotion_value = prepare_promotion(
+        e2e_staff_api_client,
+        product_id,
+        channel_id,
+        promotion_value,
+        promotion_value_type,
+    )
+
+    voucher_discount_value, voucher_code = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        product_id,
+        voucher_discount_type,
+        voucher_discount_value,
+    )
+
+    # prices are updated in the background, we need to force it to retrieve the correct
+    # ones
+    recalculate_discounted_price_for_products_task()
+
+    # Step 1 - Create checkout for product with promotion
+    lines = [
+        {"variantId": product_variant_id, "quantity": 1},
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+    )
+    checkout_id = checkout_data["id"]
+    checkout_lines = checkout_data["lines"][0]
+
+    assert checkout_data["isShippingRequired"] is True
+    unit_price_with_promotion = round(
+        float(product_variant_price - expected_promotion_discount), 2
+    )
+    assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price_with_promotion
+    assert checkout_lines["undiscountedUnitPrice"]["amount"] == product_variant_price
+
+    # Step 2 Add voucher code to checkout
+    checkout_data = checkout_add_promo_code(
+        e2e_not_logged_api_client, checkout_id, voucher_code
+    )
+    assert checkout_data["discount"]["amount"] == expected_voucher_discount
+    assert checkout_data["lines"][0]["unitPrice"]["gross"]["amount"] == round(
+        float(unit_price_with_promotion - expected_voucher_discount), 2
+    )
+
+    # Step 3 Add variant to the checkout
+    lines_add = [
+        {"variantId": product_variant_id, "quantity": 1},
+    ]
+    checkout_data = checkout_lines_add(
+        e2e_staff_api_client,
+        checkout_id,
+        lines_add,
+    )
+    checkout_lines = checkout_data["lines"][0]
+    assert checkout_lines["quantity"] == 2
+    assert checkout_lines["unitPrice"]["gross"]["amount"] == expected_unit_price
+    subtotal_amount = expected_unit_price * 2
+    assert checkout_lines["totalPrice"]["gross"]["amount"] == subtotal_amount
+
+    # Step 4 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    total_gross_amount = round(subtotal_amount + shipping_price, 2)
+    assert checkout_data["totalPrice"]["gross"]["amount"] == total_gross_amount
+
+    # Step 5 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client, checkout_id, total_gross_amount
+    )
+
+    # Step 6 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["discounts"][0]["type"] == "VOUCHER"
+    assert order_data["voucher"]["code"] == voucher_code
+
+    order_line = order_data["lines"][0]
+    assert order_line["unitDiscountType"] == "FIXED"
+    assert order_line["unitPrice"]["gross"]["amount"] == expected_unit_price
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_data["subtotal"]["gross"]["amount"] == subtotal_amount
+    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
+        product_variant_price
+    )
+    assert f"Promotion: {promotion_id}" in order_line["unitDiscountReason"]
+    assert (
+        f"Entire order voucher code: {voucher_code}"
+        not in order_line["unitDiscountReason"]
+    )

--- a/saleor/tests/e2e/shop/utils/preparing_shop.py
+++ b/saleor/tests/e2e/shop/utils/preparing_shop.py
@@ -137,14 +137,13 @@ def prepare_shop(
     return created_channels, tax_config
 
 
-def prepare_default_shop(
-    e2e_staff_api_client,
-):
+def prepare_default_shop(e2e_staff_api_client, channel_order_settings=None):
     created_warehouse = create_warehouse(e2e_staff_api_client)
 
     created_channel = create_channel(
         e2e_staff_api_client,
         warehouse_ids=[created_warehouse["id"]],
+        order_settings=channel_order_settings,
     )
 
     created_shipping_zone = create_shipping_zone(


### PR DESCRIPTION
This change modifies how the ENTIRE_ORDER voucher is propagated when converting a checkout into an order.

Previously, during the conversion, the voucher discount was also added to the line.unitDiscount field, and line.unitDiscountReason included information about the entire-order voucher.

When use_legacy_line_voucher_propagation_for_order is set to True, this legacy behavior is preserved.

When set to False, the ENTIRE_ORDER voucher no longer affects line.unitDiscount or line.unitDiscountReason. This aligns with the approach used when re-calculating order prices.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
