### PR TITLE
Add GraphQL metrics

### DIFF
--- a/saleor/core/telemetry/__init__.py
+++ b/saleor/core/telemetry/__init__.py
@@ -2,8 +2,7 @@ from importlib import import_module
 from typing import Any
 
 from django.conf import settings
-from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.util.types import Attributes, AttributeValue
+from opentelemetry.util.types import Attributes
 
 from .metric import Meter, MeterProxy, MetricType
 from .trace import Link, SpanKind, Tracer, TracerProxy
@@ -59,8 +58,6 @@ __all__ = [
     "Unit",
     "MetricType",
     "SpanKind",
-    "SpanAttributes",
-    "AttributeValue",
     "Scope",
     "Link",
     "TelemetryTaskContext",

--- a/saleor/core/telemetry/metric.py
+++ b/saleor/core/telemetry/metric.py
@@ -135,9 +135,12 @@ class Meter:
         return get_instrument_method(instrument)(amount, attributes)
 
     @contextmanager
-    def record_duration(self, metric_name: str) -> Iterator[dict[str, AttributeValue]]:
+    def record_duration(
+        self, metric_name: str, attributes: dict[str, AttributeValue] | None = None
+    ) -> Iterator[dict[str, AttributeValue]]:
         start = time.monotonic_ns()
-        attributes: dict[str, AttributeValue] = {}
+        if attributes is None:
+            attributes = {}
         try:
             yield attributes
         finally:

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -185,7 +185,7 @@ class BulkError(BaseObjectType):
 
 class AccountError(Error):
     code = AccountErrorCode(description="The error code.", required=True)
-    address_type = AddressTypeEnum(  # type: ignore[has-type]
+    address_type = AddressTypeEnum(
         description="A type of address that causes the error.", required=False
     )
 
@@ -270,7 +270,7 @@ class CheckoutError(Error):
         description="List of line Ids which cause the error.",
         required=False,
     )
-    address_type = AddressTypeEnum(  # type: ignore[has-type]
+    address_type = AddressTypeEnum(
         description="A type of address that causes the error.", required=False
     )
 
@@ -375,7 +375,7 @@ class OrderError(Error):
         description="List of product variants that are associated with the error",
         required=False,
     )
-    address_type = AddressTypeEnum(  # type: ignore[has-type]
+    address_type = AddressTypeEnum(
         description="A type of address that causes the error.", required=False
     )
 

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -185,7 +185,7 @@ class BulkError(BaseObjectType):
 
 class AccountError(Error):
     code = AccountErrorCode(description="The error code.", required=True)
-    address_type = AddressTypeEnum(
+    address_type = AddressTypeEnum(  # type: ignore[has-type]
         description="A type of address that causes the error.", required=False
     )
 
@@ -270,7 +270,7 @@ class CheckoutError(Error):
         description="List of line Ids which cause the error.",
         required=False,
     )
-    address_type = AddressTypeEnum(
+    address_type = AddressTypeEnum(  # type: ignore[has-type]
         description="A type of address that causes the error.", required=False
     )
 
@@ -375,7 +375,7 @@ class OrderError(Error):
         description="List of product variants that are associated with the error",
         required=False,
     )
-    address_type = AddressTypeEnum(
+    address_type = AddressTypeEnum(  # type: ignore[has-type]
         description="A type of address that causes the error.", required=False
     )
 

--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -14,6 +14,7 @@ METRIC_GRAPHQL_QUERY_COUNT = meter.create_metric(
     unit=Unit.REQUEST,
     description="Number of GraphQL queries.",
 )
+
 METRIC_GRAPHQL_QUERY_DURATION = meter.create_metric(
     "saleor.graphql.query_duration",
     scope=Scope.SERVICE,
@@ -21,6 +22,7 @@ METRIC_GRAPHQL_QUERY_DURATION = meter.create_metric(
     unit=Unit.MILLISECOND,
     description="Duration of GraphQL queries.",
 )
+
 METRIC_GRAPHQL_QUERY_COST = meter.create_metric(
     "saleor.graphql.query_cost",
     scope=Scope.SERVICE,
@@ -32,16 +34,16 @@ METRIC_GRAPHQL_QUERY_COST = meter.create_metric(
 
 # Helper functions
 def record_graphql_query_count(
-    operation_name: str = "",
-    operation_type: str = "",
-    operation_identifier: str = "",
     amount: int = 1,
+    operation_name: str | None = "",
+    operation_type: str | None = "",
+    operation_identifier: str | None = "",
     error_type: str | None = None,
 ) -> None:
     attributes = {
-        saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier,
-        graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name,
-        graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type,
+        saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier or "",
+        graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name or "",
+        graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type or "",
     }
     if error_type:
         attributes[error_attributes.ERROR_TYPE] = error_type

--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -8,7 +8,7 @@ from ..core.telemetry import MetricType, Scope, Unit, meter, saleor_attributes
 
 # Initialize metrics
 METRIC_GRAPHQL_QUERY_COUNT = meter.create_metric(
-    "saleor.graphql.query_count",
+    "saleor.graphql.operation.count",
     scope=Scope.SERVICE,
     type=MetricType.COUNTER,
     unit=Unit.REQUEST,
@@ -16,15 +16,15 @@ METRIC_GRAPHQL_QUERY_COUNT = meter.create_metric(
 )
 
 METRIC_GRAPHQL_QUERY_DURATION = meter.create_metric(
-    "saleor.graphql.query_duration",
+    "saleor.graphql.operation.duration",
     scope=Scope.SERVICE,
     type=MetricType.HISTOGRAM,
-    unit=Unit.MILLISECOND,
+    unit=Unit.SECOND,
     description="Duration of GraphQL queries.",
 )
 
 METRIC_GRAPHQL_QUERY_COST = meter.create_metric(
-    "saleor.graphql.query_cost",
+    "saleor.graphql.operation.cost",
     scope=Scope.SERVICE,
     type=MetricType.HISTOGRAM,
     unit=Unit.REQUEST,

--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -61,3 +61,20 @@ def record_graphql_query_duration() -> AbstractContextManager[
         saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
     }
     return meter.record_duration(METRIC_GRAPHQL_QUERY_DURATION, attributes=attributes)
+
+
+def record_graphql_query_cost(
+    cost: int,
+    operation_name: str | None = "",
+    operation_type: str | None = "",
+    operation_identifier: str | None = "",
+    error_type: str | None = None,
+) -> None:
+    attributes = {
+        saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier or "",
+        graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name or "",
+        graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type or "",
+    }
+    if error_type:
+        attributes[error_attributes.ERROR_TYPE] = error_type
+    meter.record(METRIC_GRAPHQL_QUERY_COST, cost, Unit.REQUEST, attributes=attributes)

--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -1,6 +1,7 @@
 from contextlib import AbstractContextManager
 
 from opentelemetry.semconv._incubating.attributes import graphql_attributes
+from opentelemetry.semconv.attributes import error_attributes
 from opentelemetry.util.types import AttributeValue
 
 from ..core.telemetry import MetricType, Scope, Unit, meter, saleor_attributes
@@ -31,12 +32,19 @@ METRIC_GRAPHQL_QUERY_COST = meter.create_metric(
 
 # Helper functions
 def record_graphql_query_count(
-    identifier: str, operation_type: str, amount: int = 1
+    operation_name: str = "",
+    operation_type: str = "",
+    operation_identifier: str = "",
+    amount: int = 1,
+    error_type: str | None = None,
 ) -> None:
     attributes = {
-        saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: identifier,
+        saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier,
+        graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name,
         graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type,
     }
+    if error_type:
+        attributes[error_attributes.ERROR_TYPE] = error_type
     meter.record(
         METRIC_GRAPHQL_QUERY_COUNT, amount, Unit.REQUEST, attributes=attributes
     )
@@ -45,4 +53,9 @@ def record_graphql_query_count(
 def record_graphql_query_duration() -> AbstractContextManager[
     dict[str, AttributeValue]
 ]:
-    return meter.record_duration(METRIC_GRAPHQL_QUERY_DURATION)
+    attributes: dict[str, AttributeValue] = {
+        graphql_attributes.GRAPHQL_OPERATION_NAME: "",
+        graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
+        saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
+    }
+    return meter.record_duration(METRIC_GRAPHQL_QUERY_DURATION, attributes=attributes)

--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -1,0 +1,48 @@
+from contextlib import AbstractContextManager
+
+from opentelemetry.semconv._incubating.attributes import graphql_attributes
+from opentelemetry.util.types import AttributeValue
+
+from ..core.telemetry import MetricType, Scope, Unit, meter, saleor_attributes
+
+# Initialize metrics
+METRIC_GRAPHQL_QUERY_COUNT = meter.create_metric(
+    "saleor.graphql.query_count",
+    scope=Scope.SERVICE,
+    type=MetricType.COUNTER,
+    unit=Unit.REQUEST,
+    description="Number of GraphQL queries.",
+)
+METRIC_GRAPHQL_QUERY_DURATION = meter.create_metric(
+    "saleor.graphql.query_duration",
+    scope=Scope.SERVICE,
+    type=MetricType.HISTOGRAM,
+    unit=Unit.MILLISECOND,
+    description="Duration of GraphQL queries.",
+)
+METRIC_GRAPHQL_QUERY_COST = meter.create_metric(
+    "saleor.graphql.query_cost",
+    scope=Scope.SERVICE,
+    type=MetricType.HISTOGRAM,
+    unit=Unit.REQUEST,
+    description="Cost of GraphQL queries.",
+)
+
+
+# Helper functions
+def record_graphql_query_count(
+    identifier: str, operation_type: str, amount: int = 1
+) -> None:
+    attributes = {
+        saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: identifier,
+        graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type,
+    }
+    meter.record(
+        METRIC_GRAPHQL_QUERY_COUNT, amount, Unit.REQUEST, attributes=attributes
+    )
+
+
+def record_graphql_query_duration() -> AbstractContextManager[
+    dict[str, AttributeValue]
+]:
+    return meter.record_duration(METRIC_GRAPHQL_QUERY_DURATION)

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -51,6 +51,9 @@ This query will have cost of 200 (100 x 2 for each product):
 { products(first: 100) { complexity } }
 """
 
+# GraphQL operations that fail before cost can be calculated have a fixed cost of 1.
+QUERY_COST_FAILED_OPERATION = 1
+
 COST_MAP = {
     "Query": {
         "address": {"complexity": 1},

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -199,14 +199,18 @@ def test_graphql_query_record_metrics_invalid_query(
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
         },
     )
+    assert (
+        call(error_attributes.ERROR_TYPE, error_type)
+        in mock_meter.record_duration().__enter__().__setitem__.call_args_list
+    )
     if operation_type:
         assert (
-            call("graphql.operation.type", operation_type)
+            call(graphql_attributes.GRAPHQL_OPERATION_TYPE, operation_type)
             in mock_meter.record_duration().__enter__().__setitem__.call_args_list
         )
     if operation_identifier:
         assert (
-            call("graphql.operation.identifier", operation_identifier)
+            call(saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER, operation_identifier)
             in mock_meter.record_duration().__enter__().__setitem__.call_args_list
         )
 
@@ -276,10 +280,14 @@ def test_graphql_query_record_metrics_cost_exceeded(
         },
     )
     assert (
-        call("graphql.operation.type", "query")
+        call(error_attributes.ERROR_TYPE, "QueryCostError")
         in mock_meter.record_duration().__enter__().__setitem__.call_args_list
     )
     assert (
-        call("graphql.operation.identifier", "productVariant")
+        call(graphql_attributes.GRAPHQL_OPERATION_TYPE, "query")
+        in mock_meter.record_duration().__enter__().__setitem__.call_args_list
+    )
+    assert (
+        call(saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER, "productVariant")
         in mock_meter.record_duration().__enter__().__setitem__.call_args_list
     )

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -1,14 +1,20 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
+import graphene
+import pytest
+from django.test import override_settings
 from opentelemetry.semconv._incubating.attributes import graphql_attributes
+from opentelemetry.semconv.attributes import error_attributes
 
 from ...core.telemetry import Unit, saleor_attributes
+from ...graphql.api import backend, schema
 from ..metrics import (
     METRIC_GRAPHQL_QUERY_COUNT,
     METRIC_GRAPHQL_QUERY_DURATION,
     record_graphql_query_count,
     record_graphql_query_duration,
 )
+from ..views import GraphQLView
 
 
 @patch("saleor.graphql.metrics.meter")
@@ -50,3 +56,190 @@ def test_record_graphql_query_duration(mock_meter):
         METRIC_GRAPHQL_QUERY_DURATION, attributes=call_attributes
     )
     assert result == mock_context_manager
+
+
+@patch("saleor.graphql.metrics.meter")
+def test_graphql_query_record_metrics(mock_meter, rf):
+    # given
+    request = rf.post(
+        path="/graphql",
+        data={
+            "query": "query shopQuery { shop { name } }",
+            "operationName": "shopQuery",
+        },
+        content_type="application/json",
+    )
+
+    # when
+    view = GraphQLView.as_view(backend=backend, schema=schema)
+    view(request)
+
+    # then
+    mock_meter.record.assert_called_once_with(
+        METRIC_GRAPHQL_QUERY_COUNT,
+        1,
+        Unit.REQUEST,
+        attributes={
+            saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "shop",
+            graphql_attributes.GRAPHQL_OPERATION_NAME: "shopQuery",
+            graphql_attributes.GRAPHQL_OPERATION_TYPE: "query",
+        },
+    )
+
+    mock_meter.record_duration.assert_called_once_with(
+        METRIC_GRAPHQL_QUERY_DURATION,
+        attributes={
+            saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
+            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
+            graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
+        },
+    )
+    set_attr_calls = mock_meter.record_duration().__enter__().__setitem__.call_args_list
+    assert call("graphql.operation.identifier", "shop") in set_attr_calls
+    assert call("graphql.operation.name", "shopQuery") in set_attr_calls
+    assert call("graphql.operation.type", "query") in set_attr_calls
+
+
+@pytest.mark.parametrize(
+    ("data", "error_type", "operation_name", "operation_type", "operation_identifier"),
+    [
+        ("", "GraphQLError", "", "", ""),
+        (
+            {"query": "{"},
+            "GraphQLSyntaxError",
+            "",
+            "",
+            "",
+        ),
+        (
+            {
+                "query": "query { ... { __schema { __typename } } ... { shop { name } } }"
+            },
+            "GraphQLError",
+            "",
+            "",
+            "",
+        ),
+        (
+            {"query": "{ products(first: 9999999999) { edges { node { id } } } }"},
+            "GraphQLError",
+            "",
+            "query",
+            "products",
+        ),
+    ],
+)
+@patch("saleor.graphql.metrics.meter")
+def test_graphql_query_record_metrics_invalid_query(
+    mock_meter,
+    data,
+    error_type,
+    operation_name,
+    operation_type,
+    operation_identifier,
+    rf,
+):
+    # given
+    request = rf.post(
+        path="/graphql",
+        data=data,
+        content_type="application/json",
+    )
+
+    # when
+    view = GraphQLView.as_view(backend=backend, schema=schema)
+    view(request)
+
+    # then
+    mock_meter.record.assert_called_once_with(
+        METRIC_GRAPHQL_QUERY_COUNT,
+        1,
+        Unit.REQUEST,
+        attributes={
+            saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier,
+            graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name,
+            graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type,
+            error_attributes.ERROR_TYPE: error_type,
+        },
+    )
+
+    mock_meter.record_duration.assert_called_once_with(
+        METRIC_GRAPHQL_QUERY_DURATION,
+        attributes={
+            saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
+            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
+            graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
+        },
+    )
+    if operation_type:
+        assert (
+            call("graphql.operation.type", operation_type)
+            in mock_meter.record_duration().__enter__().__setitem__.call_args_list
+        )
+    if operation_identifier:
+        assert (
+            call("graphql.operation.identifier", operation_identifier)
+            in mock_meter.record_duration().__enter__().__setitem__.call_args_list
+        )
+
+
+@override_settings(GRAPHQL_QUERY_MAX_COMPLEXITY=1)
+@patch("saleor.graphql.metrics.meter")
+def test_graphql_query_record_metrics_cost_exceeded(
+    mock_meter,
+    api_client,
+    variant_with_many_stocks,
+    channel_USD,
+):
+    # given
+    query_fields = "\n".join(
+        [
+            f"p{i}:  productVariant(id: $id, channel: $channel) {{ id }}"
+            for i in range(20)
+        ]
+    )
+    query = f"""
+        query variantAvailability($id: ID!, $channel: String) {{
+            {query_fields}
+        }}
+    """
+
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant_with_many_stocks.pk),
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    api_client.post_graphql(query, variables)
+
+    # then
+    # check that saleor.graphql.query_count is recorded
+    mock_meter.record.assert_called_once_with(
+        METRIC_GRAPHQL_QUERY_COUNT,
+        1,
+        Unit.REQUEST,
+        attributes={
+            saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "productVariant",
+            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
+            graphql_attributes.GRAPHQL_OPERATION_TYPE: "query",
+            error_attributes.ERROR_TYPE: "QueryCostError",
+        },
+    )
+
+    # check that saleor.graphql.query_duration is recorded and has correct attributes
+    mock_meter.record_duration.assert_called_once_with(
+        METRIC_GRAPHQL_QUERY_DURATION,
+        attributes={
+            saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
+            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
+            graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
+        },
+    )
+    assert (
+        call("graphql.operation.type", "query")
+        in mock_meter.record_duration().__enter__().__setitem__.call_args_list
+    )
+    assert (
+        call("graphql.operation.identifier", "productVariant")
+        in mock_meter.record_duration().__enter__().__setitem__.call_args_list
+    )

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -77,7 +77,7 @@ def test_graphql_query_record_metrics(mock_meter, rf, channel_USD, product_list)
     view(request)
 
     # then
-    # check that saleor.graphql.query_count is recorded
+    # check that saleor.graphql.operation.count is recorded
     mock_meter.record.assert_any_call(
         METRIC_GRAPHQL_QUERY_COUNT,
         1,
@@ -89,7 +89,7 @@ def test_graphql_query_record_metrics(mock_meter, rf, channel_USD, product_list)
         },
     )
 
-    # check that saleor.graphql.query_cost is recorded
+    # check that saleor.graphql.operation.cost is recorded
     mock_meter.record.assert_any_call(
         METRIC_GRAPHQL_QUERY_COST,
         5,
@@ -101,7 +101,7 @@ def test_graphql_query_record_metrics(mock_meter, rf, channel_USD, product_list)
         },
     )
 
-    # check that saleor.graphql.query_duration is recorded and has correct attributes
+    # check that saleor.graphql.operation.duration is recorded and has correct attributes
     mock_meter.record_duration.assert_called_once_with(
         METRIC_GRAPHQL_QUERY_DURATION,
         attributes={
@@ -245,7 +245,7 @@ def test_graphql_query_record_metrics_cost_exceeded(
     api_client.post_graphql(query, variables)
 
     # then
-    # check that saleor.graphql.query_count is recorded
+    # check that saleor.graphql.operation.count is recorded
     mock_meter.record.assert_any_call(
         METRIC_GRAPHQL_QUERY_COUNT,
         1,
@@ -270,7 +270,7 @@ def test_graphql_query_record_metrics_cost_exceeded(
         },
     )
 
-    # check that saleor.graphql.query_duration is recorded and has correct attributes
+    # check that saleor.graphql.operation.duration is recorded and has correct attributes
     mock_meter.record_duration.assert_called_once_with(
         METRIC_GRAPHQL_QUERY_DURATION,
         attributes={

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from ...core.telemetry import Unit
+from ...core.telemetry.attributes import (
+    SALEOR_GRAPHQL_IDENTIFIER,
+    SALEOR_GRAPHQL_OPERATION_TYPE,
+)
+from ..metrics import (
+    METRIC_GRAPHQL_QUERY_COUNT,
+    METRIC_GRAPHQL_QUERY_DURATION,
+    record_graphql_query_count,
+    record_graphql_query_duration,
+)
+
+
+@patch("saleor.graphql.metrics.meter")
+def test_record_graphql_query_count(mock_meter):
+    # when
+    record_graphql_query_count("identifier", "query", 5)
+
+    # then
+    mock_meter.record.assert_called_once_with(
+        METRIC_GRAPHQL_QUERY_COUNT,
+        5,
+        Unit.REQUEST,
+        attributes={
+            SALEOR_GRAPHQL_IDENTIFIER: "identifier",
+            SALEOR_GRAPHQL_OPERATION_TYPE: "query",
+        },
+    )
+
+
+@patch("saleor.graphql.metrics.meter")
+def test_record_graphql_query_duration(mock_meter):
+    # given
+    mock_context_manager = object()
+    mock_meter.record_duration.return_value = mock_context_manager
+
+    # when
+    result = record_graphql_query_duration()
+
+    # then
+    mock_meter.record_duration.assert_called_once_with(METRIC_GRAPHQL_QUERY_DURATION)
+    assert result == mock_context_manager

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import traceback
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 from uuid import UUID
 
 import graphene
@@ -55,6 +55,12 @@ AVAILABLE_SOURCE_SERVICE_NAMES_FOR_SPAN_TAG = {
 }
 
 INTERNAL_ERROR_MESSAGE = "Internal Server Error"
+
+# When reporting GraphQL metrics, the identifier or operation_type may be unknown in some
+# cases, e.g. when query parsing fails. We still want to report these cases, so we
+# define constants for them.
+GRAPHQL_IDENTIFIER_UNKNOWN: Final = "UNKNOWN"
+GRAPHQL_OPERATION_TYPE_UNKNOWN: Final = "UNKNOWN"
 
 
 def resolve_global_ids_to_primary_keys(
@@ -208,7 +214,7 @@ def requestor_is_superuser(requestor):
 
 
 def query_identifier(document: GraphQLDocument) -> str:
-    """Generate a fingerprint for a GraphQL query.
+    """Generate a identifier for a GraphQL query.
 
     For queries identifier is sorted set of all root objects separated by `,`.
     e.g
@@ -250,13 +256,13 @@ def query_identifier(document: GraphQLDocument) -> str:
             for selection in selections:
                 labels.append(selection.name.value)
     if not labels:
-        return "undefined"
+        return GRAPHQL_IDENTIFIER_UNKNOWN
     return ", ".join(sorted(set(labels)))
 
 
 def query_fingerprint(document: GraphQLDocument) -> str:
     """Generate a fingerprint for a GraphQL query."""
-    label = "unknown"
+    label = GRAPHQL_IDENTIFIER_UNKNOWN
     for definition in document.document_ast.definitions:
         if getattr(definition, "operation", None) in {
             "query",
@@ -270,6 +276,10 @@ def query_fingerprint(document: GraphQLDocument) -> str:
             break
     query_hash = hashlib.md5(document.document_string.encode("utf-8")).hexdigest()
     return f"{label}:{query_hash}"
+
+
+def query_operation_type(fingerprint: str) -> str:
+    return fingerprint.split(":")[0]
 
 
 def format_error(error, handled_exceptions, query=None):

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import traceback
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import graphene
@@ -55,12 +55,6 @@ AVAILABLE_SOURCE_SERVICE_NAMES_FOR_SPAN_TAG = {
 }
 
 INTERNAL_ERROR_MESSAGE = "Internal Server Error"
-
-# When reporting GraphQL metrics, the identifier or operation_type may be unknown in some
-# cases, e.g. when query parsing fails. We still want to report these cases, so we
-# define constants for them.
-GRAPHQL_IDENTIFIER_UNKNOWN: Final = "UNKNOWN"
-GRAPHQL_OPERATION_TYPE_UNKNOWN: Final = "UNKNOWN"
 
 
 def resolve_global_ids_to_primary_keys(
@@ -256,13 +250,13 @@ def query_identifier(document: GraphQLDocument) -> str:
             for selection in selections:
                 labels.append(selection.name.value)
     if not labels:
-        return GRAPHQL_IDENTIFIER_UNKNOWN
+        return "undefined"
     return ", ".join(sorted(set(labels)))
 
 
 def query_fingerprint(document: GraphQLDocument) -> str:
     """Generate a fingerprint for a GraphQL query."""
-    label = GRAPHQL_IDENTIFIER_UNKNOWN
+    label = "unknown"
     for definition in document.document_ast.definitions:
         if getattr(definition, "operation", None) in {
             "query",
@@ -276,10 +270,6 @@ def query_fingerprint(document: GraphQLDocument) -> str:
             break
     query_hash = hashlib.md5(document.document_string.encode("utf-8")).hexdigest()
     return f"{label}:{query_hash}"
-
-
-def query_operation_type(fingerprint: str) -> str:
-    return fingerprint.split(":")[0]
 
 
 def format_error(error, handled_exceptions, query=None):

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -41,8 +41,6 @@ from .metrics import (
 )
 from .query_cost_map import COST_MAP
 from .utils import (
-    GRAPHQL_IDENTIFIER_UNKNOWN,
-    GRAPHQL_OPERATION_TYPE_UNKNOWN,
     format_error,
     get_source_service_name_value,
     query_fingerprint,
@@ -272,7 +270,7 @@ class GraphQLView(View):
             tracer.start_as_current_span(
                 "GraphQL Operation", scope=Scope.SERVICE
             ) as span,
-            record_graphql_query_duration(),
+            record_graphql_query_duration() as query_duration_attrs,
         ):
             span.set_attribute(saleor_attributes.OPERATION_NAME, "graphql_query")
             span.set_attribute(saleor_attributes.COMPONENT, "graphql")
@@ -287,47 +285,56 @@ class GraphQLView(View):
 
             if error or document is None:
                 error_description = self.format_span_error_description(error)
-                span.set_status(status=StatusCode.ERROR, description=error_description)
-                record_graphql_query_count(
-                    identifier=GRAPHQL_IDENTIFIER_UNKNOWN,
-                    operation_type=GRAPHQL_OPERATION_TYPE_UNKNOWN,
+                error_type = (
+                    error.errors[0].__class__.__name__
+                    if error and error.errors
+                    else None
                 )
+                span.set_status(status=StatusCode.ERROR, description=error_description)
+                record_graphql_query_count(error_type=error_type)
                 return error
 
             try:
                 query_contains_schema = check_if_query_contains_only_schema(document)
             except GraphQLError as e:
                 span.set_status(status=StatusCode.ERROR, description=str(e))
-                record_graphql_query_count(
-                    identifier=GRAPHQL_IDENTIFIER_UNKNOWN,
-                    operation_type=GRAPHQL_OPERATION_TYPE_UNKNOWN,
-                )
+                record_graphql_query_count(error_type=e.__class__.__name__)
                 return ExecutionResult(errors=[e], invalid=True)
 
             # Query identifier and fingerprint cannot be calculated earlier, as they
             # require a parsed and valid GraphQL document.
-            _query_identifier = query_identifier(document)
-            _query_fingerprint = query_fingerprint(document)
+            operation_identifier = query_identifier(document)
+            operation_fingerprint = query_fingerprint(document)
+            operation_type = document.get_operation_type(operation_name)
 
-            self._query = _query_identifier
+            self._query = operation_identifier
             raw_query_string = document.document_string
             span.update_name(raw_query_string)
             span.set_attribute(graphql_attributes.GRAPHQL_DOCUMENT, raw_query_string)
-            if operation_type := document.get_operation_type(operation_name):
+            if operation_type:
                 span.set_attribute(
                     graphql_attributes.GRAPHQL_OPERATION_TYPE, operation_type
+                )
+                query_duration_attrs[graphql_attributes.GRAPHQL_OPERATION_TYPE] = (
+                    operation_type
                 )
             if operation_name:
                 span.set_attribute(
                     graphql_attributes.GRAPHQL_OPERATION_NAME, operation_name
                 )
+                query_duration_attrs[graphql_attributes.GRAPHQL_OPERATION_NAME] = (
+                    operation_name
+                )
 
             span.set_attribute(
-                saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER, _query_identifier
+                saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER, operation_identifier
+            )
+            query_duration_attrs[saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER] = (
+                operation_identifier
             )
             span.set_attribute(
                 saleor_attributes.GRAPHQL_DOCUMENT_FINGERPRINT,
-                _query_fingerprint,
+                operation_fingerprint,
             )
 
             source_service_name = get_source_service_name_value(
@@ -352,7 +359,10 @@ class GraphQLView(View):
                 error_description = self.format_span_error_description(result)
                 span.set_status(status=StatusCode.ERROR, description=error_description)
                 record_graphql_query_count(
-                    identifier=_query_identifier, operation_type=operation_type or ""
+                    operation_name=operation_name or "",
+                    operation_identifier=operation_identifier,
+                    operation_type=operation_type or "",
+                    error_type=cost_errors[0].__class__.__name__,
                 )
                 return set_query_cost_on_result(result, query_cost)
 
@@ -370,6 +380,7 @@ class GraphQLView(View):
 
             try:
                 response = None
+                error_type = None
                 should_use_cache_for_scheme = query_contains_schema & (
                     not settings.DEBUG
                 )
@@ -387,6 +398,7 @@ class GraphQLView(View):
                         **extra_options,
                     )
                     if response.errors:
+                        error_type = response.errors[0].__class__.__name__
                         error_description = self.format_span_error_description(response)
                         span.set_status(
                             status=StatusCode.ERROR, description=error_description
@@ -395,6 +407,12 @@ class GraphQLView(View):
                     if should_use_cache_for_scheme:
                         cache.set(key, response)
 
+                record_graphql_query_count(
+                    operation_name=operation_name or "",
+                    operation_identifier=operation_identifier,
+                    operation_type=operation_type or "",
+                    error_type=error_type,
+                )
                 return set_query_cost_on_result(response, query_cost)
             except Exception as e:
                 span.set_status(status=StatusCode.ERROR, description=str(e))
@@ -404,11 +422,14 @@ class GraphQLView(View):
                 # As it's a validation error we want to raise GraphQLError instead.
                 if str(e).startswith(INT_ERROR_MSG) or isinstance(e, ValueError):
                     e = GraphQLError(str(e))
+                record_graphql_query_count(
+                    operation_name=operation_name or "",
+                    operation_identifier=operation_identifier,
+                    operation_type=operation_type or "",
+                    error_type=e.__class__.__name__,
+                )
                 return ExecutionResult(errors=[e], invalid=True)
             finally:
-                record_graphql_query_count(
-                    identifier=_query_identifier, operation_type=operation_type or ""
-                )
                 clear_context(context)
 
     @staticmethod

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -359,9 +359,9 @@ class GraphQLView(View):
                 error_description = self.format_span_error_description(result)
                 span.set_status(status=StatusCode.ERROR, description=error_description)
                 record_graphql_query_count(
-                    operation_name=operation_name or "",
+                    operation_name=operation_name,
                     operation_identifier=operation_identifier,
-                    operation_type=operation_type or "",
+                    operation_type=operation_type,
                     error_type=cost_errors[0].__class__.__name__,
                 )
                 return set_query_cost_on_result(result, query_cost)
@@ -408,9 +408,9 @@ class GraphQLView(View):
                         cache.set(key, response)
 
                 record_graphql_query_count(
-                    operation_name=operation_name or "",
+                    operation_name=operation_name,
                     operation_identifier=operation_identifier,
-                    operation_type=operation_type or "",
+                    operation_type=operation_type,
                     error_type=error_type,
                 )
                 return set_query_cost_on_result(response, query_cost)
@@ -423,9 +423,9 @@ class GraphQLView(View):
                 if str(e).startswith(INT_ERROR_MSG) or isinstance(e, ValueError):
                     e = GraphQLError(str(e))
                 record_graphql_query_count(
-                    operation_name=operation_name or "",
+                    operation_name=operation_name,
                     operation_identifier=operation_identifier,
-                    operation_type=operation_type or "",
+                    operation_type=operation_type,
                     error_type=e.__class__.__name__,
                 )
                 return ExecutionResult(errors=[e], invalid=True)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -370,7 +370,7 @@ class GraphQLView(View):
                 result = ExecutionResult(errors=cost_errors, invalid=True)
                 error_description = self.format_span_error_description(result)
                 span.set_status(status=StatusCode.ERROR, description=error_description)
-                error_type = cost_errors[0].__class__.__name__
+                error_type = cost_errors[0].__class__.__name__ if cost_errors else None
                 record_graphql_query_count(
                     operation_name=operation_name,
                     operation_identifier=operation_identifier,
@@ -384,7 +384,8 @@ class GraphQLView(View):
                     operation_type=operation_type,
                     error_type=error_type,
                 )
-                query_duration_attrs[error_attributes.ERROR_TYPE] = error_type
+                if error_type:
+                    query_duration_attrs[error_attributes.ERROR_TYPE] = error_type
                 return set_query_cost_on_result(result, query_cost)
 
             extra_options: dict[str, Any | None] = {}


### PR DESCRIPTION
This PR adds new GraphQL metrics in the GraphQL view:
- `saleor.graphql.query_count` - to track the number of GraphQL queries
- `saleor.graphql.query_duration` - to track the duration of query execution
- `saleor.graphql.query_cost` - to track the query cost 

Metrics consistently use the same attributes:
- `graphql.operation.name` - name of the query (as in the `operationName` passed to the GraphQL request)
- `graphql.operation.type` - type of the query ("query", "mutation" or "subscription")
- `saleor.graphql.identifier` - sorted set of all root objects, calculated from query fingeprint

Metrics are tracked for failed and successful requests separately. For example, the GraphQL view has a few paths where it returns a "failed" response - each is recorded separately with the "error.type" metric attribute set, which indicates the type of error.

In a separate PR I'll add support for calculate this metrics when generating GraphQL payload for subscription webhooks.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
