### PR TITLE
Move ChannelContextType to core module

### DIFF
--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -1,12 +1,10 @@
 import collections
 import itertools
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING
 
 import graphene
-from django.db.models import Model
 from django_countries.fields import Country
 from graphene.types.objecttype import ObjectType
-from graphene.types.resolver import get_default_resolver
 from promise import Promise
 
 from ...channel import models
@@ -19,7 +17,6 @@ from ...permission.enums import (
 )
 from ..account.enums import CountryCodeEnum
 from ..core import ResolveInfo
-from ..core.context import ChannelContext
 from ..core.descriptions import (
     ADDED_IN_318,
     ADDED_IN_320,
@@ -39,7 +36,6 @@ from ..core.scalars import Day, Hour, Minute
 from ..core.types import BaseObjectType, CountryDisplay, ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
 from ..tax.dataloaders import TaxConfigurationByChannelId
-from ..translations.resolvers import resolve_translation
 from ..warehouse.dataloaders import WarehousesByChannelIdLoader
 from ..warehouse.types import Warehouse
 from .dataloaders import ChannelWithHasOrdersByIdLoader
@@ -51,56 +47,6 @@ from .enums import (
 
 if TYPE_CHECKING:
     from ...shipping.models import ShippingZone
-
-T = TypeVar("T", bound=Model)
-
-
-class ChannelContextTypeForObjectType(ModelObjectType[T]):
-    """A Graphene type that supports resolvers' root as ChannelContext objects."""
-
-    class Meta:
-        abstract = True
-
-    @staticmethod
-    def resolver_with_context(
-        attname, default_value, root: ChannelContext, info: ResolveInfo, **args
-    ):
-        resolver = get_default_resolver()
-        return resolver(attname, default_value, root.node, info, **args)
-
-    @staticmethod
-    def resolve_id(root: ChannelContext[T], _info: ResolveInfo):
-        return root.node.pk
-
-    @staticmethod
-    def resolve_translation(
-        root: ChannelContext[T], info: ResolveInfo, *, language_code
-    ):
-        # Resolver for TranslationField; needs to be manually specified.
-        return resolve_translation(root.node, info, language_code=language_code)
-
-
-class ChannelContextType(ChannelContextTypeForObjectType[T]):
-    """A Graphene type that supports resolvers' root as ChannelContext objects."""
-
-    class Meta:
-        abstract = True
-
-    @classmethod
-    def is_type_of(cls, root: ChannelContext[T] | T, _info: ResolveInfo) -> bool:
-        # Unwrap node from ChannelContext if it didn't happen already
-        if isinstance(root, ChannelContext):
-            root = root.node
-
-        if isinstance(root, cls):
-            return True
-
-        if cls._meta.model._meta.proxy:
-            model = root._meta.model
-        else:
-            model = cast(type[Model], root._meta.model._meta.concrete_model)
-
-        return model == cls._meta.model
 
 
 class StockSettings(BaseObjectType):

--- a/saleor/graphql/core/types/context.py
+++ b/saleor/graphql/core/types/context.py
@@ -1,0 +1,59 @@
+from typing import TypeVar, cast
+
+from django.db.models import Model
+from graphene.types.resolver import get_default_resolver
+
+from ...translations.resolvers import resolve_translation
+from .. import ResolveInfo
+from ..context import ChannelContext
+from .model import ModelObjectType
+
+T = TypeVar("T", bound=Model)
+
+
+class ChannelContextTypeForObjectType(ModelObjectType[T]):
+    """A Graphene type that supports resolvers' root as ChannelContext objects."""
+
+    class Meta:
+        abstract = True
+
+    @staticmethod
+    def resolver_with_context(
+        attname, default_value, root: ChannelContext, info: ResolveInfo, **args
+    ):
+        resolver = get_default_resolver()
+        return resolver(attname, default_value, root.node, info, **args)
+
+    @staticmethod
+    def resolve_id(root: ChannelContext[T], _info: ResolveInfo):
+        return root.node.pk
+
+    @staticmethod
+    def resolve_translation(
+        root: ChannelContext[T], info: ResolveInfo, *, language_code
+    ):
+        # Resolver for TranslationField; needs to be manually specified.
+        return resolve_translation(root.node, info, language_code=language_code)
+
+
+class ChannelContextType(ChannelContextTypeForObjectType[T]):
+    """A Graphene type that supports resolvers' root as ChannelContext objects."""
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def is_type_of(cls, root: ChannelContext[T] | T, _info: ResolveInfo) -> bool:
+        # Unwrap node from ChannelContext if it didn't happen already
+        if isinstance(root, ChannelContext):
+            root = root.node
+
+        if isinstance(root, cls):
+            return True
+
+        if cls._meta.model._meta.proxy:
+            model = root._meta.model
+        else:
+            model = cast(type[Model], root._meta.model._meta.concrete_model)
+
+        return model == cls._meta.model

--- a/saleor/graphql/discount/types/sales.py
+++ b/saleor/graphql/discount/types/sales.py
@@ -5,15 +5,20 @@ from ....discount import DiscountValueType, models
 from ....permission.enums import DiscountPermissions
 from ....product.models import Category, Collection, Product, ProductVariant
 from ...channel.dataloaders import ChannelBySlugLoader
-from ...channel.types import Channel, ChannelContext, ChannelContextType
+from ...channel.types import Channel
 from ...core import ResolveInfo
 from ...core.connection import CountableConnection, create_connection_slice
-from ...core.context import ChannelQsContext, get_database_connection_name
+from ...core.context import (
+    ChannelContext,
+    ChannelQsContext,
+    get_database_connection_name,
+)
 from ...core.descriptions import DEPRECATED_IN_3X_TYPE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import ConnectionField, PermissionsField
 from ...core.scalars import DateTime
 from ...core.types import BaseObjectType, ModelObjectType, NonNullList
+from ...core.types.context import ChannelContextType
 from ...meta.types import ObjectWithMetadata
 from ...product.types import (
     CategoryCountableConnection,

--- a/saleor/graphql/discount/types/vouchers.py
+++ b/saleor/graphql/discount/types/vouchers.py
@@ -4,15 +4,20 @@ from graphene import relay
 from ....discount import models
 from ....permission.enums import DiscountPermissions
 from ...channel.dataloaders import ChannelByIdLoader
-from ...channel.types import Channel, ChannelContext, ChannelContextType
+from ...channel.types import Channel
 from ...core import ResolveInfo, types
 from ...core.connection import CountableConnection, create_connection_slice
-from ...core.context import ChannelQsContext, get_database_connection_name
+from ...core.context import (
+    ChannelContext,
+    ChannelQsContext,
+    get_database_connection_name,
+)
 from ...core.descriptions import ADDED_IN_318, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import ConnectionField, PermissionsField
 from ...core.scalars import DateTime
 from ...core.types import ModelObjectType, Money, NonNullList
+from ...core.types.context import ChannelContextType
 from ...meta.types import ObjectWithMetadata
 from ...product.types import (
     CategoryCountableConnection,

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -6,11 +6,12 @@ from ...permission.enums import PagePermissions
 from ...permission.utils import has_one_of_permissions
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ..channel.dataloaders import ChannelBySlugLoader
-from ..channel.types import ChannelContext, ChannelContextType
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
+from ..core.context import ChannelContext
 from ..core.doc_category import DOC_CATEGORY_MENU
 from ..core.types import NonNullList
+from ..core.types.context import ChannelContextType
 from ..meta.types import ObjectWithMetadata
 from ..page.dataloaders import PageByIdLoader
 from ..page.types import Page

--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -13,7 +13,6 @@ from ....thumbnail.utils import (
     get_thumbnail_size,
 )
 from ...channel.dataloaders import ChannelBySlugLoader
-from ...channel.types import ChannelContextType
 from ...core import ResolveInfo
 from ...core.connection import (
     CountableConnection,
@@ -30,6 +29,7 @@ from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.federation import federated_entity
 from ...core.fields import FilterConnectionField, JSONString, PermissionsField
 from ...core.types import Image, NonNullList, ThumbnailField
+from ...core.types.context import ChannelContextType
 from ...core.utils import from_global_id_or_error
 from ...meta.types import ObjectWithMetadata
 from ...translations.fields import TranslationField

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -50,7 +50,6 @@ from ...attribute.types import (
     SelectedAttribute,
 )
 from ...channel.dataloaders import ChannelBySlugLoader
-from ...channel.types import ChannelContextType
 from ...channel.utils import get_default_channel_slug_or_graphql_error
 from ...core.connection import (
     CountableConnection,
@@ -85,6 +84,7 @@ from ...core.types import (
     ThumbnailField,
     Weight,
 )
+from ...core.types.context import ChannelContextType
 from ...core.utils import from_global_id_or_error
 from ...core.validators import validate_one_of_args_is_in_query
 from ...meta.types import ObjectWithMetadata

--- a/saleor/graphql/shipping/mutations/shipping_price_create.py
+++ b/saleor/graphql/shipping/mutations/shipping_price_create.py
@@ -2,8 +2,8 @@ import graphene
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_SHIPPING
 from ...core.fields import JSONString
 from ...core.mutations import DeprecatedModelMutation

--- a/saleor/graphql/shipping/mutations/shipping_price_delete.py
+++ b/saleor/graphql/shipping/mutations/shipping_price_delete.py
@@ -4,8 +4,8 @@ import graphene
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_SHIPPING
 from ...core.mutations import BaseMutation
 from ...core.types import ShippingError

--- a/saleor/graphql/shipping/mutations/shipping_price_exclude_products.py
+++ b/saleor/graphql/shipping/mutations/shipping_price_exclude_products.py
@@ -3,8 +3,8 @@ import graphene
 from ....permission.enums import ShippingPermissions
 from ....product import models as product_models
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_SHIPPING
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, NonNullList, ShippingError

--- a/saleor/graphql/shipping/mutations/shipping_price_remove_product_from_exclude.py
+++ b/saleor/graphql/shipping/mutations/shipping_price_remove_product_from_exclude.py
@@ -4,8 +4,8 @@ import graphene
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_SHIPPING
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, ShippingError

--- a/saleor/graphql/shipping/mutations/shipping_price_update.py
+++ b/saleor/graphql/shipping/mutations/shipping_price_update.py
@@ -2,8 +2,8 @@ import graphene
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import ShippingError
 from ...plugins.dataloaders import get_plugin_manager_promise

--- a/saleor/graphql/shipping/mutations/shipping_zone_create.py
+++ b/saleor/graphql/shipping/mutations/shipping_zone_create.py
@@ -2,8 +2,8 @@ import graphene
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_SHIPPING
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import BaseInputObjectType, NonNullList, ShippingError

--- a/saleor/graphql/shipping/mutations/shipping_zone_delete.py
+++ b/saleor/graphql/shipping/mutations/shipping_zone_delete.py
@@ -2,8 +2,8 @@ import graphene
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import ShippingError
 from ...plugins.dataloaders import get_plugin_manager_promise

--- a/saleor/graphql/shipping/mutations/shipping_zone_update.py
+++ b/saleor/graphql/shipping/mutations/shipping_zone_update.py
@@ -2,8 +2,8 @@ import graphene
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
-from ...channel.types import ChannelContext
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_SHIPPING
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import NonNullList, ShippingError

--- a/saleor/graphql/shipping/schema.py
+++ b/saleor/graphql/shipping/schema.py
@@ -2,10 +2,9 @@ import graphene
 
 from ...permission.enums import ShippingPermissions
 from ...shipping import models
-from ..channel.types import ChannelContext
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.context import get_database_connection_name
+from ..core.context import ChannelContext, get_database_connection_name
 from ..core.doc_category import DOC_CATEGORY_SHIPPING
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.utils import from_global_id_or_error

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -10,9 +10,13 @@ from ...shipping import models
 from ...shipping.interface import ShippingMethodData
 from ..account.enums import CountryCodeEnum
 from ..channel.dataloaders import ChannelByIdLoader
-from ..channel.types import Channel, ChannelContext, ChannelContextType
+from ..channel.types import Channel
 from ..core.connection import CountableConnection, create_connection_slice
-from ..core.context import ChannelQsContext, get_database_connection_name
+from ..core.context import (
+    ChannelContext,
+    ChannelQsContext,
+    get_database_connection_name,
+)
 from ..core.descriptions import DEFAULT_DEPRECATION_REASON, RICH_CONTENT
 from ..core.doc_category import DOC_CATEGORY_SHIPPING
 from ..core.fields import ConnectionField, JSONString, PermissionsField
@@ -26,6 +30,7 @@ from ..core.types import (
     NonNullList,
     Weight,
 )
+from ..core.types.context import ChannelContextType
 from ..meta.types import ObjectWithMetadata
 from ..shipping.resolvers import resolve_price_range, resolve_shipping_translation
 from ..tax.dataloaders import TaxClassByIdLoader


### PR DESCRIPTION
I want to merge this change because, as `ChannelContextType` is more generic type than channel related, I've extracted it to the core. (Some modules do not need to import the whole channel module as they only need the channel wrapper)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
