### PR TITLE
Add static typing for `PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION`

### DIFF
--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -185,7 +185,7 @@ class PaymentMethodTokenizationBaseRequestData:
 @dataclass
 class PaymentMethodTokenizationBaseResponseData:
     error: str | None
-    data: dict | None
+    data: JSONValue | None
 
 
 @dataclass

--- a/saleor/webhook/response_schemas/payment.py
+++ b/saleor/webhook/response_schemas/payment.py
@@ -11,7 +11,10 @@ from pydantic import (
 
 from ...graphql.core.utils import str_to_enum
 from ...payment import TokenizedPaymentFlow
-from ...payment.interface import StoredPaymentMethodRequestDeleteResult
+from ...payment.interface import (
+    PaymentGatewayInitializeTokenizationResult,
+    StoredPaymentMethodRequestDeleteResult,
+)
 from .utils.annotations import DefaultIfNone, EnumByName, OnErrorDefault, OnErrorSkip
 from .utils.validators import lower_values
 
@@ -119,6 +122,29 @@ class StoredPaymentMethodDeleteRequestedSchema(BaseModel):
         str | None,
         Field(
             description="Error message if the request to delete the stored payment method failed that will be passed to the frontend.",
+            default=None,
+        ),
+    ]
+
+
+class PaymentGatewayInitializeTokenizationSessionSchema(BaseModel):
+    result: Annotated[
+        EnumByName[PaymentGatewayInitializeTokenizationResult],
+        Field(
+            description="Result of the payment gateway initialization.",
+        ),
+    ]
+    data: Annotated[
+        DefaultIfNone[JsonValue],
+        Field(
+            description="A data required to finalize the initialization.",
+            default=None,
+        ),
+    ]
+    error: Annotated[
+        str | None,
+        Field(
+            description="Error message that will be passed to the frontend.",
             default=None,
         ),
     ]

--- a/saleor/webhook/transport/list_stored_payment_methods.py
+++ b/saleor/webhook/transport/list_stored_payment_methods.py
@@ -119,6 +119,7 @@ def get_response_for_payment_gateway_initialize_tokenization(
     response_data: dict | None,
 ) -> "PaymentGatewayInitializeTokenizationResponseData":
     data = None
+    error: str | None = None
     if response_data is None:
         result = PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER
         error = "Failed to delivery request."
@@ -130,8 +131,8 @@ def get_response_for_payment_gateway_initialize_tokenization(
                 )
             )
             result = gateway_initialize_model.result
-            error = gateway_initialize_model.result
-            data = gateway_initialize_model.error
+            error = gateway_initialize_model.error
+            data = gateway_initialize_model.data
         except ValidationError as e:
             result = PaymentGatewayInitializeTokenizationResult.FAILED_TO_INITIALIZE
             error = parse_validation_error(e)

--- a/saleor/webhook/transport/tests/test_list_stored_payment_methods.py
+++ b/saleor/webhook/transport/tests/test_list_stored_payment_methods.py
@@ -247,10 +247,7 @@ def test_get_response_for_payment_gateway_initialize_tokenization_valid_response
     response = get_response_for_payment_gateway_initialize_tokenization(response_data)
 
     # then
-    assert (
-        response.result.name
-        == response_data["result"]
-    )
+    assert response.result.name == response_data["result"]
     assert response.error == response_data.get("error")
     assert response.data == response_data.get("data")
 


### PR DESCRIPTION
Introduce static typing for `PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION` webhook

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
