### PR TITLE
Properly return CANCEL fulfilments in order resolver for app [3.20]

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -9,7 +9,7 @@ from .....core.prices import quantize_price
 from .....core.taxes import zero_taxed_money
 from .....order import OrderStatus
 from .....order.events import transaction_event
-from .....order.models import Order, OrderGrantedRefund
+from .....order.models import FulfillmentStatus, Order, OrderGrantedRefund
 from .....order.utils import (
     get_order_country,
     update_order_authorize_data,
@@ -29,6 +29,33 @@ from ....tests.utils import (
     get_graphql_content,
     get_graphql_content_from_response,
 )
+
+
+@pytest.fixture
+def fulfilled_order_with_canceled_fulfillment(fulfilled_order):
+    fulfillment = fulfilled_order.fulfillments.first()
+    fulfillment.status = FulfillmentStatus.CANCELED
+
+    fulfillment.save()
+
+    return fulfilled_order
+
+
+USER_ORDER = """
+query OrdersQuery {
+    me {
+        orders(first: 1) {
+        edges {
+            node {
+                fulfillments {
+                   status
+                }
+            }
+        }
+    }
+    }
+}
+"""
 
 ORDERS_FULL_QUERY = """
 query OrdersQuery {
@@ -120,6 +147,7 @@ query OrdersQuery {
                 }
                 fulfillments {
                     fulfillmentOrder
+                    status
                 }
                 payments{
                     id
@@ -1850,3 +1878,66 @@ def test_order_payment_status_with_transaction_and_without_granted_refunds(
     assert data["paymentStatusDisplay"] == dict(ChargeStatus.CHOICES).get(
         expected_payment_status.value
     )
+
+
+def test_order_query_canceled_fulfillment_visible_for_staff(
+    staff_api_client,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
+    fulfilled_order_with_canceled_fulfillment,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+
+    assert order_data["fulfillments"][0]["status"] == "CANCELED"
+
+
+def test_order_query_canceled_fulfillment_not_visible_for_normal_user(
+    user_api_client,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
+    fulfilled_order_with_canceled_fulfillment,
+):
+    # given
+    fulfilled_order_with_canceled_fulfillment.user = user_api_client.user
+
+    # when
+    response = user_api_client.post_graphql(USER_ORDER)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["me"]["orders"]["edges"][0]["node"]
+
+    # User can't see his/her fulfillent of type CANCEL, so the listy is empty
+    assert order_data["fulfillments"] == []
+
+
+def test_order_query_canceled_fulfillment_visible_for_app(
+    app_api_client,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
+    fulfilled_order_with_canceled_fulfillment,
+    permission_manage_orders,
+    permission_manage_shipping,
+):
+    # given
+
+    app = app_api_client.app
+    app.permissions.add(*[permission_manage_orders, permission_manage_shipping])
+
+    # when
+    response = app_api_client.post_graphql(ORDERS_FULL_QUERY)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+
+    assert order_data["fulfillments"][0]["status"] == "CANCELED"

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -35,7 +35,7 @@ from ...order.utils import (
 from ...payment import ChargeStatus, TransactionKind
 from ...payment.dataloaders import PaymentsByOrderIdLoader
 from ...payment.model_helpers import get_last_payment, get_total_authorized
-from ...permission.auth_filters import AuthorizationFilters
+from ...permission.auth_filters import AuthorizationFilters, is_app, is_staff_user
 from ...permission.enums import (
     AccountPermissions,
     AppPermission,
@@ -1945,8 +1945,11 @@ class Order(ModelObjectType[models.Order]):
     @staticmethod
     def resolve_fulfillments(root: models.Order, info):
         def _resolve_fulfillments(fulfillments):
-            user = info.context.user
-            if user and user.is_staff:
+            return_all_fulfillments = is_staff_user(info.context) or is_app(
+                info.context
+            )
+
+            if return_all_fulfillments:
                 return fulfillments
             return filter(
                 lambda fulfillment: fulfillment.status != FulfillmentStatus.CANCELED,


### PR DESCRIPTION
I want to merge this change because it's a port of #17677 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
