### PR TITLE
Enable filtering of orders based on metadata from associated transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,12 @@ All notable, unreleased changes to this project will be documented in this file.
     - Filter by number of lines in the order.
     - Filter by order total gross and net price amount.
     - Filter by order metadata.
-    - Filter by order by associated lines metadata.
+    - Filter by associated lines metadata.
     - Filter by the product type of related order lines.
     - Filter by associated event type and date.
     - Filter by associated payment method name and type.
     - Filter by associated billing and shipping address phone number and country code.
+    - Filter by associated transactionItems metadata.
 - Extend the `Page` type with an `attribute` field. Adds support for querying a specific attribute on a page by `slug`, returning the matching attribute and its assigned values, or null if no match is found.
 - Enhanced order search options. Orders can now be searched using:
   - The order's ID

--- a/saleor/graphql/order/tests/queries/test_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_where.py
@@ -2516,6 +2516,66 @@ def test_orders_filter_by_transaction_payment_details(
 
 
 @pytest.mark.parametrize(
+    ("metadata", "expected_indexes"),
+    [
+        ({"key": "foo"}, [0, 1]),
+        ({"key": "foo", "value": {"eq": "bar"}}, [0]),
+        ({"key": "foo", "value": {"eq": "baz"}}, []),
+        ({"key": "foo", "value": {"oneOf": ["bar", "zaz"]}}, [0, 1]),
+        ({"key": "notfound"}, []),
+        ({"key": "foo", "value": {"eq": None}}, []),
+        ({"key": "foo", "value": {"oneOf": []}}, []),
+        (None, []),
+    ],
+)
+def test_orders_filter_by_transaction_metadata(
+    metadata,
+    expected_indexes,
+    order_list,
+    staff_api_client,
+    permission_group_manage_orders,
+    transaction_item_generator,
+):
+    # given
+    transaction_item_generator(
+        order_id=order_list[0].pk,
+        charged_value=order_list[0].total.gross.amount,
+        metadata={"foo": "bar"},
+    )
+
+    transaction_item_generator(
+        order_id=order_list[0].pk,
+        charged_value=order_list[0].total.gross.amount,
+        metadata={},
+    )
+
+    transaction_item_generator(
+        order_id=order_list[1].pk,
+        charged_value=order_list[1].total.gross.amount,
+        metadata={"foo": "zaz"},
+    )
+
+    transaction_item_generator(
+        order_id=order_list[2].pk,
+        charged_value=order_list[2].total.gross.amount,
+        metadata={},
+    )
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variables = {"where": {"transactions": {"metadata": metadata}}}
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+    assert len(orders) == len(expected_indexes)
+    numbers = {node["node"]["number"] for node in orders}
+    assert numbers == {str(order_list[i].number) for i in expected_indexes}
+
+
+@pytest.mark.parametrize(
     ("address_filter", "expected_indexes"),
     [
         ({"phoneNumber": {"eq": "+48123456789"}}, [0]),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13201,6 +13201,9 @@ input LinesFilterInput @doc(category: "Orders") {
 input TransactionFilterInput @doc(category: "Orders") {
   """Filter by payment method details used to pay for the order."""
   paymentMethodDetails: PaymentMethodDetailsFilterInput
+
+  """Filter by metadata fields of transactions."""
+  metadata: MetadataFilterInput
 }
 
 input PaymentMethodDetailsFilterInput {

--- a/saleor/payment/tests/fixtures/transaction_item.py
+++ b/saleor/payment/tests/fixtures/transaction_item.py
@@ -32,9 +32,12 @@ def transaction_item_generator():
         cc_last_digits=None,
         cc_exp_month=None,
         cc_exp_year=None,
+        metadata=None,
     ):
         if available_actions is None:
             available_actions = []
+        if metadata is None:
+            metadata = {}
         transaction = TransactionItem.objects.create(
             token=uuid.uuid4(),
             name=name,
@@ -56,6 +59,7 @@ def transaction_item_generator():
             cc_last_digits=cc_last_digits,
             cc_exp_month=cc_exp_month,
             cc_exp_year=cc_exp_year,
+            metadata=metadata,
         )
         create_manual_adjustment_events(
             transaction=transaction,


### PR DESCRIPTION
I want to merge this change because it adds a possibility to filter orders by transactionItem's metadata

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
