### PR TITLE
Fix IntegrityError when providing tracking as null to orderFulfill mutation

### DIFF
--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -278,7 +278,7 @@ class OrderFulfill(BaseMutation):
             "allow_stock_to_be_exceeded", False
         )
         approved = site.settings.fulfillment_auto_approve
-        tracking_number = cleaned_input.get("tracking_number", "")
+        tracking_number = cleaned_input.get("tracking_number") or ""
         try:
             fulfillments = create_fulfillments(
                 user,

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -189,11 +189,13 @@ def test_order_fulfill_no_channel_access(
     assert_no_permission(response)
 
 
+@pytest.mark.parametrize("input_tracking_number", [None, "", "test_tracking_number"])
 @pytest.mark.parametrize("fulfillment_auto_approve", [True, False])
 @patch("saleor.graphql.order.mutations.order_fulfill.create_fulfillments")
 def test_order_fulfill_with_tracking_number(
     mock_create_fulfillments,
     fulfillment_auto_approve,
+    input_tracking_number,
     staff_api_client,
     staff_user,
     order_with_lines,
@@ -225,7 +227,7 @@ def test_order_fulfill_with_tracking_number(
                     "stocks": [{"quantity": 2, "warehouse": warehouse_id}],
                 },
             ],
-            "trackingNumber": "test_tracking_number",
+            "trackingNumber": input_tracking_number,
         },
     }
     response = staff_api_client.post_graphql(query, variables)
@@ -239,6 +241,7 @@ def test_order_fulfill_with_tracking_number(
             {"order_line": order_line2, "quantity": 2},
         ]
     }
+    expected_tracking_number = input_tracking_number or ""
     mock_create_fulfillments.assert_called_once_with(
         staff_user,
         None,
@@ -249,7 +252,7 @@ def test_order_fulfill_with_tracking_number(
         notify_customer=True,
         allow_stock_to_be_exceeded=False,
         auto_approved=fulfillment_auto_approve,
-        tracking_number="test_tracking_number",
+        tracking_number=expected_tracking_number,
     )
 
 


### PR DESCRIPTION
I want to merge this change because when passing `"trackingNumber": null`  to `orderFulfill` mutation, it was raising the non-handled exception. This PR fixes the issue.

Skipping changelog as I am going to port this to 3.21 also

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
