### PR TITLE
Update payment_gateway_initialize.py

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/payment_gateway_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/payment_gateway_initialize.py
@@ -77,6 +77,11 @@ class PaymentGatewayInitialize(TransactionSessionBase):
         payment_gateways_response: list[PaymentGatewayData],
     ) -> list[PaymentGatewayConfig]:
         response = []
+
+        # Fix: Ensure payment_gateways_response is a list
+        if payment_gateways_response is None:
+            payment_gateways_response = []
+
         payment_gateways_response_dict = {
             gateway.app_identifier: gateway for gateway in payment_gateways_response
         }


### PR DESCRIPTION
fix(payment): Handle missing webhook response gracefully in paymentGatewayInitialize

If the payment gateway webhook fails to respond, payment_gateways_response can be None. This caused a TypeError because the code tried to iterate over None. Now, we treat a missing response as an empty list, so the mutation won't crash - instead, it returns a sensible error to the client.
