### PR TITLE
Drop unneeded draft word from OrderWhereInput filter

### DIFF
--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -127,7 +127,7 @@ class OrderQueries(graphene.ObjectType):
         sort_by=OrderSortingInput(description="Sort orders."),
         filter=OrderFilterInput(description="Filtering options for orders."),
         where=OrderWhereInput(
-            description="Where filtering options for draft orders." + ADDED_IN_322
+            description="Where filtering options for orders." + ADDED_IN_322
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -784,7 +784,7 @@ type Query {
     filter: OrderFilterInput
 
     """
-    Where filtering options for draft orders.
+    Where filtering options for orders.
     
     Added in Saleor 3.22.
     """


### PR DESCRIPTION
I want to merge this change because:
`draft orders` -> `orders` for `orders` query

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
