### PR TITLE
Fix race condition in TransactionCreate mutation when updating checkout/order prices

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
 from typing import TYPE_CHECKING, Optional, cast
+from uuid import UUID as UUID_TYPE
 
 import graphene
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-from .....app.models import App
 from .....checkout.actions import (
     transaction_amounts_for_checkout_updated_without_price_recalculation,
 )
@@ -64,6 +64,7 @@ from .utils import get_transaction_item
 
 if TYPE_CHECKING:
     from .....accounts.models import User
+    from .....app.models import App
     from .....plugins.manager import PluginsManager
 
 
@@ -299,16 +300,19 @@ class TransactionEventReport(ModelMutation):
         transaction: payment_models.TransactionItem,
         manager: "PluginsManager",
         user: Optional["User"],
-        app: Optional[App],
+        app: Optional["App"],
         previous_authorized_value: Decimal,
         previous_charged_value: Decimal,
         previous_refunded_value: Decimal,
         related_granted_refund: Optional[order_models.OrderGrantedRefund],
     ):
-        order = cast(order_models.Order, transaction.order)
+        order = None
+        # This is executed after we ensure that the transaction is not a checkout
+        # transaction, so we can safely cast the order_id to UUID.
+        order_id = cast(UUID_TYPE, transaction.order_id)
         with traced_atomic_transaction():
             order, transaction = get_order_and_transaction_item_locked_for_update(
-                order.pk, transaction.pk
+                order_id, transaction.pk
             )
             updates_amounts_for_order(order)
         update_order_search_vector(order)
@@ -332,7 +336,7 @@ class TransactionEventReport(ModelMutation):
         transaction: payment_models.TransactionItem,
         manager: "PluginsManager",
         user: Optional["User"],
-        app: Optional[App],
+        app: Optional["App"],
         previous_authorized_value: Decimal,
         previous_charged_value: Decimal,
         previous_refunded_value: Decimal,

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -6,10 +6,16 @@ from django.core.exceptions import ValidationError
 from .....app.models import App
 from .....checkout.actions import transaction_amounts_for_checkout_updated
 from .....core.exceptions import PermissionDenied
+from .....order import OrderStatus
 from .....order import models as order_models
 from .....order.actions import order_transaction_updated
 from .....order.events import transaction_event as order_transaction_event
 from .....order.fetch import fetch_order_info
