### PR TITLE
Prefer input email over account email for checkout/order

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -289,7 +289,11 @@ class CheckoutInfo:
         return address.country.code
 
     def get_customer_email(self) -> str | None:
-        return self.user.email if self.user else self.checkout.email
+        if self.checkout.email:
+            return self.checkout.email
+        if self.user:
+            return self.user.email
+        return None
 
 
 @dataclass(frozen=True)

--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -237,7 +237,11 @@ class Checkout(models.Model):
         return iter(self.lines.all())
 
     def get_customer_email(self) -> str | None:
-        return self.user.email if self.user else self.email
+        if self.email:
+            return self.email
+        if self.user:
+            return self.user.email
+        return None
 
     def is_shipping_required(self) -> bool:
         """Return `True` if any of the lines requires shipping."""

--- a/saleor/discount/tests/test_utils/test_get_customer_email_for_voucher_usage.py
+++ b/saleor/discount/tests/test_utils/test_get_customer_email_for_voucher_usage.py
@@ -36,8 +36,7 @@ def test_get_customer_email_for_voucher_usage_for_checkout_info_without_user(
     # given
     expected_email = "test@example.com"
     checkout_info.user = None
-    checkout_info.email = expected_email
-    checkout_info.save()
+    checkout_info.checkout.email = expected_email
 
     # when
     result = get_customer_email_for_voucher_usage(checkout_info)

--- a/saleor/discount/tests/test_utils/test_get_customer_email_for_voucher_usage.py
+++ b/saleor/discount/tests/test_utils/test_get_customer_email_for_voucher_usage.py
@@ -1,0 +1,132 @@
+from ...utils.voucher import get_customer_email_for_voucher_usage
+
+
+def test_get_customer_email_for_voucher_usage_for_checkout_info_without_user_data(
+    checkout_info, customer_user
+):
+    # given
+    checkout_info.user = None
+    checkout_info.checkout.email = None
+    checkout_info.checkout.user = None
+
+    # when
+    result = get_customer_email_for_voucher_usage(checkout_info)
+
+    # then
+    assert result is None
+
+
+def test_get_customer_email_for_voucher_usage_for_checkout_info_with_user(
+    checkout_info, customer_user
+):
+    # given
+    checkout_info.user = customer_user
+    checkout_info.checkout.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(checkout_info)
+
+    # then
+    assert result == checkout_info.user.email
+
+
+def test_get_customer_email_for_voucher_usage_for_checkout_info_without_user(
+    checkout_info,
+):
+    # given
+    expected_email = "test@example.com"
+    checkout_info.user = None
+    checkout_info.email = expected_email
+    checkout_info.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(checkout_info)
+
+    # then
+    assert result == expected_email
+
+
+def test_get_customer_email_for_voucher_usage_for_checkout_with_user(
+    checkout, customer_user
+):
+    # given
+    checkout_email = "checkout@example.com"
+    checkout.email = checkout_email
+    checkout.user = customer_user
+    checkout.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(checkout)
+
+    # then
+    assert result == customer_user.email
+
+
+def test_get_customer_email_for_voucher_usage_for_checkout_without_user(checkout):
+    # given
+    expected_checkout_email = "checkout@example.com"
+    checkout.user = None
+    checkout.email = expected_checkout_email
+    checkout.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(checkout)
+
+    # then
+    assert result == expected_checkout_email
+
+
+def test_get_customer_email_for_voucher_usage_for_checkout_without_user_details(
+    checkout,
+):
+    # given
+    checkout.user = None
+    checkout.email = None
+    checkout.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(checkout)
+
+    # then
+    assert result is None
+
+
+def test_get_customer_email_for_voucher_usage_for_order_with_user(order, customer_user):
+    # given
+    order_email = "order@example.com"
+    order.user_email = order_email
+    order.user = customer_user
+    order.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(order)
+
+    # then
+    assert result == customer_user.email
+
+
+def test_get_customer_email_for_voucher_usage_for_order_without_user(order):
+    # given
+    expected_order_email = "order@example.com"
+    order.user = None
+    order.user_email = expected_order_email
+    order.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(order)
+
+    # then
+    assert result == expected_order_email
+
+
+def test_get_customer_email_for_voucher_usage_for_order_without_user_details(order):
+    # given
+    order.user = None
+    order.user_email = ""
+    order.save()
+
+    # when
+    result = get_customer_email_for_voucher_usage(order)
+
+    # then
+    assert result is None

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -263,8 +263,7 @@ def get_customer_email_for_voucher_usage(
     """
 
     if source_object.user:
-        user = cast("User", source_object.user)
-        return user.email
+        return source_object.user.email
     return source_object.get_customer_email()
 
 

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -263,7 +263,8 @@ def get_customer_email_for_voucher_usage(
     """
 
     if source_object.user:
-        return source_object.user.email
+        user = cast("User", source_object.user)
+        return user.email
     return source_object.get_customer_email()
 
 

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Sequence
 from dataclasses import asdict, dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 from uuid import UUID
 
 from django.db.models import Exists, F, OuterRef
@@ -13,7 +13,7 @@ from ...channel.models import Channel
 from ...core.db.connection import allow_writer
 from ...core.taxes import zero_money
 from ...core.utils.promo_code import InvalidPromoCode
-from ...order.models import Order
+from ...order.models import Order, OrderLine
 from .. import DiscountType, VoucherType
 from ..interface import DiscountInfo, VoucherInfo
 from ..models import (
@@ -30,9 +30,9 @@ from .shared import update_discount
 if TYPE_CHECKING:
     from ...account.models import User
     from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
+    from ...checkout.models import Checkout
     from ...core.pricing.interface import LineInfo
     from ...order.fetch import EditableOrderLineInfo
-    from ...order.models import OrderLine
     from ...plugins.manager import PluginsManager
     from ..models import Voucher
 
@@ -251,6 +251,23 @@ def get_the_cheapest_line(
     return min(lines_info, key=lambda line_info: line_info.variant_discounted_price)
 
 
+def get_customer_email_for_voucher_usage(
+    source_object: Union["Order", "Checkout", "CheckoutInfo"],
+):
+    """Get customer email for voucher.
+
+    Always prioritize the user's email over the email assigned to the
+    source object in terms of voucher application.
+    If the source object has associated user, return the user's email.
+    Otherwise, return the customer email from the source object.
+    """
+
+    if source_object.user:
+        user = cast("User", source_object.user)
+        return user.email
+    return source_object.get_customer_email()
+
+
 def validate_voucher_for_checkout(
     manager: "PluginsManager",
     voucher: "Voucher",
@@ -267,7 +284,7 @@ def validate_voucher_for_checkout(
         checkout_info.checkout.currency,
     )
 
-    customer_email = cast(str, checkout_info.get_customer_email())
+    customer_email = cast(str, get_customer_email_for_voucher_usage(checkout_info))
     validate_voucher(
         voucher,
         subtotal,
@@ -288,7 +305,7 @@ def validate_voucher_in_order(
 
     subtotal = order.subtotal
     quantity = get_total_quantity(lines)
-    customer_email = order.get_customer_email()
+    customer_email = get_customer_email_for_voucher_usage(order)
     tax_configuration = channel.tax_configuration
     prices_entered_with_tax = tax_configuration.prices_entered_with_tax
     value = subtotal.gross if prices_entered_with_tax else subtotal.net

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -1400,9 +1400,11 @@ def test_checkout_create_logged_in_customer_custom_email(
     assert new_checkout is not None
     checkout_data = content["data"]["checkoutCreate"]["checkout"]
     assert checkout_data["token"] == str(new_checkout.token)
+    assert checkout_data["email"] == custom_email
+    assert new_checkout.email == custom_email
+
     checkout_user = new_checkout.user
     assert customer.id == checkout_user.id
-    assert new_checkout.email == custom_email
 
 
 def test_checkout_create_logged_in_customer_custom_addresses(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -18,6 +18,7 @@ MUTATION_CHECKOUT_CUSTOMER_ATTACH = """
         checkoutCustomerAttach(id: $id, customerId: $customerId) {
             checkout {
                 token
+                email
             }
             errors {
                 code
@@ -49,6 +50,7 @@ def test_checkout_customer_attach(
 
     data = content["data"]["checkoutCustomerAttach"]
     assert not data["errors"]
+    assert data["checkout"]["email"] == customer_user2.email
     checkout.refresh_from_db()
     assert checkout.user == customer_user2
     assert checkout.email == customer_user2.email

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -32,8 +32,10 @@ CHECKOUT_EMAIL_UPDATE_MUTATION = """
 """
 
 
-def test_checkout_email_update(user_api_client, checkout_with_item):
+def test_anonymous_checkout_email_update(user_api_client, checkout_with_item):
+    # given
     checkout = checkout_with_item
+    assert checkout.user is None
     checkout.email = None
     checkout.save(update_fields=["email"])
     previous_last_change = checkout.last_change
@@ -41,12 +43,41 @@ def test_checkout_email_update(user_api_client, checkout_with_item):
     email = "test@example.com"
     variables = {"id": to_global_id_or_none(checkout), "email": email}
 
+    # when
     response = user_api_client.post_graphql(CHECKOUT_EMAIL_UPDATE_MUTATION, variables)
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["checkoutEmailUpdate"]
     assert not data["errors"]
+    assert data["checkout"]["email"] == email
     checkout.refresh_from_db()
     assert checkout.email == email
+    assert checkout.last_change != previous_last_change
+
+
+def test_authenticated_checkout_email_update(user_api_client, checkout_with_item):
+    # given
+    expected_email = "new-email@example.com"
+    checkout = checkout_with_item
+    checkout.user = user_api_client.user
+    assert checkout.email != expected_email
+    checkout.save(update_fields=["email"])
+    previous_last_change = checkout.last_change
+
+    variables = {"id": to_global_id_or_none(checkout), "email": expected_email}
+
+    # when
+    response = user_api_client.post_graphql(CHECKOUT_EMAIL_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutEmailUpdate"]
+    assert not data["errors"]
+    assert data["checkout"]["email"] == expected_email
+
+    checkout.refresh_from_db()
+    assert checkout.email == expected_email
     assert checkout.last_change != previous_last_change
 
 

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -15,12 +15,7 @@ from .....checkout.error_codes import OrderCreateFromCheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout, CheckoutLine
 from .....checkout.payment_utils import update_checkout_payment_statuses
-from .....core.taxes import (
-    TaxDataError,
-    TaxError,
-    zero_money,
-    zero_taxed_money,
-)
+from .....core.taxes import TaxDataError, TaxError, zero_money, zero_taxed_money
 from .....discount import DiscountType, DiscountValueType, RewardValueType
 from .....discount.models import CheckoutLineDiscount, OrderLineDiscount
 from .....giftcard import GiftCardEvents
@@ -562,6 +557,7 @@ def test_order_from_checkout_gift_card_bought(
     checkout.metadata_storage.store_value_in_private_metadata(
         items={"accepted": "false"}
     )
+    checkout.email = customer_user.email
     checkout.user = customer_user
     checkout.save()
     checkout.metadata_storage.save()

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -4801,3 +4801,77 @@ def test_query_checkout_voucher_by_customer_no_permission(
 
     # then
     assert_no_permission(response)
+
+
+CHECKOUT_EMAIL_QUERY = """
+query getCheckout($id: ID) {
+    checkout(id: $id) {
+        email
+    }
+}
+"""
+
+
+def test_query_checkout_email_for_anonymous_user_without_email(
+    user_api_client,
+    checkout_with_item,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.user = None
+    checkout.email = None
+    checkout.save(update_fields=["email", "user"])
+
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = user_api_client.post_graphql(CHECKOUT_EMAIL_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["email"] is None
+
+
+def test_query_checkout_email_for_anonymous_user(
+    user_api_client,
+    checkout_with_item,
+):
+    # given
+    expected_email = "expected@example.com"
+
+    checkout = checkout_with_item
+    assert checkout.user is None
+    checkout.email = expected_email
+    checkout.save(update_fields=["email"])
+
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = user_api_client.post_graphql(CHECKOUT_EMAIL_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["email"] == expected_email
+
+
+def test_query_checkout_email_with_explicit_email_for_authenticated_user(
+    user_api_client,
+    checkout_with_item,
+):
+    # given
+    expected_email = "expected@example.com"
+
+    checkout = checkout_with_item
+    checkout.user = user_api_client.user
+    checkout.email = expected_email
+    checkout.save(update_fields=["user", "email"])
+
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    # when
+    response = user_api_client.post_graphql(CHECKOUT_EMAIL_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    # Return the email explicitly assigned to the user
+    assert content["data"]["checkout"]["email"] == expected_email

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -10,7 +10,10 @@ from ....core.postgres import FlatConcatSearchVector
 from ....core.taxes import zero_taxed_money
 from ....core.tracing import traced_atomic_transaction
 from ....discount.models import VoucherCode
-from ....discount.utils.voucher import add_voucher_usage_by_customer
+from ....discount.utils.voucher import (
+    add_voucher_usage_by_customer,
+    get_customer_email_for_voucher_usage,
+)
 from ....order import OrderStatus, models
 from ....order.actions import order_created
 from ....order.calculations import fetch_order_prices_if_expired
@@ -92,7 +95,9 @@ class DraftOrderComplete(BaseMutation):
         ):
             code = VoucherCode.objects.filter(code=order.voucher_code).first()
             if code:
-                add_voucher_usage_by_customer(code, order.get_customer_email())
+                add_voucher_usage_by_customer(
+                    code, get_customer_email_for_voucher_usage(order)
+                )
 
     @classmethod
     def perform_mutation(  # type: ignore[override]

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -9,6 +9,7 @@ from ....core.taxes import TaxError
 from ....core.tracing import traced_atomic_transaction
 from ....discount.utils.voucher import (
     create_or_update_voucher_discount_objects_for_order,
+    get_customer_email_for_voucher_usage,
     increase_voucher_usage,
 )
 from ....order import OrderOrigin, OrderStatus, events, models
@@ -29,11 +30,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import (
-    ADDED_IN_318,
-    ADDED_IN_321,
-    DEPRECATED_IN_3X_INPUT,
-)
+from ...core.descriptions import ADDED_IN_318, ADDED_IN_321, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelWithRestrictedChannelAccessMutation
@@ -51,11 +48,7 @@ from ..utils import (
     validate_variant_channel_listings,
 )
 from . import draft_order_cleaner
-from .utils import (
-    ShippingMethodUpdateMixin,
-    get_variant_rule_info_map,
-    save_addresses,
-)
+from .utils import ShippingMethodUpdateMixin, get_variant_rule_info_map, save_addresses
 
 
 class OrderLineInput(BaseInputObjectType):
@@ -461,9 +454,7 @@ class DraftOrderCreate(
         create_or_update_voucher_discount_objects_for_order(instance)
 
         # handle voucher usage
-        user_email = instance.user_email
-        if not user_email and instance.user:
-            user_email = instance.user.email
+        user_email = get_customer_email_for_voucher_usage(instance)
 
         channel = instance.channel
         if not channel.include_draft_order_in_voucher_usage:

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -7,6 +7,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....discount.models import VoucherCode
 from ....discount.utils.voucher import (
     create_or_update_voucher_discount_objects_for_order,
+    get_customer_email_for_voucher_usage,
     increase_voucher_usage,
     release_voucher_code_usage,
 )
@@ -292,9 +293,7 @@ class DraftOrderUpdate(
         create_or_update_voucher_discount_objects_for_order(instance)
 
         # handle voucher usage
-        user_email = instance.user_email
-        if not user_email and instance.user:
-            user_email = instance.user.email
+        user_email = get_customer_email_for_voucher_usage(instance)
 
         channel = instance.channel
         if not channel.include_draft_order_in_voucher_usage:
@@ -311,7 +310,9 @@ class DraftOrderUpdate(
         elif old_voucher:
             # handle removing voucher
             voucher_code = VoucherCode.objects.filter(code=old_voucher_code).first()
-            release_voucher_code_usage(voucher_code, old_voucher, user_email)
+            # user_email is None as we do not have anything to release in terms of
+            # apply once per customer
+            release_voucher_code_usage(voucher_code, old_voucher, user_email=None)
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -2489,11 +2489,17 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
 
         def _resolve_user_email(user):
             requester = get_user_or_app_from_context(info.context)
+            email_to_return = None
+            if order.user_email:
+                email_to_return = order.user_email
+            elif user:
+                email_to_return = user.email
+
             if order.use_old_id is False or is_owner_or_has_one_of_perms(
                 requester, user, OrderPermissions.MANAGE_ORDERS
             ):
-                return user.email if user else order.user_email
-            return obfuscate_email(user.email if user else order.user_email)
+                return email_to_return
+            return obfuscate_email(email_to_return)
 
         if not order.user_id:
             return _resolve_user_email(None)

--- a/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
@@ -170,7 +170,7 @@ def test_checkout_add_payment(
     # given
     checkout = checkout_without_shipping_required
     checkout.billing_address = address
-    checkout.email = "old@example"
+    checkout.email = customer_user.email
     checkout.user = customer_user
     checkout.save()
 

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -426,10 +426,11 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
         return self.total_charged_amount > 0
 
     def get_customer_email(self):
+        if self.user_email:
+            return self.user_email
         if self.user_id:
-            # we know that when user_id is set, user is set as well
             return cast("User", self.user).email
-        return self.user_email
+        return None
 
     def __repr__(self):
         return f"<Order #{self.id!r}>"

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -318,6 +318,7 @@ def test_add_gift_cards_to_order(
 ):
     # given
     checkout = checkout_with_item
+    checkout.email = staff_user.email
     checkout.user = staff_user
     checkout.gift_cards.add(gift_card, gift_card_expiry_date)
     manager = get_plugins_manager(allow_replica=False)
@@ -373,6 +374,7 @@ def test_add_gift_cards_to_order_with_more_than_total(
     # given
     checkout = checkout_with_item
     checkout.user = staff_user
+    checkout.email = staff_user.email
     checkout.gift_cards.add(gift_card_expiry_date, gift_card)
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)


### PR DESCRIPTION
I want to merge this change because it fixes the issue with always prioritize the user.email instead of the one provided explicitly by the user. 
Previously, we were always use `checkout.user.email`/ `order.user.email`, now if the email is explicitly provided by `checkoutEmailUpdate` mutation, we will prioritize the provided one. 

Port of changes: https://github.com/saleor/saleor/pull/17753


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
