### PR TITLE
Add static typing for paymenr method tokenization

### DIFF
--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -358,11 +358,12 @@ def test_payment_method_initialize_tokenization_missing_required_id(
     channel_USD,
 ):
     # given
-    expected_error_msg = "Missing payment method `id` in response."
-    mock_request.return_value = {
+    return_value = {
         "result": result,
         "data": None,
     }
+    mock_request.return_value = return_value
+    expected_error_msg = f"Missing value for field: id. Input: {return_value}."
 
     plugin = webhook_plugin()
 

--- a/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
@@ -367,14 +367,14 @@ def test_payment_method_process_tokenization_missing_required_id(
     webhook_plugin,
     payment_method_process_tokenization_app,
     channel_USD,
-    app,
 ):
     # given
-    expected_error_msg = "Missing payment method `id` in response."
-    mock_request.return_value = {
+    return_value = {
         "result": result,
         "data": None,
     }
+    mock_request.return_value = return_value
+    expected_error_msg = f"Missing value for field: id. Input: {return_value}."
 
     plugin = webhook_plugin()
 

--- a/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
@@ -356,10 +356,7 @@ def test_stored_payment_method_request_delete_missing_result_in_response_from_we
     assert not EventDelivery.objects.exists()
 
     assert response.result == StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE
-    assert (
-        response.error
-        == "Incorrect value ({}) for field: result. Error: Field required."
-    )
+    assert response.error == "Missing value for field: result. Input: {}."
 
 
 @mock.patch("saleor.webhook.transport.synchronous.transport.cache.delete")

--- a/saleor/webhook/response_schemas/payment.py
+++ b/saleor/webhook/response_schemas/payment.py
@@ -166,7 +166,7 @@ def clean_result(result: str):
     return PaymentMethodTokenizationResult[result]
 
 
-class PaymentMethodTokenizationSchema(BaseModel):
+class PaymentMethodTokenizationSuccessSchema(BaseModel):
     id: Annotated[str, Field(description="ID of the payment method.")]
     result: Annotated[  # type: ignore[name-defined]
         Literal[
@@ -182,13 +182,6 @@ class PaymentMethodTokenizationSchema(BaseModel):
         DefaultIfNone[JsonValue],
         Field(
             description="A data passes to the client.",
-            default=None,
-        ),
-    ]
-    error: Annotated[
-        str | None,
-        Field(
-            description="Error message that will be passed to the frontend.",
             default=None,
         ),
     ]

--- a/saleor/webhook/response_schemas/payment.py
+++ b/saleor/webhook/response_schemas/payment.py
@@ -6,15 +6,20 @@ from pydantic import (
     BaseModel,
     Field,
     JsonValue,
+    ValidationInfo,
     field_validator,
+    model_validator,
 )
 
+from ...app.models import App
 from ...graphql.core.utils import str_to_enum
 from ...payment import TokenizedPaymentFlow
 from ...payment.interface import (
     PaymentGatewayInitializeTokenizationResult,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteResult,
 )
+from ..transport.utils import to_payment_app_id
 from .utils.annotations import DefaultIfNone, EnumByName, OnErrorDefault, OnErrorSkip
 from .utils.validators import lower_values
 
@@ -137,9 +142,102 @@ class PaymentGatewayInitializeTokenizationSessionSchema(BaseModel):
     data: Annotated[
         DefaultIfNone[JsonValue],
         Field(
+            default=None,
             description="A data required to finalize the initialization.",
+        ),
+    ]
+    error: Annotated[
+        str | None,
+        Field(
+            description="Error message that will be passed to the frontend.",
             default=None,
         ),
+    ]
+
+
+def clean_id(payment_method_id: str, info: ValidationInfo) -> str:
+    app: App | None = info.context.get("app", None) if info.context else None
+    if not app:
+        raise RuntimeError("Missing app in context")
+    return to_payment_app_id(app, payment_method_id)
+
+
+def clean_result(result: str):
+    return PaymentMethodTokenizationResult[result]
+
+
+class PaymentMethodTokenizationSchema(BaseModel):
+    id: Annotated[str, Field(description="ID of the payment method.")]
+    result: Annotated[  # type: ignore[name-defined]
+        Literal[
+            PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+            PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+        ],
+        Field(
+            description="Result of the payment method tokenization.",
+        ),
+        AfterValidator(clean_result),
+    ]
+    data: Annotated[
+        DefaultIfNone[JsonValue],
+        Field(
+            description="A data passes to the client.",
+            default=None,
+        ),
+    ]
+    error: Annotated[
+        str | None,
+        Field(
+            description="Error message that will be passed to the frontend.",
+            default=None,
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def clean_id(self, info: ValidationInfo):
+        payment_method_id = self.id
+        self.id = clean_id(payment_method_id, info)
+        return self
+
+
+class PaymentMethodTokenizationPendingSchema(BaseModel):
+    id: Annotated[
+        str | None, Field(description="ID of the payment method.", default=None)
+    ]
+    result: Annotated[  # type: ignore[name-defined]
+        Literal[PaymentMethodTokenizationResult.PENDING.name],
+        Field(
+            description="Result of the payment method tokenization.",
+        ),
+        AfterValidator(clean_result),
+    ]
+    data: Annotated[
+        DefaultIfNone[JsonValue],
+        Field(
+            description="A data passes to the client.",
+            default=None,
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def clean_id(self, info: ValidationInfo):
+        payment_method_id = self.id
+        if payment_method_id is None:
+            return self
+        self.id = clean_id(payment_method_id, info)
+        return self
+
+
+class PaymentMethodTokenizationFailedSchema(BaseModel):
+    result: Annotated[  # type: ignore[name-defined]
+        Literal[
+            PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+            PaymentMethodTokenizationResult.FAILED_TO_DELIVER.name,
+        ],
+        Field(
+            description="Result of the payment method tokenization.",
+        ),
+        AfterValidator(clean_result),
     ]
     error: Annotated[
         str | None,

--- a/saleor/webhook/response_schemas/utils/helpers.py
+++ b/saleor/webhook/response_schemas/utils/helpers.py
@@ -10,7 +10,12 @@ def parse_validation_error(error: ValidationError) -> str:
         loc_data = error_data["loc"]
         if loc_data:
             field = str(loc_data[0])
-        error_msg.append(
-            f"Incorrect value ({error_data['input']}) for field: {field}. Error: {error_data['msg']}."
-        )
+        if error_data.get("type") == "missing":
+            error_msg.append(
+                f"Missing value for field: {field}. Input: {error_data['input']}."
+            )
+        else:
+            error_msg.append(
+                f"Incorrect value ({error_data['input']}) for field: {field}. Error: {error_data['msg']}."
+            )
     return "\n\n".join(error_msg)

--- a/saleor/webhook/tests/response_schemas/test_helpers.py
+++ b/saleor/webhook/tests/response_schemas/test_helpers.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ValidationError
 from ...response_schemas.utils.helpers import parse_validation_error
 
 
-class TestSchema(BaseModel):
+class ExampleSchema(BaseModel):
     field1: int
     field2: str
 
@@ -14,7 +14,7 @@ def test_parse_validation_error_single_error():
 
     # when
     try:
-        TestSchema.model_validate(invalid_data)
+        ExampleSchema.model_validate(invalid_data)
     except ValidationError as error:
         error_msg = parse_validation_error(error)
 
@@ -30,7 +30,7 @@ def test_parse_validation_error_multiple_errors():
 
     # when
     try:
-        TestSchema.model_validate(invalid_data)
+        ExampleSchema.model_validate(invalid_data)
     except ValidationError as error:
         error_msg = parse_validation_error(error)
 
@@ -39,3 +39,17 @@ def test_parse_validation_error_multiple_errors():
         f"Incorrect value ({invalid_data['field1']}) for field: field1. Error: Input should be a valid integer, unable to parse string as an integer.\n\n"
         f"Incorrect value ({invalid_data['field2']}) for field: field2. Error: Input should be a valid string."
     )
+
+
+def test_parse_validation_error_missing_field_value():
+    # given
+    invalid_data = {"field1": 1232}
+
+    # when
+    try:
+        ExampleSchema.model_validate(invalid_data)
+    except ValidationError as error:
+        error_msg = parse_validation_error(error)
+
+    # then
+    assert error_msg == f"Missing value for field: field2. Input: {invalid_data}."

--- a/saleor/webhook/tests/response_schemas/test_payment.py
+++ b/saleor/webhook/tests/response_schemas/test_payment.py
@@ -5,16 +5,21 @@ from pydantic import ValidationError
 
 from ....payment.interface import (
     PaymentGatewayInitializeTokenizationResult,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteResult,
 )
 from ...response_schemas.payment import (
     CreditCardInfoSchema,
     ListStoredPaymentMethodsSchema,
     PaymentGatewayInitializeTokenizationSessionSchema,
+    PaymentMethodTokenizationFailedSchema,
+    PaymentMethodTokenizationPendingSchema,
+    PaymentMethodTokenizationSchema,
     StoredPaymentMethodDeleteRequestedSchema,
     StoredPaymentMethodSchema,
 )
 from ...response_schemas.utils.annotations import logger as annotations_logger
+from ...transport.utils import to_payment_app_id
 
 
 @pytest.mark.parametrize(
@@ -561,6 +566,8 @@ def test_stored_payment_method_delete_requested_schema_invalid(data, invalid_fie
     assert exc_info.value.errors()[0]["loc"][0] == invalid_field
 
 
+
+
 @pytest.mark.parametrize(
     "data",
     [
@@ -598,7 +605,7 @@ def test_stored_payment_method_delete_requested_schema_invalid(data, invalid_fie
         },
     ],
 )
-def test_payment_gateway_initizlize_tokenization_session_schema_valid(data):
+def test_payment_gateway_initialize_tokenization_session_schema_valid(data):
     # when
     schema = PaymentGatewayInitializeTokenizationSessionSchema.model_validate(data)
 
@@ -653,7 +660,7 @@ def test_payment_gateway_initizlize_tokenization_session_schema_valid(data):
         ),
     ],
 )
-def test_payment_gateway_initizlize_tokenization_session_schema_invalid(
+def test_payment_gateway_initialize_tokenization_session_schema_invalid(
     data, invalid_field
 ):
     # when
@@ -663,3 +670,242 @@ def test_payment_gateway_initizlize_tokenization_session_schema_invalid(
     # then
     assert len(exc_info.value.errors()) == 1
     assert exc_info.value.errors()[0]["loc"][0] == invalid_field
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # SUCCESSFULLY_TOKENIZED with not data and no error
+        {
+            "id": "123",
+            "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        },
+        # ADDITIONAL_ACTION_REQUIRED with data and error as none
+        {
+            "id": "456",
+            "result": PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+            "data": {"action": "verify"},
+            "error": None,
+        },
+        # SUCCESSFULLY_TOKENIZED with no data and no error
+        {
+            "id": "789",
+            "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        },
+    ],
+)
+def test_payment_method_tokenization_schema_valid(data, app):
+    # when
+    schema = PaymentMethodTokenizationSchema.model_validate(data, context={"app": app})
+
+    # then
+    assert schema.result == PaymentMethodTokenizationResult[data["result"]]
+    assert schema.data == data.get("data")
+    assert schema.error == data.get("error")
+    assert schema.id == to_payment_app_id(app, data["id"])
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_error_field"),
+    [
+        # Missing `id` field
+        (
+            {
+                "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+                "data": {"key": "value"},
+            },
+            "id",
+        ),
+        # Missing `result` field
+        (
+            {
+                "id": "123",
+                "data": {"key": "value"},
+                "error": None,
+            },
+            "result",
+        ),
+        # Invalid `result` value
+        (
+            {
+                "id": "123",
+                "result": "INVALID_RESULT",
+            },
+            "result",
+        ),
+        # `id` field with wrong type
+        (
+            {
+                "id": 123,
+                "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+                "data": {"key": "value"},
+                "error": None,
+            },
+            "id",
+        ),
+        # `error` field with wrong type
+        (
+            {
+                "id": "123",
+                "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+                "data": {"key": "value"},
+                "error": 123,
+            },
+            "error",
+        ),
+    ],
+)
+def test_payment_method_tokenization_schema_invalid(data, expected_error_field):
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        PaymentMethodTokenizationSchema.model_validate(data)
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"][0] == expected_error_field
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # All fields provided
+        {
+            "id": "123",
+            "result": PaymentMethodTokenizationResult.PENDING.name,
+            "data": {"status": "pending"},
+        },
+        # `id` is None
+        {
+            "id": None,
+            "result": PaymentMethodTokenizationResult.PENDING.name,
+            "data": {"status": "pending"},
+        },
+        # No data provided
+        {
+            "id": "456",
+            "result": PaymentMethodTokenizationResult.PENDING.name,
+        },
+    ],
+)
+def test_payment_method_tokenization_pending_schema_valid(data, app):
+    # when
+    schema = PaymentMethodTokenizationPendingSchema.model_validate(
+        data, context={"app": app}
+    )
+
+    # then
+    assert schema.result == PaymentMethodTokenizationResult.PENDING
+    assert schema.data == data.get("data", None)
+    assert schema.id == (to_payment_app_id(app, data["id"]) if data["id"] else None)
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_error_field"),
+    [
+        # Missing `result` field
+        (
+            {
+                "id": "123",
+                "data": {"status": "pending"},
+            },
+            "result",
+        ),
+        # Invalid `result` value
+        (
+            {
+                "id": "123",
+                "result": "INVALID_RESULT",
+                "data": {"status": "pending"},
+            },
+            "result",
+        ),
+        # `id` field with wrong type
+        (
+            {
+                "id": 123,
+                "result": PaymentMethodTokenizationResult.PENDING.name,
+                "data": {"status": "pending"},
+            },
+            "id",
+        ),
+    ],
+)
+def test_payment_method_tokenization_pending_schema_invalid(data, expected_error_field):
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        PaymentMethodTokenizationPendingSchema.model_validate(data)
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"][0] == expected_error_field
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # `FAILED_TO_TOKENIZE`` with error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+            "error": "Tokenization failed.",
+        },
+        # `FAILED_TO_DELIVER`` with error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_DELIVER.name,
+            "error": "Tokenization failed.",
+        },
+        # `FAILED_TO_TOKENIZE` without error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+            "error": None,
+        },
+        # `FAILED_TO_DELIVER` without error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_DELIVER.name,
+        },
+    ],
+)
+def test_payment_method_tokenization_failed_schema_valid(data):
+    # when
+    schema = PaymentMethodTokenizationFailedSchema.model_validate(data)
+
+    # then
+    assert schema.result == PaymentMethodTokenizationResult[data["result"]]
+    assert schema.error == data.get("error")
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_error_field"),
+    [
+        # Missing `result` field
+        (
+            {
+                "error": "Tokenization failed due to invalid input.",
+            },
+            "result",
+        ),
+        # Invalid `result` value
+        (
+            {
+                "result": "INVALID_RESULT",
+                "error": "Invalid result value.",
+            },
+            "result",
+        ),
+        # `error` field with wrong type
+        (
+            {
+                "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+                "error": 123,  # Should be a string or None
+            },
+            "error",
+        ),
+    ],
+)
+def test_payment_method_tokenization_failed_schema_invalid(data, expected_error_field):
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        PaymentMethodTokenizationFailedSchema.model_validate(data)
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"][0] == expected_error_field

