### PR TITLE
Refactor `draftOrderUpdate` mutation

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -422,11 +422,6 @@ class DraftOrderCreate(
                         instance, method, manager, update_shipping_discount=False
                     )
 
-            if instance.undiscounted_base_shipping_price_amount is None:
-                instance.undiscounted_base_shipping_price_amount = (
-                    instance.base_shipping_price_amount
-                )
-
             if "voucher" in cleaned_input:
                 cls.handle_order_voucher(
                     cleaned_input,

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -102,17 +102,11 @@ class DraftOrderUpdate(
         cls, info: ResolveInfo, instance: models.Order, data: dict, **kwargs
     ):
         cls.clean_channel_id(instance, data)
-        manager = get_plugin_manager_promise(info.context).get()
         shipping_address = data.pop("shipping_address", None)
         billing_address = data.pop("billing_address", None)
-        redirect_url = data.pop("redirect_url", None)
+        redirect_url = data.pop("redirect_url", "")
 
-        shipping_method_input = {}
-        if "shipping_method" in data:
-            shipping_method_input["shipping_method"] = get_shipping_model_by_object_id(
-                object_id=data.pop("shipping_method", None),
-                error_field="shipping_method",
-            )
+        shipping_method_input = cls.clean_shipping_method(instance, data)
 
         if email := data.get("user_email", None):
             try:
@@ -129,7 +123,7 @@ class DraftOrderUpdate(
         draft_order_cleaner.clean_voucher_and_voucher_code(channel, cleaned_input)
 
         cls.clean_addresses(
-            info, instance, cleaned_input, shipping_address, billing_address, manager
+            info, instance, cleaned_input, shipping_address, billing_address
         )
 
         draft_order_cleaner.clean_redirect_url(redirect_url, cleaned_input)
@@ -150,6 +144,18 @@ class DraftOrderUpdate(
                 )
 
     @classmethod
+    def clean_shipping_method(cls, instance, cleaned_input):
+        shipping_method_input = {}
+        if "shipping_method" in cleaned_input:
+            shipping_method = get_shipping_model_by_object_id(
+                object_id=cleaned_input.pop("shipping_method", None),
+                error_field="shipping_method",
+            )
+            shipping_method_input["shipping_method"] = shipping_method
+
+        return shipping_method_input
+
+    @classmethod
     def clean_addresses(
         cls,
         info: ResolveInfo,
@@ -157,7 +163,6 @@ class DraftOrderUpdate(
         cleaned_input,
         shipping_address,
         billing_address,
-        manager,
     ):
         save_shipping_address = cleaned_input.get("save_shipping_address")
         save_billing_address = cleaned_input.get("save_billing_address")
@@ -208,45 +213,21 @@ class DraftOrderUpdate(
         info: ResolveInfo,
         instance,
         cleaned_input,
-        old_voucher,
-        old_voucher_code,
         changed_fields,
     ):
         updated_fields = changed_fields
-        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             # Process addresses
             address_fields = save_addresses(instance, cleaned_input)
             updated_fields.extend(address_fields)
 
             if "shipping_method" in cleaned_input:
-                method = cleaned_input["shipping_method"]
-                if method is None:
-                    ShippingMethodUpdateMixin.clear_shipping_method_from_order(instance)
-                else:
-                    ShippingMethodUpdateMixin.process_shipping_method(
-                        instance, method, manager, update_shipping_discount=True
-                    )
                 updated_fields.extend(SHIPPING_METHOD_UPDATE_FIELDS)
-
-            if instance.undiscounted_base_shipping_price_amount is None:
-                instance.undiscounted_base_shipping_price_amount = (
-                    instance.base_shipping_price_amount
-                )
-                updated_fields.append("undiscounted_base_shipping_price_amount")
-
-            if "voucher" in cleaned_input:
-                cls.handle_order_voucher(
-                    cleaned_input,
-                    instance,
-                    old_voucher,
-                    old_voucher_code,
-                )
 
             # In case nothing change, do not update perform post-process actions;
             # do not call the `DRAFT_ORDER_UPDATED` event.
             if not updated_fields:
-                return
+                return False
 
             if (
                 "shipping_address" in updated_fields
@@ -256,25 +237,28 @@ class DraftOrderUpdate(
                 updated_fields.append("display_gross_prices")
 
             update_order_search_vector(instance, save=False)
-            # Post-process the results
-            updated_fields.extend(
-                [
-                    "search_vector",
-                    "updated_at",
-                ]
-            )
+            updated_fields.append("search_vector")
 
             if cls.should_invalidate_prices(cleaned_input):
                 invalidate_order_prices(instance)
-                updated_fields.extend(["should_refresh_prices"])
+                updated_fields.append("should_refresh_prices")
 
-            instance.save(update_fields=updated_fields)
+            cls._save_order_instance(instance, updated_fields)
 
-            call_order_event(
-                manager,
-                WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
-                instance,
-            )
+            return True
+
+    @classmethod
+    def _save_order_instance(cls, instance, modified_instance_fields):
+        update_fields = ["updated_at"] + modified_instance_fields
+        instance.save(update_fields=update_fields)
+
+    @classmethod
+    def _post_save_action(cls, instance, manager):
+        call_order_event(
+            manager,
+            WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
+            instance,
+        )
 
     @classmethod
     def handle_order_voucher(
@@ -284,6 +268,9 @@ class DraftOrderUpdate(
         old_voucher,
         old_voucher_code,
     ):
+        if "voucher" not in cleaned_input:
+            return
+
         voucher = cleaned_input["voucher"]
         if voucher is None and old_voucher is None:
             return
@@ -314,17 +301,20 @@ class DraftOrderUpdate(
             release_voucher_code_usage(voucher_code, old_voucher, user_email)
 
     @classmethod
-    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
-        instance = cls.get_instance(info, **data)
-        channel_id = cls.get_instance_channel_id(instance, **data)
+    def handle_shipping(cls, cleaned_input, instance: models.Order, manager):
+        if "shipping_method" not in cleaned_input:
+            return
 
-        cls.check_channel_permissions(info, [channel_id])
+        method = cleaned_input["shipping_method"]
+        if method is None:
+            ShippingMethodUpdateMixin.clear_shipping_method_from_order(instance)
+        else:
+            ShippingMethodUpdateMixin.process_shipping_method(
+                instance, method, manager, update_shipping_discount=True
+            )
 
-        old_instance_data = instance.serialize_for_comparison()
-        old_voucher = instance.voucher
-        old_voucher_code = instance.voucher_code
-        data = data["input"]
-        cleaned_input = cls.clean_input(info, instance, data)
+    @classmethod
+    def handle_metadata(cls, instance: models.Order, cleaned_input):
         metadata_list: list[MetadataInput] = cleaned_input.pop("metadata", None)
         private_metadata_list: list[MetadataInput] = cleaned_input.pop(
             "private_metadata", None
@@ -336,23 +326,43 @@ class DraftOrderUpdate(
         private_metadata_collection = cls.create_metadata_from_graphql_input(
             private_metadata_list, error_field_name="private_metadata"
         )
-
-        instance = cls.construct_instance(instance, cleaned_input)
-
         cls.validate_and_update_metadata(
             instance, metadata_collection, private_metadata_collection
         )
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        instance = cls.get_instance(info, **data)
+        channel_id = cls.get_instance_channel_id(instance, **data)
+
+        cls.check_channel_permissions(info, [channel_id])
+
+        old_instance_data = instance.serialize_for_comparison()
+        old_voucher = instance.voucher
+        old_voucher_code = instance.voucher_code
+        data = data["input"]
+        cleaned_input = cls.clean_input(info, instance, data)
+
+        cls.handle_metadata(instance, cleaned_input)
+
+        instance = cls.construct_instance(instance, cleaned_input)
+
         cls.clean_instance(info, instance)
+
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.handle_shipping(cleaned_input, instance, manager)
+        cls.handle_order_voucher(cleaned_input, instance, old_voucher, old_voucher_code)
+
         new_instance_data = instance.serialize_for_comparison()
         changed_fields = cls.diff_instance_data_fields(
             instance.comparison_fields,
             old_instance_data,
             new_instance_data,
         )
-        cls._save(
-            info, instance, cleaned_input, old_voucher, old_voucher_code, changed_fields
-        )
-        cls._save_m2m(info, instance, cleaned_input)
+
+        order_modified = cls._save(info, instance, cleaned_input, changed_fields)
+        if order_modified:
+            cls._post_save_action(instance, manager)
 
         return DraftOrderUpdate(order=SyncWebhookControlContext(node=instance))
 


### PR DESCRIPTION
I want to merge this change because it refactors `draftOrderUpdate` mutation. The changes are needed to apply `InstanceTracker`.

The main purpose of the PR is to decouple the tracker application (https://github.com/saleor/saleor/pull/17656) and mutation refactor for efficient review

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
