### PR TITLE
Use dataloader in checkout resolver 

### DIFF
--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from ...checkout import models
 from ...core.exceptions import PermissionDenied
 from ...permission.enums import (
@@ -10,6 +12,7 @@ from ..core.tracing import traced_resolver
 from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
 from ..utils import get_user_or_app_from_context
+from .dataloaders.models import CheckoutByTokenLoader
 
 
 def resolve_checkout_lines(info):
@@ -33,30 +36,35 @@ def resolve_checkout(info, token, id):
     validate_one_of_args_is_in_query("id", id, "token", token)
 
     if id:
-        _, token = from_global_id_or_error(id, only_type="Checkout")
-    checkout = (
-        models.Checkout.objects.using(get_database_connection_name(info.context))
-        .filter(token=token)
-        .first()
-    )
-    if checkout is None:
-        return None
-    # always return checkout for active channel
-    if checkout.channel.is_active:
-        return SyncWebhookControlContext(node=checkout, allow_sync_webhooks=True)
+        _, token = from_global_id_or_error(id, only_type="Checkout", raise_error=True)
+        token = UUID(token)
 
-    # resolve checkout for staff or app
-    if requester := get_user_or_app_from_context(info.context):
-        has_manage_checkout = requester.has_perm(CheckoutPermissions.MANAGE_CHECKOUTS)
-        has_impersonate_user = requester.has_perm(AccountPermissions.IMPERSONATE_USER)
-        has_handle_payments = requester.has_perm(PaymentPermissions.HANDLE_PAYMENTS)
-        if has_manage_checkout or has_impersonate_user or has_handle_payments:
+    def with_checkout(checkout):
+        if checkout is None:
+            return None
+        # always return checkout for active channel
+        if checkout.channel.is_active:
             return SyncWebhookControlContext(node=checkout, allow_sync_webhooks=True)
+        # resolve checkout for staff or app
+        if requester := get_user_or_app_from_context(info.context):
+            has_manage_checkout = requester.has_perm(
+                CheckoutPermissions.MANAGE_CHECKOUTS
+            )
+            has_impersonate_user = requester.has_perm(
+                AccountPermissions.IMPERSONATE_USER
+            )
+            has_handle_payments = requester.has_perm(PaymentPermissions.HANDLE_PAYMENTS)
+            if has_manage_checkout or has_impersonate_user or has_handle_payments:
+                return SyncWebhookControlContext(
+                    node=checkout, allow_sync_webhooks=True
+                )
 
-    raise PermissionDenied(
-        permissions=[
-            CheckoutPermissions.MANAGE_CHECKOUTS,
-            AccountPermissions.IMPERSONATE_USER,
-            PaymentPermissions.HANDLE_PAYMENTS,
-        ]
-    )
+        raise PermissionDenied(
+            permissions=[
+                CheckoutPermissions.MANAGE_CHECKOUTS,
+                AccountPermissions.IMPERSONATE_USER,
+                PaymentPermissions.HANDLE_PAYMENTS,
+            ]
+        )
+
+    return CheckoutByTokenLoader(info.context).load(token).then(with_checkout)

--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -46,7 +46,7 @@ def resolve_checkout(info, token, id):
 
         def _with_channel(channel):
             # always return checkout for active channel
-            if checkout.channel.is_active:
+            if channel.is_active:
                 return SyncWebhookControlContext(
                     node=checkout, allow_sync_webhooks=True
                 )

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout.py
@@ -1,0 +1,74 @@
+import pytest
+
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+CHECKOUT_DETAILS_QUERY = """
+query checkout($id: ID){
+  checkout(
+		id:$id
+	) {
+		shippingMethods{
+			active
+			message
+		}
+		lines{
+			id
+			variant{
+				product{
+					name
+				}
+			}
+			totalPrice{
+				gross{
+					amount
+				}
+				net{
+					amount
+				}
+			}
+		}
+		totalPrice{
+			gross{
+				amount
+			}
+		}
+		subtotalPrice{
+			gross{
+				amount
+			}
+		}
+		shippingPrice{
+			net{
+				amount
+			}
+			gross{
+				amount
+			}
+		}
+
+  }
+}
+"""
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_user_checkout_details(
+    user_api_client,
+    checkouts_for_benchmarks,
+    count_queries,
+):
+    # given
+    checkout = checkouts_for_benchmarks[0]
+    checkout_id = to_global_id_or_none(checkout)
+
+    # when
+    content = get_graphql_content(
+        user_api_client.post_graphql(
+            CHECKOUT_DETAILS_QUERY, variables={"id": checkout_id}
+        )
+    )
+
+    # then
+    assert content["data"]["checkout"] is not None


### PR DESCRIPTION
I want to merge this change because it adds usage of dataloader to the `checkout` resolver. 
It saves us one DB, as the dataloader data is re-used later.
 Additionally in case of thread race between `checkout` resolver & `checkoutComplete`, we should be consistent when handling the case of non-existing checkout. 
Previously, there was a case where `resolve_checkout` successfully retrieved the `checkout` object, but later checkout's dataloader calls failed to find it (checkout converted to order). With this change, the same instance of the checkout object is reused throughout the resolver chain.

Port of changes from https://github.com/saleor/saleor/pull/17739

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
