### PR TITLE
Fix race condition in TransactionUpdate mutation when updating checkout/order prices

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -347,7 +347,6 @@ class TransactionCreate(BaseMutation):
             manager,
             user,
             app,
-            money_data,
         )
 
         if transaction_event:

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -1,7 +1,6 @@
 import uuid
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional, Union, cast
-from uuid import UUID
+from typing import Optional, Union
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -9,25 +8,12 @@ from django.core.validators import URLValidator
 from django.db.models import Model
 
 from .....checkout import models as checkout_models
-from .....checkout.actions import (
-    transaction_amounts_for_checkout_updated_without_price_recalculation,
-)
 from .....core.prices import quantize_price
-from .....core.tracing import traced_atomic_transaction
-from .....order import OrderStatus
 from .....order import models as order_models
-from .....order.actions import order_transaction_updated
 from .....order.events import transaction_event as order_transaction_event
-from .....order.fetch import fetch_order_info
-from .....order.search import update_order_search_vector
-from .....order.utils import refresh_order_status, updates_amounts_for_order
 from .....payment import TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionCreateErrorCode
-from .....payment.lock_objects import (
-    get_checkout_and_transaction_item_locked_for_update,
-    get_order_and_transaction_item_locked_for_update,
-)
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....payment.utils import (
     create_manual_adjustment_events,
@@ -47,11 +33,7 @@ from ...enums import TransactionActionEnum
 from ...types import TransactionItem
 from ...utils import metadata_contains_empty_key
 from ..payment.payment_check_balance import MoneyInput
-
-if TYPE_CHECKING:
-    from .....account.models import User
-    from .....app.models import App
-    from .....plugins.manager import PluginsManager
+from .utils import process_order_or_checkout_with_transaction
 
 
 class TransactionCreateInput(BaseInputObjectType):
@@ -317,102 +299,6 @@ class TransactionCreate(BaseMutation):
         )
 
     @classmethod
-    def process_order_with_transaction(
-        cls,
-        transaction: payment_models.TransactionItem,
-        manager: "PluginsManager",
-        user: Optional["User"],
-        app: Optional["App"],
-        money_data: dict[str, Decimal],
-        previous_authorized_value: Decimal = Decimal(0),
-        previous_charged_value: Decimal = Decimal(0),
-        previous_refunded_value: Decimal = Decimal(0),
-    ):
-        order = None
-        # This is executed after we ensure that the transaction is not a checkout
-        # transaction, so we can safely cast the order_id to UUID.
-        order_id = cast(UUID, transaction.order_id)
-        with traced_atomic_transaction():
-            order, transaction = get_order_and_transaction_item_locked_for_update(
-                order_id, transaction.pk
-            )
-            update_fields = []
-            if money_data:
-                updates_amounts_for_order(order, save=False)
-                update_fields.extend(
-                    [
-                        "total_charged_amount",
-                        "charge_status",
-                        "total_authorized_amount",
-                        "authorize_status",
-                    ]
-                )
-            if (
-                order.channel.automatically_confirm_all_new_orders
-                and order.status == OrderStatus.UNCONFIRMED
-            ):
-                status_updated = refresh_order_status(order)
-                if status_updated:
-                    update_fields.append("status")
-            if update_fields:
-                update_fields.append("updated_at")
-                order.save(update_fields=update_fields)
-
-        update_order_search_vector(order)
-
-        order_info = fetch_order_info(order)
-        order_transaction_updated(
-            order_info=order_info,
-            transaction_item=transaction,
-            manager=manager,
-            user=user,
-            app=app,
-            previous_authorized_value=previous_authorized_value,
-            previous_charged_value=previous_charged_value,
-            previous_refunded_value=previous_refunded_value,
-        )
-
-    @classmethod
-    def process_order_or_checkout_with_transaction(
-        cls,
-        transaction: payment_models.TransactionItem,
-        manager: "PluginsManager",
-        user: Optional["User"],
-        app: Optional["App"],
-        money_data: dict[str, Decimal],
-        previous_authorized_value: Decimal = Decimal(0),
-        previous_charged_value: Decimal = Decimal(0),
-        previous_refunded_value: Decimal = Decimal(0),
-    ):
-        checkout_deleted = False
-        if transaction.checkout_id and money_data:
-            with traced_atomic_transaction():
-                locked_checkout, transaction = (
-                    get_checkout_and_transaction_item_locked_for_update(
-                        transaction.checkout_id, transaction.pk
-                    )
-                )
-                if transaction.checkout_id and locked_checkout:
-                    transaction_amounts_for_checkout_updated_without_price_recalculation(
-                        transaction, locked_checkout, manager, user, app
-                    )
-                else:
-                    checkout_deleted = True
-                    # If the checkout was deleted, we still want to update the order associated with the transaction.
-
-        if transaction.order_id or checkout_deleted:
-            cls.process_order_with_transaction(
-                transaction,
-                manager,
-                user,
-                app,
-                money_data,
-                previous_authorized_value,
-                previous_charged_value,
-                previous_refunded_value,
-            )
-
-    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls,
         _root,
