### PR TITLE
Telemetry - refactor OTEL auto configurator use

### DIFF
--- a/saleor/core/telemetry/__init__.py
+++ b/saleor/core/telemetry/__init__.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 from importlib import import_module
 from typing import Any
@@ -31,15 +30,9 @@ def otel_configure_sdk():
     configurator.configure(resource_attributes={SERVICE_INSTANCE_ID: str(uuid.uuid4())})
 
 
-TELEMETRY_DISABLE_AUTO_CONFIGURE = (
-    os.environ.get("TELEMETRY_DISABLE_AUTO_CONFIGURE", "").lower() == "true"
-)
-
-
 def initialize_telemetry() -> None:
     """Initialize telemetry components lazily to ensure fork safety in multi-process environments."""
-    if not TELEMETRY_DISABLE_AUTO_CONFIGURE:
-        otel_configure_sdk()
+    otel_configure_sdk()
 
     # To avoid importing Django before instrumenting libs
     from django.conf import settings


### PR DESCRIPTION
I want to merge this change because we decided there is no need for the `TELEMETRY_DISABLE_AUTO_CONFIGURE` env variable, as we want OTEL to be always enabled


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
