### PR TITLE
Add Semgrep rule to prevent using Django's default token generator

### DIFF
--- a/.semgrep/Makefile
+++ b/.semgrep/Makefile
@@ -7,4 +7,5 @@ scan:
 		--disable-version-check \
 		--error \
 		-c . \
+		--exclude ../.semgrep/ \
 		../

--- a/.semgrep/correctness/django/django-no-default-token-generator.py
+++ b/.semgrep/correctness/django/django-no-default-token-generator.py
@@ -1,0 +1,13 @@
+def test_using_default_token_generator():
+    # ruleid: django-no-default-token-generator
+    from django.contrib.auth.tokens import default_token_generator
+
+
+def test_using_token_generator_class():
+    # ruleid: django-no-default-token-generator
+    from django.contrib.auth.tokens import PasswordResetTokenGenerator
+
+def test_ok_not_using_django_builtin_default_token_generator():
+    # ok: django-no-default-token-generator
+    from saleor.core.tokens import token_generator
+

--- a/.semgrep/correctness/django/django-no-default-token-generator.yaml
+++ b/.semgrep/correctness/django/django-no-default-token-generator.yaml
@@ -1,0 +1,20 @@
+rules:
+  # Ensures we use settings.TOKEN_GENERATOR_CLASS instead of Django's
+  # token generator classes (django.contrib.auth.tokens.*)
+  - id: django-no-default-token-generator
+    version: 1.0.0
+    message: The default Django's token generator class shouldn't be used directly,
+      instead it should select it based on `settings.TOKEN_GENERATOR_CLASS`.
+      Replace `from django.contrib.auth.tokens import default_token_generator`
+      by `from saleor.core.tokens import token_generator`
+    metadata:
+      category: correctness
+      technology:
+        - django 
+    languages:
+      - python
+    severity: ERROR
+    pattern: |
+      from django.contrib.auth.tokens import $X
+    fix:
+      from saleor.core.tokens import token_generator


### PR DESCRIPTION
This is a follow-up for https://github.com/saleor/saleor/pull/17701, it adds a Semgrep rule that ensures developers do not accidentally use Django's default token generator.


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
