### PR TITLE
Make sure to set default value for legacy-discount-propagation flag

### DIFF
--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -294,8 +294,11 @@ class ChannelCreate(DeprecatedModelMutation):
             cleaned_input["slug"] = slugify(slug)
         if stock_settings := cleaned_input.get("stock_settings"):
             cleaned_input["allocation_strategy"] = stock_settings["allocation_strategy"]
-        if order_settings := cleaned_input.get("order_settings"):
-            clean_input_order_settings(order_settings, cleaned_input, instance)
+
+        order_settings = cleaned_input.get("order_settings") or {
+            "use_legacy_line_discount_propagation_for_order": False
+        }
+        clean_input_order_settings(order_settings, cleaned_input, instance)
 
         if checkout_settings := cleaned_input.get("checkout_settings"):
             clean_input_checkout_settings(checkout_settings, cleaned_input)

--- a/saleor/graphql/channel/tests/mutations/test_channel_create.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_create.py
@@ -899,7 +899,12 @@ def test_channel_create_set_allow_unpaid_orders(
 
 @pytest.mark.parametrize(
     ("use_legacy_input", "expected_result"),
-    [(True, True), (False, False), (None, False)],
+    [
+        ({"useLegacyLineDiscountPropagation": True}, True),
+        ({"useLegacyLineDiscountPropagation": False}, False),
+        (None, False),
+        ({"allowUnpaidOrders": False}, False),
+    ],
 )
 def test_channel_create_set_use_legacy_line_discount_propagation(
     use_legacy_input,
@@ -918,7 +923,7 @@ def test_channel_create_set_use_legacy_line_discount_propagation(
             "slug": slug,
             "currencyCode": currency_code,
             "defaultCountry": default_country,
-            "orderSettings": {"useLegacyLineDiscountPropagation": use_legacy_input},
+            "orderSettings": use_legacy_input,
         }
     }
 

--- a/saleor/graphql/channel/tests/mutations/test_channel_update.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_update.py
@@ -1635,12 +1635,14 @@ def test_channel_update_default_transaction_flow_strategy_with_payment_permissio
 @pytest.mark.parametrize(
     ("use_legacy_input", "expected_result", "current_value_on_db"),
     [
-        (True, True, True),
-        (True, True, False),
-        (False, False, True),
-        (False, False, False),
+        ({"useLegacyLineDiscountPropagation": True}, True, True),
+        ({"useLegacyLineDiscountPropagation": True}, True, False),
+        ({"useLegacyLineDiscountPropagation": False}, False, True),
+        ({"useLegacyLineDiscountPropagation": False}, False, False),
         (None, True, True),
         (None, False, False),
+        ({"allowUnpaidOrders": False}, False, False),
+        ({"allowUnpaidOrders": True}, True, True),
     ],
 )
 def test_channel_update_set_use_legacy_line_discount_propagation(
@@ -1659,7 +1661,7 @@ def test_channel_update_set_use_legacy_line_discount_propagation(
     variables = {
         "id": channel_id,
         "input": {
-            "orderSettings": {"useLegacyLineDiscountPropagation": use_legacy_input},
+            "orderSettings": use_legacy_input,
         },
     }
 


### PR DESCRIPTION
I want to merge this change because it fixes the incorrect value for `use_legacy_line_discount_propagation_for_order`. 
When input `orderSettings` is not provided, previously we were setting this flag to `True`. According to the docs, by default we always set it to `False` when creating new channels. 
This PR fixes it, set it to False, when `useLegacyLineDiscountPropagation` is missing

Note: Skipping changelog as this feature is introduced on main, so nothing to "report"

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
