### PR TITLE
Apply `InstanceTracker` to `DraftOrderUpdate` mutation

### DIFF
--- a/saleor/core/utils/tests/test_update_mutation_manager.py
+++ b/saleor/core/utils/tests/test_update_mutation_manager.py
@@ -1,5 +1,4 @@
-from saleor.order import OrderStatus
-
+from ....order import OrderStatus
 from ..update_mutation_manager import InstanceTracker
 
 
@@ -71,15 +70,11 @@ def test_instance_tracker_foreign_relation(order_with_lines):
 
     # when
     modified_fields = tracker.get_modified_fields()
-    foreign_modifications = tracker.get_foreign_modifications()
+    foreign_modified_fields = tracker.get_foreign_modified_fields()
 
     # then
     assert modified_fields == ["status", "shipping_address"]
-    assert foreign_modifications["shipping_address"] == (
-        shipping_address,
-        ["last_name"],
-        False,
-    )
+    assert foreign_modified_fields["shipping_address"] == ["last_name"]
 
 
 def test_instance_tracker_foreign_relation_new_instance(order_with_lines):
@@ -100,12 +95,8 @@ def test_instance_tracker_foreign_relation_new_instance(order_with_lines):
 
     # when
     modified_fields = tracker.get_modified_fields()
-    foreign_modifications = tracker.get_foreign_modifications()
+    foreign_modified_fields = tracker.get_foreign_modified_fields()
 
     # then
     assert modified_fields == ["status", "shipping_address"]
-    assert foreign_modifications["shipping_address"] == (
-        order.shipping_address,
-        foreign_fields_to_track,
-        True,
-    )
+    assert foreign_modified_fields["shipping_address"] == foreign_fields_to_track

--- a/saleor/core/utils/tests/test_update_mutation_manager.py
+++ b/saleor/core/utils/tests/test_update_mutation_manager.py
@@ -1,0 +1,103 @@
+from saleor.order import OrderStatus
+
+from ..update_mutation_manager import InstanceTracker
+
+
+def test_instance_tracker(product):
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(product, fields_to_track)
+
+    # when
+    product.name = product.name + "_updated"
+    modified_field = tracker.get_modified_fields()
+
+    # then
+    assert modified_field == ["name"]
+
+
+def test_instance_tracker_no_instance_on_init(product):
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(None, fields_to_track)
+
+    # when
+    tracker.instance = product
+    modified_fields = tracker.get_modified_fields()
+
+    # then
+    assert modified_fields == fields_to_track
+
+
+def test_instance_tracker_no_instance_on_init_and_on_get_modified_fields():
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(None, fields_to_track)
+
+    # when
+    modified_fields = tracker.get_modified_fields()
+
+    # then
+    assert modified_fields == []
+
+
+def test_instance_tracker_remove_instance(product):
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(product, fields_to_track)
+
+    # when
+    tracker.instance = None
+    modified_fields = tracker.get_modified_fields()
+
+    # then
+    assert modified_fields == fields_to_track
+
+
+def test_instance_tracker_foreign_relation(order_with_lines):
+    # given
+    order = order_with_lines
+    fields_to_track = ["status", "shipping_address", "billing_address"]
+    foreign_fields_to_track = ["last_name", "first_name"]
+    tracker = InstanceTracker(
+        order,
+        fields_to_track,
+        foreign_fields_to_track={"shipping_address": foreign_fields_to_track},
+    )
+
+    order.status = OrderStatus.FULFILLED
+    shipping_address = order.shipping_address
+    shipping_address.last_name = "new_last_name"
+
+    # when
+    modified_fields = tracker.get_modified_fields()
+    foreign_modified_fields = tracker.get_foreign_modified_fields()
+
+    # then
+    assert modified_fields == ["status", "shipping_address"]
+    assert foreign_modified_fields["shipping_address"] == ["last_name"]
+
+
+def test_instance_tracker_foreign_relation_new_instance(order_with_lines):
+    # given
+    order = order_with_lines
+    order.shipping_address = None
+
+    fields_to_track = ["status", "shipping_address", "billing_address"]
+    foreign_fields_to_track = ["last_name", "first_name"]
+    tracker = InstanceTracker(
+        order,
+        fields_to_track,
+        foreign_fields_to_track={"shipping_address": foreign_fields_to_track},
+    )
+
+    order.status = OrderStatus.FULFILLED
+    order.shipping_address = order.billing_address
+
+    # when
+    modified_fields = tracker.get_modified_fields()
+    foreign_modified_fields = tracker.get_foreign_modified_fields()
+
+    # then
+    assert modified_fields == ["status", "shipping_address"]
+    assert foreign_modified_fields["shipping_address"] == foreign_fields_to_track

