### PR TITLE
Implementation of resource limits. 

### DIFF
--- a/saleor/core/rlimit.py
+++ b/saleor/core/rlimit.py
@@ -1,0 +1,60 @@
+import resource
+
+from django.core.exceptions import ImproperlyConfigured
+
+RLIMIT_TYPE = resource.RLIMIT_DATA
+
+
+def is_soft_limit_set_without_hard_limit(soft_limit_in_MB, hard_limit_in_MB):
+    return soft_limit_in_MB is not None and hard_limit_in_MB is None
+
+
+def is_hard_limit_set_without_soft_limit(soft_limit_in_MB, hard_limit_in_MB):
+    return soft_limit_in_MB is None and hard_limit_in_MB is not None
+
+
+def validate_and_set_rlimit(soft_limit_in_MB, hard_limit_in_MB):
+    """Set the memory limit for the process.
+
+    This function sets the soft and hard memory limits for the process using
+    the resource module. The limits are specified in megabytes (MB) and
+    are converted to bytes before being set. If the limits are not specified,
+    the function sets the limits to infinity (no limit).
+    If the soft limit is reached, the process will raise a `MemoryError`.
+    """
+
+    try:
+        soft_limit_in_MB = int(soft_limit_in_MB) if soft_limit_in_MB else None
+        hard_limit_in_MB = int(hard_limit_in_MB) if hard_limit_in_MB else None
+    except ValueError as e:
+        raise ImproperlyConfigured(
+            "Memory limits must be integers(`SOFT_MEMORY_LIMIT_IN_MB` or `HARD_MEMORY_LIMIT_IN_MB`)."
+        ) from e
+
+    if is_soft_limit_set_without_hard_limit(
+        soft_limit_in_MB, hard_limit_in_MB
+    ) or is_hard_limit_set_without_soft_limit(soft_limit_in_MB, hard_limit_in_MB):
+        raise ImproperlyConfigured(
+            "Both `SOFT_MEMORY_LIMIT_IN_MB` and `HARD_MEMORY_LIMIT_IN_MB` must be set to enable memory limits."
+        )
+
+    soft_memory_limit = (
+        soft_limit_in_MB * 1000 * 1000 if soft_limit_in_MB else resource.RLIM_INFINITY
+    )
+    hard_memory_limit = (
+        hard_limit_in_MB * 1000 * 1000 if hard_limit_in_MB else resource.RLIM_INFINITY
+    )
+    if soft_memory_limit > hard_memory_limit:
+        raise ImproperlyConfigured(
+            "Soft memory limit cannot be greater than hard memory limit."
+        )
+    if soft_memory_limit < 0 and soft_memory_limit != resource.RLIM_INFINITY:
+        raise ImproperlyConfigured(
+            "Soft memory limit(SOFT_MEMORY_LIMIT_IN_MB) cannot be negative."
+        )
+    if hard_memory_limit < 0 and hard_memory_limit != resource.RLIM_INFINITY:
+        raise ImproperlyConfigured(
+            "Hard memory limit(HARD_MEMORY_LIMIT_IN_MB) cannot be negative."
+        )
+
+    resource.setrlimit(RLIMIT_TYPE, (soft_memory_limit, hard_memory_limit))

