### PR TITLE
add message about automatically created transaction event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,3 +117,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixes incorrect gift card balances after covering the full order total - #17566 by @korycins
 - Fixes tax class not clearing when selecting a shipping method without a tax class - #17560 by @korycins
 - The prices for draft orders created in `OrderBulkCreate` now are properly calculated - #17583 by @IKarbowiak
+- Automatically created `CHARGE_REQUEST` / `AUTHORIZATION_REQUEST` TransactionEvent objects will now contain a message that they were created by Saleor automatically - #17672 by @lkostrowski

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1643,6 +1643,12 @@ def handle_transaction_initialize_session(
                 "currency": transaction_item.currency,
                 "amount_value": amount,
                 "idempotency_key": idempotency_key,
+                # This event is created event if app returns different one. It is confusing,
+                # so we add an extra message here. It's not perfect, because it will be fixed
+                # string in English. Eventually we should add some flags to the TransactionEvent model,
+                # to mark it as created by Saleor, and Dashboard can display it properly.
+                # https://linear.app/saleor/issue/EXT-2234/add-created-by-saleor-flag-to-transaction-events
+                "message": "Automatically created by Saleor",
             },
         )
     except IntegrityError as e:


### PR DESCRIPTION
I want to merge this change because it add message for confusing, automatically created event 

- [ ] tests

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