--- a/saleor/webhook/transport/list_stored_payment_methods.py
+++ b/saleor/webhook/transport/list_stored_payment_methods.py
@@ -21,6 +21,9 @@ from ...webhook.utils import get_webhooks_for_event
 from ..response_schemas.payment import (
     ListStoredPaymentMethodsSchema,
     PaymentGatewayInitializeTokenizationSessionSchema,
+    PaymentMethodTokenizationFailedSchema,
+    PaymentMethodTokenizationPendingSchema,
+    PaymentMethodTokenizationSchema,
     StoredPaymentMethodDeleteRequestedSchema,
 )
 from ..response_schemas.utils.helpers import parse_validation_error
@@ -146,31 +149,52 @@ def get_response_for_payment_method_tokenization(
     response_data: dict | None, app: "App"
 ) -> "PaymentMethodTokenizationResponseData":
     data = None
+    error: str | None = None
     payment_method_id = None
     if response_data is None:
         result = PaymentMethodTokenizationResult.FAILED_TO_DELIVER
         error = "Failed to delivery request."
     else:
         try:
-            response_result = response_data.get("result") or ""
-            result = PaymentMethodTokenizationResult[response_result]
-            error = response_data.get("error", None)
-            data = response_data.get("data", None)
-        except KeyError:
+            response_model = _validate_payment_method_response(response_data, app)
+            result = response_model.result
+            error = getattr(response_model, "error", None)
+            data = getattr(response_model, "data", None)
+            payment_method_id = getattr(response_model, "id", None)
+        except ValidationError as e:
             result = PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
