### PR TITLE
Make `transactionId` in `OrderGrantRefundCreateInput` required

### DIFF
--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -84,12 +84,10 @@ class OrderGrantRefundCreateInput(BaseInputObjectType):
             "be equal or greater than provided `amount`."
             "If `amount` is not provided in the input and calculated automatically by "
             "Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be "
-            "used."
-            "Field will be required starting from Saleor 3.21."
-            + ADDED_IN_320
-            + PREVIEW_FEATURE
+            "used. "
+            "Field required starting from Saleor 3.21." + ADDED_IN_320 + PREVIEW_FEATURE
         ),
-        required=False,
+        required=True,
     )
 
     class Meta:

--- a/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
@@ -102,15 +102,31 @@ mutation OrderGrantRefundCreate(
 
 @pytest.mark.parametrize("reason", ["", "Reason", None])
 def test_grant_refund_by_user(
-    reason, staff_api_client, permission_manage_orders, order
+    reason,
+    staff_api_client,
+    permission_manage_orders,
+    order,
+    transaction_item_generator,
 ):
     # given
     order_id = to_global_id_or_none(order)
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+
     amount = Decimal("10.00")
+    transaction_item = transaction_item_generator(
+        charged_value=amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
+
     variables = {
         "id": order_id,
-        "input": {"amount": amount, "reason": reason},
+        "input": {
+            "amount": amount,
+            "reason": reason,
+            "transactionId": transaction_item_id,
+        },
     }
 
     # when
@@ -150,18 +166,30 @@ def test_grant_refund_by_user(
         == OrderGrantedRefundStatusEnum.NONE.name
     )
     assert granted_refund_assigned_to_order["transactionEvents"] == []
-    assert not granted_refund_assigned_to_order["transaction"]
+    assert granted_refund_assigned_to_order["transaction"]["id"] == transaction_item_id
 
 
 @pytest.mark.parametrize("reason", ["", "Reason", None])
-def test_grant_refund_by_app(reason, app_api_client, permission_manage_orders, order):
+def test_grant_refund_by_app(
+    reason, app_api_client, permission_manage_orders, order, transaction_item_generator
+):
     # given
     order_id = to_global_id_or_none(order)
     app_api_client.app.permissions.set([permission_manage_orders])
     amount = Decimal("10.00")
+    transaction_item = transaction_item_generator(
+        charged_value=amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
-        "input": {"amount": amount, "reason": reason},
+        "input": {
+            "amount": amount,
+            "reason": reason,
+            "transactionId": transaction_item_id,
+        },
     }
 
     # when
@@ -194,17 +222,29 @@ def test_grant_refund_by_app(reason, app_api_client, permission_manage_orders, o
 
     assert granted_refund["status"] == OrderGrantedRefundStatusEnum.NONE.name
     assert granted_refund["transactionEvents"] == []
-    assert not granted_refund["transaction"]
+    assert granted_refund["transaction"]["id"] == transaction_item_id
 
 
-def test_grant_refund_by_app_missing_permission(app_api_client, order):
+def test_grant_refund_by_app_missing_permission(
+    app_api_client, order, transaction_item_generator
+):
     # given
     order_id = to_global_id_or_none(order)
     amount = Decimal("10.00")
     reason = "Granted refund reason."
+    transaction_item = transaction_item_generator(
+        charged_value=amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
-        "input": {"amount": amount, "reason": reason},
+        "input": {
+            "amount": amount,
+            "reason": reason,
+            "transactionId": transaction_item_id,
+        },
     }
 
     # when
@@ -214,14 +254,26 @@ def test_grant_refund_by_app_missing_permission(app_api_client, order):
     assert_no_permission(response)
 
 
-def test_grant_refund_by_user_missing_permission(staff_api_client, order):
+def test_grant_refund_by_user_missing_permission(
+    staff_api_client, order, transaction_item_generator
+):
     # given
     order_id = to_global_id_or_none(order)
     amount = Decimal("10.00")
     reason = "Granted refund reason."
+    transaction_item = transaction_item_generator(
+        charged_value=amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
-        "input": {"amount": amount, "reason": reason},
+        "input": {
+            "amount": amount,
+            "reason": reason,
+            "transactionId": transaction_item_id,
+        },
     }
 
     # when
@@ -231,14 +283,26 @@ def test_grant_refund_by_user_missing_permission(staff_api_client, order):
     assert_no_permission(response)
 
 
-def test_grant_refund_incorrect_order_id(staff_api_client, permission_manage_orders):
+def test_grant_refund_incorrect_order_id(
+    staff_api_client, permission_manage_orders, transaction_item_generator, order
+):
     # given
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     amount = Decimal("10.00")
     reason = "Granted refund reason."
+    transaction_item = transaction_item_generator(
+        charged_value=amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": "wrong-id",
-        "input": {"amount": amount, "reason": reason},
+        "input": {
+            "amount": amount,
+            "reason": reason,
+            "transactionId": transaction_item_id,
+        },
     }
 
     # when
@@ -255,14 +319,28 @@ def test_grant_refund_incorrect_order_id(staff_api_client, permission_manage_ord
 
 
 def test_grant_refund_with_only_include_grant_refund_for_shipping(
-    staff_api_client, permission_manage_orders, order_with_lines
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    transaction_item_generator,
 ):
     # given
-    order_id = to_global_id_or_none(order_with_lines)
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+    amount = Decimal("20")
+    transaction_item = transaction_item_generator(
+        charged_value=amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
-        "input": {"grantRefundForShipping": True},
+        "input": {
+            "grantRefundForShipping": True,
+            "transactionId": transaction_item_id,
+        },
     }
 
     # when
@@ -291,7 +369,10 @@ def test_grant_refund_with_only_include_grant_refund_for_shipping(
 
 
 def test_grant_refund_with_only_lines(
-    staff_api_client, permission_manage_orders, order_with_lines
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
@@ -299,6 +380,13 @@ def test_grant_refund_with_only_lines(
     first_line = order.lines.first()
     staff_api_client.user.user_permissions.add(permission_manage_orders)
 
+    charged_amount = Decimal("20.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     expected_reason = "Reason"
     variables = {
         "id": order_id,
@@ -309,7 +397,8 @@ def test_grant_refund_with_only_lines(
                     "quantity": 1,
                     "reason": expected_reason,
                 },
-            ]
+            ],
+            "transactionId": transaction_item_id,
         },
     }
 
@@ -348,18 +437,29 @@ def test_grant_refund_with_only_lines(
 
 
 def test_grant_refund_with_include_grant_refund_for_shipping_and_lines(
-    staff_api_client, permission_manage_orders, order_with_lines
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
     order_id = to_global_id_or_none(order)
     first_line = order.lines.first()
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+    charged_amount = Decimal("30.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
         "input": {
             "grantRefundForShipping": True,
             "lines": [{"id": to_global_id_or_none(first_line), "quantity": 1}],
+            "transactionId": transaction_item_id,
         },
     }
 
@@ -401,13 +501,22 @@ def test_grant_refund_with_include_grant_refund_for_shipping_and_lines(
 
 
 def test_grant_refund_with_provided_lines_shipping_and_amount(
-    staff_api_client, permission_manage_orders, order_with_lines
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
     order_id = to_global_id_or_none(order)
     first_line = order.lines.first()
     expected_amount = Decimal("10.0")
+    transaction_item = transaction_item_generator(
+        charged_value=expected_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     variables = {
         "id": order_id,
@@ -415,6 +524,7 @@ def test_grant_refund_with_provided_lines_shipping_and_amount(
             "grantRefundForShipping": True,
             "lines": [{"id": to_global_id_or_none(first_line), "quantity": 1}],
             "amount": expected_amount,
+            "transactionId": transaction_item_id,
         },
     }
 
@@ -454,16 +564,27 @@ def test_grant_refund_with_provided_lines_shipping_and_amount(
 
 
 def test_grant_refund_without_lines_and_amount_and_grant_for_shipping(
-    staff_api_client, permission_manage_orders, order_with_lines
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
     order_id = to_global_id_or_none(order)
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+    charged_amount = Decimal("10.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
         "input": {
             "reason": "Reason",
+            "transactionId": transaction_item_id,
         },
     }
 
@@ -484,18 +605,29 @@ def test_grant_refund_without_lines_and_amount_and_grant_for_shipping(
 
 
 def test_grant_refund_with_incorrect_line_id(
-    staff_api_client, permission_manage_orders, order_with_lines
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
     order_id = to_global_id_or_none(order)
+    charged_amount = Decimal("10.0")
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
         "input": {
             "lines": [
                 {"id": graphene.Node.to_global_id("OrderLine", 1), "quantity": 1}
             ],
+            "transactionId": transaction_item_id,
         },
     }
 
@@ -522,6 +654,7 @@ def test_grant_refund_with_line_that_belongs_to_another_order(
     permission_manage_orders,
     order_with_lines,
     order_with_lines_for_cc,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
@@ -529,10 +662,18 @@ def test_grant_refund_with_line_that_belongs_to_another_order(
     another_order_id = to_global_id_or_none(another_order)
     first_line = order.lines.first()
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+    charged_amount = Decimal("10.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": another_order_id,
         "input": {
             "lines": [{"id": to_global_id_or_none(first_line), "quantity": 1}],
+            "transactionId": transaction_item_id,
         },
     }
 
@@ -558,16 +699,25 @@ def test_grant_refund_with_bigger_quantity_than_available(
     staff_api_client,
     permission_manage_orders,
     order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
     order_id = to_global_id_or_none(order)
     first_line = order.lines.first()
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+    charged_amount = Decimal("10.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
         "input": {
             "lines": [{"id": to_global_id_or_none(first_line), "quantity": 100}],
+            "transactionId": transaction_item_id,
         },
     }
 
@@ -596,15 +746,24 @@ def test_grant_refund_with_refund_for_shipping_already_processed(
     staff_api_client,
     permission_manage_orders,
     order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
     order_id = to_global_id_or_none(order)
     staff_api_client.user.user_permissions.add(permission_manage_orders)
+    charged_amount = Decimal("10.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
     variables = {
         "id": order_id,
         "input": {
             "grantRefundForShipping": True,
+            "transactionId": transaction_item_id,
         },
     }
     order.granted_refunds.create(shipping_costs_included=True)
@@ -629,6 +788,7 @@ def test_grant_refund_with_lines_and_existing_other_grant_refund(
     staff_api_client,
     permission_manage_orders,
     order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
@@ -637,11 +797,20 @@ def test_grant_refund_with_lines_and_existing_other_grant_refund(
     first_line.quantity = 2
     first_line.save(update_fields=["quantity"])
 
+    charged_amount = Decimal("20.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
+
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     variables = {
         "id": order_id,
         "input": {
             "lines": [{"id": to_global_id_or_none(first_line), "quantity": 1}],
+            "transactionId": transaction_item_id,
         },
     }
     granted_refund = order.granted_refunds.create(shipping_costs_included=False)
@@ -679,6 +848,7 @@ def test_grant_refund_with_lines_and_existing_other_grant_and_refund_exceeding_q
     staff_api_client,
     permission_manage_orders,
     order_with_lines,
+    transaction_item_generator,
 ):
     # given
     order = order_with_lines
@@ -687,11 +857,20 @@ def test_grant_refund_with_lines_and_existing_other_grant_and_refund_exceeding_q
     first_line.quantity = 1
     first_line.save(update_fields=["quantity"])
 
+    charged_amount = Decimal("10.0")
+    transaction_item = transaction_item_generator(
+        charged_value=charged_amount, order_id=order.id
+    )
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
+
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     variables = {
         "id": order_id,
         "input": {
             "lines": [{"id": to_global_id_or_none(first_line), "quantity": 1}],
+            "transactionId": transaction_item_id,
         },
     }
     granted_refund = order.granted_refunds.create(shipping_costs_included=False)
@@ -724,17 +903,26 @@ def test_grant_refund_updates_order_charge_status(
     # given
     order = order_with_lines
     order_id = to_global_id_or_none(order)
-    order.payment_transactions.create(
+    amount = Decimal("10.00")
+    authorized_value = Decimal(12)
+    transaction_item = order.payment_transactions.create(
         charged_value=order.total.gross.amount,
-        authorized_value=Decimal(12),
+        authorized_value=authorized_value,
         currency=order_with_lines.currency,
     )
     staff_api_client.user.user_permissions.add(permission_manage_orders)
-    amount = Decimal("10.00")
+    transaction_item_id = graphene.Node.to_global_id(
+        "TransactionItem", transaction_item.token
+    )
+
     reason = "Granted refund reason."
     variables = {
         "id": order_id,
-        "input": {"amount": amount, "reason": reason},
+        "input": {
+            "amount": amount,
+            "reason": reason,
+            "transactionId": transaction_item_id,
+        },
     }
     update_order_charge_data(order)
     assert order.charge_status == OrderChargeStatusEnum.FULL.value

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23855,13 +23855,13 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   grantRefundForShipping: Boolean
 
   """
-  The ID of the transaction item related to the granted refund. If `amount` provided in the input, the transaction.chargedAmount needs to be equal or greater than provided `amount`.If `amount` is not provided in the input and calculated automatically by Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be used.Field will be required starting from Saleor 3.21.
+  The ID of the transaction item related to the granted refund. If `amount` provided in the input, the transaction.chargedAmount needs to be equal or greater than provided `amount`.If `amount` is not provided in the input and calculated automatically by Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be used. Field required starting from Saleor 3.21.
   
   Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
-  transactionId: ID
+  transactionId: ID!
 }
 
 input OrderGrantRefundCreateLineInput @doc(category: "Orders") {


### PR DESCRIPTION
Mark `transactionId` field of `OrderGrantRefundCreateInput` input as required.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
