### PR TITLE
Revert additional .quantitze in `normalize_tax_rate_for_db`

### DIFF
--- a/saleor/tax/tests/test_checkout_calculations.py
+++ b/saleor/tax/tests/test_checkout_calculations.py
@@ -269,9 +269,9 @@ def test_calculate_checkout_shipping_with_weighted_taxes(
     weighted_tax_amount = weighted_tax_amount / sum(
         line_info.line.total_price.net.amount for line_info in lines
     )
-    assert checkout.shipping_tax_rate == Decimal(weighted_tax_amount).quantize(
-        Decimal("0.0001")
-    )
+    assert checkout.shipping_tax_rate.quantize(Decimal("0.0001")) == Decimal(
+        weighted_tax_amount
+    ).quantize(Decimal("0.0001"))
     assert checkout.shipping_price == TaxedMoney(
         net=Money(expected_net, "USD"), gross=Money(expected_gross, "USD")
     )

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -201,7 +201,7 @@ def test_calculate_order_shipping_with_weighted_taxes(
         line.total_price.net.amount for line in lines
     )
     assert (
-        order.shipping_tax_rate
+        order.shipping_tax_rate.quantize(Decimal("0.0001"))
         == Decimal(weighted_tax_amount).quantize(Decimal("0.0001"))
         == Decimal(expected_shipping_tax_rate).quantize(Decimal("0.0001"))
     )

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -251,7 +251,6 @@ def _get_weighted_tax_rate_for_shipping(
     weighted_sum = sum(
         [rate * weight for rate, weight in tax_rates_with_weights.items()], Decimal(0)
     )
-
     return (weighted_sum / total_weight).quantize(Decimal(".0001"))
 
 
@@ -327,7 +326,7 @@ def normalize_tax_rate_for_db(tax_rate: Decimal) -> Decimal:
     # Percentage values are used to represent tax rates in tax apps and flat rates, but
     # in the database rates are stored as fractional values. Example: tax app returns
     # `10%` as `10`, but in the database it's stored as `0.1`.
-    return (tax_rate / 100).quantize(Decimal(".0001"))
+    return tax_rate / 100
 
 
 def denormalize_tax_rate_from_db(tax_rate: Decimal) -> Decimal:


### PR DESCRIPTION
I want to merge this change because quantitze added to normalize_tax_rate_for_db in [PR](https://github.com/saleor/saleor/pull/17726/files#diff-6a4a7eab95a8b54684716cf6a3f5c0588839fc2a8e2528394a31962b4bab347aR330), can cause that we will lose the precision while calcualte the undiscounted amount. The PR revert this change.

Port of chagnes from: https://github.com/saleor/saleor/pull/17777

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
