### PR TITLE
Add checkout filtering and sorting functionality to user checkouts query

### DIFF
--- a/saleor/graphql/account/tests/queries/test_user_checkouts_filter.py
+++ b/saleor/graphql/account/tests/queries/test_user_checkouts_filter.py
@@ -1,0 +1,51 @@
+import graphene
+import pytest
+
+from ....tests.utils import get_graphql_content
+
+USER_CHECKOUTS_QUERY = """
+query ($userId: ID!, $filter: CheckoutFilterInput, $sortBy: CheckoutSortingInput) {
+  user(id: $userId) {
+    checkouts(filter: $filter, sortBy: $sortBy, first: 5) {
+      edges {
+        node {
+          id
+          updatedAt
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.mark.django_db
+def test_user_checkouts_with_filter_and_sort(
+    staff_api_client,
+    permission_manage_users,
+    user_checkout,
+    channel_USD,
+):
+    # Give staff user permission
+    staff_api_client.user.user_permissions.add(permission_manage_users)
+
+    # Assign channel to the checkout (if needed)
+    user_checkout.channel = channel_USD
+    user_checkout.save()
+
+    user_id = graphene.Node.to_global_id("User", user_checkout.user.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    variables = {
+        "userId": user_id,
+        "filter": {"channels": [channel_id]},
+        "sortBy": {"field": "CREATION_DATE", "direction": "DESC"},
+    }
+
+    # When
+    response = staff_api_client.post_graphql(USER_CHECKOUTS_QUERY, variables)
+    content = get_graphql_content(response)
+
+    # Then
+    checkouts = content["data"]["user"]["checkouts"]["edges"]
+    assert len(checkouts) >= 1
+    assert checkouts[0]["node"]["id"] is not None

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -27,6 +27,8 @@ from ..app.types import App
 from ..channel.dataloaders import ChannelBySlugLoader
 from ..channel.types import Channel
 from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUserLoader
+from ..checkout.filters import CheckoutFilterInput
+from ..checkout.sorters import CheckoutSortingInput
 from ..checkout.types import Checkout, CheckoutCountableConnection
 from ..core import ResolveInfo
 from ..core.connection import (
@@ -384,6 +386,8 @@ class User(ModelObjectType[models.User]):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
+        sort_by=CheckoutSortingInput(description="Sort checkouts."),
+        filter=CheckoutFilterInput(description="Filtering options for checkouts."),
     )
     gift_cards = ConnectionField(
         "saleor.graphql.giftcard.types.GiftCardCountableConnection",

--- a/saleor/graphql/checkout/filters.py
+++ b/saleor/graphql/checkout/filters.py
@@ -188,3 +188,9 @@ def _filter_price(qs, _, field_name, value, currency):
         )
     qs = qs.filter(currency=currency)
     return filter_where_by_numeric_field(qs, field_name, value)
+
+
+def filter_checkouts(qs, filter_input):
+    if filter_input:
+        return CheckoutFilter(filter_input, queryset=qs).qs
+    return qs

--- a/saleor/graphql/checkout/sorters.py
+++ b/saleor/graphql/checkout/sorters.py
@@ -37,3 +37,17 @@ class CheckoutSortingInput(SortInputObjectType):
         doc_category = DOC_CATEGORY_CHECKOUT
         sort_enum = CheckoutSortField
         type_name = "checkouts"
+
+
+def sort_checkouts(qs, sort_by_input):
+    if sort_by_input:
+        field = sort_by_input.get("field")
+        direction = sort_by_input.get("direction")
+        if field:
+            sort_fields = getattr(CheckoutSortField, field)
+            ordering = []
+            for f in sort_fields:
+                order = f if direction == "ASC" else f"-{f}"
+                ordering.append(order)
+            qs = qs.order_by(*ordering)
+    return qs


### PR DESCRIPTION
I want to merge this change because it adds support for `filter` and `sortBy` inputs to the `user.checkouts` field, aligning its capabilities with the top-level `checkouts` query. This improves API consistency and allows clients to retrieve filtered and sorted checkout data for a specific user directly.

Fix: #12520

Co-authored by: Carey Wang <@nikoishere>
Co-authored by: Cherine Cho <@CherineCho2016>

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact
- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined