### PR TITLE
Use Q to build single query when fetching voucher usage

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 
 from django.conf import settings
-from django.db.models import Exists, F, Func, OuterRef, Subquery, Value
+from django.db.models import Exists, F, Func, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Greatest
 from django.utils import timezone
 
@@ -71,31 +71,25 @@ def _bulk_release_voucher_usage(order_ids):
         .values("count")
         .order_by()
     )
-
     vouchers = Voucher.objects.filter(usage_limit__isnull=False)
     codes = VoucherCode.objects.filter(
         Exists(voucher_orders),
         Exists(vouchers.filter(id=OuterRef("voucher_id"))),
     ).annotate(order_count=Subquery(count_orders))
-
     codes.update(used=Greatest(F("used") - F("order_count"), 0))
 
     orders = Order.objects.filter(id__in=order_ids)
     voucher_codes = VoucherCode.objects.filter(
         Exists(orders.filter(voucher_code=OuterRef("code")))
     )
-    # Only delete voucher customers for orders that have no user associated
-    # as voucher are associated with user's email account
     VoucherCustomer.objects.filter(
         Exists(voucher_codes.filter(id=OuterRef("voucher_code_id"))),
         Exists(
-            orders.filter(user_email=OuterRef("customer_email"), user_id__isnull=True)
+            orders.filter(
+                Q(user_email=OuterRef("customer_email"), user_id__isnull=True)
+                | Q(user__email=OuterRef("customer_email"))
+            )
         ),
-    ).delete()
-
-    VoucherCustomer.objects.filter(
-        Exists(voucher_codes.filter(id=OuterRef("voucher_code_id"))),
-        Exists(orders.filter(user__email=OuterRef("customer_email"))),
     ).delete()
 
 

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -706,7 +706,12 @@ def test_delete_expired_orders_task_schedule_itself(
 
 
 def test_bulk_release_voucher_usage_voucher_usage_mismatch(
-    order_list, allocations, channel_USD, voucher_customer
+    order_list,
+    allocations,
+    channel_USD,
+    voucher_customer,
+    customer_user,
+    customer_user2,
 ):
     # We can have mismatch between `voucher.used` and number of order utilizing
     # the voucher. It can happen in following cases:
@@ -745,25 +750,41 @@ def test_bulk_release_voucher_usage_voucher_usage_mismatch(
     now = timezone.now()
     code = voucher_customer.voucher_code
     voucher = code.voucher
-    code.used = 1
+    code.used = 3
     voucher.usage_limit = 3
     code.save(update_fields=["used"])
     voucher.save(update_fields=["usage_limit"])
 
+    third_email = "third@example.com"
+    VoucherCustomer.objects.create(
+        voucher_code=code, customer_email=customer_user2.email
+    )
+    VoucherCustomer.objects.create(voucher_code=code, customer_email=third_email)
+
     order_1 = order_list[0]
+    order_1.user = customer_user
     order_1.status = OrderStatus.UNCONFIRMED
     order_1.created_at = now - datetime.timedelta(minutes=10)
     order_1.voucher_code = code.code
     order_1.save()
 
     order_2 = order_list[1]
+    order_2.user = customer_user2
     order_2.status = OrderStatus.UNCONFIRMED
     order_2.created_at = now - datetime.timedelta(minutes=10)
     order_2.voucher_code = code.code
     order_2.save()
 
+    order_3 = order_list[2]
+    order_3.user = None
+    order_3.user_email = third_email
+    order_3.status = OrderStatus.UNCONFIRMED
+    order_3.created_at = now - datetime.timedelta(minutes=10)
+    order_3.voucher_code = code.code
+    order_3.save()
+
     # when
-    _bulk_release_voucher_usage([order_1.pk, order_2.pk])
+    _bulk_release_voucher_usage([order_1.pk, order_2.pk, order_3.pk])
 
     # then
     code.refresh_from_db()


### PR DESCRIPTION
I want to merge this change because it covers the suggestion mentioned here:
https://github.com/saleor/saleor/pull/17766#discussion_r2120304545

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
