### PR TITLE
Refactor `productVariantUpdate` mutations

### DIFF
--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -31,6 +31,7 @@ from ...product import models as product_models
 from ...product.error_codes import ProductErrorCode
 from ..core.utils import from_global_id_or_error, get_duplicated_values
 from ..core.validators import validate_one_of_args_is_in_mutation
+from ..product.utils import get_used_attribute_values_for_variant
 from ..utils import get_nodes
 from .enums import AttributeValueBulkActionEnum
 
@@ -49,7 +50,7 @@ class AttrValuesForSelectableFieldInput:
 
 @dataclass
 class AttrValuesInput:
-    global_id: str | None = None
+    global_id: str
     external_reference: str | None = None
     values: list[str] | None = None
     dropdown: AttrValuesForSelectableFieldInput | None = None
@@ -1612,3 +1613,37 @@ def prepare_error_list_from_error_attribute_mapping(
         errors.append(error)
 
     return errors
+
+
+def has_input_modified_attribute_values(
+    variant: product_models.ProductVariant, attributes_data: T_INPUT_MAP
+) -> bool:
+    """Compare already assigned attribute values with values from AttrValuesInput.
+
+    Return:
+        `False` if the attribute values are equal, otherwise `True`.
+
+    """
+    if variant.product_id is not None:
+        assigned_attributes = get_used_attribute_values_for_variant(variant)
+        input_attribute_values: defaultdict[str, list[str]] = defaultdict(list)
+        for attr, attr_data in attributes_data:
+            values = get_values_from_attribute_values_input(attr, attr_data)
+            if attr_data.global_id is not None:
+                input_attribute_values[attr_data.global_id].extend(values)
+        if input_attribute_values != assigned_attributes:
+            return True
+    return False
+
+
+def get_values_from_attribute_values_input(
+    attribute: attribute_models.Attribute, attribute_data: AttrValuesInput
+) -> list[str]:
+    """Format attribute values of type FILE."""
+    if attribute.input_type == AttributeInputType.FILE:
+        return (
+            [slugify(attribute_data.file_url.split("/")[-1])]
+            if attribute_data.file_url
+            else []
+        )
+    return attribute_data.values or []

--- a/saleor/graphql/product/mutations/product_variant/product_variant_cleaner.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_cleaner.py
@@ -1,0 +1,69 @@
+from collections import defaultdict
+
+from django.core.exceptions import ValidationError
+
+from .....attribute import models as attribute_models
+from .....product.error_codes import ProductErrorCode
+from ....attribute.utils import (
+    AttrValuesInput,
+    get_values_from_attribute_values_input,
+)
+
+T_INPUT_MAP = list[tuple[attribute_models.Attribute, AttrValuesInput]]
+
+
+def clean_weight(cleaned_input: dict):
+    weight = cleaned_input.get("weight")
+    if weight and weight.value < 0:
+        raise ValidationError(
+            {
+                "weight": ValidationError(
+                    "Product variant can't have negative weight.",
+                    code=ProductErrorCode.INVALID.value,
+                )
+            }
+        )
+
+
+def clean_quantity_limit(cleaned_input: dict):
+    quantity_limit_per_customer = cleaned_input.get("quantity_limit_per_customer")
+    if quantity_limit_per_customer is not None and quantity_limit_per_customer < 1:
+        raise ValidationError(
+            {
+                "quantity_limit_per_customer": ValidationError(
+                    (
+                        "Product variant can't have "
+                        "quantity_limit_per_customer lower than 1."
+                    ),
+                    code=ProductErrorCode.INVALID.value,
+                )
+            }
+        )
+
+
+def clean_preorder_settings(cleaned_input: dict):
+    preorder_settings = cleaned_input.get("preorder")
+    if preorder_settings:
+        cleaned_input["is_preorder"] = True
+        cleaned_input["preorder_global_threshold"] = preorder_settings.get(
+            "global_threshold"
+        )
+        cleaned_input["preorder_end_date"] = preorder_settings.get("end_date")
+
+
+def validate_duplicated_attribute_values(
+    attributes_data: T_INPUT_MAP,
+    used_attribute_values: list[dict[str, list[str]]],
+):
+    attribute_values: defaultdict[str, list[str]] = defaultdict(list)
+    for attr, attr_data in attributes_data:
+        values = get_values_from_attribute_values_input(attr, attr_data)
+        attribute_values[attr_data.global_id].extend(values)
+
+    if attribute_values in used_attribute_values:
+        raise ValidationError(
+            "Duplicated attribute values for product variant.",
+            code=ProductErrorCode.DUPLICATED_INPUT_ITEM.value,
+            params={"attributes": attribute_values.keys()},
+        )
+    used_attribute_values.append(attribute_values)

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -1,10 +1,6 @@
-from collections import defaultdict
-
 import graphene
 from django.core.exceptions import ValidationError
-from django.utils.text import slugify
 
-from .....attribute import AttributeInputType
 from .....attribute import models as attribute_models
 from .....core.tracing import traced_atomic_transaction
 from .....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
@@ -32,6 +28,7 @@ from ...utils import (
     get_used_variants_attribute_values,
 )
 from ..product.product_create import StockInput
+from . import product_variant_cleaner as cleaner
 
 T_INPUT_MAP = list[tuple[attribute_models.Attribute, AttrValuesInput]]
 
@@ -132,37 +129,6 @@ class ProductVariantCreate(DeprecatedModelMutation):
         support_private_meta_field = True
 
     @classmethod
-    def clean_attributes(
-        cls, attributes: dict, product_type: models.ProductType
-    ) -> T_INPUT_MAP:
-        attributes_qs = product_type.variant_attributes.all()
-        attributes = AttributeAssignmentMixin.clean_input(attributes, attributes_qs)
-        return attributes
-
-    @classmethod
-    def validate_duplicated_attribute_values(
-        cls, attributes_data, used_attribute_values, instance=None
-    ):
-        attribute_values = defaultdict(list)
-        for attr, attr_data in attributes_data:
-            if attr.input_type == AttributeInputType.FILE:
-                values = (
-                    [slugify(attr_data.file_url.split("/")[-1])]
-                    if attr_data.file_url
-                    else []
-                )
-            else:
-                values = attr_data.values
-            attribute_values[attr_data.global_id].extend(values)
-        if attribute_values in used_attribute_values:
-            raise ValidationError(
-                "Duplicated attribute values for product variant.",
-                code=ProductErrorCode.DUPLICATED_INPUT_ITEM.value,
-                params={"attributes": attribute_values.keys()},
-            )
-        used_attribute_values.append(attribute_values)
-
-    @classmethod
     def clean_input(
         cls,
         info: ResolveInfo,
@@ -172,57 +138,22 @@ class ProductVariantCreate(DeprecatedModelMutation):
     ):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 
-        weight = cleaned_input.get("weight")
-        if weight and weight.value < 0:
-            raise ValidationError(
-                {
-                    "weight": ValidationError(
-                        "Product variant can't have negative weight.",
-                        code=ProductErrorCode.INVALID.value,
-                    )
-                }
-            )
-
-        quantity_limit_per_customer = cleaned_input.get("quantity_limit_per_customer")
-        if quantity_limit_per_customer is not None and quantity_limit_per_customer < 1:
-            raise ValidationError(
-                {
-                    "quantity_limit_per_customer": ValidationError(
-                        (
-                            "Product variant can't have "
-                            "quantity_limit_per_customer lower than 1."
-                        ),
-                        code=ProductErrorCode.INVALID.value,
-                    )
-                }
-            )
-
-        stocks = cleaned_input.get("stocks")
-        if stocks:
+        cleaner.clean_weight(cleaned_input)
+        cleaner.clean_quantity_limit(cleaned_input)
+        if stocks := cleaned_input.get("stocks"):
             cls.check_for_duplicates_in_stocks(stocks)
+        cls.clean_attributes(cleaned_input)
+        if "sku" in cleaned_input:
+            cleaned_input["sku"] = clean_variant_sku(cleaned_input.get("sku"))
+        cleaner.clean_preorder_settings(cleaned_input)
 
-        if instance.pk:
-            # If the variant is getting updated,
-            # simply retrieve the associated product type
-            product_type = instance.product.product_type
-            used_attribute_values = get_used_variants_attribute_values(instance.product)
-        else:
-            # If the variant is getting created, no product type is associated yet,
-            # retrieve it from the required "product" input field
-            product = cleaned_input["product"]
-            if not product:
-                raise ValidationError(
-                    {
-                        "product": ValidationError(
-                            "Product cannot be set empty.",
-                            code=ProductErrorCode.INVALID.value,
-                        )
-                    }
-                )
-            product_type = cleaned_input["product"].product_type
-            used_attribute_values = get_used_variants_attribute_values(
-                cleaned_input["product"]
-            )
+        return cleaned_input
+
+    @classmethod
+    def clean_attributes(cls, cleaned_input: dict):
+        product = cls.get_product(cleaned_input)
+        product_type = product.product_type
+        used_attribute_values = get_used_variants_attribute_values(product)
 
         variant_attributes_ids = {
             graphene.Node.to_global_id("Attribute", attr_id)
@@ -230,6 +161,7 @@ class ProductVariantCreate(DeprecatedModelMutation):
                 product_type.variant_attributes.all().values_list("pk", flat=True)
             )
         }
