### PR TITLE
[PoC] Ability to define conditions for triggering the webhook

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -29977,6 +29977,7 @@ type Subscription @doc(category: "Miscellaneous") {
     List of channel slugs. The event will be sent only if the object belongs to one of the provided channels. If the channel slug list is empty, objects that belong to any channel will be sent. Maximally 500 items.
     """
     channels: [String!]
+    requires: [Requirement!]
   ): CheckoutUpdated @doc(category: "Checkout")
 
   """
@@ -30006,6 +30007,15 @@ type Subscription @doc(category: "Miscellaneous") {
     """
     channels: [String!]
   ): CheckoutMetadataUpdated @doc(category: "Checkout")
+
+  """
+  Event sent when taxes are calculated.
+  
+  Added in Saleor 3.21.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  calculateTaxes(requires: [Requirement!]): CalculateTaxes @doc(category: "Taxes")
 }
 
 interface Event {
@@ -30332,6 +30342,13 @@ type CheckoutUpdated implements Event @doc(category: "Checkout") {
   checkout: Checkout
 }
 
+enum Requirement {
+  HAS_SHIPPING_ADDRESS
+  HAS_BILLING_ADDRESS
+  HAS_LINES
+  HAS_DELIVERY_METHOD
+}
+
 """
 Event sent when checkout is fully paid with transactions. The checkout is considered as fully paid when the checkout `charge_status` is `FULL` or `OVERCHARGED`. The event is not sent when the checkout authorization flow strategy is used.
 """
@@ -30369,6 +30386,103 @@ type CheckoutMetadataUpdated implements Event @doc(category: "Checkout") {
   """The checkout the event relates to."""
   checkout: Checkout
 }
+
+"""Synchronous webhook for calculating checkout/order taxes."""
+type CalculateTaxes implements Event @doc(category: "Taxes") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+  taxBase: TaxableObject!
+}
+
+"""Taxable object."""
+type TaxableObject @doc(category: "Taxes") {
+  """The source object related to this tax object."""
+  sourceObject: TaxSourceObject!
+
+  """Determines if prices contain entered tax.."""
+  pricesEnteredWithTax: Boolean!
+
+  """The currency of the object."""
+  currency: String!
+
+  """
+  The price of shipping method, includes shipping voucher discount if applied.
+  """
+  shippingPrice: Money!
+
+  """The address data."""
+  address: Address
+
+  """List of discounts."""
+  discounts: [TaxableObjectDiscount!]!
+
+  """List of lines assigned to the object."""
+  lines: [TaxableObjectLine!]!
+  channel: Channel!
+}
+
+"""Taxable object discount."""
+type TaxableObjectDiscount @doc(category: "Taxes") {
+  """The name of the discount."""
+  name: String
+
+  """The amount of the discount."""
+  amount: Money!
+
+  """
+  Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
+  """
+  type: TaxableObjectDiscountTypeEnum!
+}
+
+"""
+Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
+"""
+enum TaxableObjectDiscountTypeEnum @doc(category: "Taxes") {
+  SUBTOTAL
+  SHIPPING
+}
+
+type TaxableObjectLine @doc(category: "Taxes") {
+  """The source line related to this tax line."""
+  sourceLine: TaxSourceLine!
+
+  """Number of items."""
+  quantity: Int!
+
+  """Determines if taxes are being charged for the product."""
+  chargeTaxes: Boolean!
+
+  """The product name."""
+  productName: String!
+
+  """The variant name."""
+  variantName: String!
+
+  """The product sku."""
+  productSku: String
+
+  """
+  Price of the single item in the order line. The price includes catalogue promotions, specific product and applied once per order voucher discounts. The price does not include the entire order discount.
+  """
+  unitPrice: Money!
+
+  """
+  Price of the order line. The price includes catalogue promotions, specific product and applied once per order voucher discounts. The price does not include the entire order discount.
+  """
+  totalPrice: Money!
+}
+
+union TaxSourceLine = CheckoutLine | OrderLine
 
 enum DistanceUnitsEnum {
   MM
@@ -33145,103 +33259,6 @@ type ShippingListMethodsForCheckout implements Event @doc(category: "Checkout") 
   """Shipping methods that can be used with this checkout."""
   shippingMethods: [ShippingMethod!]
 }
-
-"""Synchronous webhook for calculating checkout/order taxes."""
-type CalculateTaxes implements Event @doc(category: "Taxes") {
-  """Time of the event."""
-  issuedAt: DateTime
-
-  """Saleor version that triggered the event."""
-  version: String
-
-  """The user or application that triggered the event."""
-  issuingPrincipal: IssuingPrincipal
-
-  """The application receiving the webhook."""
-  recipient: App
-  taxBase: TaxableObject!
-}
-
-"""Taxable object."""
-type TaxableObject @doc(category: "Taxes") {
-  """The source object related to this tax object."""
-  sourceObject: TaxSourceObject!
-
-  """Determines if prices contain entered tax.."""
-  pricesEnteredWithTax: Boolean!
-
-  """The currency of the object."""
-  currency: String!
-
-  """
-  The price of shipping method, includes shipping voucher discount if applied.
-  """
-  shippingPrice: Money!
-
-  """The address data."""
-  address: Address
-
-  """List of discounts."""
-  discounts: [TaxableObjectDiscount!]!
-
-  """List of lines assigned to the object."""
-  lines: [TaxableObjectLine!]!
-  channel: Channel!
-}
-
-"""Taxable object discount."""
-type TaxableObjectDiscount @doc(category: "Taxes") {
-  """The name of the discount."""
-  name: String
-
-  """The amount of the discount."""
-  amount: Money!
-
-  """
-  Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
-  """
-  type: TaxableObjectDiscountTypeEnum!
-}
-
-"""
-Indicates which part of the order the discount should affect: SUBTOTAL or SHIPPING.
-"""
-enum TaxableObjectDiscountTypeEnum @doc(category: "Taxes") {
-  SUBTOTAL
-  SHIPPING
-}
-
-type TaxableObjectLine @doc(category: "Taxes") {
-  """The source line related to this tax line."""
-  sourceLine: TaxSourceLine!
-
-  """Number of items."""
-  quantity: Int!
-
-  """Determines if taxes are being charged for the product."""
-  chargeTaxes: Boolean!
-
-  """The product name."""
-  productName: String!
-
-  """The variant name."""
-  variantName: String!
-
-  """The product sku."""
-  productSku: String
-
-  """
-  Price of the single item in the order line. The price includes catalogue promotions, specific product and applied once per order voucher discounts. The price does not include the entire order discount.
-  """
-  unitPrice: Money!
-
-  """
-  Price of the order line. The price includes catalogue promotions, specific product and applied once per order voucher discounts. The price does not include the entire order discount.
-  """
-  totalPrice: Money!
-}
-
-union TaxSourceLine = CheckoutLine | OrderLine
 
 """Event sent when user wants to initialize the payment gateway."""
 type PaymentGatewayInitializeSession implements Event @doc(category: "Payments") {

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -2594,7 +2594,15 @@ class WarehouseMetadataUpdated(SubscriptionObjectType, WarehouseBase):
         description = "Event sent when warehouse metadata is updated."
 
 
+def default_resolver(root, info, requires=None):
+    return Observable.from_([root])
+
+
 def default_channel_filterable_resolver(root, info, channels=None):
+    return Observable.from_([root])
+
+
+def checkout_updated_resolver(root, info, channels=None, requires=None):
     return Observable.from_([root])
 
 
@@ -2607,6 +2615,13 @@ channels_argument = graphene.Argument(
         f"{MAX_FILTERABLE_CHANNEL_SLUGS_LIMIT} items."
     ),
 )
+
+
+class Requirement(graphene.Enum):
+    HAS_SHIPPING_ADDRESS = "HAS_SHIPPING_ADDRESS"
+    HAS_BILLING_ADDRESS = "HAS_BILLING_ADDRESS"
+    HAS_LINES = "HAS_LINES"
+    HAS_DELIVERY_METHOD = "HAS_DELIVERY_METHOD"
 
 
 class Subscription(SubscriptionObjectType):
@@ -2768,8 +2783,9 @@ class Subscription(SubscriptionObjectType):
         description=(
             "Event sent when checkout is updated." + ADDED_IN_321 + PREVIEW_FEATURE
         ),
-        resolver=default_channel_filterable_resolver,
+        resolver=checkout_updated_resolver,
         channels=channels_argument,
+        requires=graphene.Argument(NonNullList(Requirement)),
         doc_category=DOC_CATEGORY_CHECKOUT,
     )
     checkout_fully_paid = BaseField(
@@ -2791,6 +2807,15 @@ class Subscription(SubscriptionObjectType):
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_CHECKOUT,
+    )
+
+    calculate_taxes = BaseField(
+        CalculateTaxes,
+        description=(
+            "Event sent when taxes are calculated." + ADDED_IN_321 + PREVIEW_FEATURE
+        ),
+        resolver=default_resolver,
+        requires=graphene.Argument(NonNullList(Requirement)),
     )
 
     class Meta:


### PR DESCRIPTION
This PR is a poc for providing a flexible interface to control when webhooks are triggered.

TLDR
When creating a subscription, apps can define a custom list of `requires` enums. These enums represent the conditions that must be met before a webhook is triggered. For example:

SYNC example:
```graphql
subscription {
  calculateTaxes(
    requires: [HAS_SHIPPING_ADDRESS, HAS_BILLING_ADDRESS, HAS_LINES, HAS_DELIVERY_METHOD]
  ) {
    taxBase {
      currency
    }
  }
}
```

In this case, the synchronous `calculateTaxes` webhook will only be triggered when the checkout meets **all** the following conditions:
- Has a shipping address
- Has a billing address
- Contains at least one line
- Has a delivery method assigned

ASYNC example:

```graphql
subscription {
  checkoutUpdated(
    channels: ["channel-pln", "default-channel"]
    requires: [HAS_SHIPPING_ADDRESS, HAS_LINES]
  ) {
    checkout {
      id
      channel {
        slug
      }
    }
  }
}
```

Here, the asynchronous `checkoutUpdated` webhook will only be triggered for checkouts that:
- belong to `channel-pln` or `default-channel`
- Have a shipping address
- Contain at least one line


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