-            error = "Missing or incorrect `result` in response."
-
-        try:
-            payment_method_id = response_data["id"]
-            payment_method_id = to_payment_app_id(app, payment_method_id)
-        except KeyError:
-            if result in [
-                PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
-                PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED,
-            ]:
-                result = PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
-                error = "Missing payment method `id` in response."
+            error = parse_validation_error(e)
+        except ValueError as e:
+            result = PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
+            error = str(e)
 
     return PaymentMethodTokenizationResponseData(
         result=result, error=error, data=data, id=payment_method_id
     )
+
+
+def _validate_payment_method_response(response_data: dict, app):
+    context = {
+        "app": app,
+    }
+    match response_data.get("result"):
+        case (
+            PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name
+            | PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name
+        ):
+            return PaymentMethodTokenizationSchema.model_validate(
+                response_data, context=context
+            )
+        case PaymentMethodTokenizationResult.PENDING.name:
+            return PaymentMethodTokenizationPendingSchema.model_validate(
+                response_data, context=context
+            )
+        case (
+            PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name
+            | PaymentMethodTokenizationResult.FAILED_TO_DELIVER.name
+        ):
+            return PaymentMethodTokenizationFailedSchema.model_validate(
+                response_data, context=context
+            )
+        case _:
+            raise ValueError("Missing or invalid `result` in response.")