+from .....order.search import update_order_search_vector
+from .....order.utils import (
+    update_order_status,
+    updates_amounts_for_order,
+)
 from .....payment import models as payment_models
 from .....payment.error_codes import (
     TransactionCreateErrorCode,
@@ -183,6 +189,42 @@ class TransactionUpdate(TransactionCreate):
         if app and not transaction.user_id and not transaction_has_assigned_app:
             transaction_data["app"] = app
             transaction_data["app_identifier"] = app.identifier
+
+    # TODO (ENG-295): Remove this method when this will be refactored to use
+    # the new functions `process_order_or_checkout_with_transaction`.
+    @classmethod
+    def update_order(
+        cls,
+        order: order_models.Order,
+        money_data: dict,
+        update_search_vector: bool = True,
+    ) -> None:
+        update_fields = []
+        if money_data:
+            updates_amounts_for_order(order, save=False)
+            update_fields.extend(
+                [
+                    "total_authorized_amount",
+                    "total_charged_amount",
+                    "authorize_status",
+                    "charge_status",
+                ]
+            )
+        if (
+            order.channel.automatically_confirm_all_new_orders
+            and order.status == OrderStatus.UNCONFIRMED
+        ):
+            update_order_status(order)
+
+        if update_search_vector:
+            update_order_search_vector(order, save=False)
+            update_fields.append(
+                "search_vector",
+            )
+
+        if update_fields:
+            update_fields.append("updated_at")
+            order.save(update_fields=update_fields)
 
     @classmethod
     def perform_mutation(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -1,12 +1,14 @@
 from decimal import Decimal
 from unittest.mock import patch
 
+import before_after
 import graphene
 import pytest
 from freezegun import freeze_time
 
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
+from .....checkout.complete_checkout import create_order_from_checkout
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
 from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
@@ -14,6 +16,10 @@ from .....order.models import Order
 from .....order.utils import update_order_authorize_data, update_order_charge_data
 from .....payment import TransactionEventType
 from .....payment.error_codes import TransactionCreateErrorCode
+from .....payment.lock_objects import (
+    get_checkout_and_transaction_item_locked_for_update,
+    get_order_and_transaction_item_locked_for_update,
+)
 from .....payment.models import TransactionItem
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -403,7 +409,7 @@ def test_transaction_create_for_draft_order(
 
 
 def test_transaction_create_for_checkout_by_app(
-    checkout_with_items, permission_manage_payments, app_api_client
+    checkout_with_prices, permission_manage_payments, app_api_client, plugins_manager
 ):
     # given
     name = "Credit Card"
@@ -418,7 +424,7 @@ def test_transaction_create_for_checkout_by_app(
     external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
 
     variables = {
-        "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+        "id": graphene.Node.to_global_id("Checkout", checkout_with_prices.pk),
         "transaction": {
             "name": name,
             "pspReference": psp_reference,
@@ -439,13 +445,13 @@ def test_transaction_create_for_checkout_by_app(
     )
 
     # then
-    checkout_with_items.refresh_from_db()
-    assert checkout_with_items.charge_status == CheckoutChargeStatus.NONE
-    assert checkout_with_items.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+    checkout_with_prices.refresh_from_db()
+    assert checkout_with_prices.charge_status == CheckoutChargeStatus.NONE
+    assert checkout_with_prices.authorize_status == CheckoutAuthorizeStatus.PARTIAL
 
     available_actions = list(set(available_actions))
 
-    transaction = checkout_with_items.payment_transactions.first()
+    transaction = checkout_with_prices.payment_transactions.first()
     content = get_graphql_content(response)
     data = content["data"]["transactionCreate"]["transaction"]
     assert data["actions"] == available_actions
@@ -468,7 +474,7 @@ def test_transaction_create_for_checkout_by_app(
 
 
 def test_transaction_create_for_checkout_by_app_metadata_null_value(
-    checkout_with_items, permission_manage_payments, app_api_client
+    checkout_with_prices, permission_manage_payments, app_api_client
 ):
     # given
     name = "Credit Card"
@@ -481,7 +487,7 @@ def test_transaction_create_for_checkout_by_app_metadata_null_value(
     external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
 
     variables = {
-        "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+        "id": graphene.Node.to_global_id("Checkout", checkout_with_prices.pk),
         "transaction": {
             "name": name,
             "pspReference": psp_reference,
@@ -502,13 +508,13 @@ def test_transaction_create_for_checkout_by_app_metadata_null_value(
     )
 
     # then
-    checkout_with_items.refresh_from_db()
-    assert checkout_with_items.charge_status == CheckoutChargeStatus.NONE
-    assert checkout_with_items.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+    checkout_with_prices.refresh_from_db()
+    assert checkout_with_prices.charge_status == CheckoutChargeStatus.NONE
+    assert checkout_with_prices.authorize_status == CheckoutAuthorizeStatus.PARTIAL
 
     available_actions = list(set(available_actions))
 
-    transaction = checkout_with_items.payment_transactions.first()
+    transaction = checkout_with_prices.payment_transactions.first()
     content = get_graphql_content(response)
     data = content["data"]["transactionCreate"]["transaction"]
     assert data["actions"] == available_actions
@@ -1116,7 +1122,7 @@ def test_transaction_create_for_order_updates_order_total_charged_by_staff(
 
 
 def test_transaction_create_for_checkout_by_staff(
-    checkout_with_items, permission_manage_payments, staff_api_client
+    checkout_with_prices, permission_manage_payments, staff_api_client
 ):
     # given
     name = "Credit Card"
@@ -1130,7 +1136,7 @@ def test_transaction_create_for_checkout_by_staff(
     private_metadata = {"key": "test-2", "value": "321"}
 
     variables = {
-        "id": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
+        "id": graphene.Node.to_global_id("Checkout", checkout_with_prices.pk),
         "transaction": {
             "name": name,
             "pspReference": psp_reference,
@@ -1152,10 +1158,10 @@ def test_transaction_create_for_checkout_by_staff(
     # then
     available_actions = list(set(available_actions))
 
-    checkout_with_items.refresh_from_db()
-    assert checkout_with_items.charge_status == CheckoutChargeStatus.NONE
-    assert checkout_with_items.authorize_status == CheckoutAuthorizeStatus.PARTIAL
-    transaction = checkout_with_items.payment_transactions.first()
+    checkout_with_prices.refresh_from_db()
+    assert checkout_with_prices.charge_status == CheckoutChargeStatus.NONE
+    assert checkout_with_prices.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+    transaction = checkout_with_prices.payment_transactions.first()
     content = get_graphql_content(response)
     data = content["data"]["transactionCreate"]["transaction"]
     assert data["actions"] == available_actions
@@ -2466,3 +2472,165 @@ def test_transaction_create_create_event_message_is_empty(
     event = transaction.events.last()
     assert event.message == ""
     assert event.psp_reference == transaction_reference
+
+
+@patch(
+    "saleor.graphql.payment.mutations.transaction.transaction_create.get_order_and_transaction_item_locked_for_update",
+    wraps=get_order_and_transaction_item_locked_for_update,
+)
+def test_lock_order_during_updating_order_amounts(
+    mocked_get_order_and_transaction_item_locked_for_update,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    charged_value = order.total.gross.amount
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order.pk),
+        "transaction": {
+            "name": "Credit Card",
+            "pspReference": "PSP reference - 123",
+            "availableActions": [],
+            "amountCharged": {
+                "amount": charged_value,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    order.refresh_from_db()
+    transaction_pk = order.payment_transactions.get().pk
+    assert order.total_charged.amount == charged_value
+    assert order.charge_status == OrderChargeStatus.FULL
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
+    mocked_get_order_and_transaction_item_locked_for_update.assert_called_once_with(
+        order.pk, transaction_pk
+    )
+
+
+@patch(
+    "saleor.graphql.payment.mutations.transaction.transaction_create.get_checkout_and_transaction_item_locked_for_update",
+    wraps=get_checkout_and_transaction_item_locked_for_update,
+)
+def test_lock_checkout_during_updating_checkout_amounts(
+    mocked_get_checkout_and_transaction_item_locked_for_update,
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_items,
+    plugins_manager,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+    ]
+    metadata = {"key": "test-1", "value": "123"}
+    private_metadata = {"key": "test-2", "value": "321"}
+
+    checkout = checkout_with_items
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    assert checkout.channel.automatically_complete_fully_paid_checkouts is False
+
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountCharged": {
+                "amount": checkout_info.checkout.total.gross.amount,
+                "currency": "USD",
+            },
+            "metadata": [metadata],
+            "privateMetadata": [private_metadata],
+        },
+    }
+
+    # when
+    app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    checkout.refresh_from_db()
+    transaction_pk = checkout.payment_transactions.get().pk
+    assert checkout.charge_status == CheckoutChargeStatus.FULL
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_get_checkout_and_transaction_item_locked_for_update.assert_called_once_with(
+        checkout.pk, transaction_pk
+    )
+
+
+def test_transaction_create_create_checkout_completed_race_condition(
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+    available_actions = [
+        TransactionActionEnum.CHARGE.name,
+        TransactionActionEnum.CHARGE.name,
+    ]
+    authorized_value = Decimal(checkout_info.checkout.total.gross.amount)
+    metadata = {"key": "test-1", "value": "123"}
+    private_metadata = {"key": "test-2", "value": "321"}
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "availableActions": available_actions,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "metadata": [metadata],
+            "privateMetadata": [private_metadata],
+            "externalUrl": external_url,
+        },
+    }
+
+    # when
+    def complete_checkout(*args, **kwargs):
+        create_order_from_checkout(
+            checkout_info, plugins_manager, user=None, app=app_api_client.app
+        )
+
+    with before_after.after(
+        "saleor.graphql.payment.mutations.transaction.transaction_create.recalculate_transaction_amounts",
+        complete_checkout,
+    ):
+        app_api_client.post_graphql(
+            MUTATION_TRANSACTION_CREATE,
+            variables,
+            permissions=[permission_manage_payments],
+        )
+
+    # then
+    order = Order.objects.get(checkout_token=checkout.pk)
+
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.charge_status == OrderChargeStatus.NONE
+    assert order.authorize_status == OrderAuthorizeStatus.FULL

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -204,7 +204,7 @@ def update_order_status(order: Order):
         # another process.
         locked_order = Order.objects.select_for_update().get(pk=order.pk)
 
-        status_updated = refresh_order_status(order)
+        status_updated = refresh_order_status(locked_order)
 
         # we would like to update the status for the order provided as the argument
         # to ensure that the reference order has up to date status


### PR DESCRIPTION
I want to merge this change to fix a race condition in the TransactionCreate mutation when updating checkout/order prices



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
