### PR TITLE
Separate parse logic for transaction item webhooks

### DIFF
--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -129,9 +129,18 @@ class TransactionRequestEventResponse:
 
 
 @dataclass
-class TransactionRequestResponse:
+class TransactionResponseBase:
     psp_reference: str | None
-    available_actions: list[str] | None = None
+    available_actions: list[str] | None
+
+
+@dataclass
+class TransactionSessionResponse(TransactionResponseBase):
+    event: TransactionRequestEventResponse
+
+
+@dataclass
+class TransactionRequestResponse(TransactionResponseBase):
     event: Optional["TransactionRequestEventResponse"] = None
 
 

--- a/saleor/payment/tests/test_utils/test_parse_transaction_action_data_for_action_webhook.py
+++ b/saleor/payment/tests/test_utils/test_parse_transaction_action_data_for_action_webhook.py
@@ -1,0 +1,270 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+from freezegun import freeze_time
+
+from ... import TransactionEventType
+from ...interface import (
+    TransactionRequestEventResponse,
+    TransactionRequestResponse,
+)
+from ...utils import (
+    parse_transaction_action_data_for_action_webhook,
+)
+
+
+def test_parse_transaction_action_data_for_action_webhook_with_only_psp_reference():
+    # given
+    expected_psp_reference = "psp:122:222"
+    response_data = {"pspReference": expected_psp_reference}
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.CHARGE_REQUEST, Decimal(10.00)
+    )
+
+    # then
+    assert isinstance(parsed_data, TransactionRequestResponse)
+
+    assert parsed_data.psp_reference == expected_psp_reference
+    assert parsed_data.event is None
+
+
+@pytest.mark.parametrize(
+    ("event_time", "expected_datetime"),
+    [
+        (
+            "2023-10-17T10:18:28.111Z",
+            datetime.datetime(2023, 10, 17, 10, 18, 28, 111000, tzinfo=datetime.UTC),
+        ),
+        ("2011-11-04", datetime.datetime(2011, 11, 4, 0, 0, tzinfo=datetime.UTC)),
+        (
+            "2011-11-04T00:05:23",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-11-04T00:05:23Z",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
+        ),
+        (
+            "20111104T000523",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-W01-2T00:05:23.283",
+            datetime.datetime(2011, 1, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-11-04 00:05:23.283",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-11-04 00:05:23.283+00:00",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
+        ),
+        (
+            "1994-11-05T13:15:30Z",
+            datetime.datetime(1994, 11, 5, 13, 15, 30, tzinfo=datetime.UTC),
+        ),
+    ],
+)
+def test_parse_transaction_action_data_for_action_webhook_with_provided_time(
+    event_time, expected_datetime
+):
+    # given
+    request_event_amount = Decimal(10.00)
+    expected_psp_reference = "psp:122:222"
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_SUCCESS
+    event_url = "http://localhost:3000/event/ref123"
+    event_cause = "No cause"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_cause,
+    }
+
+    # when
+    parsed_data, error_msg = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
+    )
+    # then
+    assert isinstance(parsed_data, TransactionRequestResponse)
+    assert parsed_data.event is not None
+    assert parsed_data.event.time == expected_datetime
+
+
+def test_parse_transaction_action_data_for_action_webhook_with_event_all_fields_provided():
+    # given
+    request_event_amount = Decimal(10.00)
+
+    expected_psp_reference = "psp:122:222"
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_SUCCESS
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+    event_cause = "No cause"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_cause,
+    }
+
+    # when
+    parsed_data, error_msg = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
+    )
+    # then
+    assert isinstance(parsed_data, TransactionRequestResponse)
+    assert error_msg is None
+
+    assert parsed_data.psp_reference == expected_psp_reference
+    assert isinstance(parsed_data.event, TransactionRequestEventResponse)
+    assert parsed_data.event.psp_reference == expected_psp_reference
+    assert parsed_data.event.amount == event_amount
+    assert parsed_data.event.time == datetime.datetime.fromisoformat(event_time)
+    assert parsed_data.event.external_url == event_url
+    assert parsed_data.event.message == event_cause
+    assert parsed_data.event.type == event_type
+
+
+def test_parse_transaction_action_data_for_action_webhook_with_incorrect_result():
+    # given
+    request_event_amount = Decimal(10.00)
+    expected_psp_reference = "psp:122:222"
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_SUCCESS
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+    event_cause = "No cause"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_cause,
+    }
+
+    # when
+    parsed_data, error_msg = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.REFUND_REQUEST, request_event_amount
+    )
+
+    # then
+    assert parsed_data is None
+    assert (
+        error_msg
+        == f"Missing or invalid value for `result`: {response_data['result']}. Possible values: {TransactionEventType.REFUND_SUCCESS.upper()}, {TransactionEventType.REFUND_FAILURE.upper()}."
+    )
+
+
+@freeze_time("2018-05-31 12:00:01")
+def test_parse_transaction_action_data_for_action_webhook_with_event_only_mandatory_fields():
+    # given
+    expected_psp_reference = "psp:122:222"
+    expected_amount = Decimal("10.00")
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.CHARGE_REQUEST, expected_amount
+    )
+
+    # then
+    assert isinstance(parsed_data, TransactionRequestResponse)
+
+    assert parsed_data.psp_reference == expected_psp_reference
+    assert isinstance(parsed_data.event, TransactionRequestEventResponse)
+    assert parsed_data.event.psp_reference == expected_psp_reference
+    assert parsed_data.event.type == TransactionEventType.CHARGE_SUCCESS
+    assert parsed_data.event.amount == expected_amount
+    assert parsed_data.event.time == datetime.datetime.now(tz=datetime.UTC)
+    assert parsed_data.event.external_url == ""
+    assert parsed_data.event.message == ""
+
+
+def test_parse_transaction_action_data_for_action_webhook_use_provided_amount_when_event_amount_is_missing():
+    # given
+    request_event_amount = Decimal(10.00)
+    response_data = {
+        "pspReference": "123",
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
+    )
+
+    # then
+    assert isinstance(parsed_data, TransactionRequestResponse)
+    assert parsed_data.event is not None
+    assert parsed_data.event.amount == request_event_amount
+
+
+def test_parse_transaction_action_data_for_action_webhook_skips_input_amount_when_event_has_amount():
+    # given
+    request_event_amount = Decimal(10.00)
+    expected_amount = Decimal(12.00)
+
+    assert request_event_amount != expected_amount
+    response_data = {
+        "pspReference": "123",
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+        "amount": expected_amount,
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
+    )
+
+    # then
+    assert isinstance(parsed_data, TransactionRequestResponse)
+    assert parsed_data.event is not None
+    assert parsed_data.event.amount == expected_amount
+
+
+@freeze_time("2018-05-31 12:00:01")
+def test_parse_transaction_action_data_for_action_webhook_with_missing_psp_reference():
+    # given
+    response_data = {}
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_action_webhook(
+        response_data, TransactionEventType.AUTHORIZATION_REQUEST, Decimal(10.00)
+    )
+
+    # then
+    assert parsed_data is None
+
+
+def test_parse_transaction_action_data_for_action_webhook_with_missing_optional_psp_reference():
+    # given
+    response_data = {
+        "result": TransactionEventType.CHARGE_FAILURE.upper(),
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_action_webhook(
+        response_data,
+        TransactionEventType.CHARGE_REQUEST,
+        Decimal("10.00"),
+    )
+
+    # then
+    assert parsed_data

--- a/saleor/payment/tests/test_utils/test_parse_transaction_action_data_for_session_webhook.py
+++ b/saleor/payment/tests/test_utils/test_parse_transaction_action_data_for_session_webhook.py
@@ -1,0 +1,261 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+from freezegun import freeze_time
+
+from ... import TransactionEventType
+from ...interface import TransactionRequestEventResponse, TransactionSessionResponse
+from ...utils import (
+    parse_transaction_action_data_for_session_webhook,
+)
+
+
+@pytest.mark.parametrize(
+    ("event_time", "expected_datetime"),
+    [
+        (
+            "2023-10-17T10:18:28.111Z",
+            datetime.datetime(2023, 10, 17, 10, 18, 28, 111000, tzinfo=datetime.UTC),
+        ),
+        ("2011-11-04", datetime.datetime(2011, 11, 4, 0, 0, tzinfo=datetime.UTC)),
+        (
+            "2011-11-04T00:05:23",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-11-04T00:05:23Z",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
+        ),
+        (
+            "20111104T000523",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-W01-2T00:05:23.283",
+            datetime.datetime(2011, 1, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-11-04 00:05:23.283",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
+        ),
+        (
+            "2011-11-04 00:05:23.283+00:00",
+            datetime.datetime(2011, 11, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
+        ),
+        (
+            "1994-11-05T13:15:30Z",
+            datetime.datetime(1994, 11, 5, 13, 15, 30, tzinfo=datetime.UTC),
+        ),
+    ],
+)
+def test_parse_transaction_action_data_for_session_webhook_with_provided_time(
+    event_time, expected_datetime
+):
+    # given
+    request_event_amount = Decimal(10.00)
+    expected_psp_reference = "psp:122:222"
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_SUCCESS
+    event_url = "http://localhost:3000/event/ref123"
+    event_cause = "No cause"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_cause,
+    }
+
+    # when
+    parsed_data, error_msg = parse_transaction_action_data_for_session_webhook(
+        response_data, request_event_amount
+    )
+    # then
+    assert isinstance(parsed_data, TransactionSessionResponse)
+    assert parsed_data.event.time == expected_datetime
+
+
+def test_parse_transaction_action_data_for_session_webhook_with_event_all_fields_provided():
+    # given
+    request_event_amount = Decimal(10.00)
+
+    expected_psp_reference = "psp:122:222"
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_SUCCESS
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+    event_cause = "No cause"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_cause,
+    }
+
+    # when
+    parsed_data, error_msg = parse_transaction_action_data_for_session_webhook(
+        response_data, request_event_amount
+    )
+    # then
+    assert isinstance(parsed_data, TransactionSessionResponse)
+    assert error_msg is None
+
+    assert parsed_data.psp_reference == expected_psp_reference
+    assert isinstance(parsed_data.event, TransactionRequestEventResponse)
+    assert parsed_data.event.psp_reference == expected_psp_reference
+    assert parsed_data.event.amount == event_amount
+    assert parsed_data.event.time == datetime.datetime.fromisoformat(event_time)
+    assert parsed_data.event.external_url == event_url
+    assert parsed_data.event.message == event_cause
+    assert parsed_data.event.type == event_type
+
+
+def test_parse_transaction_action_data_for_session_webhook_with_incorrect_result():
+    # given
+    request_event_amount = Decimal(10.00)
+    expected_psp_reference = "psp:122:222"
+    event_amount = 12.00
+    event_type = TransactionEventType.REFUND_SUCCESS
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+    event_cause = "No cause"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_cause,
+    }
+
+    # when
+    parsed_data, error_msg = parse_transaction_action_data_for_session_webhook(
+        response_data, request_event_amount
+    )
+
+    # then
+    assert parsed_data is None
+    assert (
+        f"Missing or invalid value for `result`: {response_data['result']}" in error_msg
+    )
+
+
+@freeze_time("2018-05-31 12:00:01")
+def test_parse_transaction_action_data_for_session_webhook_with_event_only_mandatory_fields():
+    # given
+    expected_psp_reference = "psp:122:222"
+    expected_amount = Decimal("10.00")
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_session_webhook(
+        response_data, expected_amount
+    )
+
+    # then
+    assert isinstance(parsed_data, TransactionSessionResponse)
+
+    assert parsed_data.psp_reference == expected_psp_reference
+    assert isinstance(parsed_data.event, TransactionRequestEventResponse)
+    assert parsed_data.event.psp_reference == expected_psp_reference
+    assert parsed_data.event.type == TransactionEventType.CHARGE_SUCCESS
+    assert parsed_data.event.amount == expected_amount
+    assert parsed_data.event.time == datetime.datetime.now(tz=datetime.UTC)
+    assert parsed_data.event.external_url == ""
+    assert parsed_data.event.message == ""
+
+
+def test_parse_transaction_action_data_for_session_webhook_use_provided_amount_when_event_amount_is_missing():
+    # given
+    request_event_amount = Decimal(10.00)
+    response_data = {
+        "pspReference": "123",
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_session_webhook(
+        response_data, request_event_amount
+    )
+
+    # then
+    assert isinstance(parsed_data, TransactionSessionResponse)
+    assert parsed_data.event.amount == request_event_amount
+
+
+def test_parse_transaction_action_data_for_session_webhook_skips_input_amount_when_event_has_amount():
+    # given
+    request_event_amount = Decimal(10.00)
+    expected_amount = Decimal(12.00)
+
+    assert request_event_amount != expected_amount
+    response_data = {
+        "pspReference": "123",
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+        "amount": expected_amount,
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_session_webhook(
+        response_data, request_event_amount
+    )
+
+    # then
+    assert isinstance(parsed_data, TransactionSessionResponse)
+    assert parsed_data.event.amount == expected_amount
+
+
+@freeze_time("2018-05-31 12:00:01")
+def test_parse_transaction_action_data_for_session_webhook_with_empty_response():
+    # given
+    response_data = {}
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_session_webhook(
+        response_data, Decimal(10.00)
+    )
+
+    # then
+    assert parsed_data is None
+
+
+def test_parse_transaction_action_data_for_session_webhook_with_missing_optional_psp_reference():
+    # given
+    response_data = {
+        "result": TransactionEventType.CHARGE_FAILURE.upper(),
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_session_webhook(
+        response_data, Decimal("10.00")
+    )
+
+    # then
+    assert parsed_data
+
+
+def test_parse_transaction_action_data_with_missing_mandatory_event_fields():
+    # given
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+    }
+
+    # when
+    parsed_data, _ = parse_transaction_action_data_for_session_webhook(
+        response_data, Decimal("10.00")
+    )
+
+    # then
+    assert parsed_data is None

--- a/saleor/payment/tests/test_utils/test_utils.py
+++ b/saleor/payment/tests/test_utils/test_utils.py
@@ -6,19 +6,17 @@ from unittest.mock import patch
 import pytest
 from freezegun import freeze_time
 
-from ...checkout import CheckoutAuthorizeStatus, calculations
-from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
-from ...order import OrderAuthorizeStatus, OrderChargeStatus, OrderGrantedRefundStatus
-from ...plugins.manager import get_plugins_manager
-from .. import TransactionEventType
-from ..interface import (
+from ....checkout import CheckoutAuthorizeStatus, calculations
+from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from ....order import OrderAuthorizeStatus, OrderChargeStatus, OrderGrantedRefundStatus
+from ....plugins.manager import get_plugins_manager
+from ... import TransactionEventType
+from ...interface import (
     PaymentLineData,
     PaymentLinesData,
-    TransactionRequestEventResponse,
-    TransactionRequestResponse,
 )
-from ..models import TransactionEvent
-from ..utils import (
+from ...models import TransactionEvent
+from ...utils import (
     create_failed_transaction_event,
     create_manual_adjustment_events,
     create_payment_lines_information,
@@ -29,7 +27,6 @@ from ..utils import (
     get_correct_event_types_based_on_request_type,
     get_transaction_event_amount,
     logger,
-    parse_transaction_action_data,
     recalculate_refundable_for_checkout,
     try_void_or_refund_inactive_payment,
 )
@@ -270,278 +267,6 @@ def test_try_void_or_refund_inactive_payment_transaction_success(
     )
     assert get_channel_slug_from_payment_mock.called
     assert refund_or_void_mock.called
-
-
-def test_parse_transaction_action_data_with_only_psp_reference():
-    # given
-    expected_psp_reference = "psp:122:222"
-    response_data = {"pspReference": expected_psp_reference}
-
-    # when
-    parsed_data, _ = parse_transaction_action_data(
-        response_data, TransactionEventType.CHARGE_REQUEST, Decimal(10.00)
-    )
-
-    # then
-    assert isinstance(parsed_data, TransactionRequestResponse)
-
-    assert parsed_data.psp_reference == expected_psp_reference
-    assert parsed_data.event is None
-
-
-@pytest.mark.parametrize(
-    ("event_time", "expected_datetime"),
-    [
-        (
-            "2023-10-17T10:18:28.111Z",
-            datetime.datetime(2023, 10, 17, 10, 18, 28, 111000, tzinfo=datetime.UTC),
-        ),
-        ("2011-11-04", datetime.datetime(2011, 11, 4, 0, 0, tzinfo=datetime.UTC)),
-        (
-            "2011-11-04T00:05:23",
-            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
-        ),
-        (
-            "2011-11-04T00:05:23Z",
-            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
-        ),
-        (
-            "20111104T000523",
-            datetime.datetime(2011, 11, 4, 0, 5, 23, tzinfo=datetime.UTC),
-        ),
-        (
-            "2011-W01-2T00:05:23.283",
-            datetime.datetime(2011, 1, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
-        ),
-        (
-            "2011-11-04 00:05:23.283",
-            datetime.datetime(2011, 11, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
-        ),
-        (
-            "2011-11-04 00:05:23.283+00:00",
-            datetime.datetime(2011, 11, 4, 0, 5, 23, 283000, tzinfo=datetime.UTC),
-        ),
-        (
-            "1994-11-05T13:15:30Z",
-            datetime.datetime(1994, 11, 5, 13, 15, 30, tzinfo=datetime.UTC),
-        ),
-    ],
-)
-def test_parse_transaction_action_data_with_provided_time(
-    event_time, expected_datetime
-):
-    # given
-    request_event_amount = Decimal(10.00)
-    expected_psp_reference = "psp:122:222"
-    event_amount = 12.00
-    event_type = TransactionEventType.CHARGE_SUCCESS
-    event_url = "http://localhost:3000/event/ref123"
-    event_cause = "No cause"
-
-    response_data = {
-        "pspReference": expected_psp_reference,
-        "amount": event_amount,
-        "result": event_type.upper(),
-        "time": event_time,
-        "externalUrl": event_url,
-        "message": event_cause,
-    }
-
-    # when
-    parsed_data, error_msg = parse_transaction_action_data(
-        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
-    )
-    # then
-    assert parsed_data.event.time == expected_datetime
-
-
-def test_parse_transaction_action_data_with_event_all_fields_provided():
-    # given
-    request_event_amount = Decimal(10.00)
-
-    expected_psp_reference = "psp:122:222"
-    event_amount = 12.00
-    event_type = TransactionEventType.CHARGE_SUCCESS
-    event_time = "2022-11-18T13:25:58.169685+00:00"
-    event_url = "http://localhost:3000/event/ref123"
-    event_cause = "No cause"
-
-    response_data = {
-        "pspReference": expected_psp_reference,
-        "amount": event_amount,
-        "result": event_type.upper(),
-        "time": event_time,
-        "externalUrl": event_url,
-        "message": event_cause,
-    }
-
-    # when
-    parsed_data, error_msg = parse_transaction_action_data(
-        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
-    )
-    # then
-    assert isinstance(parsed_data, TransactionRequestResponse)
-    assert error_msg is None
-
-    assert parsed_data.psp_reference == expected_psp_reference
-    assert isinstance(parsed_data.event, TransactionRequestEventResponse)
-    assert parsed_data.event.psp_reference == expected_psp_reference
-    assert parsed_data.event.amount == event_amount
-    assert parsed_data.event.time == datetime.datetime.fromisoformat(event_time)
-    assert parsed_data.event.external_url == event_url
-    assert parsed_data.event.message == event_cause
-    assert parsed_data.event.type == event_type
-
-
-def test_parse_transaction_action_data_with_incorrect_result():
-    # given
-    request_event_amount = Decimal(10.00)
-    expected_psp_reference = "psp:122:222"
-    event_amount = 12.00
-    event_type = TransactionEventType.CHARGE_SUCCESS
-    event_time = "2022-11-18T13:25:58.169685+00:00"
-    event_url = "http://localhost:3000/event/ref123"
-    event_cause = "No cause"
-
-    response_data = {
-        "pspReference": expected_psp_reference,
-        "amount": event_amount,
-        "result": event_type.upper(),
-        "time": event_time,
-        "externalUrl": event_url,
-        "message": event_cause,
-    }
-
-    # when
-    parsed_data, error_msg = parse_transaction_action_data(
-        response_data, TransactionEventType.REFUND_REQUEST, request_event_amount
-    )
-
-    # then
-    assert parsed_data is None
-    assert (
-        error_msg
-        == f"Missing or invalid value for `result`: {response_data['result']}. Possible values: {TransactionEventType.REFUND_SUCCESS.upper()}, {TransactionEventType.REFUND_FAILURE.upper()}."
-    )
-
-
-@freeze_time("2018-05-31 12:00:01")
-def test_parse_transaction_action_data_with_event_only_mandatory_fields():
-    # given
-    expected_psp_reference = "psp:122:222"
-    expected_amount = Decimal("10.00")
-    response_data = {
-        "pspReference": expected_psp_reference,
-        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
-    }
-
-    # when
-    parsed_data, _ = parse_transaction_action_data(
-        response_data, TransactionEventType.CHARGE_REQUEST, expected_amount
-    )
-
-    # then
-    assert isinstance(parsed_data, TransactionRequestResponse)
-
-    assert parsed_data.psp_reference == expected_psp_reference
-    assert isinstance(parsed_data.event, TransactionRequestEventResponse)
-    assert parsed_data.event.psp_reference == expected_psp_reference
-    assert parsed_data.event.type == TransactionEventType.CHARGE_SUCCESS
-    assert parsed_data.event.amount == expected_amount
-    assert parsed_data.event.time == datetime.datetime.now(tz=datetime.UTC)
-    assert parsed_data.event.external_url == ""
-    assert parsed_data.event.message == ""
-
-
-def test_parse_transaction_action_data_use_provided_amount_when_event_amount_is_missing():
-    # given
-    request_event_amount = Decimal(10.00)
-    response_data = {
-        "pspReference": "123",
-        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
-    }
-
-    # when
-    parsed_data, _ = parse_transaction_action_data(
-        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
-    )
-
-    # then
-    assert isinstance(parsed_data, TransactionRequestResponse)
-    assert parsed_data.event.amount == request_event_amount
-
-
-def test_parse_transaction_action_data_skips_input_amount_when_event_has_amount():
-    # given
-    request_event_amount = Decimal(10.00)
-    expected_amount = Decimal(12.00)
-
-    assert request_event_amount != expected_amount
-    response_data = {
-        "pspReference": "123",
-        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
-        "amount": expected_amount,
-    }
-
-    # when
-    parsed_data, _ = parse_transaction_action_data(
-        response_data, TransactionEventType.CHARGE_REQUEST, request_event_amount
-    )
-
-    # then
-    assert isinstance(parsed_data, TransactionRequestResponse)
-    assert parsed_data.event.amount == expected_amount
-
-
-@freeze_time("2018-05-31 12:00:01")
-def test_parse_transaction_action_data_with_missing_psp_reference():
-    # given
-    response_data = {}
-
-    # when
-    parsed_data, _ = parse_transaction_action_data(
-        response_data, TransactionEventType.AUTHORIZATION_REQUEST, Decimal(10.00)
-    )
-
-    # then
-    assert parsed_data is None
-
-
-def test_parse_transaction_action_data_with_missing_optional_psp_reference():
-    # given
-    response_data = {
-        "result": TransactionEventType.CHARGE_FAILURE.upper(),
-    }
-
-    # when
-    parsed_data, _ = parse_transaction_action_data(
-        response_data,
-        TransactionEventType.CHARGE_REQUEST,
-        Decimal("10.00"),
-    )
-
-    # then
-    assert parsed_data
-
-
-def test_parse_transaction_action_data_with_missing_mandatory_event_fields():
-    # given
-    expected_psp_reference = "psp:122:222"
-
-    response_data = {
-        "pspReference": expected_psp_reference,
-    }
-
-    # when
-    parsed_data, _ = parse_transaction_action_data(
-        response_data,
-        TransactionEventType.CHARGE_REQUEST,
-        Decimal("10.00"),
-        event_is_optional=False,
-    )
-
-    # then
-    assert parsed_data is None
 
 
 def test_create_failed_transaction_event(transaction_item_generator):


### PR DESCRIPTION
I want to merge this change because it separates the logic related to processing the session and request action webhooks. 
The logic was always separated, but it was done deep inside the code. As I am going to extend the session layer, I split the layers into two. 
Changes:
- separate logic responsible for parsing the payload
- move utils tests to `test_utils` directory. 
- Move tests for `parse_transaction_action_data_for_action_webhook` to separate file
- Move tests for `parse_transaction_action_data_for_session_webhook` to separate file

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
