### PR TITLE
Fix warning in `test_helpers.py`

### DIFF
--- a/saleor/webhook/tests/response_schemas/test_helpers.py
+++ b/saleor/webhook/tests/response_schemas/test_helpers.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ValidationError
 from ...response_schemas.utils.helpers import parse_validation_error
 
 
-class TestSchema(BaseModel):
+class ExampleSchema(BaseModel):
     field1: int
     field2: str
 
@@ -14,7 +14,7 @@ def test_parse_validation_error_single_error():
 
     # when
     try:
-        TestSchema.model_validate(invalid_data)
+        ExampleSchema.model_validate(invalid_data)
     except ValidationError as error:
         error_msg = parse_validation_error(error)
 
@@ -30,7 +30,7 @@ def test_parse_validation_error_multiple_errors():
 
     # when
     try:
-        TestSchema.model_validate(invalid_data)
+        ExampleSchema.model_validate(invalid_data)
     except ValidationError as error:
         error_msg = parse_validation_error(error)
 


### PR DESCRIPTION
Change `TestSchema` to `ExampleSchema` to get rid of pytest warning

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
