### PR TITLE
Simplify usage of synchronous webhooks in the Transaction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Introduce `useLegacyLineVoucherPropagation` flag to control legacy propagation behavior for specific voucher types - #17587 - by @korycins
 - Add filterable subscriptions for checkout events (`checkoutCreated`, `checkoutUpdated`, `checkoutFullyPaid`, `checkoutMetadataUpdated`) - #17647 by @korycins
 
+
 ### Webhooks
 
 - Fixed webhookTrigger payload type for events related to ProductVariant - #16956 by @delemeator
@@ -82,6 +83,9 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed webhook `PRODUCT_VARIANT_METADATA_UPDATED` not being sent when `productVariantUpdate` mutation was called. Now, when `metadata` or `privateMetadata` is included in `ProductVariantUpdateInput`, both `PRODUCT_VARIANT_METADATA_UPDATED` and `PRODUCT_VARIANT_UPDATED` will be emitted (if subscribed) - #17406 by @lkostrowski
 - Update Draft Order shipping via `orderUpdateShipping` will emit `DRAFT_ORDER_UPDATED` webhook. Previously it was `ORDER_UPDATED` - #17480 by @lkostrowski
 - Update editable Order shipping via `orderUpdateShipping` will emit `ORDER_UPDATED` webhook when `shippingMethod` will be cleared (by passing `null` to graphQL input). - #17480 by @lkostrowski
+- Webhook `TRANSACTION_CANCELATION_REQUESTED` now provides a decimal value in the action.amount field instead of null - #17690 by @korycins
+- `TransactionAction.amount` field in subscription payload for webhooks: `TransactionRefundRequested`, `TransactionChargeRequested`, `TransactionCancelationRequested`, is now a non-null field - #17690 by @korycins
+- Field `amount` in the response for synchronous webhooks: `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED`, `TRANSACTION_INITIALIZE_SESSION`, `TRANSACTION_PROCESS_SESSION` is now optional field. If omitted, the system will default to using the `action.amount` specified in the payload. - #17690 by @korycins
 
 ### Other changes
 - Fixed outdated documentation links - #17675 by @krzysztofwolski

