### PR TITLE
Lock order during order amounts recalculation in TransactionEventReport mutation

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -5,8 +5,10 @@ from uuid import uuid4
 
 import graphene
 import pytest
+from django.db import transaction as database_transaction
 from django.utils import timezone
 from freezegun import freeze_time
+from psycopg.errors import QueryCanceled
 
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
@@ -17,6 +19,7 @@ from .....order.models import Order
 from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment.models import TransactionEvent
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
+from .....tests import race_condition
 from ....core.enums import TransactionEventReportErrorCode
 from ....core.utils import to_global_id_or_none
 from ....order.enums import OrderAuthorizeStatusEnum, OrderChargeStatusEnum
@@ -3304,3 +3307,79 @@ def test_transaction_event_report_empty_message(
     assert event.app == app_api_client.app
     assert event.user is None
     assert event.message == ""
+
+
+# transaction=True is required to ensure that the order is locked without it second context will not
+# be able to trying to acquire a lock on the order.
+@pytest.mark.django_db(transaction=True)
+def test_lock_order_during_updating_order_amounts(
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    psp_reference = "111-abc"
+    amount = order.total.gross.amount
+    transaction = transaction_item_generator(
+        app=app_api_client.app,
+        order_id=order.pk,
+    )
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+
+    # when & then
+    def check_if_order_is_locked(*args, **kwargs):
+        # This function will be called when the order amounts are being updated
+        # We will try to acquire a lock on the order row to check if it's locked.
+        cxn = database_transaction.get_connection()
+        new_cxn = cxn.get_new_connection(cxn.get_connection_params())
+        with new_cxn.cursor() as cursor:
+            cursor.execute("SET statement_timeout = 100")
+            with pytest.raises(QueryCanceled):
+                cursor.execute(
+                    """
+                    SELECT *
+                    FROM "order_order"
+                    WHERE "order_order"."id" = %s
+                    FOR UPDATE
+                    """,
+                    [order.pk],
+                )
+
+    with race_condition.RunBefore(
+        "saleor.order.utils.update_order_charge_data",
+        check_if_order_is_locked,
+    ):
+        app_api_client.post_graphql(
+            query,
+            variables,
+            permissions=[permission_manage_payments],
+            check_no_permissions=False,
+        )

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -72,6 +72,7 @@ from .base_calculations import base_order_total
 from .error_codes import OrderErrorCode
 from .fetch import OrderLineInfo, fetch_draft_order_lines_info
 from .models import Order, OrderGrantedRefund, OrderLine
+from .search import update_order_search_vector
 
 if TYPE_CHECKING:
     from ..app.models import App
@@ -1181,6 +1182,41 @@ def updates_amounts_for_order(order: Order, save: bool = True):
                 "authorize_status",
             ]
         )
+
+
+def updates_amounts_and_search_vector_for_order_with_lock(order: Order, update_fields):
+    with transaction.atomic():
+        # Add a transaction block to ensure that the order status won't be overridden by
+        # another process.
+        locked_order = (
+            Order.objects.prefetch_related(
+                "payments", "payment_transactions", "granted_refunds"
+            )
+            .select_for_update()
+            .get(pk=order.pk)
+        )
+
+        order_payments = locked_order.payments.all()
+        order_transactions = locked_order.payment_transactions.all()
+        order_granted_refunds = locked_order.granted_refunds.all()
+
+        update_order_search_vector(locked_order, save=False)
+        update_order_charge_data(
+            order=locked_order,
+            order_payments=order_payments,
+            order_transactions=order_transactions,
+            order_granted_refunds=order_granted_refunds,
+            with_save=False,
+        )
+        update_order_authorize_data(
+            order=locked_order,
+            order_payments=order_payments,
+            order_transactions=order_transactions,
+            order_granted_refunds=order_granted_refunds,
+            with_save=False,
+        )
+        locked_order.save(update_fields=update_fields)
+    return locked_order
 
 
 def update_order_display_gross_prices(order: "Order"):


### PR DESCRIPTION
Port #17742 

I want to merge this change because adding a lock on the order during order amounts recalculation in the TransactionEventReport mutation.



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
