### PR TITLE
Refactor select for update utils

### DIFF
--- a/saleor/checkout/lock_objects.py
+++ b/saleor/checkout/lock_objects.py
@@ -1,0 +1,9 @@
+from .models import Checkout, CheckoutLine
+
+
+def checkout_qs_select_for_update():
+    return Checkout.objects.order_by("pk").select_for_update(of=(["self"]))
+
+
+def checkout_lines_qs_select_for_update():
+    return CheckoutLine.objects.order_by("id").select_for_update(of=(["self"]))

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -55,6 +55,7 @@ from ..warehouse.models import Warehouse
 from ..warehouse.reservations import reserve_stocks_and_preorders
 from . import AddressType, base_calculations, calculations
 from .error_codes import CheckoutErrorCode
+from .lock_objects import checkout_lines_qs_select_for_update
 from .models import Checkout, CheckoutLine, CheckoutMetadata
 
 if TYPE_CHECKING:
@@ -114,10 +115,6 @@ def invalidate_checkout_prices(
         checkout.save(update_fields=updated_fields)
 
     return updated_fields
-
-
-def checkout_lines_qs_select_for_update():
-    return CheckoutLine.objects.order_by("id").select_for_update(of=(["self"]))
 
 
 def checkout_lines_bulk_update(

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -9,7 +9,6 @@ from .....app.models import App
 from .....checkout.actions import (
     transaction_amounts_for_checkout_updated_without_price_recalculation,
 )
-from .....checkout.models import Checkout
 from .....core.exceptions import PermissionDenied
 from .....core.prices import quantize_price
 from .....core.tracing import traced_atomic_transaction
@@ -24,6 +23,11 @@ from .....order.utils import (
 )
 from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment import models as payment_models
+from .....payment.lock_objects import (
+    get_checkout_and_transaction_item_locked_for_update,
+    get_order_and_transaction_item_locked_for_update,
+    transaction_item_qs_select_for_update,
+)
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....payment.utils import (
     authorization_success_already_exists,
@@ -303,16 +307,9 @@ class TransactionEventReport(ModelMutation):
     ):
         order = cast(order_models.Order, transaction.order)
         with traced_atomic_transaction():
-            order = (
-                order_models.Order.objects.prefetch_related(
-                    "payments", "payment_transactions", "granted_refunds"
-                )
-                .select_for_update()
-                .get(pk=order.pk)
+            order, transaction = get_order_and_transaction_item_locked_for_update(
+                order.pk, transaction.pk
             )
-            transaction = payment_models.TransactionItem.objects.select_for_update(
-                of=("self",)
-            ).get(pk=transaction.pk)
             updates_amounts_for_order(order)
         update_order_search_vector(order)
         order_info = fetch_order_info(order)
@@ -344,14 +341,11 @@ class TransactionEventReport(ModelMutation):
         checkout_deleted = False
         if transaction.checkout_id:
             with traced_atomic_transaction():
-                locked_checkout = (
-                    Checkout.objects.select_for_update()
-                    .filter(pk=transaction.checkout_id)
-                    .first()
+                locked_checkout, transaction = (
+                    get_checkout_and_transaction_item_locked_for_update(
+                        transaction.checkout_id, transaction.pk
+                    )
                 )
-                transaction = payment_models.TransactionItem.objects.select_for_update(
-                    of=("self",)
-                ).get(pk=transaction.pk)
                 if transaction.checkout_id and locked_checkout:
                     transaction_amounts_for_checkout_updated_without_price_recalculation(
                         transaction, locked_checkout, manager, user, app
@@ -460,8 +454,8 @@ class TransactionEventReport(ModelMutation):
             # thread race. We need to be sure, that we will always create a single event
             # on our side for specific action.
             _transaction = (
-                payment_models.TransactionItem.objects.filter(pk=transaction.pk)
-                .select_for_update(of=("self",))
+                transaction_item_qs_select_for_update()
+                .filter(pk=transaction.pk)
                 .first()
             )
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
@@ -13,8 +13,8 @@ from ....core.postgres import FlatConcatSearchVector
 from ....core.tracing import traced_atomic_transaction
 from ....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
 from ....order import events as order_events
+from ....order.lock_objects import order_lines_qs_select_for_update
 from ....order.tasks import recalculate_orders_task
-from ....order.utils import order_lines_qs_select_for_update
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....product.search import prepare_product_search_vector_value

--- a/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
+++ b/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
@@ -8,7 +8,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions
 from ....warehouse import models
 from ....warehouse.error_codes import StockBulkUpdateErrorCode
-from ....warehouse.management import stock_qs_select_for_update
+from ....warehouse.lock_objects import stock_qs_select_for_update
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
 from ...core.descriptions import ADDED_IN_313, PREVIEW_FEATURE

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -21,7 +21,7 @@ from ..core.utils.events import (
     webhook_async_event_requires_sync_webhooks_to_trigger,
 )
 from ..giftcard import GiftCardLineData
-from ..order.utils import order_lines_qs_select_for_update
+from ..order.lock_objects import order_lines_qs_select_for_update
 from ..payment import (
     ChargeStatus,
     CustomPaymentChoices,

--- a/saleor/order/lock_objects.py
+++ b/saleor/order/lock_objects.py
@@ -1,0 +1,9 @@
+from .models import Order, OrderLine
+
+
+def order_lines_qs_select_for_update():
+    return OrderLine.objects.order_by("pk").select_for_update(of=["self"])
+
+
+def order_qs_select_for_update():
+    return Order.objects.order_by("pk").select_for_update(of=["self"])

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -72,10 +72,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def order_lines_qs_select_for_update():
-    return OrderLine.objects.order_by("pk").select_for_update(of=["self"])
-
-
 def get_order_country(order: Order) -> str:
     """Return country to which order will be shipped."""
     return get_active_country(

--- a/saleor/payment/lock_objects.py
+++ b/saleor/payment/lock_objects.py
@@ -1,0 +1,34 @@
+from typing import TYPE_CHECKING, Optional
+from uuid import UUID
+
+from ..checkout.lock_objects import checkout_qs_select_for_update
+from ..order.lock_objects import order_qs_select_for_update
+from .models import TransactionItem
+
+if TYPE_CHECKING:
+    from ..checkout.models import Checkout
+    from ..order.models import Order
+
+
+def transaction_item_qs_select_for_update():
+    return TransactionItem.objects.order_by("pk").select_for_update(of=["self"])
+
+
+def get_order_and_transaction_item_locked_for_update(
+    order_id: UUID, transaction_item_id: int
+) -> tuple["Order", TransactionItem]:
+    order = order_qs_select_for_update().get(pk=order_id)
+    transaction_item = transaction_item_qs_select_for_update().get(
+        pk=transaction_item_id
+    )
+    return order, transaction_item
+
+
+def get_checkout_and_transaction_item_locked_for_update(
+    checkout_id: UUID, transaction_item_id: int
+) -> tuple[Optional["Checkout"], TransactionItem]:
+    checkout = checkout_qs_select_for_update().filter(pk=checkout_id).first()
+    transaction_item = transaction_item_qs_select_for_update().get(
+        pk=transaction_item_id
+    )
+    return checkout, transaction_item

--- a/saleor/warehouse/lock_objects.py
+++ b/saleor/warehouse/lock_objects.py
@@ -1,0 +1,22 @@
+from .models import Allocation, Stock
+
+
+def stock_select_for_update_for_existing_qs(qs):
+    return qs.order_by("pk").select_for_update(of=(["self"]))
+
+
+def stock_qs_select_for_update():
+    return stock_select_for_update_for_existing_qs(Stock.objects.all())
+
+
+def allocation_with_stock_qs_select_for_update():
+    return (
+        Allocation.objects.select_related("stock")
+        .select_for_update(
+            of=(
+                "self",
+                "stock",
+            )
+        )
+        .order_by("stock__pk")
+    )

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -23,6 +23,11 @@ from ..order.fetch import OrderLineInfo
 from ..order.models import OrderLine
 from ..plugins.manager import PluginsManager
 from ..product.models import ProductVariant, ProductVariantChannelListing
+from .lock_objects import (
+    allocation_with_stock_qs_select_for_update,
+    stock_qs_select_for_update,
+    stock_select_for_update_for_existing_qs,
+)
 from .models import (
     Allocation,
     ChannelWarehouse,
@@ -39,14 +44,6 @@ if TYPE_CHECKING:
 
 
 StockData = namedtuple("StockData", ["pk", "quantity"])
-
-
-def stock_select_for_update_for_existing_qs(qs):
-    return qs.order_by("pk").select_for_update(of=(["self"]))
-
-
-def stock_qs_select_for_update():
-    return stock_select_for_update_for_existing_qs(Stock.objects.all())
 
 
 def delete_stocks(stock_pks_to_delete: list[int]):
@@ -67,19 +64,6 @@ def stock_bulk_update(stocks: list[Stock], fields_to_update: list[str]):
             .values_list("id", flat=True)
         )
         Stock.objects.bulk_update(stocks, fields_to_update)
-
-
-def allocation_with_stock_qs_select_for_update():
-    return (
-        Allocation.objects.select_related("stock")
-        .select_for_update(
-            of=(
-                "self",
-                "stock",
-            )
-        )
-        .order_by("stock__pk")
-    )
 
 
 def delete_allocations(allocation_pks_to_delete: list[int]):

--- a/saleor/warehouse/reservations.py
+++ b/saleor/warehouse/reservations.py
@@ -11,7 +11,8 @@ from django.utils import timezone
 from ..core.exceptions import InsufficientStock, InsufficientStockData
 from ..core.tracing import traced_atomic_transaction
 from ..product.models import ProductVariant, ProductVariantChannelListing
-from .management import sort_stocks, stock_qs_select_for_update
+from .lock_objects import stock_qs_select_for_update
+from .management import sort_stocks
 from .models import Allocation, PreorderReservation, Reservation
 
 if TYPE_CHECKING:


### PR DESCRIPTION
I want to merge this change because of the refactor `select_for_update` utils

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
