### PR TITLE
SCL-941 - reconfigure saleor workflows to use IAM roles instead of IAM users for CICD

### DIFF
--- a/.github/workflows/migrations-perf-test.yml
+++ b/.github/workflows/migrations-perf-test.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@d3a63ccabbed6ef817604ef6320096bde576ad40
         with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           REGION: us-east-1
           FunctionName: migrations-perf-test-manager
           Payload: >-
@@ -73,6 +75,8 @@ jobs:
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@d3a63ccabbed6ef817604ef6320096bde576ad40
         with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           REGION: us-east-1
           FunctionName: migrations-perf-test-manager
           Payload: >-

--- a/.github/workflows/migrations-perf-test.yml
+++ b/.github/workflows/migrations-perf-test.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Build and push
         uses: kciter/aws-ecr-action@79255b7c5aa03dbf6d7c46cff2bfd049874cd98d # v4
         with:
+          access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           account_id: ${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}
           repo: saleor-testenvs
           region: us-east-1

--- a/.github/workflows/migrations-perf-test.yml
+++ b/.github/workflows/migrations-perf-test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@d3a63ccabbed6ef817604ef6320096bde576ad40
-        with:}
+        with:
           REGION: us-east-1
           FunctionName: migrations-perf-test-manager
           Payload: >-

--- a/.github/workflows/migrations-perf-test.yml
+++ b/.github/workflows/migrations-perf-test.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           REGION: us-east-1
           FunctionName: migrations-perf-test-manager
           Payload: >-
@@ -77,6 +78,7 @@ jobs:
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           REGION: us-east-1
           FunctionName: migrations-perf-test-manager
           Payload: >-

--- a/.github/workflows/migrations-perf-test.yml
+++ b/.github/workflows/migrations-perf-test.yml
@@ -9,16 +9,23 @@ jobs:
     name: Run migrations performance test
     if: ${{ (((github.event.action == 'labeled') && (github.event.label.name == 'migrations perf test')) || ((github.event.action == 'opened') && contains(github.event.pull_request.labels.*.name, 'migrations perf test')) && github.repository == 'saleor/saleor') }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed by aws-actions/configure-aws-credentials
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@e4699e49fcf890a3172a02c56ba78d867dbb9fd5
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}:role/${{ secrets.AWS_TESTENVS_CICD_ROLE_NAME }}
+          aws-region: us-east-1
+
       - name: Build and push
         uses: kciter/aws-ecr-action@79255b7c5aa03dbf6d7c46cff2bfd049874cd98d # v4
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          account_id: ${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}
           repo: saleor-testenvs
           region: us-east-1
           tags: ${{ env.GITHUB_HEAD_REF_SLUG_URL }},${{ github.sha }}
@@ -29,16 +36,14 @@ jobs:
 
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@d3a63ccabbed6ef817604ef6320096bde576ad40
-        with:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:}
           REGION: us-east-1
           FunctionName: migrations-perf-test-manager
           Payload: >-
             {
               "action": "${{ github.event.action }}",
               "label": "${{ env.GITHUB_HEAD_REF_SLUG_URL }}",
-              "image": "${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ github.sha }}",
+              "image": "${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ github.sha }}",
               "pr_id": "${{ env.PULL_ID }}",
               "commit_hash": "${{ github.sha }}"
             }