--- a/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
@@ -553,7 +553,7 @@ def test_transaction_request_cancelation_for_order(
         TransactionActionData(
             transaction=transaction,
             action_type=TransactionAction.CANCEL,
-            action_value=None,
+            action_value=transaction.authorized_value,
             event=request_event,
             transaction_app_owner=transaction_request_webhook.app,
         ),
@@ -567,7 +567,7 @@ def test_transaction_request_cancelation_for_order(
     assert TransactionEvent.objects.get(
         transaction=transaction,
         type=TransactionEventType.CANCEL_REQUEST,
-        amount_value=0,
+        amount_value=transaction.authorized_value,
     )
 
 
@@ -587,14 +587,14 @@ def test_transaction_request_cancelation_for_checkout(
     transaction_request_webhook.events.create(
         event_type=WebhookEventSyncType.TRANSACTION_CANCELATION_REQUESTED
     )
-
+    expected_amount = Decimal("10")
     transaction = TransactionItem.objects.create(
         name="Credit card",
         psp_reference="PSP ref",
         available_actions=["charge", "cancel"],
         currency="USD",
         checkout_id=checkout.pk,
-        authorized_value=Decimal("10"),
+        authorized_value=expected_amount,
         app_identifier=transaction_request_webhook.app.identifier,
         app=transaction_request_webhook.app,
     )
@@ -623,7 +623,7 @@ def test_transaction_request_cancelation_for_checkout(
         TransactionActionData(
             transaction=transaction,
             action_type=TransactionAction.CANCEL,
-            action_value=None,
+            action_value=expected_amount,
             event=request_event,
             transaction_app_owner=transaction_request_webhook.app,
         ),
@@ -633,7 +633,7 @@ def test_transaction_request_cancelation_for_checkout(
     assert TransactionEvent.objects.get(
         transaction=transaction,
         type=TransactionEventType.CANCEL_REQUEST,
-        amount_value=0,
+        amount_value=expected_amount,
     )
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15384,7 +15384,7 @@ type Mutation {
     actionType: TransactionActionEnum!
 
     """
-    Transaction request amount. If empty for refund or capture, maximal possible amount will be used.
+    Transaction request amount. If empty, maximal possible amount will be used.
     """
     amount: PositiveDecimal
 
@@ -33029,8 +33029,8 @@ type TransactionAction @doc(category: "Payments") {
   """Determines the action type."""
   actionType: TransactionActionEnum!
 
-  """Transaction request amount. Null when action type is VOID."""
-  amount: PositiveDecimal
+  """Transaction request amount."""
+  amount: PositiveDecimal!
 
   """Currency code."""
   currency: String!

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1767,7 +1767,8 @@ class TransactionAction(SubscriptionObjectType, AbstractType):
         description="Determines the action type.",
     )
     amount = PositiveDecimal(
-        description="Transaction request amount. Null when action type is VOID.",
+        description="Transaction request amount.",
+        required=True,
     )
     currency = graphene.String(
         description="Currency code.",
@@ -1779,9 +1780,7 @@ class TransactionAction(SubscriptionObjectType, AbstractType):
 
     @staticmethod
     def resolve_amount(root: TransactionActionData, _info: ResolveInfo):
-        if root.action_value is not None:
-            return quantize_price(root.action_value, root.transaction.currency)
-        return None
+        return quantize_price(root.action_value, root.transaction.currency)
 
     @staticmethod
     def resolve_currency(root: TransactionActionData, _info: ResolveInfo):

--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -168,6 +168,9 @@ def request_cancelation_action(
     app: App | None,
     action: str,
 ):
+    if cancel_value is None:
+        cancel_value = transaction.authorized_value
+
     transaction_action_data = _create_transaction_data(
         transaction=transaction,
         action_type=action,
@@ -195,7 +198,7 @@ def request_cancelation_action(
 def _create_transaction_data(
     transaction: TransactionItem,
     action_type: str,
-    action_value: Decimal | None,
+    action_value: Decimal,
     request_event: TransactionEvent,
     granted_refund: OrderGrantedRefund | None = None,
 ):

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -114,7 +114,7 @@ class TransactionActionData:
     transaction: TransactionItem
     event: "TransactionEvent"
     transaction_app_owner: Optional["App"]
-    action_value: Decimal | None = None
+    action_value: Decimal
     granted_refund: Optional["OrderGrantedRefund"] = None
 
 

--- a/saleor/payment/tests/test_gateway.py
+++ b/saleor/payment/tests/test_gateway.py
@@ -1217,7 +1217,7 @@ def test_request_cancelation_action_on_order(
         TransactionActionData(
             transaction=transaction,
             action_type=TransactionAction.CANCEL,
-            action_value=None,
+            action_value=transaction.authorized_value,
             event=requested_event,
             transaction_app_owner=app,
         ),
@@ -1259,7 +1259,9 @@ def test_request_cancelation_action_by_app(
         app=webhook_app,
     )
     requested_event = transaction.events.create(
-        currency=transaction.currency, type=TransactionEventType.CANCEL_REQUEST
+        currency=transaction.currency,
+        type=TransactionEventType.CANCEL_REQUEST,
+        amount_value=transaction.authorized_value,
     )
     mocked_is_active.side_effect = [False, True]
 
@@ -1281,7 +1283,7 @@ def test_request_cancelation_action_by_app(
         TransactionActionData(
             transaction=transaction,
             action_type=TransactionAction.CANCEL,
-            action_value=None,
+            action_value=transaction.authorized_value,
             event=requested_event,
             transaction_app_owner=webhook_app,
         ),
@@ -1326,6 +1328,7 @@ def test_request_cancelation_action_on_checkout(
     requested_event = transaction.events.create(
         currency=transaction.currency,
         type=TransactionEventType.CANCEL_REQUEST,
+        amount_value=transaction.authorized_value,
     )
     mocked_is_active.side_effect = [False, True]
 
@@ -1347,7 +1350,7 @@ def test_request_cancelation_action_on_checkout(
         TransactionActionData(
             transaction=transaction,
             action_type=TransactionAction.CANCEL,
-            action_value=None,
+            action_value=transaction.authorized_value,
             event=requested_event,
             transaction_app_owner=app,
         ),

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
@@ -72,6 +72,7 @@ def test_order_transaction_cancel_request(
         action_type=TransactionAction.CANCEL,
         event=request_event,
         transaction_app_owner=None,
+        action_value=authorized_value,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(
@@ -100,7 +101,11 @@ def test_order_transaction_cancel_request(
             },
             "checkout": None,
         },
-        "action": {"actionType": "CANCEL", "amount": None, "currency": order.currency},
+        "action": {
+            "actionType": "CANCEL",
+            "amount": quantize_price(authorized_value, "USD"),
+            "currency": order.currency,
+        },
     }
 
 
@@ -143,6 +148,7 @@ def test_checkout_transaction_cancel_request(
         action_type=TransactionAction.CANCEL,
         event=request_event,
         transaction_app_owner=None,
+        action_value=authorized_value,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(
@@ -182,5 +188,9 @@ def test_checkout_transaction_cancel_request(
                 },
             },
         },
-        "action": {"actionType": "CANCEL", "amount": None, "currency": "USD"},
+        "action": {
+            "actionType": "CANCEL",
+            "amount": quantize_price(authorized_value, "USD"),
+            "currency": "USD",
+        },
     }

--- a/saleor/webhook/tests/test_tasks.py
+++ b/saleor/webhook/tests/test_tasks.py
@@ -642,12 +642,15 @@ def test_handle_transaction_request_task_with_missing_required_event_field(
     app,
 ):
     # given
-    expected_psp_reference = "psp:123:111"
     mocked_webhook_response.text = json.dumps(
-        {"pspReference": expected_psp_reference, "amount": 12.00}
+        {
+            "result": TransactionEventType.REFUND_REQUEST.upper(),
+        }
     )
     mocked_webhook_response.content = json.dumps(
-        {"pspReference": expected_psp_reference, "amount": 12.00}
+        {
+            "result": TransactionEventType.REFUND_REQUEST.upper(),
+        }
     )
     mocked_post_request.return_value = mocked_webhook_response
 


### PR DESCRIPTION
This PR changes:
- `amount` in the response of synchronous webhooks for: `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED`, `TRANSACTION_INITIALIZE_SESSION`, `TRANSACTION_PROCESS_SESSION` is now optional. If not provided we will use the one that Saleor was requesting
- Subscription for cancel event will set the `action.amount` value. Previously we were sending the null there
- We're changing the `action.amount` field from optional to required. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1570

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
