### PR TITLE
Get rid of `payment_status` filter from order where

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12785,9 +12785,6 @@ input OrderWhereInput @doc(category: "Orders") {
   """Filter by user email."""
   userEmail: StringFilterInput
 
-  """Filter by payment status."""
-  paymentStatus: PaymentStatusEnumFilterInput
-
   """Filter by authorize status."""
   authorizeStatus: OrderAuthorizeStatusEnumFilterInput
 
@@ -12834,14 +12831,6 @@ input IntFilterInput {
 
   """The value in range."""
   range: IntRangeInput
-}
-
-input PaymentStatusEnumFilterInput @doc(category: "Orders") {
-  """The value equal to."""
-  eq: PaymentChargeStatusEnum
-
-  """The value included in."""
-  oneOf: [PaymentChargeStatusEnum!]
 }
 
 """Filter by authorize status."""


### PR DESCRIPTION
I want to remove the filtering by `payment_status` in `where` for now, as it's using the old payment plugins approach, we should discuss if we want to implement such filter and what should be the shape of it.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
