### PR TITLE
Drop graphql.operation.name attribute from metrics

### DIFF
--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -58,7 +58,6 @@ def record_graphql_query_count(
 ) -> None:
     attributes = {
         saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier or "",
-        graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name or "",
         graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type or "",
     }
     if error_type:
@@ -72,7 +71,6 @@ def record_graphql_query_duration() -> AbstractContextManager[
     dict[str, AttributeValue]
 ]:
     attributes: dict[str, AttributeValue] = {
-        graphql_attributes.GRAPHQL_OPERATION_NAME: "",
         graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
         saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
     }
@@ -88,7 +86,6 @@ def record_graphql_query_cost(
 ) -> None:
     attributes = {
         saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier or "",
-        graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name or "",
         graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type or "",
     }
     if error_type:

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -109,7 +109,6 @@ def test_graphql_query_record_metrics(mock_meter, rf, channel_USD, product_list)
     )
     set_attr_calls = mock_meter.record_duration().__enter__().__setitem__.call_args_list
     assert call("graphql.operation.identifier", "products") in set_attr_calls
-    assert call("graphql.operation.name", "productsQuery") in set_attr_calls
     assert call("graphql.operation.type", "query") in set_attr_calls
 
 

--- a/saleor/graphql/tests/test_metrics.py
+++ b/saleor/graphql/tests/test_metrics.py
@@ -33,7 +33,6 @@ def test_record_graphql_query_count(mock_meter):
         1,
         Unit.REQUEST,
         attributes={
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "name",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "query",
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "identifier",
         },
@@ -51,7 +50,6 @@ def test_record_graphql_query_duration(mock_meter):
 
     # then
     call_attributes = {
-        graphql_attributes.GRAPHQL_OPERATION_NAME: "",
         graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
         saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
     }
@@ -86,7 +84,6 @@ def test_graphql_query_record_metrics(mock_meter, rf, channel_USD, product_list)
         Unit.REQUEST,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "products",
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "productsQuery",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "query",
         },
     )
@@ -98,7 +95,6 @@ def test_graphql_query_record_metrics(mock_meter, rf, channel_USD, product_list)
         Unit.COST,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "products",
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "productsQuery",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "query",
         },
     )
@@ -108,7 +104,6 @@ def test_graphql_query_record_metrics(mock_meter, rf, channel_USD, product_list)
         METRIC_GRAPHQL_QUERY_DURATION,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
         },
     )
@@ -175,7 +170,6 @@ def test_graphql_query_record_metrics_invalid_query(
         Unit.REQUEST,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier,
-            graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name,
             graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type,
             error_attributes.ERROR_TYPE: error_type,
         },
@@ -187,7 +181,6 @@ def test_graphql_query_record_metrics_invalid_query(
         Unit.COST,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: operation_identifier,
-            graphql_attributes.GRAPHQL_OPERATION_NAME: operation_name,
             graphql_attributes.GRAPHQL_OPERATION_TYPE: operation_type,
             error_attributes.ERROR_TYPE: error_type,
         },
@@ -197,7 +190,6 @@ def test_graphql_query_record_metrics_invalid_query(
         METRIC_GRAPHQL_QUERY_DURATION,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
         },
     )
@@ -254,7 +246,6 @@ def test_graphql_query_record_metrics_cost_exceeded(
         Unit.REQUEST,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "productVariant",
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "query",
             error_attributes.ERROR_TYPE: "QueryCostError",
         },
@@ -266,7 +257,6 @@ def test_graphql_query_record_metrics_cost_exceeded(
         Unit.COST,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "productVariant",
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "query",
             error_attributes.ERROR_TYPE: "QueryCostError",
         },
@@ -277,7 +267,6 @@ def test_graphql_query_record_metrics_cost_exceeded(
         METRIC_GRAPHQL_QUERY_DURATION,
         attributes={
             saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER: "",
-            graphql_attributes.GRAPHQL_OPERATION_NAME: "",
             graphql_attributes.GRAPHQL_OPERATION_TYPE: "",
         },
     )

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -328,9 +328,6 @@ class GraphQLView(View):
                 span.set_attribute(
                     graphql_attributes.GRAPHQL_OPERATION_NAME, operation_name
                 )
-                query_duration_attrs[graphql_attributes.GRAPHQL_OPERATION_NAME] = (
-                    operation_name
-                )
 
             span.set_attribute(
                 saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER, operation_identifier


### PR DESCRIPTION
Drop attribute `graphql.operation.name` from metrics as it produces high cardinality of values and doesn't seem useful now; if needed, it can be reintroduced in the future.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