--- a/saleor/webhook/transport/list_stored_payment_methods.py
+++ b/saleor/webhook/transport/list_stored_payment_methods.py
@@ -23,7 +23,7 @@ from ..response_schemas.payment import (
     PaymentGatewayInitializeTokenizationSessionSchema,
     PaymentMethodTokenizationFailedSchema,
     PaymentMethodTokenizationPendingSchema,
-    PaymentMethodTokenizationSchema,
+    PaymentMethodTokenizationSuccessSchema,
     StoredPaymentMethodDeleteRequestedSchema,
 )
 from ..response_schemas.utils.helpers import parse_validation_error
@@ -182,7 +182,7 @@ def _validate_payment_method_response(response_data: dict, app):
             PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name
             | PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name
         ):
-            return PaymentMethodTokenizationSchema.model_validate(
+            return PaymentMethodTokenizationSuccessSchema.model_validate(
                 response_data, context=context
             )
         case PaymentMethodTokenizationResult.PENDING.name:

--- a/saleor/webhook/transport/list_stored_payment_methods.py
+++ b/saleor/webhook/transport/list_stored_payment_methods.py
@@ -197,4 +197,15 @@ def _validate_payment_method_response(response_data: dict, app):
                 response_data, context=context
             )
         case _:
-            raise ValueError("Missing or invalid `result` in response.")
+            possible_values = ", ".join(
+                [value.name for value in PaymentMethodTokenizationResult]
+            )
+            logger.warning(
+                "Invalid value for `result`: %s. Possible values: %s.",
+                response_data.get("result"),
+                possible_values,
+                extra={"app": app.id},
+            )
+            raise ValueError(
+                f"Missing or invalid value for `result`: {response_data.get('result')}. Possible values: {possible_values}."
+            )

