### PR TITLE
Adjust `createdAt` and `updatedAt` orders filters

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -37,7 +37,6 @@ from ..core.types import (
     NonNullList,
 )
 from ..core.types.filter_input import (
-    DateTimeFilterInput,
     FilterInputDescriptions,
     GlobalIDFilterInput,
     IntFilterInput,
@@ -56,7 +55,6 @@ from ..utils.filters import (
     filter_where_by_numeric_field,
     filter_where_by_range_field,
     filter_where_by_value_field,
-    filter_where_range_field,
 )
 from .enums import (
     OrderAuthorizeStatusEnum,
@@ -385,12 +383,12 @@ class OrderWhere(WhereFilterSet):
         help_text="Filter by channel.",
     )
     created_at = ObjectTypeWhereFilter(
-        input_class=DateTimeFilterInput,
+        input_class=DateTimeRangeInput,
         method="filter_created_at_range",
         help_text="Filter order by created at date.",
     )
     updated_at = ObjectTypeWhereFilter(
-        input_class=DateTimeFilterInput,
+        input_class=DateTimeRangeInput,
         method="filter_updated_at_range",
         help_text="Filter order by updated at date.",
     )
@@ -472,11 +470,11 @@ class OrderWhere(WhereFilterSet):
 
     @staticmethod
     def filter_created_at_range(qs, _, value):
-        return filter_where_range_field(qs, "created_at", value)
+        return filter_where_by_range_field(qs, "created_at", value)
 
     @staticmethod
     def filter_updated_at_range(qs, _, value):
-        return filter_where_range_field(qs, "updated_at", value)
+        return filter_where_by_range_field(qs, "updated_at", value)
 
     @staticmethod
     def filter_user(qs, _, value):

--- a/saleor/graphql/order/tests/queries/test_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_where.py
@@ -95,43 +95,33 @@ def test_order_filter_by_ids_empty_list(
     [
         (
             {
-                "range": {
-                    "gte": (timezone.now() + datetime.timedelta(days=3)).isoformat(),
-                    "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
-                }
+                "gte": (timezone.now() + datetime.timedelta(days=3)).isoformat(),
+                "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
             },
             [1, 2],
         ),
         (
             {
-                "range": {
-                    "gte": (timezone.now() + datetime.timedelta(days=5)).isoformat(),
-                }
+                "gte": (timezone.now() + datetime.timedelta(days=5)).isoformat(),
             },
             [1, 2],
         ),
         (
             {
-                "range": {
-                    "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
-                }
+                "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
             },
             [0, 1, 2],
         ),
         (
             {
-                "range": {
-                    "lte": (timezone.now() - datetime.timedelta(days=25)).isoformat(),
-                }
+                "lte": (timezone.now() - datetime.timedelta(days=25)).isoformat(),
             },
             [],
         ),
         (None, []),
-        ({"range": {"gte": None}}, []),
-        ({"range": {"lte": None}}, []),
-        ({"range": {"lte": None, "gte": None}}, []),
-        ({"eq": None}, []),
-        ({"oneOf": []}, []),
+        ({"gte": None}, []),
+        ({"lte": None}, []),
+        ({"lte": None, "gte": None}, []),
         ({}, []),
     ],
 )
@@ -172,43 +162,33 @@ def test_orders_filter_by_created_at(
     [
         (
             {
-                "range": {
-                    "gte": (timezone.now() + datetime.timedelta(days=3)).isoformat(),
-                    "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
-                }
+                "gte": (timezone.now() + datetime.timedelta(days=3)).isoformat(),
+                "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
             },
             [0, 1],
         ),
         (
             {
-                "range": {
-                    "gte": (timezone.now() + datetime.timedelta(days=5)).isoformat(),
-                }
+                "gte": (timezone.now() + datetime.timedelta(days=5)).isoformat(),
             },
             [0],
         ),
         (
             {
-                "range": {
-                    "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
-                }
+                "lte": (timezone.now() + datetime.timedelta(days=25)).isoformat(),
             },
             [0, 1, 2],
         ),
         (
             {
-                "range": {
-                    "lte": (timezone.now() - datetime.timedelta(days=25)).isoformat(),
-                }
+                "lte": (timezone.now() - datetime.timedelta(days=25)).isoformat(),
             },
             [],
         ),
         (None, []),
-        ({"range": {"gte": None}}, []),
-        ({"range": {"lte": None}}, []),
-        ({"range": {"lte": None, "gte": None}}, []),
-        ({"eq": None}, []),
-        ({"oneOf": []}, []),
+        ({"gte": None}, []),
+        ({"lte": None}, []),
+        ({"lte": None, "gte": None}, []),
         ({}, []),
     ],
 )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12825,10 +12825,10 @@ input OrderWhereInput @doc(category: "Orders") {
   channelId: GlobalIDFilterInput
 
   """Filter order by created at date."""
-  createdAt: DateTimeFilterInput
+  createdAt: DateTimeRangeInput
 
   """Filter order by updated at date."""
-  updatedAt: DateTimeFilterInput
+  updatedAt: DateTimeRangeInput
 
   """Filter by user."""
   user: GlobalIDFilterInput


### PR DESCRIPTION
Adjust `createdAt` and `updatedAt` orders filters - use `DateTimeRangeInput` instead of `DateTimeFilterInput` as `eq` and `oneOf` does not make sense in case of filtering by `DateTime` - you need to specify exact date with minutes and seconds to get the object.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
