### PR TITLE
Telemetry - Align span naming with OpenTelemetry

### DIFF
--- a/saleor/core/telemetry/saleor_attributes.py
+++ b/saleor/core/telemetry/saleor_attributes.py
@@ -4,7 +4,7 @@ SALEOR_ENVIRONMENT_DOMAIN: Final = "saleor.environment.domain"
 
 COMPONENT: Final = "component"
 SPAN_TYPE: Final = "span.type"
-RESOURCE_NAME: Final = "resource.name"
+OPERATION_NAME: Final = "operation.name"
 
 # GraphQL
 GRAPHQL_DOCUMENT_FINGERPRINT: Final = "graphql.document_fingerprint"

--- a/saleor/core/telemetry/tests/test_utils.py
+++ b/saleor/core/telemetry/tests/test_utils.py
@@ -127,7 +127,7 @@ def test_enrich_span_with_global_attributes():
 
         # then
         assert enriched is not None
-        assert enriched["operation.name"] == ""
+        assert enriched["operation.name"] == span_name
         assert enriched["global_key"] == "global_value"
         assert enriched["local_key"] == "local_value"
 
@@ -142,7 +142,7 @@ def test_enrich_span_with_global_attributes_none():
         enriched = enrich_span_with_global_attributes(None, span_name)
 
         # then
-        assert enriched == {"operation.name": span_name}
+        assert enriched == {"operation.name": span_name, **global_attrs}
 
 
 def test_telemetry_task_context_to_dict():