+
         attributes = cleaned_input.get("attributes")
         attributes_ids = {attr["id"] for attr in attributes or []}
         invalid_attributes = attributes_ids - variant_attributes_ids
@@ -248,16 +180,15 @@ class ProductVariantCreate(DeprecatedModelMutation):
             # the value's PK.
             try:
                 if attributes:
-                    cleaned_attributes = cls.clean_attributes(attributes, product_type)
-                    cls.validate_duplicated_attribute_values(
-                        cleaned_attributes, used_attribute_values, instance
+                    attributes_qs = product_type.variant_attributes.all()
+                    cleaned_attributes: T_INPUT_MAP = (
+                        AttributeAssignmentMixin.clean_input(attributes, attributes_qs)
+                    )
+                    cleaner.validate_duplicated_attribute_values(
+                        cleaned_attributes, used_attribute_values
                     )
                     cleaned_input["attributes"] = cleaned_attributes
-                # elif not instance.pk and not attributes:
-                elif not instance.pk and (
-                    not attributes
-                    and product_type.variant_attributes.filter(value_required=True)
-                ):
+                elif product_type.variant_attributes.filter(value_required=True):
                     # if attributes were not provided on creation
                     raise ValidationError(
                         "All required attributes must take a value.",
@@ -272,18 +203,19 @@ class ProductVariantCreate(DeprecatedModelMutation):
                     ProductErrorCode.INVALID.value,
                 )
 
-        if "sku" in cleaned_input:
-            cleaned_input["sku"] = clean_variant_sku(cleaned_input.get("sku"))
-
-        preorder_settings = cleaned_input.get("preorder")
-        if preorder_settings:
-            cleaned_input["is_preorder"] = True
-            cleaned_input["preorder_global_threshold"] = preorder_settings.get(
-                "global_threshold"
+    @classmethod
+    def get_product(cls, cleaned_input: dict) -> models.Product:
+        product = cleaned_input["product"]
+        if not product:
+            raise ValidationError(
+                {
+                    "product": ValidationError(
+                        "Product cannot be set empty.",
+                        code=ProductErrorCode.INVALID.value,
+                    )
+                }
             )
-            cleaned_input["preorder_end_date"] = preorder_settings.get("end_date")
-
-        return cleaned_input
+        return product
 
     @classmethod
     def check_for_duplicates_in_stocks(cls, stocks_data):

--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -1,31 +1,35 @@
-from collections import defaultdict
-
 import graphene
 from django.core.exceptions import ValidationError
-from django.utils.text import slugify
 
-from .....attribute import AttributeInputType
 from .....attribute import models as attribute_models
 from .....core.tracing import traced_atomic_transaction
+from .....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
 from .....permission.enums import ProductPermissions
 from .....product import models
+from .....product.error_codes import ProductErrorCode
 from .....product.utils.variants import generate_and_set_variant_name
-from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
+from ....attribute.utils import (
+    AttributeAssignmentMixin,
+    AttrValuesInput,
+    has_input_modified_attribute_values,
+)
+from ....channel import ChannelContext
 from ....core import ResolveInfo
-from ....core.mutations import ModelWithExtRefMutation
+from ....core.mutations import DeprecatedModelMutation
 from ....core.types import ProductError
 from ....core.utils import ext_ref_to_global_id_or_error
 from ....core.validators import validate_one_of_args_is_in_mutation
 from ....meta.inputs import MetadataInput
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import ProductVariant
-from ...utils import get_used_attribute_values_for_variant
-from .product_variant_create import ProductVariantCreate, ProductVariantInput
+from ...utils import clean_variant_sku, get_used_variants_attribute_values
+from . import product_variant_cleaner as cleaner
+from .product_variant_create import ProductVariantInput
 
 T_INPUT_MAP = list[tuple[attribute_models.Attribute, AttrValuesInput]]
 
 
-class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
+class ProductVariantUpdate(DeprecatedModelMutation):
     class Arguments:
         id = graphene.ID(required=False, description="ID of a product to update.")
         external_reference = graphene.String(
@@ -50,42 +54,6 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         errors_mapping = {"price_amount": "price"}
         support_meta_field = True
         support_private_meta_field = True
-
-    @classmethod
-    def clean_attributes(
-        cls, attributes: dict, product_type: models.ProductType
-    ) -> T_INPUT_MAP:
-        attributes_qs = product_type.variant_attributes.all()
-        attributes = AttributeAssignmentMixin.clean_input(
-            attributes, attributes_qs, creation=False
-        )
-        return attributes
-
-    @classmethod
-    def validate_duplicated_attribute_values(
-        cls, attributes_data, used_attribute_values, instance=None
-    ):
-        # Check if the variant is getting updated,
-        # and the assigned attributes do not change
-        if instance.product_id is not None:
-            assigned_attributes = get_used_attribute_values_for_variant(instance)
-            input_attribute_values = defaultdict(list)
-            for attr, attr_data in attributes_data:
-                if attr.input_type == AttributeInputType.FILE:
-                    values = (
-                        [slugify(attr_data.file_url.split("/")[-1])]
-                        if attr_data.file_url
-                        else []
-                    )
-                else:
-                    values = attr_data.values
-                input_attribute_values[attr_data.global_id].extend(values)
-            if input_attribute_values == assigned_attributes:
-                return
-        # if assigned attributes is getting updated run duplicated attribute validation
-        super().validate_duplicated_attribute_values(
-            attributes_data, used_attribute_values
-        )
 
     @classmethod
     def get_instance(cls, info: ResolveInfo, **data) -> models.ProductVariant | None:
@@ -131,6 +99,84 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         return None
 
     @classmethod
+    def clean_input(
+        cls,
+        info: ResolveInfo,
+        instance: models.ProductVariant,
+        data: dict,
+        **kwargs,
+    ):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        cleaner.clean_weight(cleaned_input)
+        cleaner.clean_quantity_limit(cleaned_input)
+        cls.clean_attributes(cleaned_input, instance)
+        if "sku" in cleaned_input:
+            cleaned_input["sku"] = clean_variant_sku(cleaned_input.get("sku"))
+        cleaner.clean_preorder_settings(cleaned_input)
+
+        return cleaned_input
+
+    @classmethod
+    def clean_attributes(cls, cleaned_input: dict, instance: models.ProductVariant):
+        attribute_modified = False
+        product = instance.product
+        product_type = product.product_type
+        used_attribute_values = get_used_variants_attribute_values(product)
+
+        variant_attributes_ids = {
+            graphene.Node.to_global_id("Attribute", attr_id)
+            for attr_id in list(
+                product_type.variant_attributes.all().values_list("pk", flat=True)
+            )
+        }
+
+        attributes = cleaned_input.get("attributes")
+        attributes_ids = {attr["id"] for attr in attributes or []}
+        invalid_attributes = attributes_ids - variant_attributes_ids
+        if len(invalid_attributes) > 0:
+            raise ValidationError(
+                "Given attributes are not a variant attributes.",
+                code=ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.value,
+                params={"attributes": invalid_attributes},
+            )
+
+        # Run the validation only if product type is configurable
+        if product_type.has_variants:
+            # Attributes are provided as list of `AttributeValueInput` objects.
+            # We need to transform them into the format they're stored in the
+            # `Product` model, which is HStore field that maps attribute's PK to
+            # the value's PK.
+            try:
+                if attributes:
+                    attributes_qs = product_type.variant_attributes.all()
+                    cleaned_attributes: T_INPUT_MAP = (
+                        AttributeAssignmentMixin.clean_input(
+                            attributes, attributes_qs, creation=False
+                        )
+                    )
+                    # if assigned attributes is getting updated run duplicated attribute validation
+                    attribute_modified = has_input_modified_attribute_values(
+                        instance, cleaned_attributes
+                    )
+                    if attribute_modified:
+                        cleaner.validate_duplicated_attribute_values(
+                            cleaned_attributes, used_attribute_values
+                        )
+                    cleaned_input["attributes"] = cleaned_attributes
+
+            except ValidationError as e:
+                raise ValidationError({"attributes": e}) from e
+        else:
+            if attributes:
+                raise ValidationError(
+                    "Cannot assign attributes for product type without variants",
+                    ProductErrorCode.INVALID.value,
+                )
+
+        return attribute_modified
+
+    @classmethod
     def set_track_inventory(cls, _info, instance, cleaned_input):
         track_inventory = cleaned_input.get("track_inventory")
         if track_inventory is not None:
@@ -142,7 +188,9 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         instance.save(update_fields=update_fields)
 
     @classmethod
-    def _save(cls, info: ResolveInfo, instance, cleaned_input, changed_fields) -> bool:
+    def _save(
+        cls, info: ResolveInfo, instance, cleaned_input, changed_fields
+    ) -> tuple[bool, bool, bool]:
         metadata_changed = (
             "metadata" in changed_fields or "private_metadata" in changed_fields
         )
@@ -153,8 +201,7 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
                 cls._save_variant_instance(instance, changed_fields)
                 if "sku" in changed_fields or "name" in changed_fields:
                     refresh_product_search_index = True
-            if stocks := cleaned_input.get("stocks"):
-                cls.create_variant_stocks(instance, stocks)
+
             if attributes := cleaned_input.get("attributes"):
                 AttributeAssignmentMixin.save(instance, attributes)
                 refresh_product_search_index = True
@@ -170,24 +217,58 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
             if product_update_fields:
                 instance.product.save(update_fields=product_update_fields)
 
-            if changed_fields or stocks or attributes:
-                manager = get_plugin_manager_promise(info.context).get()
-                cls.call_event(manager.product_variant_updated, instance)
-
-                if metadata_changed:
-                    cls.call_event(manager.product_variant_metadata_updated, instance)
-
-                return True
-
-            return False
+            return bool(changed_fields), bool(attributes), metadata_changed
 
     @classmethod
-    def construct_instance(cls, instance, cleaned_input) -> ProductVariant:
+    def construct_instance(cls, instance, cleaned_input) -> models.ProductVariant:
         instance = super().construct_instance(instance, cleaned_input)
         cls.set_track_inventory(None, instance, cleaned_input)
         if not instance.name:
             generate_and_set_variant_name(instance, cleaned_input.get("sku"))
         return instance
+
+    @classmethod
+    def _post_save_action(
+        cls,
+        info: ResolveInfo,
+        instance,
+        variant_modified: bool,
+        attribute_modified: bool,
+        metadata_modified: bool,
+    ):
+        if variant_modified or attribute_modified or metadata_modified:
+            manager = get_plugin_manager_promise(info.context).get()
+            cls.call_event(manager.product_variant_updated, instance)
+
+            if metadata_modified:
+                cls.call_event(manager.product_variant_metadata_updated, instance)
+
+            channel_ids = models.ProductChannelListing.objects.filter(
+                product_id=instance.product_id
+            ).values_list("channel_id", flat=True)
+            # This will recalculate discounted prices for products.
+            cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
+
+    @classmethod
+    def handle_metadata(cls, instance, cleaned_input):
+        metadata_list: list[MetadataInput] = cleaned_input.pop("metadata", None)
+        private_metadata_list: list[MetadataInput] = cleaned_input.pop(
+            "private_metadata", None
+        )
+        metadata_collection = cls.create_metadata_from_graphql_input(
+            metadata_list, error_field_name="metadata"
+        )
+        private_metadata_collection = cls.create_metadata_from_graphql_input(
+            private_metadata_list, error_field_name="private_metadata"
+        )
+        cls.validate_and_update_metadata(
+            instance, metadata_collection, private_metadata_collection
+        )
+
+    @classmethod
+    def success_response(cls, instance):
+        instance = ChannelContext(node=instance, channel_slug=None)
+        return super().success_response(instance)
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
@@ -214,41 +295,26 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         )
         old_instance_data = instance.serialize_for_comparison()  # type: ignore[union-attr]
         cleaned_input = cls.clean_input(info, instance, input)  # type: ignore[arg-type]
-        metadata_list: list[MetadataInput] = cleaned_input.pop("metadata", None)
-        private_metadata_list: list[MetadataInput] = cleaned_input.pop(
-            "private_metadata", None
-        )
 
-        metadata_collection = cls.create_metadata_from_graphql_input(
-            metadata_list, error_field_name="metadata"
-        )
-        private_metadata_collection = cls.create_metadata_from_graphql_input(
-            private_metadata_list, error_field_name="private_metadata"
-        )
+        cls.handle_metadata(instance, cleaned_input)
 
-        new_instance = cls.construct_instance(instance, cleaned_input)
-        cls.validate_and_update_metadata(
-            new_instance, metadata_collection, private_metadata_collection
-        )
-        cls.clean_instance(info, new_instance)
-        new_instance_data = new_instance.serialize_for_comparison()
+        instance = cls.construct_instance(instance, cleaned_input)
+
+        cls.clean_instance(info, instance)
+        new_instance_data = instance.serialize_for_comparison()
 
         changed_fields = cls.diff_instance_data_fields(
-            new_instance.comparison_fields,
+            instance.comparison_fields,
             old_instance_data,
             new_instance_data,
         )
 
-        variant_modified = cls._save(info, instance, cleaned_input, changed_fields)
+        variant_modified, attributes_modified, metadata_modified = cls._save(
+            info, instance, cleaned_input, changed_fields
+        )
         cls._save_m2m(info, instance, cleaned_input)
-
-        if variant_modified:
-            # add to cleaned_input popped metadata to allow running post save events
-            # that depends on the metadata inputs
-            if metadata_list:
-                cleaned_input["metadata"] = metadata_list
-            if private_metadata_list:
-                cleaned_input["private_metadata"] = private_metadata_list
-            cls.post_save_action(info, instance, cleaned_input)
+        cls._post_save_action(
+            info, instance, variant_modified, attributes_modified, metadata_modified
+        )
 
         return cls.success_response(instance)

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -2783,10 +2783,8 @@ def test_update_product_variant_with_existing_metadata_and_event_when_write_diff
     metadata_value = "mv"
 
     variant.name = "Name"
-    variant.metadata = {"key": metadata_key, "value": metadata_value}
-
-    variant.private_metadata = {"key": metadata_key, "value": metadata_value}
-
+    variant.metadata = {metadata_key: metadata_value}
+    variant.private_metadata = {metadata_key: metadata_value}
     variant.save()
 
     # When


### PR DESCRIPTION
I want to merge this change because it refactors `productVariantUpdate` mutations. The changes are needed to apply `InstanceTracker`.

The main purpose of the PR is to decouple the tracker application (https://github.com/saleor/saleor/pull/17640) and mutation refactor for efficient review.

The refactor:
1. drops inheritance from variant create mutation
2. adds cleaner module to keep shared validators
3. decouples `clean_input` and `save` functions

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
