### PR TITLE
Change Stripe plugin name to mark deprecation

### DIFF
--- a/saleor/payment/gateways/stripe/consts.py
+++ b/saleor/payment/gateways/stripe/consts.py
@@ -1,5 +1,5 @@
 PLUGIN_ID = "saleor.payments.stripe"
-PLUGIN_NAME = "Stripe"
+PLUGIN_NAME = "Stripe (deprecated)"
 WEBHOOK_PATH = "webhooks/"
 
 WEBHOOK_SUCCESS_EVENT = "payment_intent.succeeded"


### PR DESCRIPTION
I want to merge this change because it will show on dashboard that Stripe plugin is now deprecated

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