--- a/saleor/core/telemetry/tests/test_utils.py
+++ b/saleor/core/telemetry/tests/test_utils.py
@@ -9,6 +9,7 @@ from ..utils import (
     TelemetryTaskContext,
     Unit,
     convert_unit,
+    enrich_span_with_global_attributes,
     enrich_with_global_attributes,
     get_global_attributes,
     set_global_attributes,
@@ -112,6 +113,36 @@ def test_enrich_with_global_attributes_none():
 
         # then
         assert enriched == global_attrs
+
+
+def test_enrich_span_with_global_attributes():
+    # given
+    global_attrs: dict[str, AttributeValue] = {"global_key": "global_value"}
+    local_attrs: dict[str, AttributeValue] = {"local_key": "local_value"}
+    span_name = "graphql_query"
+
+    with set_global_attributes(global_attrs):
+        # when
+        enriched = enrich_span_with_global_attributes(local_attrs, span_name)
+
+        # then
+        assert enriched is not None
+        assert enriched["operation.name"] == ""
+        assert enriched["global_key"] == "global_value"
+        assert enriched["local_key"] == "local_value"
+
+
+def test_enrich_span_with_global_attributes_none():
+    # given
+    global_attrs: dict[str, AttributeValue] = {"global_key": "global_value"}
+    span_name = "graphql_query"
+
+    with set_global_attributes(global_attrs):
+        # when
+        enriched = enrich_span_with_global_attributes(None, span_name)
+
+        # then
+        assert enriched == {"operation.name": span_name}
 
 
 def test_telemetry_task_context_to_dict():

--- a/saleor/core/telemetry/trace.py
+++ b/saleor/core/telemetry/trace.py
@@ -12,7 +12,7 @@ from opentelemetry.trace import (
 )
 from opentelemetry.util.types import Attributes
 
-from .utils import Scope, enrich_with_global_attributes
+from .utils import Scope, enrich_span_with_global_attributes
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class Tracer:
             The newly created span
 
         """
-        attributes = enrich_with_global_attributes(attributes)
+        attributes = enrich_span_with_global_attributes(attributes, name)
         tracer = self._service_tracer if scope.is_service else self._core_tracer
         with tracer.start_as_current_span(
             name,
@@ -112,7 +112,7 @@ class Tracer:
             The newly created span
 
         """
-        attributes = enrich_with_global_attributes(attributes)
+        attributes = enrich_span_with_global_attributes(attributes, name)
         tracer = self._service_tracer if scope.is_service else self._core_tracer
         return tracer.start_span(
             name,

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from opentelemetry.trace import Link, SpanContext, TraceFlags
 from opentelemetry.util.types import Attributes, AttributeValue
 
-from .attributes import OPERATION_NAME
+from .saleor_attributes import OPERATION_NAME
 
 logger = logging.getLogger(__name__)
 

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from opentelemetry.trace import Link, SpanContext, TraceFlags
 from opentelemetry.util.types import Attributes, AttributeValue
 
+from .attributes import OPERATION_NAME
+
 logger = logging.getLogger(__name__)
 
 Amount = int | float
@@ -65,8 +67,14 @@ def get_global_attributes() -> dict[str, AttributeValue]:
     return _GLOBAL_ATTRS.get({})
 
 
-def enrich_with_global_attributes(attributes: Attributes) -> Attributes:
+def enrich_with_global_attributes(attributes: Attributes) -> dict[str, AttributeValue]:
     return {**(attributes or {}), **get_global_attributes()}
+
+
+def enrich_span_with_global_attributes(
+    attributes: Attributes, span_name: str
+) -> dict[str, AttributeValue]:
+    return {OPERATION_NAME: span_name, **enrich_with_global_attributes(attributes)}
 
 
 @dataclass(frozen=True)

--- a/saleor/graphql/core/dataloaders.py
+++ b/saleor/graphql/core/dataloaders.py
@@ -42,8 +42,10 @@ class DataLoader(BaseLoader, Generic[K, R]):
     def batch_load_fn(  # pylint: disable=method-hidden
         self, keys: Iterable[K]
     ) -> Promise[list[R]]:
-        with tracer.start_as_current_span("dataloader.batch_load") as span:
-            span.set_attribute(saleor_attributes.RESOURCE_NAME, self.__class__.__name__)
+        with tracer.start_as_current_span(self.__class__.__name__) as span:
+            span.set_attribute(
+                saleor_attributes.OPERATION_NAME, "dataloader.batch_load"
+            )
 
             with allow_writer_in_context(self.context):
                 results = self.batch_load(keys)

--- a/saleor/graphql/core/tracing.py
+++ b/saleor/graphql/core/tracing.py
@@ -10,8 +10,8 @@ def traced_resolver(func):
     def wrapper(*args, **kwargs):
         info = next(arg for arg in args if isinstance(arg, ResolveInfo))
         operation = f"{info.parent_type.name}.{info.field_name}"
-        with tracer.start_as_current_span("graphql.resolve") as span:
-            span.set_attribute(saleor_attributes.RESOURCE_NAME, operation)
+        with tracer.start_as_current_span(operation) as span:
+            span.set_attribute(saleor_attributes.OPERATION_NAME, "graphql.resolve")
             span.set_attribute(
                 saleor_attributes.GRAPHQL_PARENT_TYPE, info.parent_type.name
             )

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -55,7 +55,7 @@ def test_tracing_query_hashing(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     hash = hashlib.md5(
@@ -95,7 +95,7 @@ def test_tracing_query_hashing_with_fragment(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     hash = hashlib.md5(
@@ -135,7 +135,7 @@ def test_tracing_query_hashing_different_vars_same_checksum(
     # then
     fingerprints = [
         span.attributes[saleor_attributes.GRAPHQL_DOCUMENT_FINGERPRINT]
-        for span in get_spans_by_name(get_test_spans(), "graphql_query")
+        for span in get_spans_by_name(get_test_spans(), query)
     ]
     assert len(fingerprints) == QUERIES
     assert len(set(fingerprints)) == 1
@@ -163,7 +163,7 @@ def test_tracing_query_hashing_unnamed_query(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     hash = hashlib.md5(
@@ -197,7 +197,7 @@ def test_tracing_query_hashing_unnamed_query_no_query_spec(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     hash = hashlib.md5(
@@ -240,7 +240,7 @@ def test_tracing_mutation_hashing(
         permissions=[permission_manage_orders],
         check_no_permissions=False,
     )
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), mutation)
 
     # then
     hash = hashlib.md5(
@@ -283,7 +283,7 @@ def test_tracing_query_identifier_for_query(
     # when
     staff_api_client.user.user_permissions.add(permission_manage_products)
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert (
@@ -319,7 +319,7 @@ def test_tracing_query_identifier_with_fragment(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert span.attributes[saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER] == "products"
@@ -340,7 +340,7 @@ def test_tracing_query_identifier_for_unnamed_mutation(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert (
@@ -363,7 +363,7 @@ def test_tracing_query_identifier_for_named_mutation(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert (
@@ -393,7 +393,7 @@ def test_tracing_query_identifier_for_many_mutations(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert (
@@ -417,7 +417,7 @@ def test_tracing_query_identifier_undefined(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert (
@@ -447,7 +447,7 @@ def test_tracing_dont_have_app_data_staff_as_requestor(
 
     # when
     staff_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert "app.name" not in span.attributes
@@ -477,7 +477,7 @@ def test_tracing_have_app_data_app_as_requestor(
 
     # when
     app_api_client.post_graphql(query)
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
 
     # then
     assert span.attributes[saleor_attributes.SALEOR_APP_NAME] == app.name
@@ -525,7 +525,7 @@ def test_tracing_have_source_service_name_set(
     app_api_client.post_graphql(query, headers={"source-service-name": header_source})
 
     # then
-    span = get_span_by_name(get_test_spans(), "graphql_query")
+    span = get_span_by_name(get_test_spans(), query)
     assert (
         span.attributes[saleor_attributes.SALEOR_SOURCE_SERVICE_NAME] == expected_result
     )

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -13,15 +13,6 @@ from ...graphql.api import backend, schema
 from ..views import GraphQLView
 
 
-@pytest.fixture
-def get_test_spans(in_memory_span_exporter):
-    # Clear any existing spans from the buffer before test execution
-    in_memory_span_exporter.clear()
-    yield in_memory_span_exporter.get_finished_spans
-    # Clean up by clearing the buffer after test completion
-    in_memory_span_exporter.clear()
-
-
 def get_spans_by_name(spans, name) -> tuple[ReadableSpan, ...]:
     return tuple(span for span in spans if span.name == name)
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -110,6 +110,15 @@ def in_memory_span_exporter():
 
 
 @pytest.fixture
+def get_test_spans(in_memory_span_exporter):
+    # Clear any existing spans from the buffer before test execution
+    in_memory_span_exporter.clear()
+    yield in_memory_span_exporter.get_finished_spans
+    # Clean up by clearing the buffer after test completion
+    in_memory_span_exporter.clear()
+
+
+@pytest.fixture
 def capture_queries(pytestconfig):
     cfg = pytestconfig
 


### PR DESCRIPTION
I want to merge this change because it updates naming of some spans to align better with the OpenTelemetry standard, as it differs from OpenTracing. Also, there is added functionality to automatically set the `operation.name` attribute for all spans to ensure backward compatibility with Datadog

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
