### PR TITLE
Update outdated links to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Webhooks
 
 - Fixed webhookTrigger payload type for events related to ProductVariant - #16956 by @delemeator
-- Truncate lenghty responses in `EventDeliveryAttempt` objects - #17044 by @wcislo-saleor
+- Truncate lengthy responses in `EventDeliveryAttempt` objects - #17044 by @wcislo-saleor
 - Webhooks `CHECKOUT_FILTER_SHIPPING_METHODS` & `ORDER_FILTER_SHIPPING_METHODS` are no longer executed when not needed (no available shipping methods, e.g. due to lack of shipping address) - #17328 by @lkostrowski
 - New feature: sync webhooks circuit breaker - #16658 by @tomaszszymanski129
 - Fixed webhook `PRODUCT_VARIANT_METADATA_UPDATED` not being sent when `productVariantUpdate` mutation was called. Now, when `metadata` or `privateMetadata` is included in `ProductVariantUpdateInput`, both `PRODUCT_VARIANT_METADATA_UPDATED` and `PRODUCT_VARIANT_UPDATED` will be emitted (if subscribed) - #17406 by @lkostrowski
@@ -84,6 +84,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update editable Order shipping via `orderUpdateShipping` will emit `ORDER_UPDATED` webhook when `shippingMethod` will be cleared (by passing `null` to graphQL input). - #17480 by @lkostrowski
 
 ### Other changes
+- Fixed outdated documentation links - #17675 by @krzysztofwolski
 - Added support for numeric and lower-case boolean environment variables - #16313 by @NyanKiyoshi
 - Fixed a potential crash when Checkout metadata is accessed with high concurrency - #16411 by @patrys
 - Add slugs to product/category/collection/page translations. Allow to query by translated slug - #16449 by @delemeator

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@
 
 - **Cloud native** - battle tested on global brands.
 