--- a/saleor/webhook/transport/tests/test_list_stored_payment_methods.py
+++ b/saleor/webhook/transport/tests/test_list_stored_payment_methods.py
@@ -356,7 +356,8 @@ def test_get_response_for_payment_gateway_initialize_tokenization_response_is_no
         (
             {"result": "INVALID_RESULT"},
             PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
-            "Missing or invalid `result` in response.",
+            "Missing or invalid value for `result`: INVALID_RESULT. Possible values: "
+            f"{', '.join([value.name for value in PaymentMethodTokenizationResult])}.",
             None,
             None,
         ),
@@ -425,11 +426,15 @@ def test_get_response_for_payment_method_tokenization_validation_error(
 
 def test_get_response_for_payment_method_tokenization_value_error(app):
     # given
-    response_data = {"result": "INVALID_RESULT"}
+    result = "INVALID_RESULT"
+    response_data = {"result": result}
 
     # when
     response = get_response_for_payment_method_tokenization(response_data, app)
 
     # then
     assert response.result == PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
-    assert "missing or invalid `result`" in response.error.lower()
+    assert (
+        f"Missing or invalid value for `result`: {result}. Possible values: "
+        in response.error
+    )

--- a/saleor/webhook/transport/tests/test_list_stored_payment_methods.py
+++ b/saleor/webhook/transport/tests/test_list_stored_payment_methods.py
@@ -8,12 +8,14 @@ from ....payment.interface import (
     PaymentGatewayInitializeTokenizationResult,
     PaymentMethodCreditCardInfo,
     PaymentMethodData,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteResult,
 )
 from ...response_schemas.utils.annotations import logger as annotations_logger
 from ..list_stored_payment_methods import (
     get_list_stored_payment_methods_from_response,
     get_response_for_payment_gateway_initialize_tokenization,
+    get_response_for_payment_method_tokenization,
     get_response_for_stored_payment_method_request_delete,
     logger,
 )
@@ -182,7 +184,7 @@ def test_get_response_for_stored_payment_method_request_delete_valid_response(
         # Missing `result` in response
         (
             {"error": "Missing result"},
-            "Incorrect value ({'error': 'Missing result'}) for field: result. Error: Field required.",
+            "Missing value for field: result. Input: {'error': 'Missing result'}.",
         ),
         # Invalid `result` value
         (
@@ -258,7 +260,7 @@ def test_get_response_for_payment_gateway_initialize_tokenization_valid_response
         # Missing `result` in response
         (
             {"error": "Missing result"},
-            "Incorrect value ({'error': 'Missing result'}) for field: result. Error: Field required.",
+            "Missing value for field: result. Input: {'error': 'Missing result'}.",
         ),
         # Invalid `result` value
         (
@@ -291,3 +293,143 @@ def test_get_response_for_payment_gateway_initialize_tokenization_response_is_no
         response.result == PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER
     )
     assert response.error == "Failed to delivery request."
+
+
+@pytest.mark.parametrize(
+    (
+        "response_data",
+        "expected_result",
+        "expected_error",
+        "expected_id",
+        "expected_data",
+    ),
+    [
+        # Successfully tokenized
+        (
+            {
+                "id": "123",
+                "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+                "data": {"key": "value"},
+                "error": None,
+            },
+            PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
+            None,
+            "123",
+            {"key": "value"},
+        ),
+        # Additional action required
+        (
+            {
+                "id": "456",
+                "result": PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+                "data": {"action": "verify"},
+                "error": None,
+            },
+            PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED,
+            None,
+            "456",
+            {"action": "verify"},
+        ),
+        # Pending
+        (
+            {
+                "result": PaymentMethodTokenizationResult.PENDING.name,
+                "data": {"status": "pending"},
+            },
+            PaymentMethodTokenizationResult.PENDING,
+            None,
+            None,
+            {"status": "pending"},
+        ),
+        # Failed to tokenize
+        (
+            {
+                "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+                "error": "Tokenization failed",
+            },
+            PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
+            "Tokenization failed",
+            None,
+            None,
+        ),
+        # Invalid result
+        (
+            {"result": "INVALID_RESULT"},
+            PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
+            "Missing or invalid `result` in response.",
+            None,
+            None,
+        ),
+        # No response data
+        (
+            None,
+            PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+            "Failed to delivery request.",
+            None,
+            None,
+        ),
+    ],
+)
+def test_get_response_for_payment_method_tokenization(
+    response_data, expected_result, expected_error, expected_id, expected_data, app
+):
+    # when
+    response = get_response_for_payment_method_tokenization(response_data, app)
+
+    # then
+    assert response.result == expected_result
+    assert response.error == expected_error
+    assert response.id == (to_payment_app_id(app, expected_id) if expected_id else None)
+    assert response.data == expected_data
+
+
+@pytest.mark.parametrize(
+    ("response_data", "error_msg"),
+    [
+        # Missing `id` in success response
+        (
+            {
+                "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+                "data": {"key": "value"},
+            },
+            "Missing value for field: id. Input: ",
+        ),
+        # `id` as int for pending response
+        (
+            {
+                "result": PaymentMethodTokenizationResult.PENDING.name,
+                "id": 123,
+            },
+            "Incorrect value (123) for field: id. Error: Input should be a valid string.",
+        ),
+        # Invalid `error` in failed response
+        (
+            {
+                "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+                "error": 123,
+            },
+            "Incorrect value (123) for field: error. Error: Input should be a valid string.",
+        ),
+    ],
+)
+def test_get_response_for_payment_method_tokenization_validation_error(
+    response_data, error_msg, app
+):
+    # when
+    response = get_response_for_payment_method_tokenization(response_data, app)
+
+    # then
+    assert response.result == PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
+    assert error_msg in response.error
+
+
+def test_get_response_for_payment_method_tokenization_value_error(app):
+    # given
+    response_data = {"result": "INVALID_RESULT"}
+
+    # when
+    response = get_response_for_payment_method_tokenization(response_data, app)
+
+    # then
+    assert response.result == PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
+    assert "missing or invalid `result`" in response.error.lower()


### PR DESCRIPTION
Introduce static typing for following webhooks:
- `PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION`
- `PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