@@ -456,7 +342,7 @@ class TransactionCreate(BaseMutation):
                 transaction=new_transaction, money_data=money_data, user=user, app=app
             )
             recalculate_transaction_amounts(new_transaction)
-        cls.process_order_or_checkout_with_transaction(
+        process_order_or_checkout_with_transaction(
             new_transaction,
             manager,
             user,

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -1,21 +1,11 @@
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional
 
 import graphene
 from django.core.exceptions import ValidationError
 
 from .....app.models import App
-from .....checkout.actions import transaction_amounts_for_checkout_updated
 from .....core.exceptions import PermissionDenied
-from .....order import OrderStatus
-from .....order import models as order_models
-from .....order.actions import order_transaction_updated
 from .....order.events import transaction_event as order_transaction_event
-from .....order.fetch import fetch_order_info
-from .....order.search import update_order_search_vector
-from .....order.utils import (
-    update_order_status,
-    updates_amounts_for_order,
-)
 from .....payment import models as payment_models
 from .....payment.error_codes import (
     TransactionCreateErrorCode,
@@ -190,42 +180,6 @@ class TransactionUpdate(TransactionCreate):
             transaction_data["app"] = app
             transaction_data["app_identifier"] = app.identifier
 
-    # TODO (ENG-295): Remove this method when this will be refactored to use
-    # the new functions `process_order_or_checkout_with_transaction`.
-    @classmethod
-    def update_order(
-        cls,
-        order: order_models.Order,
-        money_data: dict,
-        update_search_vector: bool = True,
-    ) -> None:
-        update_fields = []
-        if money_data:
-            updates_amounts_for_order(order, save=False)
-            update_fields.extend(
-                [
-                    "total_authorized_amount",
-                    "total_charged_amount",
-                    "authorize_status",
-                    "charge_status",
-                ]
-            )
-        if (
-            order.channel.automatically_confirm_all_new_orders
-            and order.status == OrderStatus.UNCONFIRMED
-        ):
-            update_order_status(order)
-
-        if update_search_vector:
-            update_order_search_vector(order, save=False)
-            update_fields.append(
-                "search_vector",
-            )
-
-        if update_fields:
-            update_fields.append("updated_at")
-            order.save(update_fields=update_fields)
-
     @classmethod
     def perform_mutation(
         cls,
@@ -250,7 +204,6 @@ class TransactionUpdate(TransactionCreate):
             app=app,
         )
         money_data = {}
-        previous_transaction_psp_reference = instance.psp_reference
         previous_authorized_value = instance.authorized_value
         previous_charged_value = instance.charged_value
         previous_refunded_value = instance.refunded_value
@@ -262,9 +215,8 @@ class TransactionUpdate(TransactionCreate):
             money_data = cls.get_money_data_from_input(transaction, instance.currency)
             cls.update_transaction(instance, transaction, money_data, user, app)
 
-        event = None
         if transaction_event:
-            event = cls.create_transaction_event(transaction_event, instance, user, app)
+            cls.create_transaction_event(transaction_event, instance, user, app)
             if instance.order:
                 order_transaction_event(
                     order=instance.order,
@@ -273,28 +225,18 @@ class TransactionUpdate(TransactionCreate):
                     reference=transaction_event.get("psp_reference"),
                     message=transaction_event.get("message", ""),
                 )
-        if instance.order_id:
-            order = cast(order_models.Order, instance.order)
-            should_update_search_vector = bool(
-                (instance.psp_reference != previous_transaction_psp_reference)
-                or (event and event.psp_reference)
-            )
-            cls.update_order(
-                order, money_data, update_search_vector=should_update_search_vector
-            )
-            order_info = fetch_order_info(order)
-            order_transaction_updated(
-                order_info=order_info,
-                transaction_item=instance,
-                manager=manager,
-                user=user,
-                app=app,
-                previous_authorized_value=previous_authorized_value,
-                previous_charged_value=previous_charged_value,
-                previous_refunded_value=previous_refunded_value,
-            )
-        if instance.checkout_id and money_data:
-            manager = get_plugin_manager_promise(info.context).get()
-            transaction_amounts_for_checkout_updated(instance, manager, user, app)
+
+        # TransactionCreate.process_order_or_checkout_with_transaction is called to use same logic for processing
+        # order or checkout as in a transaction mutation.
+        cls.process_order_or_checkout_with_transaction(
+            instance,
+            manager,
+            user,
+            app,
+            money_data,
+            previous_authorized_value,
+            previous_charged_value,
+            previous_refunded_value,
+        )
 
         return TransactionUpdate(transaction=instance)

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -233,7 +233,6 @@ class TransactionUpdate(TransactionCreate):
             manager,
             user,
             app,
-            money_data,
             previous_authorized_value,
             previous_charged_value,
             previous_refunded_value,

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -33,7 +33,7 @@ from .transaction_create import (
     TransactionCreateInput,
     TransactionEventInput,
 )
-from .utils import get_transaction_item
+from .utils import get_transaction_item, process_order_or_checkout_with_transaction
 
 if TYPE_CHECKING:
     from .....account.models import User
@@ -228,7 +228,7 @@ class TransactionUpdate(TransactionCreate):
 
         # TransactionCreate.process_order_or_checkout_with_transaction is called to use same logic for processing
         # order or checkout as in a transaction mutation.
-        cls.process_order_or_checkout_with_transaction(
+        process_order_or_checkout_with_transaction(
             instance,
             manager,
             user,

--- a/saleor/graphql/payment/mutations/transaction/utils.py
+++ b/saleor/graphql/payment/mutations/transaction/utils.py
@@ -1,19 +1,36 @@
-from typing import TYPE_CHECKING, Optional
+from decimal import Decimal
+from typing import TYPE_CHECKING, Optional, cast
+from uuid import UUID
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv46_address
 
+from .....checkout.actions import (
+    transaction_amounts_for_checkout_updated_without_price_recalculation,
+)
 from .....core.exceptions import PermissionDenied
+from .....core.tracing import traced_atomic_transaction
 from .....core.utils import get_client_ip
+from .....order import OrderStatus
+from .....order.actions import order_transaction_updated
+from .....order.fetch import fetch_order_info
+from .....order.search import update_order_search_vector
+from .....order.utils import refresh_order_status, updates_amounts_for_order
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionUpdateErrorCode
+from .....payment.lock_objects import (
+    get_checkout_and_transaction_item_locked_for_update,
+    get_order_and_transaction_item_locked_for_update,
+)
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
 from ....core.utils import from_global_id_or_error
 from ...types import TransactionItem
 
 if TYPE_CHECKING:
-    pass
+    from .....account.models import User
+    from .....app.models import App
+    from .....plugins.manager import PluginsManager
 
 
 def get_transaction_item(
@@ -80,3 +97,97 @@ def clean_customer_ip_address(
             }
         )
     return customer_ip_address
+
+
+def process_order_with_transaction(
+    transaction: payment_models.TransactionItem,
+    manager: "PluginsManager",
+    user: Optional["User"],
+    app: Optional["App"],
+    money_data: dict[str, Decimal],
+    previous_authorized_value: Decimal = Decimal(0),
+    previous_charged_value: Decimal = Decimal(0),
+    previous_refunded_value: Decimal = Decimal(0),
+):
+    order = None
+    # This is executed after we ensure that the transaction is not a checkout
+    # transaction, so we can safely cast the order_id to UUID.
+    order_id = cast(UUID, transaction.order_id)
+    with traced_atomic_transaction():
+        order, transaction = get_order_and_transaction_item_locked_for_update(
+            order_id, transaction.pk
+        )
+        update_fields = []
+        if money_data:
+            updates_amounts_for_order(order, save=False)
+            update_fields.extend(
+                [
+                    "total_charged_amount",
+                    "charge_status",
+                    "total_authorized_amount",
+                    "authorize_status",
+                ]
+            )
+        if (
+            order.channel.automatically_confirm_all_new_orders
+            and order.status == OrderStatus.UNCONFIRMED
+        ):
+            status_updated = refresh_order_status(order)
+            if status_updated:
+                update_fields.append("status")
+        if update_fields:
+            update_fields.append("updated_at")
+            order.save(update_fields=update_fields)
+
+    update_order_search_vector(order)
+
+    order_info = fetch_order_info(order)
+    order_transaction_updated(
+        order_info=order_info,
+        transaction_item=transaction,
+        manager=manager,
+        user=user,
+        app=app,
+        previous_authorized_value=previous_authorized_value,
+        previous_charged_value=previous_charged_value,
+        previous_refunded_value=previous_refunded_value,
+    )
+
+
+def process_order_or_checkout_with_transaction(
+    transaction: payment_models.TransactionItem,
+    manager: "PluginsManager",
+    user: Optional["User"],
+    app: Optional["App"],
+    money_data: dict[str, Decimal],
+    previous_authorized_value: Decimal = Decimal(0),
+    previous_charged_value: Decimal = Decimal(0),
+    previous_refunded_value: Decimal = Decimal(0),
+):
+    checkout_deleted = False
+    if transaction.checkout_id and money_data:
+        with traced_atomic_transaction():
+            locked_checkout, transaction = (
+                get_checkout_and_transaction_item_locked_for_update(
+                    transaction.checkout_id, transaction.pk
+                )
+            )
+            if transaction.checkout_id and locked_checkout:
+                transaction_amounts_for_checkout_updated_without_price_recalculation(
+                    transaction, locked_checkout, manager, user, app
+                )
+            else:
+                checkout_deleted = True
+                # If the checkout was deleted, we still want to update the order associated with the transaction.
+
+    if transaction.order_id or checkout_deleted:
+        process_order_with_transaction(
+            transaction,
+            manager,
+            user,
+            app,
+            money_data,
+            previous_authorized_value,
+            previous_charged_value,
+            previous_refunded_value,
+        )

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2477,7 +2477,7 @@ def test_transaction_create_create_event_message_is_empty(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_create.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -2523,7 +2523,7 @@ def test_lock_order_during_updating_order_amounts(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_create.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -3330,7 +3330,7 @@ def test_transaction_event_report_empty_message(
 
 
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_event_report.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -3394,7 +3394,7 @@ def test_lock_order_during_updating_order_amounts(
 
 
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_event_report.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3395,7 +3395,7 @@ def test_transaction_update_transaction_event_empty_message(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_create.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -3445,7 +3445,7 @@ def test_lock_order_during_updating_order_amounts(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_create.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -1,18 +1,24 @@
 from decimal import Decimal
 from unittest.mock import patch
 
+import before_after
 import graphene
 import pytest
 from freezegun import freeze_time
 
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
 from .....checkout.calculations import fetch_checkout_data
+from .....checkout.complete_checkout import create_order_from_checkout
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
 from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
 from .....order.models import Order
 from .....payment import TransactionEventType
 from .....payment.error_codes import TransactionUpdateErrorCode
+from .....payment.lock_objects import (
+    get_checkout_and_transaction_item_locked_for_update,
+    get_order_and_transaction_item_locked_for_update,
+)
 from .....payment.models import TransactionEvent, TransactionItem
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from ....core.utils import to_global_id_or_none
@@ -2543,7 +2549,7 @@ def test_transaction_update_amounts_are_correct(
 
 
 def test_transaction_update_for_checkout_updates_payment_statuses(
-    checkout_with_items,
+    checkout_with_prices,
     permission_manage_payments,
     app_api_client,
     transaction_item_generator,
@@ -2553,7 +2559,7 @@ def test_transaction_update_for_checkout_updates_payment_statuses(
     current_authorized_value = Decimal("1")
     current_charged_value = Decimal("2")
     transaction = transaction_item_generator(
-        checkout_id=checkout_with_items.pk,
+        checkout_id=checkout_with_prices.pk,
         app=app,
         authorized_value=current_authorized_value,
         charged_value=current_charged_value,
@@ -2581,9 +2587,9 @@ def test_transaction_update_for_checkout_updates_payment_statuses(
     )
 
     # then
-    checkout_with_items.refresh_from_db()
-    assert checkout_with_items.charge_status == CheckoutChargeStatus.PARTIAL
-    assert checkout_with_items.authorize_status == CheckoutAuthorizeStatus.PARTIAL
+    checkout_with_prices.refresh_from_db()
+    assert checkout_with_prices.charge_status == CheckoutChargeStatus.PARTIAL
+    assert checkout_with_prices.authorize_status == CheckoutAuthorizeStatus.PARTIAL
 
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
@@ -3304,7 +3310,7 @@ def test_transaction_update_amounts_with_lot_of_decimal_places(
     assert getattr(transaction, db_field_name) == round(value, 2)
 
 
-def test_transaction_uodate_transaction_event_message_limit_exceeded(
+def test_transaction_update_transaction_event_message_limit_exceeded(
     transaction_item_created_by_app,
     order_with_lines,
     permission_manage_payments,
@@ -3345,7 +3351,7 @@ def test_transaction_uodate_transaction_event_message_limit_exceeded(
     assert event.psp_reference == transaction_reference
 
 
-def test_transaction_uodate_transaction_event_empty_message(
+def test_transaction_update_transaction_event_empty_message(
     transaction_item_created_by_app,
     order_with_lines,
     permission_manage_payments,
@@ -3384,3 +3390,170 @@ def test_transaction_uodate_transaction_event_empty_message(
     event = transaction.events.last()
     assert event.message == ""
     assert event.psp_reference == transaction_reference
+
+
+# Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
+@pytest.mark.django_db(transaction=True)
+@patch(
+    "saleor.graphql.payment.mutations.transaction.transaction_create.get_order_and_transaction_item_locked_for_update",
+    wraps=get_order_and_transaction_item_locked_for_update,
+)
+def test_lock_order_during_updating_order_amounts(
+    mocked_get_order_and_transaction_item_locked_for_update,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    unconfirmed_order_with_lines,
+    app,
+):
+    # given
+    order = unconfirmed_order_with_lines
+    current_authorized_value = Decimal("1")
+    current_charged_value = Decimal("2")
+    transaction = transaction_item_generator(
+        order_id=order.pk,
+        app=app,
+        authorized_value=current_authorized_value,
+        charged_value=current_charged_value,
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            "amountCharged": {
+                "amount": order.total.gross.amount,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    order.refresh_from_db()
+    transaction_pk = order.payment_transactions.get().pk
+    assert order.charge_status == OrderChargeStatus.FULL
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
+    mocked_get_order_and_transaction_item_locked_for_update.assert_called_once_with(
+        order.pk, transaction_pk
+    )
+
+
+# Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
+@pytest.mark.django_db(transaction=True)
+@patch(
+    "saleor.graphql.payment.mutations.transaction.transaction_create.get_checkout_and_transaction_item_locked_for_update",
+    wraps=get_checkout_and_transaction_item_locked_for_update,
+)
+def test_lock_checkout_during_updating_checkout_amounts(
+    mocked_get_checkout_and_transaction_item_locked_for_update,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+    app,
+):
+    # given
+    current_authorized_value = Decimal("1")
+    current_charged_value = Decimal("2")
+    transaction = transaction_item_generator(
+        checkout_id=checkout_with_prices.pk,
+        app=app,
+        authorized_value=current_authorized_value,
+        charged_value=current_charged_value,
+    )
+
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    assert checkout.channel.automatically_complete_fully_paid_checkouts is False
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            "amountCharged": {
+                "amount": checkout_info.checkout.total.gross.amount,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    checkout.refresh_from_db()
+    transaction_pk = checkout.payment_transactions.get().pk
+    assert checkout.charge_status == CheckoutChargeStatus.FULL
+    assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+    mocked_get_checkout_and_transaction_item_locked_for_update.assert_called_once_with(
+        checkout.pk, transaction_pk
+    )
+
+
+def test_transaction_create_create_checkout_completed_race_condition(
+    app_api_client,
+    permission_manage_payments,
+    checkout_with_prices,
+    plugins_manager,
+    transaction_item_generator,
+    app,
+):
+    # given
+    current_authorized_value = Decimal("1")
+    current_charged_value = Decimal("2")
+    transaction = transaction_item_generator(
+        checkout_id=checkout_with_prices.pk,
+        app=app,
+        authorized_value=current_authorized_value,
+        charged_value=current_charged_value,
+    )
+
+    checkout = checkout_with_prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    checkout_info, _ = fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    assert checkout.channel.automatically_complete_fully_paid_checkouts is False
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            "amountCharged": {
+                "amount": checkout_info.checkout.total.gross.amount,
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    def complete_checkout(*args, **kwargs):
+        create_order_from_checkout(
+            checkout_info, plugins_manager, user=None, app=app_api_client.app
+        )
+
+    with before_after.after(
+        "saleor.graphql.payment.mutations.transaction.transaction_update.recalculate_transaction_amounts",
+        complete_checkout,
+    ):
+        app_api_client.post_graphql(
+            MUTATION_TRANSACTION_UPDATE,
+            variables,
+            permissions=[permission_manage_payments],
+        )
+
+    # then
+    order = Order.objects.get(checkout_token=checkout.pk)
+
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.charge_status == OrderChargeStatus.FULL
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
+    assert order.total_charged.amount == checkout.total.gross.amount


### PR DESCRIPTION
I want to merge this change to fix a race condition in the TransactionUpdate mutation when updating checkout/order prices


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
