### PR TITLE
Fix returning value from scalar

### DIFF
--- a/saleor/graphql/core/federation/schema.py
+++ b/saleor/graphql/core/federation/schema.py
@@ -23,7 +23,7 @@ class _Any(graphene.Scalar):
 
     @staticmethod
     def parse_literal(any_value: Any):
-        raise any_value
+        return any_value
 
     @staticmethod
     def parse_value(any_value: Any):


### PR DESCRIPTION
Fix `parse_literal` function in the `_Any` scalar, where accidentally `raise` was used instead of `return`. 

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
