### PR TITLE
Fix `PromotionRule.giftIds` resolver

### DIFF
--- a/saleor/graphql/discount/tests/queries/test_promotion.py
+++ b/saleor/graphql/discount/tests/queries/test_promotion.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal
+from unittest.mock import patch
 
 import graphene
 
@@ -212,6 +213,52 @@ def test_query_order_promotion_with_gift_rule(
             for gift in rule_db.gifts.all()
         ]
     )
+    assert rule["giftsLimit"] == 1
+    assert rule["rewardType"] == RewardType.GIFT.upper()
+
+
+@patch(
+    "saleor.graphql.discount.types.promotions.GiftsByPromotionRuleIDLoader.batch_load"
+)
+def test_query_order_promotion_with_gift_rule_variant_removed_in_meantime(
+    mock_batch_load,
+    order_promotion_without_rules,
+    gift_promotion_rule,
+    staff_api_client,
+    permission_group_manage_discounts,
+):
+    # given
+    query = """
+        query Promotion($id: ID!) {
+            promotion(id: $id) {
+                id
+                rules {
+                    rewardType
+                    giftIds
+                    giftsLimit
+                }
+            }
+        }
+    """
+    promotion = order_promotion_without_rules
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    promotion.rules.add(gift_promotion_rule)
+
+    variables = {"id": promotion_id}
+
+    returned_gift = gift_promotion_rule.gifts.first()
+    mock_batch_load.return_value = [[None, returned_gift]]
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    rule = content["data"]["promotion"]["rules"][0]
+    assert set(rule["giftIds"]) == {
+        graphene.Node.to_global_id("ProductVariant", returned_gift.pk)
+    }
     assert rule["giftsLimit"] == 1
     assert rule["rewardType"] == RewardType.GIFT.upper()
 

--- a/saleor/graphql/discount/types/promotions.py
+++ b/saleor/graphql/discount/types/promotions.py
@@ -164,7 +164,9 @@ class PromotionRule(ModelObjectType[models.PromotionRule]):
     def resolve_gift_ids(root: models.PromotionRule, info: ResolveInfo):
         def with_gifts(gifts):
             return [
-                graphene.Node.to_global_id("ProductVariant", gift.pk) for gift in gifts
+                graphene.Node.to_global_id("ProductVariant", gift.pk)
+                for gift in gifts
+                if gift
             ]
 
         return GiftsByPromotionRuleIDLoader(info.context).load(root.id).then(with_gifts)


### PR DESCRIPTION
Fix the following error:
```AttributeError: 'NoneType' object has no attribute 'pk'
  File "promise/promise.py", line 87, in try_catch
    return (handler(*args, **kwargs), None)
  File "saleor/graphql/discount/types/promotions.py", line 165, in with_gifts
    graphene.Node.to_global_id("ProductVariant", gift.pk) for gift in gifts
```
that appears in case the returned `gift` is `None`.
The issue might happened in very rare conditions in case the product variant will be removed by some other thread.


Port of https://github.com/saleor/saleor/pull/17584

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
