### PR TITLE
Allow filtering order by `metadata` and by `fulfillment.metadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ All notable, unreleased changes to this project will be documented in this file.
     - Filter by invoice existence.
     - Filter by associated invoice creation date.
     - Filter by fulfillment existence.
-    - Filter by associated fulfillment status.
+    - Filter by associated fulfillment status and metadata.
     - Filter by number of lines in the order.
     - Filter by order total gross and net price amount.
+    - Filter by order metadata.
 - Extend the `Page` type with an `attribute` field. Adds support for querying a specific attribute on a page by `slug`, returning the matching attribute and its assigned values, or null if no match is found.
 
 ### Webhooks

--- a/saleor/graphql/core/filters/where_filters.py
+++ b/saleor/graphql/core/filters/where_filters.py
@@ -151,34 +151,32 @@ class MetadataWhereFilterBase(WhereFilterSet):
         abstract = True
 
 
+def filter_where_metadata(qs, _, value):
+    """Filter queryset by metadata."""
+    if not value:
+        return qs.none()
+    key = value["key"]
+    value_data = value.get("value")
+    if not value_data:
+        return qs.filter(metadata__has_key=key)
+    if eq := value_data.get("eq"):
+        return qs.filter(metadata__contains={key: eq})
+    if one_of := value_data.get("one_of"):
+        lookup = models.Q()
+        for item in one_of:
+            lookup |= models.Q(metadata__contains={key: item})
+        return qs.filter(lookup)
+    if (not_one_of := value_data.get("not_one_of")) is not None:
+        lookup = models.Q()
+        for item in not_one_of:
+            lookup |= models.Q(metadata__contains={key: item})
+        return qs.exclude(lookup)
+    return qs.none()
+
 
 class MetadataWhereBase(WhereFilterSet):
     metadata = ObjectTypeWhereFilter(
         input_class=MetadataFilterInput,
-        method="filter_metadata",
+        method=filter_where_metadata,
         help_text="Filter by metadata fields.",
     )
-
-    @staticmethod
-    def filter_metadata(qs, _, value):
-        """Filter queryset by metadata."""
-        if not value:
-            return qs.none()
-        key = value["key"]
-        value_data = value.get("value")
-        if not value_data:
-            return qs.filter(metadata__has_key=key)
-        if eq := value_data.get("eq"):
-            return qs.filter(metadata__contains={key: eq})
-        if one_of := value_data.get("one_of"):
-            lookup = models.Q()
-            for item in one_of:
-                lookup |= models.Q(metadata__contains={key: item})
-            return qs.filter(lookup)
-        if (not_one_of := value_data.get("not_one_of")) is not None:
-            lookup = models.Q()
-            qs = qs.filter(metadata__has_key=key)
-            for item in not_one_of:
-                lookup |= models.Q(metadata__contains={key: item})
-            return qs.exclude(lookup)
-        return qs.none()

--- a/saleor/graphql/core/filters/where_input.py
+++ b/saleor/graphql/core/filters/where_input.py
@@ -54,6 +54,7 @@ class WhereInputObjectType(FilterInputObjectType):
 class FilterInputDescriptions:
     EQ = "The value equal to."
     ONE_OF = "The value included in."
+    NOT_ONE_OF = "The value not included in."
     RANGE = "The value in range."
 
 
@@ -148,3 +149,30 @@ class PriceFilterInput(graphene.InputObjectType):
     amount = DecimalFilterInput(
         required=True, description="The amount of the price to filter by."
     )
+
+
+class MetadataValueFilterInput(graphene.InputObjectType):
+    eq = graphene.String(description=FilterInputDescriptions.EQ, required=False)
+    one_of = NonNullList(
+        graphene.String, description=FilterInputDescriptions.ONE_OF, required=False
+    )
+    not_one_of = NonNullList(
+        graphene.String, description=FilterInputDescriptions.NOT_ONE_OF, required=False
+    )
+
+    class Meta:
+        description = "Define the filtering options for metadata value fields."
+
+
+class MetadataFilterInput(graphene.InputObjectType):
+    key = graphene.String(
+        required=True,
+        description="Key to filter by. If not other fields provided - checking the existence of the key in metadata.",
+    )
+    value = MetadataValueFilterInput(
+        required=False,
+        description="Value to filter by.",
+    )
+
+    class Meta:
+        description = "Define the filtering options for metadata fields."

--- a/saleor/graphql/core/types/__init__.py
+++ b/saleor/graphql/core/types/__init__.py
@@ -119,6 +119,7 @@ __all__ = [
     "MediaInput",
     "MenuError",
     "MetadataError",
+    "MetadataFilterInput",
     "ModelObjectType",
     "Money",
     "MoneyRange",

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -27,8 +27,8 @@ from ..core.filters import (
     ObjectTypeFilter,
     ObjectTypeWhereFilter,
     OperationObjectTypeWhereFilter,
-    WhereFilterSet,
 )
+from ..core.filters.where_filters import MetadataWhereBase
 from ..core.filters.where_input import (
     FilterInputDescriptions,
     GlobalIDFilterInput,
@@ -404,8 +404,7 @@ class FulfillmentFilterInput(BaseInputObjectType):
         description = "Filter input for fulfillments."
 
 
-# TODO: metadata filter will be added later
-class OrderWhere(WhereFilterSet):
+class OrderWhere(MetadataWhereBase):
     ids = GlobalIDMultipleChoiceWhereFilter(method=filter_by_ids("Order"))
     number = OperationObjectTypeWhereFilter(
         input_class=IntFilterInput,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12816,6 +12816,8 @@ enum OrderStatusFilter @doc(category: "Orders") {
 }
 
 input OrderWhereInput @doc(category: "Orders") {
+  """Filter by metadata fields."""
+  metadata: MetadataFilterInput
   ids: [ID!]
 
   """Filter by order number."""
@@ -12894,6 +12896,29 @@ input OrderWhereInput @doc(category: "Orders") {
 
   """A list of conditions of which at least one must be met."""
   OR: [OrderWhereInput!]
+}
+
+"""Define the filtering options for metadata fields."""
+input MetadataFilterInput {
+  """
+  Key to filter by. If not other fields provided - checking the existence of the key in metadata.
+  """
+  key: String!
+
+  """Value to filter by."""
+  value: MetadataValueFilterInput
+}
+
+"""Define the filtering options for metadata value fields."""
+input MetadataValueFilterInput {
+  """The value equal to."""
+  eq: String
+
+  """The value included in."""
+  oneOf: [String!]
+
+  """The value not included in."""
+  notOneOf: [String!]
 }
 
 """Define the filtering options for integer fields."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12979,6 +12979,9 @@ input InvoiceFilterInput @doc(category: "Orders") {
 input FulfillmentFilterInput @doc(category: "Orders") {
   """Filter by fulfillment status."""
   status: FulfillmentStatusEnumFilterInput
+
+  """Filter by metadata fields."""
+  metadata: MetadataFilterInput
 }
 
 """Filter by fulfillment status."""


### PR DESCRIPTION
- Allow filters order by `metadata`
- Allow filter orders by `fulfillment.metadata`
- Allow filter just by metadata key - returns instances that has provided key in metadata 
- Allow filter by metadata key and values

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
