### PR TITLE
Telemetry - Fix flaky OTEL test

### DIFF
--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -4,24 +4,13 @@ from unittest.mock import MagicMock, patch
 import graphene
 import pytest
 from django.test import override_settings
-from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.semconv._incubating.attributes import graphql_attributes
 from opentelemetry.trace import StatusCode
 
 from ...core.telemetry import saleor_attributes
 from ...graphql.api import backend, schema
+from ...tests.utils import filter_spans_by_name, get_span_by_name
 from ..views import GraphQLView
-
-
-def get_spans_by_name(spans, name) -> tuple[ReadableSpan, ...]:
-    return tuple(span for span in spans if span.name == name)
-
-
-def get_span_by_name(spans, name) -> ReadableSpan:
-    filtered = get_spans_by_name(spans, name)
-    assert filtered, f"No span with name '{name}' found"
-    assert len(filtered) == 1, f"Multiple '{name}' spans"
-    return filtered[0]
 
 
 def test_tracing_query_hashing(
@@ -126,7 +115,7 @@ def test_tracing_query_hashing_different_vars_same_checksum(
     # then
     fingerprints = [
         span.attributes[saleor_attributes.GRAPHQL_DOCUMENT_FINGERPRINT]
-        for span in get_spans_by_name(get_test_spans(), query)
+        for span in filter_spans_by_name(get_test_spans(), query)
     ]
     assert len(fingerprints) == QUERIES
     assert len(set(fingerprints)) == 1

--- a/saleor/tests/utils.py
+++ b/saleor/tests/utils.py
@@ -2,9 +2,11 @@ import json
 import math
 from decimal import Decimal
 
+import pytest
 from django.conf import settings
 from django.db import connections
 from opentelemetry.sdk.metrics.export import DataPointT, Metric, MetricsData
+from opentelemetry.sdk.trace import ReadableSpan
 
 from ..core.db.connection import allow_writer
 
@@ -85,3 +87,13 @@ def get_metric_data_point(metrics_data: MetricsData, metric_name: str) -> DataPo
         f"For metric {metric_name} found {datapoints_count} instead of 1"
     )
     return metric_data.data.data_points[0]
+
+
+def get_span_by_name(spans: tuple[ReadableSpan, ...], name: str) -> ReadableSpan:
+    __tracebackhide__ = True
+    filtered = tuple(span for span in spans if span.name == name)
+    if not filtered:
+        pytest.fail(f"No span with name '{name}' found")
+    if len(filtered) > 1:
+        pytest.fail(f"Multiple '{name}' spans")
+    return filtered[0]

--- a/saleor/tests/utils.py
+++ b/saleor/tests/utils.py
@@ -89,11 +89,17 @@ def get_metric_data_point(metrics_data: MetricsData, metric_name: str) -> DataPo
     return metric_data.data.data_points[0]
 
 
+def filter_spans_by_name(
+    spans: tuple[ReadableSpan, ...], name
+) -> tuple[ReadableSpan, ...]:
+    return tuple(span for span in spans if span.name == name)
+
+
 def get_span_by_name(spans: tuple[ReadableSpan, ...], name: str) -> ReadableSpan:
     __tracebackhide__ = True
-    filtered = tuple(span for span in spans if span.name == name)
-    if not filtered:
+    spans = filter_spans_by_name(spans, name)
+    if not spans:
         pytest.fail(f"No span with name '{name}' found")
-    if len(filtered) > 1:
+    if len(spans) > 1:
         pytest.fail(f"Multiple '{name}' spans")
-    return filtered[0]
+    return spans[0]

--- a/saleor/webhook/transport/asynchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_transport.py
@@ -1,53 +1,40 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from celery.exceptions import Retry as CeleryTaskRetryError
 from opentelemetry.trace import StatusCode
 
-from .....core.models import EventDeliveryStatus
-from .....tests.utils import get_metric_data_point
+from .....tests.utils import get_metric_data_point, get_span_by_name
 from ...metrics import (
     METRIC_EXTERNAL_REQUEST_BODY_SIZE,
     METRIC_EXTERNAL_REQUEST_COUNT,
     METRIC_EXTERNAL_REQUEST_DURATION,
 )
-from ...utils import WebhookResponse
 from ..transport import send_webhook_request_async
 
 
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_using_scheme_method"
 )
-@patch("saleor.webhook.transport.asynchronous.transport.webhooks_otel_trace")
-@patch("saleor.webhook.transport.asynchronous.transport.attempt_update")
-@patch("saleor.webhook.transport.asynchronous.transport.handle_webhook_retry")
 def test_send_webhook_request_async_set_span_status_failed(
-    mock_handle_webhook_retry,
-    mock_attempt_update,
-    mock_webhooks_otel_trace,
     mock_send_webhook_using_scheme_method,
-    event_delivery_payload_in_database,
+    event_delivery,
+    webhook_response_failed,
+    get_test_spans,
 ):
     # given
-    event_delivery_id = event_delivery_payload_in_database.id
-    mock_span = MagicMock()
-    mock_webhooks_otel_trace.return_value.__enter__.return_value = mock_span
-
-    mock_response = MagicMock(spec=WebhookResponse)
-    mock_response.response_status_code = 500
-    mock_response.status = EventDeliveryStatus.FAILED
-    mock_response.content = ""
-    mock_send_webhook_using_scheme_method.return_value = mock_response
+    mock_send_webhook_using_scheme_method.return_value = webhook_response_failed
+    span_name = f"webhooks.{event_delivery.event_type}"
 
     # when
-    send_webhook_request_async(
-        event_delivery_id=event_delivery_id, telemetry_context={}
-    )
+    with pytest.raises(CeleryTaskRetryError):
+        send_webhook_request_async(
+            event_delivery_id=event_delivery.id, telemetry_context={}
+        )
 
     # then
-    mock_span.set_status.assert_called_once_with(
-        StatusCode.ERROR,
-    )
+    span = get_span_by_name(get_test_spans(), span_name)
+    assert span.status.status_code == StatusCode.ERROR
 
 
 @patch(


### PR DESCRIPTION
I want to merge this change because it:
- Refactors OTEL tests
- Fixes `test_send_webhook_request_async_set_span_status_failed` as it became flaky after introduction of webhook metrics


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