-- **Native-multichannel** - Per [channel](https://docs.saleor.io/docs/3.x/developer/channels) control of pricing, currencies, stock, product, and more.
+- **Native-multichannel** - Per [channel](https://docs.saleor.io/developer/channels/overview) control of pricing, currencies, stock, product, and more.
 
 ## Why API-only Architecture?
 
-Saleor's API-first extensibility provides powerful tools for developers to extend backend using [webhooks](https://docs.saleor.io/docs/3.x/developer/extending/webhooks/overview), attributes, [metadata](https://docs.saleor.io/docs/3.x/api-usage/metadata), [apps](https://docs.saleor.io/docs/3.x/developer/extending/apps/overview), [subscription queries](https://docs.saleor.io/docs/3.x/developer/extending/webhooks/subscription-webhook-payloads), [API extensions](https://docs.saleor.io/docs/3.x/developer/extending/webhooks/synchronous-events/overview), [dashboard iframes](https://docs.saleor.io/docs/3.x/developer/extending/apps/overview).
+Saleor's API-first extensibility provides powerful tools for developers to extend backend using [webhooks](https://docs.saleor.io/developer/extending/webhooks/overview), attributes, [metadata](https://docs.saleor.io/api-usage/metadata), [apps](https://docs.saleor.io/developer/extending/apps/overview), [subscription queries](https://docs.saleor.io/developer/extending/webhooks/subscription-webhook-payloads), [API extensions](https://docs.saleor.io/developer/extending/webhooks/synchronous-events/overview), [dashboard iframes](https://docs.saleor.io/developer/extending/apps/overview).
 
 Compared to traditional plugin architectures (monoliths) it provides the following benefits:
 
@@ -122,7 +122,7 @@ you need to collaborate with other developers, or you have non-trivial requireme
 
 ## Installation
 
-[See the Saleor docs](https://docs.saleor.io/docs/3.x/developer/installation) for step-by-step installation and deployment instructions.
+[See the Saleor docs](https://docs.saleor.io/setup/docker-compose) for step-by-step installation and deployment instructions. For local development without Docker, follow our [Contributing Guide](./CONTRIBUTING.md).
 
 Note:
 The `main` branch is the development version of Saleor and it may be unstable. To use the latest stable version, download it from the [Releases](https://github.com/saleor/saleor/releases/) page or switch to a release tag.

--- a/saleor/core/utils/tests/test_editorjs.py
+++ b/saleor/core/utils/tests/test_editorjs.py
@@ -13,10 +13,10 @@ from ..editorjs import clean_editor_js
         "The Saleor Winter Sale is snowed under with seasonal offers. Unreal products "
         "at unreal prices. Literally, they are not real products, but the Saleor demo "
         "store is a genuine e-commerce leader.",
-        'The Saleor Winter Sale is snowed <a href="https://docs.saleor.io/docs/">',
-        'The Saleor Sale is snowed <a href="https://docs.saleor.io/docs/">. Test.',
-        'The Saleor Winter Sale is snowed <a href="https://docs.saleor.io/docs/">. '
-        'Test <a href="https://docs.saleor.io/docs/">.',
+        'The Saleor Winter Sale is snowed <a href="https://docs.saleor.io/">',
+        'The Saleor Sale is snowed <a href="https://docs.saleor.io/">. Test.',
+        'The Saleor Winter Sale is snowed <a href="https://docs.saleor.io/">. '
+        'Test <a href="https://docs.saleor.io/">.',
         "",
         "The Saleor Winter Sale is snowed <a >",
     ],
@@ -108,7 +108,7 @@ def test_clean_editor_js_for_list():
             {
                 "data": {
                     "text": "The Saleor Winter Sale is snowed "
-                    '<a href="https://docs.saleor.io/docs/">. Test.'
+                    '<a href="https://docs.saleor.io/">. Test.'
                 },
                 "type": "paragraph",
             },
@@ -118,7 +118,7 @@ def test_clean_editor_js_for_list():
                     "style": "unordered",
                     "items": [
                         "It is a block-styled editor "
-                        '<a href="https://docs.saleor.io/docs/">.',
+                        '<a href="https://docs.saleor.io/">.',
                         "It returns clean data output in JSON",
                         "Designed to be extendable and pluggable with a simple API",
                         "",
@@ -140,9 +140,9 @@ def test_clean_editor_js_for_list():
     # then
     assert result == strip_tags(
         "The Saleor Winter Sale is snowed "
-        '<a href="https://docs.saleor.io/docs/">. Test.'
+        '<a href="https://docs.saleor.io/">. Test.'
         " It is a block-styled editor "
-        '<a href="https://docs.saleor.io/docs/">.'
+        '<a href="https://docs.saleor.io/">.'
         " It returns clean data output in JSON"
         " Designed to be extendable and pluggable with a simple API"
     )
@@ -156,7 +156,7 @@ def test_clean_editor_js_for_list_invalid_url(parse_url_mock):
     mocked_parse = mock.Mock(return_value=response_mock)
     parse_url_mock.side_effect = mocked_parse
 
-    url1 = "https://docs.saleor.io/docs/"
+    url1 = "https://docs.saleor.io/"
     url2 = "https://github.com/editor-js"
     text1 = 'The Saleor Winter Sale is snowed <a href="{}">. Test.'
     item_text_with_url = 'It is a block-styled editor <a href="{}">.'
@@ -206,7 +206,7 @@ def test_clean_editor_js_for_complex_description():
             {
                 "data": {
                     "text": "The Saleor Winter Sale is snowed"
-                    '<a href="https://docs.saleor.io/docs/">. Test.'
+                    '<a href="https://docs.saleor.io/">. Test.'
                 },
                 "type": "paragraph",
             },
@@ -278,7 +278,7 @@ def test_clean_editor_js_for_complex_description():
     # then
     assert result == strip_tags(
         "The Saleor Winter Sale is snowed"
-        '<a href="https://docs.saleor.io/docs/">. Test.'
+        '<a href="https://docs.saleor.io/">. Test.'
         " The one thing you be sure of is: Polish winters are quite"
         " unpredictable. The coldest months are January and February"
         " with temperatures around -3.0 °C (on average), but the"

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -392,7 +392,7 @@ class Manifest(BaseObjectType):
     token_target_url = graphene.String(
         description=(
             "Endpoint used during process of app installation, [see installing an app.]"
-            "(https://docs.saleor.io/docs/3.x/developer/extending/apps/installing-apps#installing-an-app)"
+            "(https://docs.saleor.io/developer/extending/apps/installing-apps#installing-an-app)"
         )
     )
     data_privacy = graphene.String(
@@ -410,7 +410,7 @@ class Manifest(BaseObjectType):
         description=(
             "List of extensions that will be mounted in Saleor's dashboard. "
             "For details, please [see the extension section.]"
-            "(https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps#key-concepts)"
+            "(https://docs.saleor.io/developer/extending/apps/extending-dashboard-with-apps#key-concepts)"
         ),
     )
     webhooks = NonNullList(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1981,7 +1981,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   CHECKOUT_METADATA_UPDATED
 
   """User notification triggered."""
-  NOTIFY_USER @deprecated(reason: "See the docs for more details about migrating from NOTIFY_USER to other events: https://docs.saleor.io/docs/next/upgrade-guides/notify-user-deprecation")
+  NOTIFY_USER @deprecated(reason: "See the docs for more details about migrating from NOTIFY_USER to other events: https://docs.saleor.io/upgrade-guides/core/3-16-to-3-17#migrating-from-notify_user")
 
   """A new page is created."""
   PAGE_CREATED
@@ -2543,7 +2543,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   CHECKOUT_METADATA_UPDATED
 
   """User notification triggered."""
-  NOTIFY_USER @deprecated(reason: "See the docs for more details about migrating from NOTIFY_USER to other events: https://docs.saleor.io/docs/next/upgrade-guides/notify-user-deprecation")
+  NOTIFY_USER @deprecated(reason: "See the docs for more details about migrating from NOTIFY_USER to other events: https://docs.saleor.io/upgrade-guides/core/3-16-to-3-17#migrating-from-notify_user")
 
   """A new page is created."""
   PAGE_CREATED
@@ -28507,7 +28507,7 @@ type Manifest @doc(category: "Apps") {
   configurationUrl: String @deprecated(reason: "Use `appUrl` instead.")
 
   """
-  Endpoint used during process of app installation, [see installing an app.](https://docs.saleor.io/docs/3.x/developer/extending/apps/installing-apps#installing-an-app)
+  Endpoint used during process of app installation, [see installing an app.](https://docs.saleor.io/developer/extending/apps/installing-apps#installing-an-app)
   """
   tokenTargetUrl: String
 
@@ -28524,7 +28524,7 @@ type Manifest @doc(category: "Apps") {
   supportUrl: String
 
   """
-  List of extensions that will be mounted in Saleor's dashboard. For details, please [see the extension section.](https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps#key-concepts)
+  List of extensions that will be mounted in Saleor's dashboard. For details, please [see the extension section.](https://docs.saleor.io/developer/extending/apps/extending-dashboard-with-apps#key-concepts)
   """
   extensions: [AppManifestExtension!]!
 

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -243,7 +243,7 @@ def deprecation_reason(enum):
     if enum.value == WebhookEventAsyncType.NOTIFY_USER:
         return (
             "See the docs for more details about migrating from NOTIFY_USER to other events: "
-            "https://docs.saleor.io/docs/next/upgrade-guides/notify-user-deprecation"
+            "https://docs.saleor.io/upgrade-guides/core/3-16-to-3-17#migrating-from-notify_user"
         )
     if enum.value == WebhookEventAsyncType.ANY:
         return DEFAULT_DEPRECATION_REASON

--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -8729,7 +8729,7 @@
           {
             "id": "IwwtFzGF2A",
             "data": {
-              "text": "3 We enable developers to <a href=\"https://docs.saleor.io/docs/3.x/developer/extending/apps/key-concepts\">extend Saleor</a> easily via [Saleor Apps](https://github.com/saleor/saleor-app-template), a robust tally of async/sync webhooks, and a composable Dashboard. "
+              "text": "3 We enable developers to <a href=\"https://docs.saleor.io/developer/extending/apps/overview\">extend Saleor</a> easily via [Saleor Apps](https://github.com/saleor/saleor-app-template), a robust tally of async/sync webhooks, and a composable Dashboard. "
             },
             "type": "paragraph"
           },


### PR DESCRIPTION
I want to merge this change because I'm on a mission to resolve all Google Search Console issues in our docs.

- checked and updated links containing outdated versioning format (`docs.saleor.io/docs', '3.x')
- added link to CONTRIBUTING guide in the readmes 'installation' section
- updated GQL Schema (changes in the field **descriptions**)

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: API reference will be updated after the next release

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
