### PR TITLE
Add webhook support for payment-method-details in TransactionAPI

### DIFF
--- a/saleor/core/management/commands/generate_json_schemas.py
+++ b/saleor/core/management/commands/generate_json_schemas.py
@@ -69,6 +69,7 @@ class Command(BaseCommand):
         path = os.path.join(SCHEMA_OUTPUT_DIR, file_name)
         with open(path, "w") as f:
             json.dump(schema, f, indent=2)
+            f.write("\n")
         self.stdout.write(self.style.SUCCESS(f"Generated {path}"))
 
     @staticmethod

--- a/saleor/json_schemas/TransactionInitializeSession.json
+++ b/saleor/json_schemas/TransactionInitializeSession.json
@@ -78,6 +78,33 @@
           "$ref": "#/$defs/JsonValue",
           "default": null,
           "description": "The JSON data that will be returned to storefront"
+        },
+        "paymentMethodDetails": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "CARD": "#/$defs/CardPaymentMethodDetails",
+                  "OTHER": "#/$defs/OtherPaymentMethodDetails"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OtherPaymentMethodDetails"
+                },
+                {
+                  "$ref": "#/$defs/CardPaymentMethodDetails"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Details of the payment method used for the transaction.",
+          "title": "Paymentmethoddetails"
         }
       },
       "required": [
@@ -163,6 +190,33 @@
           "$ref": "#/$defs/JsonValue",
           "default": null,
           "description": "The JSON data that will be returned to storefront"
+        },
+        "paymentMethodDetails": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "CARD": "#/$defs/CardPaymentMethodDetails",
+                  "OTHER": "#/$defs/OtherPaymentMethodDetails"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OtherPaymentMethodDetails"
+                },
+                {
+                  "$ref": "#/$defs/CardPaymentMethodDetails"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Details of the payment method used for the transaction.",
+          "title": "Paymentmethoddetails"
         }
       },
       "required": [
@@ -247,6 +301,33 @@
           "$ref": "#/$defs/JsonValue",
           "default": null,
           "description": "The JSON data that will be returned to storefront"
+        },
+        "paymentMethodDetails": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "CARD": "#/$defs/CardPaymentMethodDetails",
+                  "OTHER": "#/$defs/OtherPaymentMethodDetails"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OtherPaymentMethodDetails"
+                },
+                {
+                  "$ref": "#/$defs/CardPaymentMethodDetails"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Details of the payment method used for the transaction.",
+          "title": "Paymentmethoddetails"
         }
       },
       "required": [
@@ -257,6 +338,100 @@
     }
   ],
   "$defs": {
+    "CardPaymentMethodDetails": {
+      "properties": {
+        "type": {
+          "const": "CARD",
+          "description": "Type of the payment method used for the transaction.",
+          "maxLength": 32,
+          "title": "Type",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the payment method used for the transaction.",
+          "maxLength": 256,
+          "title": "Name",
+          "type": "string"
+        },
+        "brand": {
+          "anyOf": [
+            {
+              "maxLength": 40,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Brand of the card used for the transaction.",
+          "title": "Brand"
+        },
+        "firstDigits": {
+          "anyOf": [
+            {
+              "maxLength": 4,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "First digits of the card used for the transaction.",
+          "title": "Firstdigits"
+        },
+        "lastDigits": {
+          "anyOf": [
+            {
+              "maxLength": 4,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Last digits of the card used for the transaction.",
+          "title": "Lastdigits"
+        },
+        "expMonth": {
+          "anyOf": [
+            {
+              "maximum": 12,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expiration month of the card used for the transaction.",
+          "title": "Expmonth"
+        },
+        "expYear": {
+          "anyOf": [
+            {
+              "minimum": 2000,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expiration year of the card used for the transaction.",
+          "title": "Expyear"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ],
+      "title": "CardPaymentMethodDetails",
+      "type": "object"
+    },
     "JsonValue": {
       "anyOf": [
         {
@@ -284,6 +459,29 @@
         }
       ],
       "title": "JsonValue"
+    },
+    "OtherPaymentMethodDetails": {
+      "properties": {
+        "type": {
+          "const": "OTHER",
+          "description": "Type of the payment method used for the transaction.",
+          "maxLength": 32,
+          "title": "Type",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the payment method used for the transaction.",
+          "maxLength": 256,
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ],
+      "title": "OtherPaymentMethodDetails",
+      "type": "object"
     }
   }
 }

--- a/saleor/json_schemas/TransactionProcessSession.json
+++ b/saleor/json_schemas/TransactionProcessSession.json
@@ -78,6 +78,33 @@
           "$ref": "#/$defs/JsonValue",
           "default": null,
           "description": "The JSON data that will be returned to storefront"
+        },
+        "paymentMethodDetails": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "CARD": "#/$defs/CardPaymentMethodDetails",
+                  "OTHER": "#/$defs/OtherPaymentMethodDetails"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OtherPaymentMethodDetails"
+                },
+                {
+                  "$ref": "#/$defs/CardPaymentMethodDetails"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Details of the payment method used for the transaction.",
+          "title": "Paymentmethoddetails"
         }
       },
       "required": [
@@ -163,6 +190,33 @@
           "$ref": "#/$defs/JsonValue",
           "default": null,
           "description": "The JSON data that will be returned to storefront"
+        },
+        "paymentMethodDetails": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "CARD": "#/$defs/CardPaymentMethodDetails",
+                  "OTHER": "#/$defs/OtherPaymentMethodDetails"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OtherPaymentMethodDetails"
+                },
+                {
+                  "$ref": "#/$defs/CardPaymentMethodDetails"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Details of the payment method used for the transaction.",
+          "title": "Paymentmethoddetails"
         }
       },
       "required": [
@@ -247,6 +301,33 @@
           "$ref": "#/$defs/JsonValue",
           "default": null,
           "description": "The JSON data that will be returned to storefront"
+        },
+        "paymentMethodDetails": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "CARD": "#/$defs/CardPaymentMethodDetails",
+                  "OTHER": "#/$defs/OtherPaymentMethodDetails"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/OtherPaymentMethodDetails"
+                },
+                {
+                  "$ref": "#/$defs/CardPaymentMethodDetails"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Details of the payment method used for the transaction.",
+          "title": "Paymentmethoddetails"
         }
       },
       "required": [
@@ -257,6 +338,100 @@
     }
   ],
   "$defs": {
+    "CardPaymentMethodDetails": {
+      "properties": {
+        "type": {
+          "const": "CARD",
+          "description": "Type of the payment method used for the transaction.",
+          "maxLength": 32,
+          "title": "Type",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the payment method used for the transaction.",
+          "maxLength": 256,
+          "title": "Name",
+          "type": "string"
+        },
+        "brand": {
+          "anyOf": [
+            {
+              "maxLength": 40,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Brand of the card used for the transaction.",
+          "title": "Brand"
+        },
+        "firstDigits": {
+          "anyOf": [
+            {
+              "maxLength": 4,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "First digits of the card used for the transaction.",
+          "title": "Firstdigits"
+        },
+        "lastDigits": {
+          "anyOf": [
+            {
+              "maxLength": 4,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Last digits of the card used for the transaction.",
+          "title": "Lastdigits"
+        },
+        "expMonth": {
+          "anyOf": [
+            {
+              "maximum": 12,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expiration month of the card used for the transaction.",
+          "title": "Expmonth"
+        },
+        "expYear": {
+          "anyOf": [
+            {
+              "minimum": 2000,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expiration year of the card used for the transaction.",
+          "title": "Expyear"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ],
+      "title": "CardPaymentMethodDetails",
+      "type": "object"
+    },
     "JsonValue": {
       "anyOf": [
         {
@@ -284,6 +459,29 @@
         }
       ],
       "title": "JsonValue"
+    },
+    "OtherPaymentMethodDetails": {
+      "properties": {
+        "type": {
+          "const": "OTHER",
+          "description": "Type of the payment method used for the transaction.",
+          "maxLength": 32,
+          "title": "Type",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the payment method used for the transaction.",
+          "maxLength": 256,
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ],
+      "title": "OtherPaymentMethodDetails",
+      "type": "object"
     }
   }
 }

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -129,6 +129,17 @@ class TransactionRequestEventResponse:
 
 
 @dataclass
+class PaymentMethodDetails:
+    type: str
+    name: str
+    brand: str | None = None
+    first_digits: str | None = None
+    last_digits: str | None = None
+    exp_month: int | None = None
+    exp_year: int | None = None
+
+
+@dataclass
 class TransactionResponseBase:
     psp_reference: str | None
     available_actions: list[str] | None
@@ -137,6 +148,7 @@ class TransactionResponseBase:
 @dataclass
 class TransactionSessionResponse(TransactionResponseBase):
     event: TransactionRequestEventResponse
+    payment_method_details: PaymentMethodDetails | None = None
 
 
 @dataclass

--- a/saleor/webhook/tests/response_schemas/test_transaction.py
+++ b/saleor/webhook/tests/response_schemas/test_transaction.py
@@ -632,6 +632,131 @@ def test_transaction_session_action_required_schema_valid_result(result):
 @pytest.mark.parametrize(
     "result",
     [
+        TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
+        TransactionEventType.CHARGE_ACTION_REQUIRED,
+    ],
+)
+@pytest.mark.parametrize(
+    "payment_method_details",
+    [
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": "Brand",
+            "firstDigits": "1234",
+            "lastDigits": "5678",
+            "expMonth": 12,
+            "expYear": 2025,
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": "Brand",
+            "lastDigits": "5678",
+        },
+        {
+            "type": "OTHER",
+            "name": "Test Other",
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": None,
+            "firstDigits": None,
+            "lastDigits": None,
+            "expMonth": None,
+            "expYear": None,
+        },
+    ],
+)
+def test_transaction_session_action_required_schema_valid_payment_method_details(
+    payment_method_details, result
+):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": result.upper(),
+        "data": "test-data",
+        "paymentMethodDetails": payment_method_details,
+    }
+
+    # when
+    parsed_transaction = TransactionSessionActionRequiredSchema.model_validate(data)
+
+    # then
+    assert parsed_transaction.result == result
+    assert parsed_transaction.payment_method_details
+    parsed_payment_method_details = parsed_transaction.payment_method_details
+
+    assert parsed_payment_method_details.type == payment_method_details["type"].lower()
+    assert parsed_payment_method_details.name == payment_method_details["name"]
+    assert getattr(
+        parsed_payment_method_details, "brand", None
+    ) == payment_method_details.get("brand")
+    assert getattr(
+        parsed_payment_method_details, "first_digits", None
+    ) == payment_method_details.get("firstDigits")
+    assert getattr(
+        parsed_payment_method_details, "last_digits", None
+    ) == payment_method_details.get("lastDigits")
+    assert getattr(
+        parsed_payment_method_details, "exp_month", None
+    ) == payment_method_details.get("expMonth")
+    assert getattr(
+        parsed_payment_method_details, "exp_year", None
+    ) == payment_method_details.get("expYear")
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
+        TransactionEventType.CHARGE_ACTION_REQUIRED,
+    ],
+)
+@pytest.mark.parametrize(
+    "payment_method_details",
+    [
+        # unknown type
+        {
+            "type": "WRONG-TYPE",
+            "name": "Test Card",
+        },
+        # Missing name
+        {
+            "type": "CARD",
+        },
+        # Missing type
+        {
+            "name": "Test Card",
+        },
+    ],
+)
+def test_transaction_session_action_required_schema_invalid_payment_method_details(
+    payment_method_details, result
+):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": result.upper(),
+        "data": "test-data",
+        "paymentMethodDetails": payment_method_details,
+    }
+
+    # when & then
+    with pytest.raises(ValidationError):
+        TransactionSessionActionRequiredSchema.model_validate(data)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
         TransactionEventType.AUTHORIZATION_SUCCESS,
         TransactionEventType.CHARGE_SUCCESS,
         TransactionEventType.AUTHORIZATION_FAILURE,
@@ -688,6 +813,133 @@ def test_transaction_session_success_schema_valid_result(result):
 @pytest.mark.parametrize(
     "result",
     [
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_SUCCESS,
+        TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.CHARGE_REQUEST,
+    ],
+)
+@pytest.mark.parametrize(
+    "payment_method_details",
+    [
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": "Brand",
+            "firstDigits": "1234",
+            "lastDigits": "5678",
+            "expMonth": 12,
+            "expYear": 2025,
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": "Brand",
+            "lastDigits": "5678",
+        },
+        {
+            "type": "OTHER",
+            "name": "Test Other",
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": None,
+            "firstDigits": None,
+            "lastDigits": None,
+            "expMonth": None,
+            "expYear": None,
+        },
+    ],
+)
+def test_transaction_session_success_schema_valid_payment_method_details(
+    payment_method_details, result
+):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": result.upper(),
+        "data": "test-data",
+        "paymentMethodDetails": payment_method_details,
+    }
+
+    # when
+    parsed_transaction = TransactionSessionSuccessSchema.model_validate(data)
+
+    # then
+    assert parsed_transaction.result == result
+    assert parsed_transaction.payment_method_details
+    parsed_payment_method_details = parsed_transaction.payment_method_details
+
+    assert parsed_payment_method_details.type == payment_method_details["type"].lower()
+    assert parsed_payment_method_details.name == payment_method_details["name"]
+    assert getattr(
+        parsed_payment_method_details, "brand", None
+    ) == payment_method_details.get("brand")
+    assert getattr(
+        parsed_payment_method_details, "first_digits", None
+    ) == payment_method_details.get("firstDigits")
+    assert getattr(
+        parsed_payment_method_details, "last_digits", None
+    ) == payment_method_details.get("lastDigits")
+    assert getattr(
+        parsed_payment_method_details, "exp_month", None
+    ) == payment_method_details.get("expMonth")
+    assert getattr(
+        parsed_payment_method_details, "exp_year", None
+    ) == payment_method_details.get("expYear")
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_SUCCESS,
+    ],
+)
+@pytest.mark.parametrize(
+    "payment_method_details",
+    [
+        # unknown type
+        {
+            "type": "WRONG-TYPE",
+            "name": "Test Card",
+        },
+        # Missing name
+        {
+            "type": "CARD",
+        },
+        # Missing type
+        {
+            "name": "Test Card",
+        },
+    ],
+)
+def test_transaction_session_success_schema_invalid_payment_method_details(
+    payment_method_details, result
+):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": result.upper(),
+        "data": "test-data",
+        "paymentMethodDetails": payment_method_details,
+    }
+
+    # when & then
+    with pytest.raises(ValidationError):
+        TransactionSessionSuccessSchema.model_validate(data)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
         TransactionEventType.AUTHORIZATION_FAILURE,
         TransactionEventType.CHARGE_FAILURE,
         TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
@@ -735,6 +987,132 @@ def test_transaction_session_failure_schema_valid_result(result):
 
     # then
     assert transaction.result == result
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_FAILURE,
+        TransactionEventType.CHARGE_FAILURE,
+    ],
+)
+@pytest.mark.parametrize(
+    "payment_method_details",
+    [
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": "Brand",
+            "firstDigits": "1234",
+            "lastDigits": "5678",
+            "expMonth": 12,
+            "expYear": 2025,
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": "Brand",
+            "lastDigits": "5678",
+        },
+        {
+            "type": "OTHER",
+            "name": "Test Other",
+        },
+        {
+            "type": "CARD",
+            "name": "Test Card",
+            "brand": None,
+            "firstDigits": None,
+            "lastDigits": None,
+            "expMonth": None,
+            "expYear": None,
+        },
+    ],
+)
+def test_transaction_session_failure_schema_valid_payment_method_details(
+    payment_method_details, result
+):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": result.upper(),
+        "data": "test-data",
+        "paymentMethodDetails": payment_method_details,
+    }
+
+    # when
+    parsed_transaction = TransactionSessionFailureSchema.model_validate(data)
+
+    # then
+
+    assert parsed_transaction.result == result
+    assert parsed_transaction.payment_method_details
+    parsed_payment_method_details = parsed_transaction.payment_method_details
+
+    assert parsed_payment_method_details.type == payment_method_details["type"].lower()
+    assert parsed_payment_method_details.name == payment_method_details["name"]
+    assert getattr(
+        parsed_payment_method_details, "brand", None
+    ) == payment_method_details.get("brand")
+    assert getattr(
+        parsed_payment_method_details, "first_digits", None
+    ) == payment_method_details.get("firstDigits")
+    assert getattr(
+        parsed_payment_method_details, "last_digits", None
+    ) == payment_method_details.get("lastDigits")
+    assert getattr(
+        parsed_payment_method_details, "exp_month", None
+    ) == payment_method_details.get("expMonth")
+    assert getattr(
+        parsed_payment_method_details, "exp_year", None
+    ) == payment_method_details.get("expYear")
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_ACTION_REQUIRED,
+        TransactionEventType.CHARGE_ACTION_REQUIRED,
+    ],
+)
+@pytest.mark.parametrize(
+    "payment_method_details",
+    [
+        # unknown type
+        {
+            "type": "WRONG-TYPE",
+            "name": "Test Card",
+        },
+        # Missing name
+        {
+            "type": "CARD",
+        },
+        # Missing type
+        {
+            "name": "Test Card",
+        },
+    ],
+)
+def test_transaction_session_failure_schema_invalid_payment_method_details(
+    payment_method_details, result
+):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": result.upper(),
+        "data": "test-data",
+        "paymentMethodDetails": payment_method_details,
+    }
+
+    # when & then
+    with pytest.raises(ValidationError):
+        TransactionSessionFailureSchema.model_validate(data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I want to merge this change because it extends the current transaction-intialize-session & transaction-process-session,  webhooks to accept the `paymentMethodDetails` in the response. The payment details will be stored in transaction model.
This PR adds:
- new object field `paymentMethodDetails` to transaction-intialize-session & transaction-process-session
- extend pydantic validation to process `paymentMethodDetails` field
- add json scheme for two types of payment: CARD, OTHER
- add tests to cover new fields

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
