### PR TITLE
Allow filtering orders by voucher code

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -424,6 +424,11 @@ class OrderWhere(WhereFilterSet):
         method="filter_is_gift_card_bought",
         help_text="Filter based on whether the order includes a gift card purchase.",
     )
+    voucher_code = OperationObjectTypeWhereFilter(
+        input_class=StringFilterInput,
+        method="filter_voucher_code",
+        help_text="Filter by voucher code used in the order.",
+    )
 
     @staticmethod
     def filter_number(qs, _, value):
@@ -494,6 +499,10 @@ class OrderWhere(WhereFilterSet):
         if value is None:
             return qs.none()
         return filter_by_gift_card(qs, value, GiftCardEvents.BOUGHT)
+
+    @staticmethod
+    def filter_voucher_code(qs, _, value):
+        return filter_where_by_value_field(qs, "voucher_code", value)
 
 
 class OrderWhereInput(WhereInputObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12837,6 +12837,9 @@ input OrderWhereInput @doc(category: "Orders") {
   """Filter based on whether the order includes a gift card purchase."""
   isGiftCardBought: Boolean
 
+  """Filter by voucher code used in the order."""
+  voucherCode: StringFilterInput
+
   """List of conditions that must be met."""
   AND: [OrderWhereInput!]
 


### PR DESCRIPTION
Extend `OrderWhereInput` with `voucherCode`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