--- a/saleor/core/utils/tests/test_update_mutation_manager.py
+++ b/saleor/core/utils/tests/test_update_mutation_manager.py
@@ -71,11 +71,15 @@ def test_instance_tracker_foreign_relation(order_with_lines):
 
     # when
     modified_fields = tracker.get_modified_fields()
-    foreign_modified_fields = tracker.get_foreign_modified_fields()
+    foreign_modifications = tracker.get_foreign_modifications()
 
     # then
     assert modified_fields == ["status", "shipping_address"]
-    assert foreign_modified_fields["shipping_address"] == ["last_name"]
+    assert foreign_modifications["shipping_address"] == (
+        shipping_address,
+        ["last_name"],
+        False,
+    )
 
 
 def test_instance_tracker_foreign_relation_new_instance(order_with_lines):
@@ -96,8 +100,12 @@ def test_instance_tracker_foreign_relation_new_instance(order_with_lines):
 
     # when
     modified_fields = tracker.get_modified_fields()
-    foreign_modified_fields = tracker.get_foreign_modified_fields()
+    foreign_modifications = tracker.get_foreign_modifications()
 
     # then
     assert modified_fields == ["status", "shipping_address"]
-    assert foreign_modified_fields["shipping_address"] == foreign_fields_to_track
+    assert foreign_modifications["shipping_address"] == (
+        order.shipping_address,
+        foreign_fields_to_track,
+        True,
+    )

--- a/saleor/core/utils/update_mutation_manager.py
+++ b/saleor/core/utils/update_mutation_manager.py
@@ -1,0 +1,68 @@
+from copy import deepcopy
+from typing import Any, TypeVar
+
+from django.db.models import Model
+
+T = TypeVar("T", bound=Model)
+
+
+class InstanceTrackerError(Exception):
+    """Base class for tracker errors."""
+
+
+class InstanceTracker:
+    """Instance with modifications tracker.
+
+    It is used to determine modified fields of the instance.
+    """
+
+    def __init__(
+        self,
+        instance: T | None,
+        fields_to_track: list[str],
+        foreign_fields_to_track: dict[str, list[str]] | None = None,
+    ):
+        self.instance = instance
+        self.fields_to_track = fields_to_track
+        self.initial_instance_values: dict[str, Any] = deepcopy(self.get_field_values())
+        self.foreign_instance_relation: dict[str, InstanceTracker] = {}
+        self.create = instance is None
+
+        if foreign_fields_to_track:
+            for lookup, fields in foreign_fields_to_track.items():
+                foreign_instance = getattr(instance, lookup, None)
+                self.foreign_instance_relation[lookup] = InstanceTracker(
+                    foreign_instance,
+                    fields,
+                    None,
+                )
+
+    def get_field_values(self) -> dict[str, Any]:
+        """Create a dict of tracked fields with related instance values."""
+        return {
+            field: getattr(self.instance, field, None) for field in self.fields_to_track
+        }
+
+    def get_modified_fields(self) -> list[str]:
+        """Compare updated instance values with initial ones.
+
+        Raise exception when instance is None.
+        """
+        if not self.instance:
+            return self.fields_to_track
+
+        modified_instance_values: dict[str, Any] = self.get_field_values()
+        return [
+            field
+            for field in self.initial_instance_values.keys()
+            if self.initial_instance_values.get(field)
+            != modified_instance_values.get(field)
+        ]
+
+    def get_foreign_modified_fields(self) -> dict[str, list[str]]:
+        modified_fields = {}
+        for lookup, tracker in self.foreign_instance_relation.items():
+            foreign_modified = tracker.get_modified_fields()
+            if foreign_modified:
+                modified_fields[lookup] = foreign_modified
+        return modified_fields