--- a/saleor/core/tests/test_rlimit.py
+++ b/saleor/core/tests/test_rlimit.py
@@ -1,0 +1,159 @@
+import resource
+from unittest.mock import patch
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from ..rlimit import RLIMIT_TYPE, validate_and_set_rlimit
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_limit_passed_as_string(mock_setrlimit):
+    # given
+    soft_limit = "1000"
+    hard_limit = "2000"
+    expected_soft_limit = int(soft_limit) * 1000 * 1000
+    expected_hard_limit = int(hard_limit) * 1000 * 1000
+
+    # when
+    validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_called_once_with(
+        RLIMIT_TYPE,
+        (expected_soft_limit, expected_hard_limit),
+    )
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_limit_passed_as_int(mock_setrlimit):
+    # given
+    soft_limit = 1000
+    hard_limit = 2000
+    expected_soft_limit = int(soft_limit) * 1000 * 1000
+    expected_hard_limit = int(hard_limit) * 1000 * 1000
+
+    # when
+    validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_called_once_with(
+        RLIMIT_TYPE,
+        (expected_soft_limit, expected_hard_limit),
+    )
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_no_limits(mock_setrlimit):
+    # given
+    soft_limit = None
+    hard_limit = None
+    expected_soft_limit = resource.RLIM_INFINITY
+    expected_hard_limit = resource.RLIM_INFINITY
+
+    # when
+    validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_called_once_with(
+        RLIMIT_TYPE,
+        (expected_soft_limit, expected_hard_limit),
+    )
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_only_soft_limit_set(mock_setrlimit):
+    # given
+    soft_limit = 1000
+    hard_limit = None
+
+    # when
+    with pytest.raises(ImproperlyConfigured):
+        validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_not_called()
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_only_hard_limit_set(mock_setrlimit):
+    # given
+    soft_limit = None
+    hard_limit = 1000
+
+    # when
+    with pytest.raises(ImproperlyConfigured):
+        validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_not_called()
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_negative_soft_limit(mock_setrlimit):
+    # given
+    soft_limit = -10
+    hard_limit = 1000
+
+    # when
+    with pytest.raises(ImproperlyConfigured):
+        validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_not_called()
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_negative_hard_limit(mock_setrlimit):
+    # given
+    soft_limit = 1000
+    hard_limit = -10
+
+    # when
+    with pytest.raises(ImproperlyConfigured):
+        validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_not_called()
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_invalid_soft_limit(mock_setrlimit):
+    # given
+    soft_limit = "invalid"
+    hard_limit = 1000
+
+    # when
+    with pytest.raises(ImproperlyConfigured):
+        validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_not_called()
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_invalid_hard_limit(mock_setrlimit):
+    # given
+    soft_limit = 1000
+    hard_limit = "invalid"
+
+    # when
+    with pytest.raises(ImproperlyConfigured):
+        validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_not_called()
+
+
+@patch("saleor.core.rlimit.resource.setrlimit")
+def test_soft_limit_greater_than_hard_limit(mock_setrlimit):
+    # given
+    soft_limit = 2000
+    hard_limit = 1000
+
+    # when
+    with pytest.raises(ImproperlyConfigured):
+        validate_and_set_rlimit(soft_limit, hard_limit)
+
+    # then
+    mock_setrlimit.assert_not_called()

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -31,6 +31,7 @@ from . import PatchedSubscriberExecutionContext, __version__
 from .account.i18n_rules_override import i18n_rules_override
 from .core.db.patch import patch_db
 from .core.languages import LANGUAGES as CORE_LANGUAGES
+from .core.rlimit import validate_and_set_rlimit
 from .core.schedules import initiated_promotion_webhook_schedule
 from .graphql.graphql_core import (
     patch_execution_context,
@@ -66,6 +67,13 @@ def get_url_from_env(name, *, schemes=None) -> Optional[str]:
         return value
     return None
 
+
+# Possibility to set memory limits for the process. Function `validate_and_set_rlimit` set the
+# maximum size of the process's heap(`resource.RLIMIT_DATA`). If you set the memory limit and process will try to
+# allocate more memory than the limit, it will raise `MemoryError`.
+SOFT_MEMORY_LIMIT_IN_MB = os.environ.get("SOFT_MEMORY_LIMIT_IN_MB", None)
+HARD_MEMORY_LIMIT_IN_MB = os.environ.get("HARD_MEMORY_LIMIT_IN_MB", None)
+validate_and_set_rlimit(SOFT_MEMORY_LIMIT_IN_MB, HARD_MEMORY_LIMIT_IN_MB)
 
 DEBUG = get_bool_from_env("DEBUG", True)
 


### PR DESCRIPTION
I want to merge this change because of the implementation of resource limits. 

Add the possibility of set [the maximum size of the process’s heap](https://docs.python.org/3/library/resource.html#resource.RLIMIT_DATA) by `SOFT_MEMORY_LIMIT_IN_MB` and `HARD_MEMORY_LIMIT_IN_MB` environment variables.
 
 ⚠️  
It can't write a unit test for the memory limit because the memory limit can't be increased after we set it. This is because when we set the memory limit, that limit is valid until the end of the life of the process. 

### How it works:
After the memory limit is set in the environment variables, Seleor will have limited ability to use the process heap. If a process tries to allocate more memory than is available, the `MemoryError' will be thrown. This error should be logged. This log should allow you to find places in your code that use too much memory.

### Internal links:
Example of Memory Error:
https://saleor.sentry.io/issues/6559865061/events/eed7d780b9fe469cb78cf65fdeeaf841/

Test results & description:
https://app.datadoghq.com/notebook/12346085/rlimit-test-dev-infra

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
