### PR TITLE
Remove pytest-celery from license-checking exception

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -50,6 +50,3 @@ jobs:
             # Authorize.Net Python SDK was reviewed as compatible with our project.
             # License: https://github.com/AuthorizeNet/sdk-python/blob/bfcfb73ac74e33544845e435bb2ad54a22641583/LICENSE.txt
             - authorizenet
-            # pytest-celery is licensed under BSD-3-Clause (false positive).
-            # Bug fix: https://github.com/celery/pytest-celery/pull/438
-            - pytest-celery


### PR DESCRIPTION
Version v1.2.0 (https://github.com/celery/pytest-celery/releases/tag/v1.2.0) fixed the issue where the project was incorrectly flagged as being proprietary instead of BSD-3-Clause.

This commit thus removes pytest-celery from the exception list.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
