### PR TITLE
Lock order during order amounts recalculation in TransactionEventReport mutation

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -13,10 +13,9 @@ from .....core.utils.events import call_event
 from .....order import models as order_models
 from .....order.actions import order_transaction_updated
 from .....order.fetch import fetch_order_info
-from .....order.search import update_order_search_vector
 from .....order.utils import (
     calculate_order_granted_refund_status,
-    updates_amounts_for_order,
+    updates_amounts_and_search_vector_for_order_with_lock,
 )
 from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment import models as payment_models
@@ -424,9 +423,8 @@ class TransactionEventReport(ModelMutation):
             )
             if transaction.order_id:
                 order = cast(order_models.Order, transaction.order)
-                update_order_search_vector(order, save=False)
-                updates_amounts_for_order(order, save=False)
-                order.save(
+                order = updates_amounts_and_search_vector_for_order_with_lock(
+                    order,
                     update_fields=[
                         "total_charged_amount",
                         "charge_status",
@@ -434,7 +432,7 @@ class TransactionEventReport(ModelMutation):
                         "total_authorized_amount",
                         "authorize_status",
                         "search_vector",
-                    ]
+                    ],
                 )
                 order_info = fetch_order_info(order)
                 order_transaction_updated(

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -60,6 +60,7 @@ from . import (
 from .error_codes import OrderErrorCode
 from .fetch import OrderLineInfo, fetch_draft_order_lines_info
 from .models import Order, OrderGrantedRefund, OrderLine
+from .search import update_order_search_vector
 
 if TYPE_CHECKING:
     from ..app.models import App
@@ -1162,6 +1163,41 @@ def updates_amounts_for_order(order: Order, save: bool = True):
                 "authorize_status",
             ]
         )
+
+
+def updates_amounts_and_search_vector_for_order_with_lock(order: Order, update_fields):
+    with transaction.atomic():
+        # Add a transaction block to ensure that the order status won't be overridden by
+        # another process.
+        locked_order = (
+            Order.objects.prefetch_related(
+                "payments", "payment_transactions", "granted_refunds"
+            )
+            .select_for_update()
+            .get(pk=order.pk)
+        )
+
+        order_payments = locked_order.payments.all()
+        order_transactions = locked_order.payment_transactions.all()
+        order_granted_refunds = locked_order.granted_refunds.all()
+
+        update_order_search_vector(locked_order, save=False)
+        update_order_charge_data(
+            order=locked_order,
+            order_payments=order_payments,
+            order_transactions=order_transactions,
+            order_granted_refunds=order_granted_refunds,
+            with_save=False,
+        )
+        update_order_authorize_data(
+            order=locked_order,
+            order_payments=order_payments,
+            order_transactions=order_transactions,
+            order_granted_refunds=order_granted_refunds,
+            with_save=False,
+        )
+        locked_order.save(update_fields=update_fields)
+    return locked_order
 
 
 def update_order_display_gross_prices(order: "Order"):


### PR DESCRIPTION
I want to merge this change because adding a lock on the order during order amounts recalculation in the TransactionEventReport mutation. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
