### PR TITLE
Apply `InstanceTracker` to `ProductUpdate` mutation

### DIFF
--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -1653,3 +1653,15 @@ def get_values_from_attribute_values_input(
             else []
         )
     return attribute_data.values or []
+
+
+def has_product_input_modified_attribute_values(
+    product: product_models.Product, attributes_data: T_INPUT_MAP
+) -> bool:
+    """Compare already assigned attribute values with values from AttrValuesInput.
+
+    Return:
+        `False` if the attribute values are equal, otherwise `True`.
+
+    """
+    return True

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -1630,6 +1630,7 @@ def has_input_modified_attribute_values(
         `False` if the attribute values are equal, otherwise `True`.
 
     """
+    # TODO: scl-924
     if variant.product_id is not None:
         assigned_attributes = get_used_attribute_values_for_variant(variant)
         input_attribute_values: defaultdict[str, list[str]] = defaultdict(list)
@@ -1664,4 +1665,5 @@ def has_product_input_modified_attribute_values(
         `False` if the attribute values are equal, otherwise `True`.
 
     """
+    # TODO: scl-924
     return True

--- a/saleor/graphql/product/mutations/utils.py
+++ b/saleor/graphql/product/mutations/utils.py
@@ -17,6 +17,22 @@ PRODUCT_VARIANT_UPDATE_FIELDS = {
 }
 
 
+PRODUCT_UPDATE_FIELDS = {
+    "category",
+    "collections",
+    "name",
+    "slug",
+    "external_reference",
+    "description",
+    "description_plaintext",
+    "weight",
+    "rating",
+    "tax_class",
+    "metadata",
+    "private_metadata",
+}
+
+
 def clean_tax_code(cleaned_input: dict):
     """Clean deprecated `taxCode` field.
 

--- a/saleor/graphql/product/mutations/utils.py
+++ b/saleor/graphql/product/mutations/utils.py
@@ -30,6 +30,8 @@ PRODUCT_UPDATE_FIELDS = {
     "tax_class",
     "metadata",
     "private_metadata",
+    "seo_description",
+    "seo_title",
 }
 
 


### PR DESCRIPTION
I want to merge this change because it applies `InstanceTracker` to `ProductUpdate` mutation in order to control emitted events and db calls.

- The product instance should be saved only when some field has been modified.
- The save call should be performed only on modified fields
- Events should be emitted only when product or attribute or collection have changed

There is a missing logic for comparing actual and input attributes: https://linear.app/saleor/issue/SCL-924. This PR assumes that if the input contains whatever attributes, these attribute require updating, what is in line with behaviour from main branch.

Internal issue: https://linear.app/saleor/issue/SCL-845


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
