### PR TITLE
Add test cases for account address forms and default address removal

### DIFF
--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -388,3 +388,92 @@ def test_substitute_invalid_values(country_area_input, country_area_output, is_v
         assert "country_area" in errors
     else:
         assert not errors
+
+@pytest.fixture
+def address(db):
+    return Address.objects.create(
+        first_name="John",
+        last_name="Doe",
+        street_address_1="Tęczowa 7",
+        city="WROCŁAW",
+        postal_code="53-601",
+        country="PL",
+        phone="+48713988102",
+        company_name="Mirumee Software"
+    )
+
+def test_address_form_with_metadata():
+    # Prepare form data including metadata
+    data = {
+        "first_name": "Meta",
+        "last_name": "Data",
+        "street_address_1": "123 Main St",
+        "city": "Warsaw",
+        "postal_code": "00-001",
+        "country": "PL",
+        "metadata": {"key": "value"},
+    }
+
+    # Get the address form for country PL
+    form = forms.get_address_form(data, country_code="PL")
+
+    # Verify that the form is valid and metadata is retained
+    assert form.is_valid()
+    assert form.cleaned_data.get("metadata") == {"key": "value"}
+
+
+def test_address_form_with_unknown_country_code():
+    # Prepare form data with an invalid country code
+    data = {
+        "first_name": "Unknown",
+        "last_name": "Nation",
+        "street_address_1": "Unknown Street",
+        "city": "Nowhere",
+        "postal_code": "00000",
+        "country": "XX",
+    }
+
+    # Get the form using an unknown country code
+    form = forms.get_address_form(data, country_code="XX")
+    errors = form.errors
+
+    # Form should be invalid and return an error for the country field
+    assert not form.is_valid()
+    assert "country" in errors
+
+
+from saleor.account.models import Address, User
+from ...checkout.utils import get_user_checkout
+
+@pytest.mark.django_db
+def test_deleting_default_address_clears_it_from_user():
+    # Create a user and an address instance
+    user = User.objects.create_user(email="user@example.com", password="1234")
+    address = Address.objects.create(
+        first_name="John",
+        last_name="Doe",
+        street_address_1="123 Main St",
+        city="Testville",
+        postal_code="12345",
+        country="US"
+    )
+
+    # Assign the address as both default shipping and billing address
+    user.default_shipping_address = address
+    user.default_billing_address = address
+    user.save()
+    user.addresses.add(address)
+
+    # Verify address is correctly set
+    user.refresh_from_db()
+    assert user.default_shipping_address == address
+    assert user.default_billing_address == address
+
+    # Remove the address from user's address list before deleting
+    user.addresses.remove(address)
+    address.delete()
+
+    # Reload the user and ensure default addresses are cleared
+    user.refresh_from_db()
+    assert user.default_shipping_address is None
+    assert user.default_billing_address is None


### PR DESCRIPTION
I want to merge this change because...

This PR adds three test cases for the account module:
- Valid address form with metadata
- Invalid address form with unknown country code
- Deleting a default address removes it from user's default fields

These tests aim to improve coverage of form validation and user address logic.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
