### PR TITLE
Fix flaky test for exclude sm pregenerated webhook paylaod

### DIFF
--- a/saleor/graphql/webhook/tests/pregenerated_subscription/test_exclude_shipping_methods_pregenerated_payloads.py
+++ b/saleor/graphql/webhook/tests/pregenerated_subscription/test_exclude_shipping_methods_pregenerated_payloads.py
@@ -58,19 +58,19 @@ def test_shipping_methods_use_pregenerated_payloads_app_without_subscription(
 
     # then
     assert content["data"]["checkout"]["id"] == checkout_global_id
-    assert content["data"]["checkout"]["shippingMethods"] == [
-        {
-            "id": shipping_method_global_ids[0],
-            "name": "DHL",
-            "active": True,
-            "message": "",
-        },
-        {
-            "id": shipping_method_global_ids[1],
-            "name": "DHL",
-            "active": False,
-            "message": exclude_msg,
-        },
-    ]
+    assert len(content["data"]["checkout"]["shippingMethods"]) == 2
+    assert {
+        "id": shipping_method_global_ids[0],
+        "name": "DHL",
+        "active": True,
+        "message": "",
+    } in content["data"]["checkout"]["shippingMethods"]
+    assert {
+        "id": shipping_method_global_ids[1],
+        "name": "DHL",
+        "active": False,
+        "message": exclude_msg,
+    } in content["data"]["checkout"]["shippingMethods"]
+
     mock_request.assert_called_once()
     mock_generate_payload.assert_not_called()


### PR DESCRIPTION
I want to merge this change because it fixes the flaky test with different ordering on the response. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