@@ -48,6 +53,9 @@ jobs:
     name: Cleanup after migrations performance test
     if: ${{ (((github.event.action == 'unlabeled') && (github.event.label.name == 'migrations perf test')) || ((github.event.action == 'closed') && contains(github.event.pull_request.labels.*.name, 'migrations perf test')) && github.repository == 'saleor/saleor') }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed by aws-actions/configure-aws-credentials
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@e4699e49fcf890a3172a02c56ba78d867dbb9fd5
@@ -56,18 +64,22 @@ jobs:
         run: |
           echo "PULL_ID=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}:role/${{ secrets.AWS_TESTENVS_CICD_ROLE_NAME }}
+          aws-region: us-east-1
+
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@d3a63ccabbed6ef817604ef6320096bde576ad40
         with:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           REGION: us-east-1
           FunctionName: migrations-perf-test-manager
           Payload: >-
             {
               "action": "${{ github.event.action }}",
               "label": "${{ env.GITHUB_HEAD_REF_SLUG_URL }}",
-              "image": "${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ github.sha }}",
+              "image": "${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ github.sha }}",
               "pr_id": "${{ env.PULL_ID }}",
               "commit_hash": "${{ github.sha }}"
             }

--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -11,21 +11,28 @@ jobs:
     name: Remove test environment deployment
     if: ${{ ((github.event.action == 'unlabeled') && (github.event.label.name == 'test deployment')) || ((github.event.action == 'closed') && contains(github.event.pull_request.labels.*.name, 'test deployment')) }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed by aws-actions/configure-aws-credentials
+      contents: read
     steps:
       - uses: rlespinasse/github-slug-action@3.1.0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}:role/${{ secrets.AWS_TESTENVS_CICD_ROLE_NAME }}
+          aws-region: us-east-1
 
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@v3.3.0
         with:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           REGION: us-east-1
           FunctionName: test-env-manager
           Payload: >-
             {
               "action": "${{ github.event.action }}",
               "label": "${{ env.GITHUB_HEAD_REF_SLUG_URL }}",
-              "image": "${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ env.GITHUB_HEAD_REF_SLUG_URL }}"
+              "image": "${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ env.GITHUB_HEAD_REF_SLUG_URL }}"
             }
           LogType: Tail
 

--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@v3.3.0
         with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           REGION: us-east-1
           FunctionName: test-env-manager
           Payload: >-

--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           REGION: us-east-1
           FunctionName: test-env-manager
           Payload: >-

--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       id-token: write # needed by aws-actions/configure-aws-credentials
       contents: read
+      deployments: write
     steps:
       - uses: rlespinasse/github-slug-action@3.1.0
 

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           REGION: us-east-1
           FunctionName: test-env-manager
           Payload: >-

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       id-token: write # needed by aws-actions/configure-aws-credentials
       contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@3.1.0

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -11,6 +11,9 @@ jobs:
     name: Deploy test environment for labeled pull requests
     if: ${{ ((github.event.action == 'labeled') && (github.event.label.name == 'test deployment')) || ((github.event.action != 'labeled') && contains(github.event.pull_request.labels.*.name, 'test deployment')) }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed by aws-actions/configure-aws-credentials
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@3.1.0
@@ -30,12 +33,18 @@ jobs:
           env: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
           ref: ${{ github.head_ref }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}:role/${{ secrets.AWS_TESTENVS_CICD_ROLE_NAME }}
+          aws-region: us-east-1
+
       - name: Build and push
         uses: kciter/aws-ecr-action@79255b7c5aa03dbf6d7c46cff2bfd049874cd98d # v4
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          account_id: ${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}
           repo: saleor-testenvs
           region: us-east-1
           tags: ${{ env.GITHUB_HEAD_REF_SLUG_URL }},${{ github.sha }}
@@ -43,15 +52,13 @@ jobs:
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@v3.3.0
         with:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           REGION: us-east-1
           FunctionName: test-env-manager
           Payload: >-
             {
               "action": "${{ github.event.action }}",
               "label": "${{ env.GITHUB_HEAD_REF_SLUG_URL }}",
-              "image": "${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ github.sha }}"
+              "image": "${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/saleor-testenvs:${{ github.sha }}"
             }
           LogType: Tail
 

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@v3.3.0
         with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           REGION: us-east-1
           FunctionName: test-env-manager
           Payload: >-


### PR DESCRIPTION
I want to merge this change because...

we are migrating our GHA workflows - they will use IAM roles instead of Access Keys of IAM users from now on.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
