### PR TITLE
Telemetry - Add explicit histogram bucket boundaries for metrics

### DIFF
--- a/saleor/core/telemetry/__init__.py
+++ b/saleor/core/telemetry/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 from django.conf import settings
 from opentelemetry.util.types import Attributes
 
-from .metric import Meter, MeterProxy, MetricType
+from .metric import DEFAULT_DURATION_BUCKETS, Meter, MeterProxy, MetricType
 from .trace import Link, SpanKind, Tracer, TracerProxy
 from .utils import (
     Scope,
@@ -63,4 +63,5 @@ __all__ = [
     "TelemetryTaskContext",
     "task_with_telemetry_context",
     "get_task_context",
+    "DEFAULT_DURATION_BUCKETS",
 ]

--- a/saleor/core/telemetry/metric.py
+++ b/saleor/core/telemetry/metric.py
@@ -31,6 +31,26 @@ class MetricType(Enum):
     HISTOGRAM = "histogram"
 
 
+DEFAULT_DURATION_BUCKETS = [
+    0.01,  # 10ms
+    0.025,  # 25ms
+    0.05,  # 50ms
+    0.1,  # 100ms
+    0.2,  # 200ms
+    0.3,  # 300ms
+    0.4,  # 400ms
+    0.6,  # 600ms
+    0.8,  # 800ms
+    1,  # 1s
+    1.5,  # 1.5s
+    2.5,  # 2.5s
+    4,  # 4s
+    7,  # 7s
+    18,  # 18s
+    30,  # 30s
+]
+
+
 def get_instrument_method(
     instrument: Synchronous,
 ) -> Callable[[Amount, Attributes], None]:

--- a/saleor/graphql/metrics.py
+++ b/saleor/graphql/metrics.py
@@ -4,7 +4,14 @@ from opentelemetry.semconv._incubating.attributes import graphql_attributes
 from opentelemetry.semconv.attributes import error_attributes
 from opentelemetry.util.types import AttributeValue
 
-from ..core.telemetry import MetricType, Scope, Unit, meter, saleor_attributes
+from ..core.telemetry import (
+    DEFAULT_DURATION_BUCKETS,
+    MetricType,
+    Scope,
+    Unit,
+    meter,
+    saleor_attributes,
+)
 
 # Initialize metrics
 METRIC_GRAPHQL_QUERY_COUNT = meter.create_metric(
@@ -21,14 +28,34 @@ METRIC_GRAPHQL_QUERY_DURATION = meter.create_metric(
     type=MetricType.HISTOGRAM,
     unit=Unit.SECOND,
     description="Duration of GraphQL queries.",
+    bucket_boundaries=DEFAULT_DURATION_BUCKETS,
 )
 
+QUERY_COST_BUCKETS = [
+    0,
+    5,
+    10,
+    25,
+    50,
+    100,
+    250,
+    500,
+    1000,
+    2000,
+    5000,
+    10000,
+    15000,
+    20000,
+    30000,
+    50000,
+]
 METRIC_GRAPHQL_QUERY_COST = meter.create_metric(
     "saleor.graphql.operation.cost",
     scope=Scope.SERVICE,
     type=MetricType.HISTOGRAM,
     unit=Unit.COST,
     description="Cost of GraphQL queries.",
+    bucket_boundaries=QUERY_COST_BUCKETS,
 )
 
 METRIC_REQUEST_COUNT = meter.create_metric(
@@ -45,6 +72,7 @@ METRIC_REQUEST_DURATION = meter.create_metric(
     type=MetricType.HISTOGRAM,
     unit=Unit.SECOND,
     description="Duration of API requests.",
+    bucket_boundaries=DEFAULT_DURATION_BUCKETS,
 )
 
 

--- a/saleor/webhook/transport/metrics.py
+++ b/saleor/webhook/transport/metrics.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 from opentelemetry.semconv.attributes import error_attributes, server_attributes
 
 from ...core.models import EventDeliveryStatus
-from ...core.telemetry import MetricType, Scope, Unit, meter
+from ...core.telemetry import DEFAULT_DURATION_BUCKETS, MetricType, Scope, Unit, meter
 from .utils import WebhookResponse
 
 # Initialize metrics
@@ -20,13 +20,34 @@ METRIC_EXTERNAL_REQUEST_DURATION = meter.create_metric(
     type=MetricType.HISTOGRAM,
     unit=Unit.SECOND,
     description="Duration of webhook event delivery.",
+    bucket_boundaries=DEFAULT_DURATION_BUCKETS,
 )
+
+BODY_SIZE_BUCKETS = [
+    0,  # 0B
+    100,  # 100B
+    500,  # 500B
+    1000,  # 1KB
+    2000,  # 2KB
+    4000,  # 4KB
+    8000,  # 8KB
+    16000,  # 16KB
+    32000,  # 32KB
+    64000,  # 64KB
+    128000,  # 128KB
+    256000,  # 256KB
+    512000,  # 512KB
+    1048576,  # 1MB
+    2097152,  # 2MB
+    4194304,  # 4MB
+]
 METRIC_EXTERNAL_REQUEST_BODY_SIZE = meter.create_metric(
     "saleor.external_request.body.size",
     scope=Scope.SERVICE,
     type=MetricType.HISTOGRAM,
     unit=Unit.BYTE,
     description="Size of webhook event payloads.",
+    bucket_boundaries=BODY_SIZE_BUCKETS,
 )
 
 


### PR DESCRIPTION
I want to merge this change because it introduces custom histogram bucket boundaries, which are better suited for Saleor's typical usage patterns and improve measurement accuracy. This PR introduces custom bucket boundaries for duration, query cost, and body size metrics.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