--- a/saleor/core/utils/update_mutation_manager.py
+++ b/saleor/core/utils/update_mutation_manager.py
@@ -60,13 +60,11 @@ class InstanceTracker:
             != modified_instance_values.get(field)
         ]
 
-    def get_foreign_modifications(self) -> dict[str, tuple[T, list[str], bool]]:
-        modifications = {}
+    def get_foreign_modified_fields(self) -> dict[str, list[str]]:
+        modified_fields = {}
         for lookup, tracker in self.foreign_instance_relation.items():
             tracker.instance = getattr(self.instance, lookup, None)
-            if tracker.instance is None:
-                continue
-            if modified_fields := tracker.get_modified_fields():
-                is_created = tracker.initial_instance_values == {}
-                modifications[lookup] = (tracker.instance, modified_fields, is_created)
-        return modifications
+            foreign_modified = tracker.get_modified_fields()
+            if foreign_modified:
+                modified_fields[lookup] = foreign_modified
+        return modified_fields

--- a/saleor/core/utils/update_mutation_manager.py
+++ b/saleor/core/utils/update_mutation_manager.py
@@ -60,11 +60,13 @@ class InstanceTracker:
             != modified_instance_values.get(field)
         ]
 
-    def get_foreign_modified_fields(self) -> dict[str, list[str]]:
-        modified_fields = {}
+    def get_foreign_modifications(self) -> dict[str, tuple[T, list[str], bool]]:
+        modifications = {}
         for lookup, tracker in self.foreign_instance_relation.items():
             tracker.instance = getattr(self.instance, lookup, None)
-            foreign_modified = tracker.get_modified_fields()
-            if foreign_modified:
-                modified_fields[lookup] = foreign_modified
-        return modified_fields
+            if tracker.instance is None:
+                continue
+            if modified_fields := tracker.get_modified_fields():
+                is_created = tracker.initial_instance_values == {}
+                modifications[lookup] = (tracker.instance, modified_fields, is_created)
+        return modifications

