### PR TITLE
Bump runner

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
I want to merge this change because we cannot release `3.19` patch releases anymore (https://github.com/saleor/saleor/actions/runs/15051686068).