### PR TITLE
Add attributes where parameter to pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - You can now filter and search orders using the new `where` and `search` fields on the `pages` query.
   - Use `where` to define complex conditions with `AND`/`OR` logic and operators like `eq`, `oneOf`, `range`.
   - Use `search` to perform full-text search across relevant fields.
+- Add support for filtering `pages` by associated attributes
 - You can now filter and search orders using the new `where` and `search` fields on the `orders` query.
   - Use `where` to define complex conditions with `AND`/`OR` logic and operators like `eq`, `oneOf`, `range`.
   - Use `search` to perform full-text search across relevant fields.
@@ -36,6 +37,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - The order external reference
 - Extend sorting options. You can now sort orders by their status.
 - Add support for payment method details in the Transaction API. The payment method details associated with a transaction can now be persisted on the Saleor side. See [docs](https://docs.saleor.io/developer/payments/transactions#via-transaction-mutations) to learn more.
+
 
 ### Webhooks
 - Transaction webhooks responsible for processing payments can now return payment method details`, which will be associated with the corresponding transaction. See [docs](https://docs.saleor.io/developer/extending/webhooks/synchronous-events/transaction#response-4) to learn more.

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -1,7 +1,10 @@
 import django_filters
 import graphene
-from django.db.models import Q
+from django.db.models import Exists, FloatField, OuterRef, Q
+from django.db.models.functions import Cast
 
+from ...attribute import AttributeInputType
+from ...attribute.models import AssignedPageAttributeValue, Attribute, AttributeValue
 from ...page import models
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.filters import (
@@ -12,20 +15,26 @@ from ..core.filters import (
 )
 from ..core.filters.where_filters import (
     GlobalIDMultipleChoiceWhereFilter,
+    ListObjectTypeWhereFilter,
     MetadataWhereBase,
     OperationObjectTypeWhereFilter,
 )
 from ..core.filters.where_input import (
+    DecimalFilterInput,
     GlobalIDFilterInput,
     StringFilterInput,
     WhereInputObjectType,
 )
+from ..core.types.base import BaseInputObjectType
+from ..core.types.common import DateRangeInput, DateTimeRangeInput
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import (
     filter_by_id,
     filter_by_ids,
+    filter_range_field,
     filter_slug_list,
     filter_where_by_id_field,
+    filter_where_by_numeric_field,
     filter_where_by_value_field,
 )
 from .types import Page, PageType
@@ -54,6 +63,206 @@ def filter_page_type_search(qs, _, value):
     return qs.filter(Q(name__trigram_similar=value) | Q(slug__trigram_similar=value))
 
 
+def filter_by_slug_and_name(qs, attr_id, attr_value):
+    if not {"slug", "name"}.intersection(attr_value.keys()):
+        return AttributeValue.objects.none()
+    attribute_values = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
+    if "slug" in attr_value:
+        attribute_values = filter_where_by_value_field(
+            attribute_values, "slug", attr_value["slug"]
+        )
+    if "name" in attr_value:
+        attribute_values = filter_where_by_value_field(
+            attribute_values, "name", attr_value["name"]
+        )
+    return attribute_values
+
+
+def filter_by_numeric_attribute(qs, attr_id, attr_value):
+    if not {"slug", "name", "numeric"}.intersection(attr_value.keys()):
+        return Q()
+
+    qs_by_numeric = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
+    if "slug" in attr_value or "name" in attr_value:
+        qs_by_numeric = filter_by_slug_and_name(qs_by_numeric, attr_id, attr_value)
+
+    if "numeric" in attr_value:
+        qs_by_numeric = qs_by_numeric.annotate(numeric_value=Cast("name", FloatField()))
+        qs_by_numeric = filter_where_by_numeric_field(
+            qs_by_numeric,
+            "numeric_value",
+            attr_value["numeric"],
+        )
+    assigned_attr_value = AssignedPageAttributeValue.objects.using(
+        qs_by_numeric.db
+    ).filter(
+        Exists(qs_by_numeric.filter(id=OuterRef("value_id"))),
+        page_id=OuterRef("id"),
+    )
+    return Q(Exists(assigned_attr_value))
+
+
+def filter_by_boolean_attribute(qs, attr_id, attr_value):
+    if not {"slug", "name", "boolean"}.intersection(attr_value.keys()):
+        return Q()
+    qs_by_boolean = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
+    if "slug" in attr_value or "name" in attr_value:
+        qs_by_boolean = filter_by_slug_and_name(qs_by_boolean, attr_id, attr_value)
+
+    if "boolean" in attr_value:
+        qs_by_boolean = qs_by_boolean.filter(boolean=attr_value["boolean"])
+    assigned_attr_value = AssignedPageAttributeValue.objects.using(
+        qs_by_boolean.db
+    ).filter(
+        Exists(qs_by_boolean.filter(id=OuterRef("value_id"))),
+        page_id=OuterRef("id"),
+    )
+    return Q(Exists(assigned_attr_value))
+
+
+def filter_by_date_attribute(qs, attr_id, attr_value):
+    if not {"slug", "name", "date"}.intersection(attr_value.keys()):
+        return Q()
+
+    qs_by_date = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
+    if "slug" in attr_value or "name" in attr_value:
+        qs_by_date = filter_by_slug_and_name(qs_by_date, attr_id, attr_value)
+
+    if "date" in attr_value:
+        qs_by_date = filter_range_field(
+            qs_by_date,
+            "date_time__date",
+            attr_value["date"],
+        )
+    assigned_attr_value = AssignedPageAttributeValue.objects.using(
+        qs_by_date.db
+    ).filter(
+        Exists(qs_by_date.filter(id=OuterRef("value_id"))),
+        page_id=OuterRef("id"),
+    )
+    return Q(Exists(assigned_attr_value))
+
+
+def filter_by_date_time_attribute(qs, attr_id, attr_value):
+    if not {"slug", "name", "date_time"}.intersection(attr_value.keys()):
+        return Q()
+
+    qs_by_date_time = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
+    if "slug" in attr_value or "name" in attr_value:
+        qs_by_date_time = filter_by_slug_and_name(qs_by_date_time, attr_id, attr_value)
+
+    if "date_time" in attr_value:
+        qs_by_date_time = filter_range_field(
+            qs_by_date_time,
+            "date_time",
+            attr_value["date_time"],
+        )
+    assigned_attr_value = AssignedPageAttributeValue.objects.using(
+        qs_by_date_time.db
+    ).filter(
+        Exists(qs_by_date_time.filter(id=OuterRef("value_id"))),
+        page_id=OuterRef("id"),
+    )
+    return Exists(assigned_attr_value)
+
+
+def filter_pages_by_attributes(qs, value):
+    attribute_slugs = {attr_filter["slug"] for attr_filter in value}
+    attributes_map = {
+        attr.slug: attr
+        for attr in Attribute.objects.using(qs.db).filter(slug__in=attribute_slugs)
+    }
+    if len(attribute_slugs) != len(attributes_map.keys()):
+        # Filter over non existing attribute
+        return qs.none()
+
+    attr_filter_expression = Q()
+    attr_without_values_input = [
+        attributes_map[attr_filter["slug"]]
+        for attr_filter in value
+        if not attr_filter.get("value")
+    ]
+    if attr_without_values_input:
+        atr_value_qs = AttributeValue.objects.using(qs.db).filter(
+            attribute_id__in=[attr.id for attr in attr_without_values_input]
+        )
+        assigned_attr_value = AssignedPageAttributeValue.objects.using(qs.db).filter(
+            Exists(atr_value_qs.filter(id=OuterRef("value_id"))),
+            page_id=OuterRef("id"),
+        )
+        attr_filter_expression = Q(Exists(assigned_attr_value))
+
+    for attr_filter in value:
+        if "value" not in attr_filter:
+            # attrs without value input are handled separately
+            continue
+        attr = attributes_map[attr_filter["slug"]]
+        attr_value = attr_filter["value"]
+        if attr.input_type == AttributeInputType.NUMERIC:
+            attr_filter_expression &= filter_by_numeric_attribute(
+                qs, attr.id, attr_value
+            )
+        elif attr.input_type == AttributeInputType.BOOLEAN:
+            attr_filter_expression &= filter_by_boolean_attribute(
+                qs, attr.id, attr_value
+            )
+        elif attr.input_type == AttributeInputType.DATE:
+            attr_filter_expression &= filter_by_date_attribute(qs, attr.id, attr_value)
+        elif attr.input_type == AttributeInputType.DATE_TIME:
+            attr_filter_expression &= filter_by_date_time_attribute(
+                qs, attr.id, attr_value
+            )
+        elif "slug" in attr_value or "name" in attr_value:
+            filtered_attr_values = filter_by_slug_and_name(
+                AttributeValue.objects.using(qs.db).filter(attribute_id=attr.id),
+                attr.id,
+                attr_value,
+            )
+            assigned_attr_value = AssignedPageAttributeValue.objects.using(
+                qs.db
+            ).filter(
+                Exists(filtered_attr_values.filter(id=OuterRef("value_id"))),
+                page_id=OuterRef("id"),
+            )
+            attr_filter_expression &= Q(Exists(assigned_attr_value))
+    if attr_filter_expression != Q():
+        return qs.filter(attr_filter_expression)
+    return qs.none()
+
+
+class AttributeValuePageInput(BaseInputObjectType):
+    slug = StringFilterInput(
+        description="Filter by slug assigned to AttributeValue.",
+    )
+    name = StringFilterInput(
+        description="Filter by name assigned to AttributeValue.",
+    )
+    numeric = DecimalFilterInput(
+        required=False,
+        description="Filter by numeric value for attributes of numeric type.",
+    )
+    date = DateRangeInput(
+        required=False,
+        description="Filter by date value for attributes of date type.",
+    )
+    date_time = DateTimeRangeInput(
+        required=False,
+        description="Filter by date time value for attributes of date time type.",
+    )
+    boolean = graphene.Boolean(
+        required=False,
+        description="Filter by boolean value for attributes of boolean type.",
+    )
+
+
+class AttributePageWhereInput(BaseInputObjectType):
+    slug = graphene.String(description="Filter by attribute slug.", required=True)
+    value = AttributeValuePageInput(
+        required=False,
+        description="Filter by values of the attribute.",
+    )
+
+
 class PageWhere(MetadataWhereBase):
     ids = GlobalIDMultipleChoiceWhereFilter(method=filter_by_ids("Page"))
     slug = OperationObjectTypeWhereFilter(
@@ -66,6 +275,11 @@ class PageWhere(MetadataWhereBase):
         method="filter_page_type",
         help_text="Filter by page type.",
     )
+    attributes = ListObjectTypeWhereFilter(
+        input_class=AttributePageWhereInput,
+        method="filter_attributes",
+        help_text="Filter by attributes associated with the page.",
+    )
 
     @staticmethod
     def filter_page_slug(qs, _, value):
@@ -76,6 +290,12 @@ class PageWhere(MetadataWhereBase):
         if not value:
             return qs
         return filter_where_by_id_field(qs, "page_type", value, "PageType")
+
+    @staticmethod
+    def filter_attributes(qs, _, value):
+        if not value:
+            return qs
+        return filter_pages_by_attributes(qs, value)
 
 
 def filter_page_search(qs, _, value):

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -79,14 +79,17 @@ def filter_by_slug_and_name(qs, attr_id, attr_value):
 
 
 def filter_by_numeric_attribute(qs, attr_id, attr_value):
-    if not {"slug", "name", "numeric"}.intersection(attr_value.keys()):
+    slug_value = attr_value.get("slug")
+    name_value = attr_value.get("name")
+    numeric_value = attr_value.get("numeric")
+    if not any([slug_value, name_value, numeric_value]):
         return Q()
 
     qs_by_numeric = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
-    if "slug" in attr_value or "name" in attr_value:
+    if slug_value or name_value:
         qs_by_numeric = filter_by_slug_and_name(qs_by_numeric, attr_id, attr_value)
 
-    if "numeric" in attr_value:
+    if numeric_value:
         qs_by_numeric = qs_by_numeric.annotate(numeric_value=Cast("name", FloatField()))
         qs_by_numeric = filter_where_by_numeric_field(
             qs_by_numeric,
@@ -103,13 +106,16 @@ def filter_by_numeric_attribute(qs, attr_id, attr_value):
 
 
 def filter_by_boolean_attribute(qs, attr_id, attr_value):
-    if not {"slug", "name", "boolean"}.intersection(attr_value.keys()):
+    slug_value = attr_value.get("slug")
+    name_value = attr_value.get("name")
+    filter_over_boolean_value = "boolean" in attr_value
+    if not any([slug_value, name_value, filter_over_boolean_value]):
         return Q()
     qs_by_boolean = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
-    if "slug" in attr_value or "name" in attr_value:
+    if slug_value or name_value:
         qs_by_boolean = filter_by_slug_and_name(qs_by_boolean, attr_id, attr_value)
 
-    if "boolean" in attr_value:
+    if filter_over_boolean_value:
         qs_by_boolean = qs_by_boolean.filter(boolean=attr_value["boolean"])
     assigned_attr_value = AssignedPageAttributeValue.objects.using(
         qs_by_boolean.db
@@ -121,14 +127,17 @@ def filter_by_boolean_attribute(qs, attr_id, attr_value):
 
 
 def filter_by_date_attribute(qs, attr_id, attr_value):
-    if not {"slug", "name", "date"}.intersection(attr_value.keys()):
+    slug_value = attr_value.get("slug")
+    name_value = attr_value.get("name")
+    date_value = attr_value.get("date")
+    if not any([slug_value, name_value, date_value]):
         return Q()
 
     qs_by_date = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
-    if "slug" in attr_value or "name" in attr_value:
+    if slug_value or name_value:
         qs_by_date = filter_by_slug_and_name(qs_by_date, attr_id, attr_value)
 
-    if "date" in attr_value:
+    if date_value:
         qs_by_date = filter_range_field(
             qs_by_date,
             "date_time__date",
@@ -144,14 +153,17 @@ def filter_by_date_attribute(qs, attr_id, attr_value):
 
 
 def filter_by_date_time_attribute(qs, attr_id, attr_value):
-    if not {"slug", "name", "date_time"}.intersection(attr_value.keys()):
+    slug_value = attr_value.get("slug")
+    name_value = attr_value.get("name")
+    date_time_value = attr_value.get("date_time")
+    if not any([slug_value, name_value, date_time_value]):
         return Q()
 
     qs_by_date_time = AttributeValue.objects.using(qs.db).filter(attribute_id=attr_id)
-    if "slug" in attr_value or "name" in attr_value:
+    if slug_value or name_value:
         qs_by_date_time = filter_by_slug_and_name(qs_by_date_time, attr_id, attr_value)
 
-    if "date_time" in attr_value:
+    if date_time_value:
         qs_by_date_time = filter_range_field(
             qs_by_date_time,
             "date_time",
@@ -193,7 +205,8 @@ def filter_pages_by_attributes(qs, value):
         attr_filter_expression = Q(Exists(assigned_attr_value))
 
     for attr_filter in value:
-        if "value" not in attr_filter:
+        attr_value = attr_filter.get("value")
+        if not attr_value:
             # attrs without value input are handled separately
             continue
         attr = attributes_map[attr_filter["slug"]]

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -316,7 +316,10 @@ class AttributePageWhereInput(BaseInputObjectType):
     slug = graphene.String(description="Filter by attribute slug.", required=True)
     value = AttributeValuePageInput(
         required=False,
-        description="Filter by values of the attribute.",
+        description=(
+            "Filter by value of the attribute. Only one value input field is allowed. "
+            "If provided more than one, the error will be raised."
+        ),
     )
 
 

--- a/saleor/graphql/page/tests/queries/test_pages_with_where.py
+++ b/saleor/graphql/page/tests/queries/test_pages_with_where.py
@@ -3,6 +3,7 @@ import datetime
 import graphene
 import pytest
 
+from .....attribute import AttributeInputType
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....page.models import Page, PageType
 from ....tests.utils import get_graphql_content
@@ -307,19 +308,10 @@ def test_pages_query_with_attribute_value_name(
         ({"numeric": {"eq": 1.2}}, 1),
         ({"numeric": {"oneOf": [1.2, 2]}}, 2),
         ({"numeric": {"range": {"gte": 1, "lte": 2}}}, 2),
-        ({"numeric": {"eq": 1.2}, "name": {"eq": "1.2"}}, 1),
-        ({"numeric": {"eq": 1.2}, "slug": {"eq": "1.2"}}, 1),
-        ({"numeric": {"eq": 1.2}, "name": {"oneOf": ["1.2", "2"]}}, 1),
-        ({"numeric": {"eq": 1.2}, "slug": {"oneOf": ["1.2", "2"]}}, 1),
-        ({"numeric": {"eq": 1.2}, "name": {"eq": "1.2"}, "slug": {"eq": "1.2"}}, 1),
-        (
-            {
-                "numeric": {"eq": 1.2},
-                "name": {"oneOf": ["1.2", "2"]},
-                "slug": {"oneOf": ["1.2", "2"]},
-            },
-            1,
-        ),
+        ({"name": {"eq": "1.2"}}, 1),
+        ({"slug": {"eq": "1.2"}}, 1),
+        ({"name": {"oneOf": ["1.2", "2"]}}, 2),
+        ({"slug": {"oneOf": ["1.2", "2"]}}, 2),
     ],
 )
 def test_pages_query_with_attribute_value_numeric(
@@ -381,33 +373,17 @@ def test_pages_query_with_attribute_value_numeric(
     ("date_input", "expected_count"),
     [
         ({"date": {"gte": "2021-01-01"}}, 2),
-        ({"name": {"eq": "date-name-1"}, "date": {"gte": "2021-01-01"}}, 1),
-        ({"slug": {"eq": "date-slug-1"}, "date": {"gte": "2021-01-01"}}, 1),
+        ({"name": {"eq": "date-name-1"}}, 1),
+        ({"slug": {"eq": "date-slug-1"}}, 1),
         (
             {
                 "name": {"oneOf": ["date-name-1", "date-name-2"]},
-                "date": {
-                    "gte": "2021-01-01",
-                },
             },
             2,
         ),
         (
             {
                 "slug": {"oneOf": ["date-slug-1", "date-slug-2"]},
-                "date": {
-                    "gte": "2021-01-01",
-                },
-            },
-            2,
-        ),
-        (
-            {
-                "slug": {"oneOf": ["date-slug-1", "date-slug-2"]},
-                "name": {"oneOf": ["date-name-1", "date-name-2"]},
-                "date": {
-                    "gte": "2021-01-01",
-                },
             },
             2,
         ),
@@ -470,22 +446,24 @@ def test_pages_query_with_attribute_value_date(
         (
             {
                 "name": {"eq": "datetime-name-1"},
-                "dateTime": {"gte": "2021-01-01T00:00:00Z"},
             },
             1,
         ),
         (
             {
                 "slug": {"eq": "datetime-slug-1"},
-                "dateTime": {"gte": "2021-01-01T00:00:00Z"},
             },
             1,
         ),
         (
             {
                 "name": {"oneOf": ["datetime-name-1", "datetime-name-2"]},
+            },
+            2,
+        ),
+        (
+            {
                 "slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]},
-                "dateTime": {"gte": "2021-01-01T00:00:00Z"},
             },
             2,
         ),
@@ -562,11 +540,16 @@ def test_pages_query_with_attribute_value_date_time(
     "boolean_input",
     [
         {"boolean": True},
-        {"name": {"eq": "True-name"}, "boolean": True},
-        {"slug": {"eq": "true_slug"}, "boolean": True},
-        {"name": {"oneOf": ["True-name", "True-name-2"]}, "boolean": True},
-        {"slug": {"oneOf": ["true_slug"]}, "boolean": True},
-        {"name": {"eq": "True-name"}, "slug": {"eq": "true_slug"}, "boolean": True},
+        {
+            "name": {"eq": "True-name"},
+        },
+        {
+            "slug": {"eq": "true_slug"},
+        },
+        {"name": {"oneOf": ["True-name", "True-name-2"]}},
+        {
+            "slug": {"oneOf": ["true_slug"]},
+        },
     ],
 )
 def test_pages_query_with_attribute_value_boolean(
@@ -620,6 +603,130 @@ def test_pages_query_with_attribute_value_boolean(
 @pytest.mark.parametrize(
     "attribute_filter",
     [
+        # When input receives None
+        [{"slug": "page-size"}, {"slug": "page-size"}],
+        [{"slug": "page-size", "value": {"slug": None}}],
+        [{"slug": "page-size", "value": {"name": None}}],
+        # Cant have multiple value input fields
+        [
+            {
+                "slug": "page-size",
+                "value": {
+                    "slug": {"eq": "true_slug"},
+                    "name": {"eq": "name"},
+                },
+            }
+        ],
+        [
+            {
+                "slug": "page-size",
+                "value": {
+                    "slug": {"oneOf": ["true_slug"]},
+                    "name": {"oneOf": ["name"]},
+                },
+            }
+        ],
+        [
+            {
+                "slug": "page-size",
+                "value": {
+                    "name": {"eq": "name"},
+                },
+            },
+            {"slug": "count", "value": {"numeric": None}},
+        ],
+        # numeric attribute
+        [{"slug": "count", "value": {"numeric": None}}],
+        [{"slug": "count", "value": {"name": None}}],
+        [{"slug": "count", "value": {"slug": None}}],
+        # Numeric can't be used with non numeric fields
+        [{"slug": "count", "value": {"boolean": False}}],
+        # boolean attribute
+        [{"slug": "boolean", "value": {"boolean": None}}],
+        [{"slug": "boolean", "value": {"name": None}}],
+        [{"slug": "boolean", "value": {"slug": None}}],
+        # Boolean can't be used with non boolean fields
+        [{"slug": "boolean", "value": {"numeric": {"eq": 1.2}}}],
+        # date attribute
+        [{"slug": "date", "value": {"date": None}}],
+        [{"slug": "date", "value": {"name": None}}],
+        [{"slug": "date", "value": {"slug": None}}],
+        # Date can't be used with non date fields
+        [{"slug": "date", "value": {"numeric": {"eq": 1.2}}}],
+        # datetime attribute
+        [{"slug": "date_time", "value": {"dateTime": None}}],
+        [{"slug": "date_time", "value": {"name": None}}],
+        [{"slug": "date_time", "value": {"slug": None}}],
+        # Date time can't be used with non date time fields
+        [{"slug": "date_time", "value": {"numeric": {"eq": 1.2}}}],
+    ],
+)
+def test_pages_query_failed_filter_validation(
+    attribute_filter,
+    staff_api_client,
+    page_list,
+    page_type,
+    size_page_attribute,
+    tag_page_attribute,
+    boolean_attribute,
+    numeric_attribute_without_unit,
+    date_attribute,
+    date_time_attribute,
+):
+    # given
+    boolean_attribute.type = "PAGE_TYPE"
+    boolean_attribute.save()
+    numeric_attribute_without_unit.type = "PAGE_TYPE"
+    numeric_attribute_without_unit.save()
+
+    page_type.page_attributes.add(size_page_attribute)
+    page_type.page_attributes.add(tag_page_attribute)
+    page_type.page_attributes.add(boolean_attribute)
+    page_type.page_attributes.add(numeric_attribute_without_unit)
+    page_type.page_attributes.add(date_attribute)
+    page_type.page_attributes.add(date_time_attribute)
+
+    size_value = size_page_attribute.values.get(slug="10")
+    tag_value = tag_page_attribute.values.get(name="About")
+    boolean_value = boolean_attribute.values.filter(boolean=True).first()
+    numeric_value = numeric_attribute_without_unit.values.first()
+    date_time_value = date_time_attribute.values.first()
+    date_value = date_attribute.values.first()
+
+    date_attribute.slug = "date"
+    date_attribute.save()
+    date_time_attribute.slug = "date_time"
+    date_time_attribute.save()
+
+    associate_attribute_values_to_instance(
+        page_list[0],
+        {
+            size_page_attribute.pk: [size_value],
+            tag_page_attribute.pk: [tag_value],
+            boolean_attribute.pk: [boolean_value],
+            numeric_attribute_without_unit.pk: [numeric_value],
+            date_attribute.pk: [date_value],
+            date_time_attribute.pk: [date_time_value],
+        },
+    )
+
+    variables = {"where": {"attributes": attribute_filter}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_filter",
+    [
         # Non-existing attribute slug
         [{"slug": "non-existing-attribute"}],
         # Existing attribute with non-existing value name
@@ -633,25 +740,6 @@ def test_pages_query_with_attribute_value_boolean(
             {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
             {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
         ],
-        # When input receives None
-        [{"slug": "page-size", "value": {"slug": None}}],
-        [{"slug": "page-size", "value": {"name": None}}],
-        # numeric attribute
-        [{"slug": "count", "value": {"numeric": None}}],
-        [{"slug": "count", "value": {"name": None}}],
-        [{"slug": "count", "value": {"slug": None}}],
-        # boolean attribute
-        [{"slug": "boolean", "value": {"boolean": None}}],
-        [{"slug": "boolean", "value": {"name": None}}],
-        [{"slug": "boolean", "value": {"slug": None}}],
-        # date attribute
-        [{"slug": "date", "value": {"date": None}}],
-        [{"slug": "date", "value": {"name": None}}],
-        [{"slug": "date", "value": {"slug": None}}],
-        # datetime attribute
-        [{"slug": "date_time", "value": {"dateTime": None}}],
-        [{"slug": "date_time", "value": {"name": None}}],
-        [{"slug": "date_time", "value": {"slug": None}}],
     ],
 )
 def test_pages_query_with_non_matching_records(
@@ -725,7 +813,6 @@ def test_pages_query_with_non_matching_records(
                 {
                     "slug": "page-size",
                     "value": {
-                        "slug": {"eq": "10"},
                         "numeric": {"range": {"lte": 89}},
                     },
                 },
@@ -743,127 +830,126 @@ def test_pages_query_with_non_matching_records(
             ],
             1,
         ),
-        (
-            [
-                {
-                    "slug": "page-size",
-                    "value": {
-                        "slug": {"eq": "10"},
-                    },
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"oneOf": ["About", "Help"]}},
-                },
-            ],
-            1,
-        ),
-        (
-            [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
-                {"slug": "boolean", "value": {"boolean": False}},
-            ],
-            0,
-        ),
-        (
-            [
-                {
-                    "slug": "tag",
-                    "value": {
-                        "name": {"eq": "About"},
-                        "slug": {"eq": "about"},
-                    },
-                },
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
-            ],
-            1,
-        ),
-        (
-            [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "15"}},
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"eq": "Help"}},
-                },
-                {"slug": "boolean", "value": {"boolean": False}},
-            ],
-            0,
-        ),
-        (
-            [
-                {
-                    "slug": "author",
-                    "value": {"slug": {"oneOf": ["test-author-1", "test-author-2"]}},
-                },
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
-            ],
-            1,
-        ),
-        (
-            [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
-                {
-                    "slug": "author",
-                    "value": {"name": {"eq": "Test author 1"}},
-                },
-            ],
-            1,
-        ),
-        (
-            [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"eq": "About"}},
-                },
-                {
-                    "slug": "author",
-                    "value": {"slug": {"eq": "test-author-1"}},
-                },
-            ],
-            1,
-        ),
-        (
-            [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"oneOf": ["10", "15"]}},
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"oneOf": ["About", "Help"]}},
-                },
-            ],
-            2,
-        ),
-        (
-            [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"oneOf": ["10", "15"]}},
-                },
-                {"slug": "boolean", "value": {"boolean": True}},
-            ],
-            1,
-        ),
+        # (
+        #     [
+        #         {
+        #             "slug": "page-size",
+        #             "value": {
+        #                 "slug": {"eq": "10"},
+        #             },
+        #         },
+        #         {
+        #             "slug": "tag",
+        #             "value": {"name": {"oneOf": ["About", "Help"]}},
+        #         },
+        #     ],
+        #     1,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"eq": "10"}},
+        #         },
+        #         {"slug": "boolean", "value": {"boolean": False}},
+        #     ],
+        #     0,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "tag",
+        #             "value": {
+        #                 "name": {"eq": "About"},
+        #             },
+        #         },
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"eq": "10"}},
+        #         },
+        #     ],
+        #     1,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"eq": "15"}},
+        #         },
+        #         {
+        #             "slug": "tag",
+        #             "value": {"name": {"eq": "Help"}},
+        #         },
+        #         {"slug": "boolean", "value": {"boolean": False}},
+        #     ],
+        #     0,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "author",
+        #             "value": {"slug": {"oneOf": ["test-author-1", "test-author-2"]}},
+        #         },
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"eq": "10"}},
+        #         },
+        #     ],
+        #     1,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"eq": "10"}},
+        #         },
+        #         {
+        #             "slug": "author",
+        #             "value": {"name": {"eq": "Test author 1"}},
+        #         },
+        #     ],
+        #     1,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"eq": "10"}},
+        #         },
+        #         {
+        #             "slug": "tag",
+        #             "value": {"name": {"eq": "About"}},
+        #         },
+        #         {
+        #             "slug": "author",
+        #             "value": {"slug": {"eq": "test-author-1"}},
+        #         },
+        #     ],
+        #     1,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"oneOf": ["10", "15"]}},
+        #         },
+        #         {
+        #             "slug": "tag",
+        #             "value": {"name": {"oneOf": ["About", "Help"]}},
+        #         },
+        #     ],
+        #     2,
+        # ),
+        # (
+        #     [
+        #         {
+        #             "slug": "page-size",
+        #             "value": {"slug": {"oneOf": ["10", "15"]}},
+        #         },
+        #         {"slug": "boolean", "value": {"boolean": True}},
+        #     ],
+        #     1,
+        # ),
     ],
 )
 def test_pages_query_with_multiple_attribute_filters(
@@ -882,6 +968,9 @@ def test_pages_query_with_multiple_attribute_filters(
     boolean_attribute.save()
 
     page_type.page_attributes.add(size_page_attribute)
+    size_page_attribute.input_type = AttributeInputType.NUMERIC
+    size_page_attribute.save()
+
     page_type.page_attributes.add(tag_page_attribute)
     page_type.page_attributes.add(author_page_attribute)
     page_type.page_attributes.add(boolean_attribute)

--- a/saleor/graphql/page/tests/queries/test_pages_with_where.py
+++ b/saleor/graphql/page/tests/queries/test_pages_with_where.py
@@ -622,8 +622,6 @@ def test_pages_query_with_attribute_value_boolean(
     [
         # Non-existing attribute slug
         [{"slug": "non-existing-attribute"}],
-        # Existing attribute with non-existing value slug
-        [{"slug": "page-size", "value": {"slug": {"eq": "non-existing-slug"}}}],
         # Existing attribute with non-existing value name
         [{"slug": "tag", "value": {"name": {"eq": "Non-existing Name"}}}],
         # Existing numeric attribute with out-of-range value
@@ -635,9 +633,28 @@ def test_pages_query_with_attribute_value_boolean(
             {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
             {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
         ],
+        # When input receives None
+        [{"slug": "page-size", "value": {"slug": None}}],
+        [{"slug": "page-size", "value": {"name": None}}],
+        # numeric attribute
+        [{"slug": "count", "value": {"numeric": None}}],
+        [{"slug": "count", "value": {"name": None}}],
+        [{"slug": "count", "value": {"slug": None}}],
+        # boolean attribute
+        [{"slug": "boolean", "value": {"boolean": None}}],
+        [{"slug": "boolean", "value": {"name": None}}],
+        [{"slug": "boolean", "value": {"slug": None}}],
+        # date attribute
+        [{"slug": "date", "value": {"date": None}}],
+        [{"slug": "date", "value": {"name": None}}],
+        [{"slug": "date", "value": {"slug": None}}],
+        # datetime attribute
+        [{"slug": "date_time", "value": {"dateTime": None}}],
+        [{"slug": "date_time", "value": {"name": None}}],
+        [{"slug": "date_time", "value": {"slug": None}}],
     ],
 )
-def test_pages_query_with_non_existing_attribute_data(
+def test_pages_query_with_non_matching_records(
     attribute_filter,
     staff_api_client,
     page_list,
@@ -646,6 +663,8 @@ def test_pages_query_with_non_existing_attribute_data(
     tag_page_attribute,
     boolean_attribute,
     numeric_attribute_without_unit,
+    date_attribute,
+    date_time_attribute,
 ):
     # given
     boolean_attribute.type = "PAGE_TYPE"
@@ -657,11 +676,20 @@ def test_pages_query_with_non_existing_attribute_data(
     page_type.page_attributes.add(tag_page_attribute)
     page_type.page_attributes.add(boolean_attribute)
     page_type.page_attributes.add(numeric_attribute_without_unit)
+    page_type.page_attributes.add(date_attribute)
+    page_type.page_attributes.add(date_time_attribute)
 
     size_value = size_page_attribute.values.get(slug="10")
     tag_value = tag_page_attribute.values.get(name="About")
     boolean_value = boolean_attribute.values.filter(boolean=True).first()
     numeric_value = numeric_attribute_without_unit.values.first()
+    date_time_value = date_time_attribute.values.first()
+    date_value = date_attribute.values.first()
+
+    date_attribute.slug = "date"
+    date_attribute.save()
+    date_time_attribute.slug = "date_time"
+    date_time_attribute.save()
 
     associate_attribute_values_to_instance(
         page_list[0],
@@ -670,6 +698,8 @@ def test_pages_query_with_non_existing_attribute_data(
             tag_page_attribute.pk: [tag_value],
             boolean_attribute.pk: [boolean_value],
             numeric_attribute_without_unit.pk: [numeric_value],
+            date_attribute.pk: [date_value],
+            date_time_attribute.pk: [date_time_value],
         },
     )
 

--- a/saleor/graphql/page/tests/queries/test_pages_with_where.py
+++ b/saleor/graphql/page/tests/queries/test_pages_with_where.py
@@ -1,6 +1,9 @@
+import datetime
+
 import graphene
 import pytest
 
+from .....attribute.utils import associate_attribute_values_to_instance
 from .....page.models import Page, PageType
 from ....tests.utils import get_graphql_content
 
@@ -144,6 +147,7 @@ def test_pages_with_where_metadata(
 def test_pages_query_with_where_by_ids(
     staff_api_client, permission_manage_pages, page_list, page_list_unpublished
 ):
+    # given
     query = QUERY_PAGES_WITH_WHERE
 
     page_ids = [
@@ -151,7 +155,641 @@ def test_pages_query_with_where_by_ids(
         for page in [page_list[0], page_list_unpublished[-1]]
     ]
     variables = {"where": {"ids": page_ids}}
+
+    # when
     staff_api_client.user.user_permissions.add(permission_manage_pages)
+
+    # then
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content["data"]["pages"]["totalCount"] == len(page_ids)
+
+
+def test_pages_query_with_attribute_slug(
+    staff_api_client, page_list, page_type, size_page_attribute
+):
+    # given
+    page_type.page_attributes.add(size_page_attribute)
+    page_attr_value = size_page_attribute.values.first()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {size_page_attribute.pk: [page_attr_value]}
+    )
+
+    variables = {"where": {"attributes": [{"slug": size_page_attribute.slug}]}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == 1
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("slug_input", "expected_count"),
+    [
+        ({"eq": "test-slug-1"}, 1),
+        ({"oneOf": ["test-slug-1", "test-slug-2"]}, 2),
+    ],
+)
+def test_pages_query_with_attribute_value_slug(
+    slug_input,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    size_page_attribute,
+):
+    # given
+    page_type.page_attributes.add(size_page_attribute)
+
+    attr_value_1 = size_page_attribute.values.first()
+    attr_value_1.slug = "test-slug-1"
+    attr_value_1.save()
+
+    attr_value_2 = size_page_attribute.values.last()
+    attr_value_2.slug = "test-slug-2"
+    attr_value_2.save()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {size_page_attribute.pk: [attr_value_1]}
+    )
+
+    associate_attribute_values_to_instance(
+        page_list[1], {size_page_attribute.pk: [attr_value_2]}
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {"slug": size_page_attribute.slug, "value": {"slug": slug_input}}
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("name_input", "expected_count"),
+    [
+        ({"eq": "test-name-1"}, 1),
+        ({"oneOf": ["test-name-1", "test-name-2"]}, 2),
+    ],
+)
+def test_pages_query_with_attribute_value_name(
+    name_input,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    size_page_attribute,
+):
+    # given
+    page_type.page_attributes.add(size_page_attribute)
+
+    attr_value_1 = size_page_attribute.values.first()
+    attr_value_1.name = "test-name-1"
+    attr_value_1.save()
+
+    attr_value_2 = size_page_attribute.values.last()
+    attr_value_2.name = "test-name-2"
+    attr_value_2.save()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {size_page_attribute.pk: [attr_value_1]}
+    )
+
+    associate_attribute_values_to_instance(
+        page_list[1], {size_page_attribute.pk: [attr_value_2]}
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {"slug": size_page_attribute.slug, "value": {"name": name_input}}
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("numeric_input", "expected_count"),
+    [
+        ({"eq": 1.2}, 1),
+        ({"oneOf": [1.2, 2]}, 2),
+        ({"range": {"gte": 1, "lte": 2}}, 2),
+    ],
+)
+def test_pages_query_with_attribute_value_numeric(
+    numeric_input,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    numeric_attribute_without_unit,
+):
+    # given
+    numeric_attribute_without_unit.type = "PAGE_TYPE"
+    numeric_attribute_without_unit.save()
+
+    page_type.page_attributes.add(numeric_attribute_without_unit)
+
+    attr_value_1 = numeric_attribute_without_unit.values.first()
+    attr_value_1.name = "1.2"
+    attr_value_1.save()
+
+    attr_value_2 = numeric_attribute_without_unit.values.last()
+    attr_value_2.name = "2"
+    attr_value_2.save()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {numeric_attribute_without_unit.pk: [attr_value_1]}
+    )
+
+    associate_attribute_values_to_instance(
+        page_list[1], {numeric_attribute_without_unit.pk: [attr_value_2]}
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": numeric_attribute_without_unit.slug,
+                    "value": {"numeric": numeric_input},
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("date_input", "expected_count"),
+    [
+        ({"gte": "2021-01-01"}, 2),
+        ({"gte": "2021-01-01", "lte": "2021-01-02"}, 1),
+    ],
+)
+def test_pages_query_with_attribute_value_date(
+    date_input,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    date_attribute,
+):
+    # given
+    date_attribute.type = "PAGE_TYPE"
+    date_attribute.save()
+
+    page_type.page_attributes.add(date_attribute)
+
+    attr_value_1 = date_attribute.values.first()
+    attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
+    attr_value_1.save()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {date_attribute.pk: [attr_value_1]}
+    )
+
+    second_attr_value = date_attribute.values.last()
+    second_attr_value.date_time = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+    second_attr_value.save()
+
+    associate_attribute_values_to_instance(
+        page_list[1], {date_attribute.pk: [second_attr_value]}
+    )
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": date_attribute.slug, "value": {"date": date_input}}]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("date_time_input", "expected_count"),
+    [
+        ({"gte": "2021-01-01T00:00:00Z"}, 2),
+        ({"gte": "2021-01-01T00:00:00Z", "lte": "2021-01-02T00:00:00Z"}, 1),
+    ],
+)
+def test_pages_query_with_attribute_value_date_time(
+    date_time_input,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    date_time_attribute,
+):
+    # given
+    date_time_attribute.type = "PAGE_TYPE"
+    date_time_attribute.save()
+
+    page_type.page_attributes.add(date_time_attribute)
+
+    attr_value_1 = date_time_attribute.values.first()
+    attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
+    attr_value_1.save()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {date_time_attribute.pk: [attr_value_1]}
+    )
+
+    second_attr_value = date_time_attribute.values.last()
+    second_attr_value.date_time = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+    second_attr_value.save()
+
+    associate_attribute_values_to_instance(
+        page_list[1], {date_time_attribute.pk: [second_attr_value]}
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": date_time_attribute.slug,
+                    "value": {"dateTime": date_time_input},
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+
+
+def test_pages_query_with_attribute_value_boolean(
+    staff_api_client, page_list, page_type, boolean_attribute
+):
+    # given
+    boolean_attribute.type = "PAGE_TYPE"
+    boolean_attribute.save()
+
+    page_type.page_attributes.add(boolean_attribute)
+
+    true_value = boolean_attribute.values.filter(boolean=True).first()
+    false_value = boolean_attribute.values.filter(boolean=False).first()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {boolean_attribute.pk: [true_value]}
+    )
+
+    associate_attribute_values_to_instance(
+        page_list[1], {boolean_attribute.pk: [false_value]}
+    )
+
+    variables = {
+        "where": {"attributes": [{"slug": "boolean", "value": {"boolean": True}}]}
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == 1
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    "attribute_filter",
+    [
+        # Non-existing attribute slug
+        [{"slug": "non-existing-attribute"}],
+        # Existing attribute with non-existing value slug
+        [{"slug": "page-size", "value": {"slug": {"eq": "non-existing-slug"}}}],
+        # Existing attribute with non-existing value name
+        [{"slug": "tag", "value": {"name": {"eq": "Non-existing Name"}}}],
+        # Existing numeric attribute with out-of-range value
+        [{"slug": "count", "value": {"numeric": {"eq": 999}}}],
+        # Existing boolean attribute with no matching boolean value
+        [{"slug": "boolean", "value": {"boolean": False}}],
+        # Multiple attributes where one doesn't exist
+        [
+            {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
+            {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
+        ],
+    ],
+)
+def test_pages_query_with_non_existing_attribute_data(
+    attribute_filter,
+    staff_api_client,
+    page_list,
+    page_type,
+    size_page_attribute,
+    tag_page_attribute,
+    boolean_attribute,
+    numeric_attribute_without_unit,
+):
+    # given
+    boolean_attribute.type = "PAGE_TYPE"
+    boolean_attribute.save()
+    numeric_attribute_without_unit.type = "PAGE_TYPE"
+    numeric_attribute_without_unit.save()
+
+    page_type.page_attributes.add(size_page_attribute)
+    page_type.page_attributes.add(tag_page_attribute)
+    page_type.page_attributes.add(boolean_attribute)
+    page_type.page_attributes.add(numeric_attribute_without_unit)
+
+    size_value = size_page_attribute.values.get(slug="10")
+    tag_value = tag_page_attribute.values.get(name="About")
+    boolean_value = boolean_attribute.values.filter(boolean=True).first()
+    numeric_value = numeric_attribute_without_unit.values.first()
+
+    associate_attribute_values_to_instance(
+        page_list[0],
+        {
+            size_page_attribute.pk: [size_value],
+            tag_page_attribute.pk: [tag_value],
+            boolean_attribute.pk: [boolean_value],
+            numeric_attribute_without_unit.pk: [numeric_value],
+        },
+    )
+
+    variables = {"where": {"attributes": attribute_filter}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == 0
+
+
+@pytest.mark.parametrize(
+    ("attribute_where_input", "expected_count_result"),
+    [
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {
+                        "slug": {"eq": "10"},
+                        "numeric": {"range": {"lte": 89}},
+                    },
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"oneOf": ["About", "Help"]}},
+                },
+                {
+                    "slug": "author",
+                    "value": {
+                        "slug": {"oneOf": ["test-author-1"]},
+                    },
+                },
+                {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {
+                        "slug": {"eq": "10"},
+                    },
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"oneOf": ["About", "Help"]}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {
+                    "slug": "tag",
+                    "value": {
+                        "name": {"eq": "About"},
+                        "slug": {"eq": "about"},
+                    },
+                },
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "15"}},
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"eq": "Help"}},
+                },
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {
+                    "slug": "author",
+                    "value": {"slug": {"oneOf": ["test-author-1", "test-author-2"]}},
+                },
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+                {
+                    "slug": "author",
+                    "value": {"name": {"eq": "Test author 1"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"eq": "About"}},
+                },
+                {
+                    "slug": "author",
+                    "value": {"slug": {"eq": "test-author-1"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"oneOf": ["10", "15"]}},
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"oneOf": ["About", "Help"]}},
+                },
+            ],
+            2,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"oneOf": ["10", "15"]}},
+                },
+                {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
+    ],
+)
+def test_pages_query_with_multiple_attribute_filters(
+    attribute_where_input,
+    expected_count_result,
+    staff_api_client,
+    page_list,
+    page_type,
+    size_page_attribute,
+    tag_page_attribute,
+    author_page_attribute,
+    boolean_attribute,
+):
+    # given
+    boolean_attribute.type = "PAGE_TYPE"
+    boolean_attribute.save()
+
+    page_type.page_attributes.add(size_page_attribute)
+    page_type.page_attributes.add(tag_page_attribute)
+    page_type.page_attributes.add(author_page_attribute)
+    page_type.page_attributes.add(boolean_attribute)
+
+    size_value = size_page_attribute.values.get(slug="10")
+    tag_value = tag_page_attribute.values.get(name="About")
+    author_value = author_page_attribute.values.get(slug="test-author-1")
+    boolean_value = boolean_attribute.values.filter(boolean=True).first()
+
+    associate_attribute_values_to_instance(
+        page_list[0],
+        {
+            size_page_attribute.pk: [size_value],
+            tag_page_attribute.pk: [tag_value],
+            author_page_attribute.pk: [author_value],
+            boolean_attribute.pk: [boolean_value],
+        },
+    )
+
+    tag_value_2 = tag_page_attribute.values.get(name="Help")
+    size_value_15 = size_page_attribute.values.get(slug="15")
+
+    associate_attribute_values_to_instance(
+        page_list[1],
+        {
+            size_page_attribute.pk: [size_value_15],
+            tag_page_attribute.pk: [tag_value_2],
+        },
+    )
+
+    variables = {"where": {"attributes": attribute_where_input}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count_result

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12818,6 +12818,9 @@ input PageWhereInput @doc(category: "Pages") {
   """Filter by page type."""
   pageType: GlobalIDFilterInput
 
+  """Filter by attributes associated with the page."""
+  attributes: [AttributePageWhereInput!]
+
   """List of conditions that must be met."""
   AND: [PageWhereInput!]
 
@@ -12853,6 +12856,34 @@ input MetadataValueFilterInput {
 
   """The value included in."""
   oneOf: [String!]
+}
+
+input AttributePageWhereInput {
+  """Filter by attribute slug."""
+  slug: String!
+
+  """Filter by values of the attribute."""
+  value: AttributeValuePageInput
+}
+
+input AttributeValuePageInput {
+  """Filter by slug assigned to AttributeValue."""
+  slug: StringFilterInput
+
+  """Filter by name assigned to AttributeValue."""
+  name: StringFilterInput
+
+  """Filter by numeric value for attributes of numeric type."""
+  numeric: DecimalFilterInput
+
+  """Filter by date value for attributes of date type."""
+  date: DateRangeInput
+
+  """Filter by date time value for attributes of date time type."""
+  dateTime: DateTimeRangeInput
+
+  """Filter by boolean value for attributes of boolean type."""
+  boolean: Boolean
 }
 
 type PageTypeCountableConnection @doc(category: "Pages") {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12862,7 +12862,9 @@ input AttributePageWhereInput {
   """Filter by attribute slug."""
   slug: String!
 
-  """Filter by values of the attribute."""
+  """
+  Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised.
+  """
   value: AttributeValuePageInput
 }
 


### PR DESCRIPTION
I want to merge this change because it adds a new `pages.where.attributes` filter. 

The filter:
- allows to provide only `attribute` slug
- allows to provide maximally one value field (like name, numeric etc)
- when filter input is invalid, the grapqhl error will be raised. Invalid means:
   -  providing multiple input values for `attribute.value` field
   -  providing incorrect input value, like `datetime` when `attribute.input_type==NUMERIC`
   -  providing `attribute.value==null` value
   -  providing  `attribute.value=={}` value
   - providing input value as null, like `attribute.value.slug==null`

Filter performance:
- 30k Page objects
- 260034 AssignedPageAttributeValue objects
- 31 Attribute objects
- 116 AttributeValue objects

Query like this:
```grapqhl
{
  pages(
    first: 100
    where: {
      attributes: [
        {
          slug:"border-style-22b4e38b"
          value:{
            slug:{eq:"no-border-style-22b4e38b-9e07ed48"},
            
          }
        },
        {
          slug:"border-style-07ded0e4",
          value:{
            numeric: {eq: 31}
          }
        },
        {
          slug:"template-e2a0e7dd",
          value:{
            slug: {oneOf: ["orange-template-e2a0e7dd-d2c984dd-1", "light-template-e2a0e7dd-d2c984dd-0"]}, 
          }
        },
        {
          slug: "border-style-7fe04afd"
          value: {
            name: {oneOf: ["Orange", "Pink", "Green", "Blue"]}
          }
        },
        {
          slug:"content-type-84d30bcf",
          value: {
            date:{
              gte:"1000-01-01"
            }
          }
        }
      ]
    }
  ) {
    edges {
      node {
        id
        slug
      }
    }
  }
}

```
takes `0.055000s` to return the response.

Same query, but without `where` parameter, takes: `0.040606s`.

[DB explain](https://explain.dalibo.com/plan/50841846f629a9f4) for attribute where.
<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