--- a/saleor/graphql/account/mutations/account/utils.py
+++ b/saleor/graphql/account/mutations/account/utils.py
@@ -1,0 +1,16 @@
+ADDRESS_UPDATE_FIELDS = {
+    "city",
+    "city_area",
+    "company_name",
+    "country",
+    "country_area",
+    "first_name",
+    "last_name",
+    "metadata",
+    "phone",
+    "postal_code",
+    "private_metadata",
+    "street_address_1",
+    "street_address_2",
+    "validation_skipped",
+}

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -372,8 +372,8 @@ class DraftOrderUpdate(
             instance,
             cls.FIELDS_TO_TRACK,
             foreign_fields_to_track={
-                "shipping_address": ADDRESS_UPDATE_FIELDS,
-                "billing_address": ADDRESS_UPDATE_FIELDS,
+                "shipping_address": list(ADDRESS_UPDATE_FIELDS),
+                "billing_address": list(ADDRESS_UPDATE_FIELDS),
             },
         )
 

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -246,23 +246,15 @@ class DraftOrderUpdate(
         instance = cast(models.Order, instance_tracker.instance)
         with traced_atomic_transaction():
             modified_foreign_fields = instance_tracker.get_foreign_modified_fields()
-            if (
-                "shipping_address" in modified_foreign_fields
-                and "shipping_address" in cleaned_input
-            ):
-                instance.shipping_address = cleaned_input["shipping_address"]
+            if "shipping_address" in modified_foreign_fields:
                 cls._save_address(
-                    cleaned_input["shipping_address"],
+                    instance.shipping_address,
                     modified_foreign_fields["shipping_address"],
                 )
 
-            if (
-                "billing_address" in modified_foreign_fields
-                and "billing_address" in cleaned_input
-            ):
-                instance.billing_address = cleaned_input["billing_address"]
+            if "billing_address" in modified_foreign_fields:
                 cls._save_address(
-                    cleaned_input["billing_address"],
+                    instance.billing_address,
                     modified_foreign_fields["billing_address"],
                 )
 
@@ -290,7 +282,7 @@ class DraftOrderUpdate(
 
     @classmethod
     def _save_address(cls, address_instance, modified_fields):
-        if address_instance.pk is None:
+        if address_instance._state.adding:
             address_instance.save()
         else:
             address_instance.save(update_fields=modified_fields)

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -108,7 +108,7 @@ class DraftOrderUpdate(
         cls.clean_channel_id(instance, data)
         shipping_address = data.pop("shipping_address", None)
         billing_address = data.pop("billing_address", None)
-        redirect_url = data.pop("redirect_url", "")
+        redirect_url = data.pop("redirect_url", None)
 
         shipping_method_input = cls.clean_shipping_method(instance, data)
 

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -1,10 +1,9 @@
-from typing import TypeVar, cast
+from typing import cast
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.db.models import Model
 
-from ....account.models import Address, User
+from ....account.models import User
 from ....checkout import AddressType
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.update_mutation_manager import InstanceTracker
@@ -42,8 +41,6 @@ from .utils import (
     SHIPPING_METHOD_UPDATE_FIELDS,
     ShippingMethodUpdateMixin,
 )
-
-T = TypeVar("T", bound=Model)
 
 
 class DraftOrderUpdate(
@@ -111,7 +108,7 @@ class DraftOrderUpdate(
         cls.clean_channel_id(instance, data)
         shipping_address = data.pop("shipping_address", None)
         billing_address = data.pop("billing_address", None)
-        redirect_url = data.pop("redirect_url", None)
+        redirect_url = data.pop("redirect_url", "")
 
         shipping_method_input = cls.clean_shipping_method(instance, data)
 
@@ -241,24 +238,28 @@ class DraftOrderUpdate(
             )
 
     @classmethod
-    def _save(cls, instance_tracker: InstanceTracker) -> bool:
+    def _save(
+        cls,
+        instance_tracker: InstanceTracker,
+        cleaned_input: dict,
+    ) -> bool:
         instance = cast(models.Order, instance_tracker.instance)
         with traced_atomic_transaction():
-            foreign_modifications: dict[str, tuple[Address, list[str], bool]] = (
-                instance_tracker.get_foreign_modifications()
-            )
-            for (
-                foreign_instance,
-                modified_fields,
-                is_created,
-            ) in foreign_modifications.values():
-                if is_created:
-                    foreign_instance.save()
-                else:
-                    foreign_instance.save(update_fields=modified_fields)
+            modified_foreign_fields = instance_tracker.get_foreign_modified_fields()
+            if "shipping_address" in modified_foreign_fields:
+                cls._save_address(
+                    instance.shipping_address,
+                    modified_foreign_fields["shipping_address"],
+                )
+
+            if "billing_address" in modified_foreign_fields:
+                cls._save_address(
+                    instance.billing_address,
+                    modified_foreign_fields["billing_address"],
+                )
 
             modified_instance_fields = instance_tracker.get_modified_fields()
-            modified_instance_fields.extend(foreign_modifications)
+            modified_instance_fields.extend(modified_foreign_fields)
             if not modified_instance_fields:
                 return False
 
@@ -278,6 +279,13 @@ class DraftOrderUpdate(
     def _save_order_instance(cls, instance, modified_instance_fields):
         update_fields = ["updated_at"] + modified_instance_fields
         instance.save(update_fields=update_fields)
+
+    @classmethod
+    def _save_address(cls, address_instance, modified_fields):
+        if address_instance._state.adding:
+            address_instance.save()
+        else:
+            address_instance.save(update_fields=modified_fields)
 
     @classmethod
     def _post_save_action(cls, instance, manager):
@@ -389,7 +397,7 @@ class DraftOrderUpdate(
         cls.handle_shipping(cleaned_input, instance, manager)
         cls.handle_order_voucher(cleaned_input, instance, old_voucher, old_voucher_code)
 
-        order_modified = cls._save(instance_tracker)
+        order_modified = cls._save(instance_tracker, cleaned_input)
         if order_modified:
             cls._post_save_action(instance, manager)
 

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -23,7 +23,6 @@ from ....shipping.utils import convert_to_shipping_method_data
 from ....webhook.event_types import WebhookEventAsyncType
 from ..utils import get_shipping_method_availability_error
 
-
 DRAFT_ORDER_UPDATE_FIELDS = {
     "base_shipping_price_amount",
     "billing_address",

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -23,7 +23,32 @@ from ....shipping.utils import convert_to_shipping_method_data
 from ....webhook.event_types import WebhookEventAsyncType
 from ..utils import get_shipping_method_availability_error
 
-SHIPPING_METHOD_UPDATE_FIELDS = [
+
+DRAFT_ORDER_UPDATE_FIELDS = {
+    "base_shipping_price_amount",
+    "billing_address",
+    "channel",
+    "collection_point",
+    "collection_point_name",
+    "customer_note",
+    "display_gross_prices",
+    "draft_save_billing_address",
+    "draft_save_shipping_address",
+    "external_reference",
+    "language_code",
+    "metadata",
+    "private_metadata",
+    "redirect_url",
+    "search_vector",
+    "shipping_address",
+    "user",
+    "user_email",
+    "voucher",
+    "voucher_code",
+    "weight",
+}
+
+SHIPPING_METHOD_UPDATE_FIELDS = {
     "currency",
     "shipping_method",
     "shipping_price_net_amount",
@@ -38,7 +63,7 @@ SHIPPING_METHOD_UPDATE_FIELDS = [
     "shipping_tax_rate",
     "should_refresh_prices",
     "updated_at",
-]
+}
 
 
 class EditableOrderValidationMixin:

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -21,8 +21,11 @@ from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent
 from .....order.utils import update_discount_for_order_line
 from .....payment.model_helpers import get_subtotal
+from .....shipping.models import ShippingMethod
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ....core.utils import snake_to_camel_case
 from ....tests.utils import assert_no_permission, get_graphql_content
+from ...mutations.draft_order_create import DraftOrderInput
 
 DRAFT_ORDER_UPDATE_MUTATION = """
         mutation draftUpdate(
@@ -3259,3 +3262,313 @@ def test_draft_order_update_with_language_code(
     order.refresh_from_db()
 
     assert order.language_code == "pl"
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
+    wraps=call_order_event,
+)
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.DraftOrderUpdate._save_order_instance"
+)
+def test_draft_order_update_no_changes(
+    save_order_mock,
+    call_event_mock,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    voucher,
+    address,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    key = "some_key"
+    value = "some_value"
+    address.metadata = {key: value}
+    address.save(update_fields=["metadata"])
+
+    order.metadata = {key: value}
+    order.private_metadata = {key: value}
+    order.shipping_address = address
+    order.billing_address = address
+    order.draft_save_billing_address = True
+    order.draft_save_shipping_address = True
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    order.customer_note = "some note"
+    order.redirect_url = "https://www.example.com"
+    order.external_reference = "some_reference_string"
+    order.language_code = "pl"
+    order.save()
+
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethod", order.shipping_method_id
+    )
+    user_id = graphene.Node.to_global_id("User", order.user_id)
+
+    address_input = {
+        snake_to_camel_case(key): value for key, value in address.as_data().items()
+    }
+    address_input["metadata"] = [{"key": key, "value": value}]
+    address_input.pop("privateMetadata")
+    skip_validation = address_input.pop("validationSkipped")
+    address_input["skipValidation"] = skip_validation
+
+    input_fields = [
+        snake_to_camel_case(key) for key in DraftOrderInput._meta.fields.keys()
+    ]
+
+    # `discount` field is unused and deprecated
+    input_fields.remove("discount")
+    # `voucher` and `voucherCode` fields can't be combined
+    input_fields.remove("voucher")
+    # `channel` can't be updated when is not None
+    input_fields.remove("channelId")
+
+    input = {
+        "billingAddress": address_input,
+        "saveBillingAddress": True,
+        "shippingAddress": address_input,
+        "saveShippingAddress": True,
+        "shippingMethod": shipping_method_id,
+        "user": user_id,
+        "userEmail": order.user_email,
+        "voucherCode": order.voucher_code,
+        "customerNote": order.customer_note,
+        "redirectUrl": order.redirect_url,
+        "externalReference": order.external_reference,
+        "metadata": [{"key": key, "value": value}],
+        "privateMetadata": [{"key": key, "value": value}],
+        "languageCode": "PL",
+    }
+    assert set(input_fields) == set(input.keys())
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variables = {"id": order_id, "input": input}
+
+    # when
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["draftOrderUpdate"]["errors"]
+    order.refresh_from_db()
+    save_order_mock.assert_not_called()
+    call_event_mock.assert_not_called()
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
+    wraps=call_order_event,
+)
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.DraftOrderUpdate._save_order_instance"
+)
+def test_draft_order_update_emit_events(
+    save_order_mock,
+    call_event_mock,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    graphql_address_data,
+    voucher,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    key = "some_key"
+    value = "some_value"
+    order.metadata = {key: value}
+    order.private_metadata = {key: value}
+    order.draft_save_billing_address = True
+    order.draft_save_shipping_address = True
+    order.voucher = voucher
+    order.voucher_code = voucher.codes.first().code
+    order.customer_note = "some note"
+    order.redirect_url = "http://localhost:8000/redirect"
+    order.external_reference = "some_reference_string"
+    order.language_code = "de"
+    order.save()
+
+    new_shipping_method = ShippingMethod.objects.create(
+        shipping_zone=order.shipping_method.shipping_zone,
+        name="new_method",
+    )
+    new_shipping_method.channel_listings.create(
+        channel=order.channel, currency=order.currency
+    )
+    new_shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethod", new_shipping_method.id
+    )
+
+    assert order.user_id != staff_api_client.user.id
+    user_id = graphene.Node.to_global_id("User", staff_api_client.user.id)
+
+    input_fields = [
+        snake_to_camel_case(key) for key in DraftOrderInput._meta.fields.keys()
+    ]
+
+    # `discount` field is unused and deprecated
+    input_fields.remove("discount")
+    # `voucher` and `voucherCode` fields can't be combined
+    input_fields.remove("voucher")
+    # `channel` can't be updated when is not None
+    input_fields.remove("channelId")
+    # `saveBillingAddress` can't be provided without billingAddress
+    input_fields.remove("saveBillingAddress")
+    # `saveShippingAddress` can't be provided without shippingAddress
+    input_fields.remove("saveShippingAddress")
+
+    assert graphql_address_data["lastName"] != order.shipping_address.last_name
+    assert graphql_address_data["lastName"] != order.billing_address.last_name
+
+    input = {
+        "billingAddress": graphql_address_data,
+        "shippingAddress": graphql_address_data,
+        "shippingMethod": new_shipping_method_id,
+        "user": user_id,
+        "userEmail": "new_" + order.user_email,
+        "voucherCode": voucher.codes.last().code,
+        "customerNote": order.customer_note + "_new",
+        "redirectUrl": "https://www.example.com",
+        "externalReference": order.external_reference + "_new",
+        "metadata": [{"key": key, "value": "new_value"}],
+        "privateMetadata": [{"key": "new_key", "value": value}],
+        "languageCode": "PL",
+    }
+    assert set(input_fields) == set(input.keys())
+
+    # fields making changes to related models (other than order)
+    non_base_model_fields = ["billingAddress", "shippingAddress"]
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    for key, value in input.items():
+        variables = {"id": order_id, "input": {key: value}}
+
+        # when
+        response = staff_api_client.post_graphql(
+            DRAFT_ORDER_UPDATE_MUTATION,
+            variables,
+        )
+        content = get_graphql_content(response)
+
+        # then
+        assert not content["data"]["draftOrderUpdate"]["errors"]
+        if key not in non_base_model_fields:
+            save_order_mock.assert_called()
+            save_order_mock.reset_mock()
+        call_event_mock.assert_called()
+        call_event_mock.reset_mock()
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
+    wraps=call_order_event,
+)
+def test_draft_order_update_address_not_changed_save_flag_changed(
+    call_event_mock,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    address,
+):
+    """Address input doesn't introduce any changes, but address save flag has changed."""
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    order.shipping_address = address
+    order.billing_address = address
+    order.draft_save_billing_address = False
+    order.draft_save_shipping_address = False
+    order.save(
+        update_fields=[
+            "shipping_address",
+            "billing_address",
+            "draft_save_billing_address",
+            "draft_save_shipping_address",
+            "status",
+        ]
+    )
+
+    address_input = {
+        snake_to_camel_case(key): value for key, value in address.as_data().items()
+    }
+    address_input.pop("privateMetadata")
+    skip_validation = address_input.pop("validationSkipped")
+    address_input["skipValidation"] = skip_validation
+
+    input = {
+        "billingAddress": address_input,
+        "saveBillingAddress": True,
+        "shippingAddress": address_input,
+        "saveShippingAddress": True,
+    }
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variables = {"id": order_id, "input": input}
+
+    # when
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["draftOrderUpdate"]["errors"]
+    order.refresh_from_db()
+    assert order.draft_save_billing_address is True
+    assert order.draft_save_shipping_address is True
+    call_event_mock.assert_called()
+
+
+@patch(
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
+    wraps=call_order_event,
+)
+def test_draft_order_update_address_not_set(
+    call_event_mock,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    graphql_address_data,
+):
+    # given
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order.shipping_address = None
+    order.billing_address = None
+    order.save(update_fields=["shipping_address", "billing_address", "status"])
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    input = {
+        "billingAddress": graphql_address_data,
+        "shippingAddress": graphql_address_data,
+    }
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variables = {"id": order_id, "input": input}
+
+    # when
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["draftOrderUpdate"]["errors"]
+    order.refresh_from_db()
+    assert order.shipping_address
+    assert order.billing_address
+    call_event_mock.assert_called()


### PR DESCRIPTION
I want to merge this change because it applies `InstanceTracker` to `DraftOrderUpdate` mutation in order to control emitted events and db calls.

1. The order instance should be saved only when some field has been modified.
2. The save call should be performed only on modified fields
3. Events should be emitted only when order or related address have changed
4. Tests should ensure:
-    that if we pass to the input all the fields with exactly the same values, then there is no save call and no events emitted
-    that at least single field modification will result with emitted events and db save call
-    we didn't omit any input field (that if we add some new input field to the mutation, the test should fail and the test should be update)
5. Address and shipping method update should be processed only if it introduce any changes

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
