### PR TITLE
Fixed appExtension.app requiring to have MANAGE_APPS

### DIFF
--- a/saleor/graphql/app/tests/queries/test_app_extension.py
+++ b/saleor/graphql/app/tests/queries/test_app_extension.py
@@ -316,7 +316,7 @@ def test_app_extension_with_app_query_by_staff_without_permissions(
     )
 
     # then
-    assert_no_permission(response)
+    get_graphql_content(response)
 
 
 def test_app_extension_with_app_query_by_app_without_permissions(
@@ -340,7 +340,7 @@ def test_app_extension_with_app_query_by_app_without_permissions(
     )
 
     # then
-    assert_no_permission(response)
+    get_graphql_content(response)
 
 
 def test_app_extension_with_app_query_by_app_with_permissions(
@@ -412,7 +412,7 @@ def test_app_extension_with_app_query_by_staff_with_permissions(
 
     # when
     response = staff_api_client.post_graphql(
-        QUERY_APP_EXTENSION_WITH_APP, variables, permissions=[permission_manage_apps]
+        QUERY_APP_EXTENSION_WITH_APP, variables, permissions=[]
     )
 
     # then

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -178,7 +178,7 @@ class AppExtension(AppManifestExtension, ModelObjectType[models.AppExtension]):
             app_id = root.app_id
         else:
             requestor = get_user_or_app_from_context(info.context)
-            if requestor and requestor.has_perm(AppPermission.MANAGE_APPS):
+            if requestor:
                 app_id = root.app_id
 
         if not app_id:


### PR DESCRIPTION
I want to merge this change because it fixes incorrect permissions when fetching apps via extensions query

Expected:
query access `appExtension.app` should resolve without MANAGE_APPS
query `appExtension` should resolve without MANAGE_APPS
query `app` should resolve without MANAGE_APPS

That means *apps are responsible of checking user permissions, but Saleor and Dashboard allow any staff user to read them*

Actual (before that change)
Resolver appExtension.app required MANAGE_APPS

Now:
Resolver appExtension.app does not require MANAGE_APPS

Together with this change Dashboard PR will be introduced

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
