### PR TITLE
Enhance `TransactionEvent` handling and add `createdAutomatically` field

### DIFF
--- a/saleor/graphql/payment/tests/queries/test_transaction.py
+++ b/saleor/graphql/payment/tests/queries/test_transaction.py
@@ -74,6 +74,7 @@ TRANSACTION_QUERY = """
                         id
                     }
                 }
+                createdAutomatically
             }
             name
             message
@@ -636,6 +637,7 @@ def test_transaction_event_by_user(
     assert event_data["amount"]["currency"] == event.currency
     assert event_data["type"] == event.type.upper()
     assert event_data["createdBy"]["id"] == to_global_id_or_none(staff_api_client.user)
+    assert event_data["createdAutomatically"] is True
 
 
 def test_transaction_event_by_app(
@@ -656,6 +658,7 @@ def test_transaction_event_by_app(
         external_url=f"http://`{TEST_SERVER_DOMAIN}/test",
         app_identifier=app_api_client.app.identifier,
         app=app_api_client.app,
+        include_in_calculations=True,
     )
 
     variables = {
@@ -687,6 +690,7 @@ def test_transaction_event_by_app(
     assert event_data["amount"]["currency"] == event.currency
     assert event_data["type"] == event.type.upper()
     assert event_data["createdBy"]["id"] == to_global_id_or_none(app_api_client.app)
+    assert event_data["createdAutomatically"] is False
 
 
 def test_transaction_event_by_reinstalled_app(

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -21,6 +21,7 @@ from ..core.descriptions import (
     ADDED_IN_313,
     ADDED_IN_314,
     ADDED_IN_315,
+    ADDED_IN_320,
     PREVIEW_FEATURE,
 )
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
@@ -348,6 +349,10 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
         description="Idempotency key assigned to the event." + ADDED_IN_314,
         required=False,
     )
+    created_automatically = graphene.Boolean(
+        description="Determines if the event was created automatically." + ADDED_IN_320,
+        required=True,
+    )
 
     class Meta:
         description = "Represents transaction's event."
@@ -406,6 +411,15 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
         if root.user_id:
             return UserByUserIdLoader(info.context).load(root.user_id)
         return None
+
+    @staticmethod
+    def resolve_created_automatically(root: models.TransactionEvent, info):
+        """Resolve createdAutomatically.
+
+        The `include_in_calculations` set to `False` means that the event was created
+        automatically by Saleor.
+        """
+        return not root.include_in_calculations
 
 
 class TransactionItem(ModelObjectType[models.TransactionItem]):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13240,6 +13240,13 @@ type TransactionEvent implements Node @doc(category: "Payments") {
   Added in Saleor 3.14.
   """
   idempotencyKey: String
+
+  """
+  Determines if the event was created automatically.
+  
+  Added in Saleor 3.20.
+  """
+  createdAutomatically: Boolean!
 }
 
 """

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -2500,7 +2500,7 @@ def test_create_transaction_event_for_transaction_session_request_events_as_resp
         transaction_webhook_response=response,
     )
 
-    # then the response event should be updated th request event with updated values
+    # then the response event should update the request event with the values
     # from the response
     assert response_event.id == request_event.id
     assert response_event.type == response_result

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1242,7 +1242,12 @@ def create_transaction_event_for_transaction_session(
         request_event.amount_value = response_event.amount
         request_event.psp_reference = response_event.psp_reference
         request_event.include_in_calculations = True
+        if response_event.time:
+            request_event.created_at = response_event.time
         request_event.app = app
+        request_event.message = response_event.message
+        if response_event.external_url:
+            request_event.external_url = response_event.external_url
         request_event_update_fields.extend(
             [
                 "type",
@@ -1250,6 +1255,9 @@ def create_transaction_event_for_transaction_session(
                 "psp_reference",
                 "include_in_calculations",
                 "app",
+                "message",
+                "created_at",
+                "external_url",
             ]
         )
         event = request_event


### PR DESCRIPTION
- Ensure that request event is correctly updated with all response data in case `*_REQEST` event is returned
- Extend `TransactionEvent` type with `createdAutomatically` field - to allow distinguish events created by Saleor and as a result of webhook response or event report
- 
<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
