### PR TITLE
Add env var support for read-replica database URL

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -119,6 +119,7 @@ DATABASES = {
         conn_max_age=DB_CONN_MAX_AGE,
     ),
     DATABASE_CONNECTION_REPLICA_NAME: dj_database_url.config(
+        env="DATABASE_URL_REPLICA",
         default="postgres://saleor:saleor@localhost:5432/saleor",
         # TODO: We need to add read only user to saleor platform,
         # and we need to update docs.


### PR DESCRIPTION
Allow setting the read-replica database URL using the DATABASE_URL_REPLICA environment variable while maintaining backward compatibility with existing setups.

The change adds the 'env' parameter to dj_database_url.config() for the replica database connection, which allows specifying a different environment variable name to read the database URL from, instead of using the default value.

Fixes #17201


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

It would be beneficial to document that option better and to integrate it to saleor-platform. 
