### PR TITLE
Refactor `productUpdate` mutation

### DIFF
--- a/saleor/graphql/product/mutations/product/product_cleaner.py
+++ b/saleor/graphql/product/mutations/product/product_cleaner.py
@@ -1,0 +1,34 @@
+from django.core.exceptions import ValidationError
+
+from .....core.utils.editorjs import clean_editor_js
+from .....product.error_codes import ProductErrorCode
+from ....core.validators import validate_slug_and_generate_if_needed
+
+
+def clean_weight(cleaned_input: dict):
+    weight = cleaned_input.get("weight")
+    if weight and weight.value < 0:
+        raise ValidationError(
+            {
+                "weight": ValidationError(
+                    "Product can't have negative weight.",
+                    code=ProductErrorCode.INVALID.value,
+                )
+            }
+        )
+
+
+def clean_slug(cleaned_input: dict, instance):
+    try:
+        validate_slug_and_generate_if_needed(instance, "name", cleaned_input)
+    except ValidationError as e:
+        e.code = ProductErrorCode.REQUIRED.value
+        raise ValidationError({"slug": e}) from e
+
+
+def clean_description(cleaned_input: dict):
+    if "description" in cleaned_input:
+        description = cleaned_input["description"]
+        cleaned_input["description_plaintext"] = (
+            clean_editor_js(description, to_string=True) if description else ""
+        )

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -1,21 +1,28 @@
 import graphene
+from django.core.exceptions import ValidationError
 
 from .....attribute import models as attribute_models
+from .....core.tracing import traced_atomic_transaction
 from .....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
 from .....permission.enums import ProductPermissions
 from .....product import models
 from ....attribute.utils import AttrValuesInput, ProductAttributeAssignmentMixin
+from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.mutations import ModelWithExtRefMutation
 from ....core.types.common import ProductError
+from ....core.validators import clean_seo_fields
+from ....meta.inputs import MetadataInput
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Product
-from .product_create import ProductCreate, ProductInput
+from ..utils import clean_tax_code
+from . import product_cleaner as cleaner
+from .product_create import ProductInput
 
 T_INPUT_MAP = list[tuple[attribute_models.Attribute, AttrValuesInput]]
 
 
-class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
+class ProductUpdate(ModelWithExtRefMutation):
     class Arguments:
         id = graphene.ID(required=False, description="ID of a product to update.")
         external_reference = graphene.String(
@@ -37,27 +44,6 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
         support_private_meta_field = True
 
     @classmethod
-    def clean_attributes(
-        cls, attributes: dict, product_type: models.ProductType
-    ) -> T_INPUT_MAP:
-        attributes_qs = product_type.product_attributes.all()
-        attributes = ProductAttributeAssignmentMixin.clean_input(
-            attributes, attributes_qs, creation=False
-        )
-        return attributes
-
-    @classmethod
-    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
-        product = models.Product.objects.get(pk=instance.pk)
-        channel_ids = set(
-            product.channel_listings.all().values_list("channel_id", flat=True)
-        )
-        cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
-
-        manager = get_plugin_manager_promise(info.context).get()
-        cls.call_event(manager.product_updated, product)
-
-    @classmethod
     def get_instance(cls, info, **data):
         """Prefetch related fields that are needed to process the mutation."""
         # If we are updating an instance and want to update its attributes,
@@ -73,3 +59,99 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
             return cls.get_node_or_error(info, object_id, only_type="Product", qs=qs)
 
         return super().get_instance(info, **data)
+
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        cleaner.clean_description(cleaned_input)
+        cleaner.clean_weight(cleaned_input)
+        cleaner.clean_slug(cleaned_input, instance)
+        cls.clean_attributes(cleaned_input, instance)
+        clean_tax_code(cleaned_input)
+        clean_seo_fields(cleaned_input)
+
+        return cleaned_input
+
+    @classmethod
+    def clean_attributes(cls, cleaned_input, instance):
+        # Attributes are provided as list of `AttributeValueInput` objects.
+        # We need to transform them into the format they're stored in the
+        # `Product` model, which is HStore field that maps attribute's PK to
+        # the value's PK.
+        attributes = cleaned_input.get("attributes")
+        product_type = instance.product_type
+        if attributes and product_type:
+            try:
+                attributes_qs = product_type.product_attributes.all()
+                cleaned_input["attributes"] = (
+                    ProductAttributeAssignmentMixin.clean_input(
+                        attributes, attributes_qs, creation=False
+                    )
+                )
+            except ValidationError as e:
+                raise ValidationError({"attributes": e}) from e
+
+    @classmethod
+    def handle_metadata(cls, instance, cleaned_input):
+        metadata_list: list[MetadataInput] = cleaned_input.pop("metadata", None)
+        private_metadata_list: list[MetadataInput] = cleaned_input.pop(
+            "private_metadata", None
+        )
+        metadata_collection = cls.create_metadata_from_graphql_input(
+            metadata_list, error_field_name="metadata"
+        )
+        private_metadata_collection = cls.create_metadata_from_graphql_input(
+            private_metadata_list, error_field_name="private_metadata"
+        )
+        cls.validate_and_update_metadata(
+            instance, metadata_collection, private_metadata_collection
+        )
+
+    @classmethod
+    def save(cls, info: ResolveInfo, instance, cleaned_input):
+        with traced_atomic_transaction():
+            instance.search_index_dirty = True
+            instance.save()
+            attributes = cleaned_input.get("attributes")
+            if attributes:
+                ProductAttributeAssignmentMixin.save(instance, attributes)
+
+    @classmethod
+    def _save_m2m(cls, _info: ResolveInfo, instance, cleaned_data):
+        collections = cleaned_data.get("collections", None)
+        if collections is not None:
+            instance.collections.set(collections)
+
+    @classmethod
+    def _post_save_action(cls, info: ResolveInfo, instance):
+        product = models.Product.objects.get(pk=instance.pk)
+        channel_ids = set(
+            product.channel_listings.all().values_list("channel_id", flat=True)
+        )
+        cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
+
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.call_event(manager.product_updated, product)
+
+    @classmethod
+    def success_response(cls, instance):
+        instance = ChannelContext(node=instance, channel_slug=None)
+        return super().success_response(instance)
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        instance = cls.get_instance(info, **data)
+        data = data.get("input")
+        cleaned_input = cls.clean_input(info, instance, data)
+
+        cls.handle_metadata(instance, cleaned_input)
+
+        instance = cls.construct_instance(instance, cleaned_input)
+
+        cls.clean_instance(info, instance)
+
+        cls.save(info, instance, cleaned_input)
+        cls._save_m2m(info, instance, cleaned_input)
+        cls._post_save_action(info, instance)
+        return cls.success_response(instance)


### PR DESCRIPTION
I want to merge this change because it refactors `productUpdate` mutation. The changes are needed to apply `InstanceTracker` (https://linear.app/saleor/issue/SCL-845/apply-instancetracker-to-productupdate-mutation).

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
