### PR TITLE
Add ChannelContext to Attribute related types

### DIFF
--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -14,6 +14,7 @@ from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ...core.enums import ErrorPolicyEnum
 from ...core.mutations import BaseMutation, DeprecatedModelMutation
@@ -197,13 +198,21 @@ class AttributeBulkCreateResult(BaseObjectType):
 def get_results(
     instances_data_with_errors_list: list[dict], reject_everything: bool = False
 ) -> list[AttributeBulkCreateResult]:
-    return [
-        AttributeBulkCreateResult(
-            attribute=None if reject_everything else data.get("instance"),
-            errors=data.get("errors"),
+    results = []
+    for data in instances_data_with_errors_list:
+        if reject_everything:
+            attribute = None
+        else:
+            attribute = data.get("instance")
+            if attribute:
+                attribute = ChannelContext(attribute, None)
+        results.append(
+            AttributeBulkCreateResult(
+                attribute=attribute,
+                errors=data.get("errors"),
+            )
         )
-        for data in instances_data_with_errors_list
-    ]
+    return results
 
 
 class AttributeBulkCreate(BaseMutation):

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -14,6 +14,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.utils import get_webhooks_for_event
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ...core.enums import ErrorPolicyEnum
 from ...core.mutations import BaseMutation, DeprecatedModelMutation
@@ -52,13 +53,21 @@ class AttributeBulkUpdateResult(BaseObjectType):
 def get_results(
     instances_data_with_errors_list: list[dict], reject_everything: bool = False
 ) -> list[AttributeBulkUpdateResult]:
-    return [
-        AttributeBulkUpdateResult(
-            attribute=None if reject_everything else data.get("instance"),
-            errors=data.get("errors"),
+    results = []
+    for data in instances_data_with_errors_list:
+        if reject_everything:
+            attribute = None
+        else:
+            attribute = data.get("instance")
+            if attribute:
+                attribute = ChannelContext(attribute, None)
+        results.append(
+            AttributeBulkUpdateResult(
+                attribute=attribute,
+                errors=data.get("errors"),
+            )
         )
-        for data in instances_data_with_errors_list
-    ]
+    return results
 
 
 class AttributeBulkUpdateInput(BaseInputObjectType):

--- a/saleor/graphql/attribute/mutations/attribute_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_create.py
@@ -8,6 +8,7 @@ from ....core.exceptions import PermissionDenied
 from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ...core.enums import MeasurementUnitsEnum
@@ -174,7 +175,7 @@ class AttributeCreate(AttributeMixin, DeprecatedModelMutation):
         cls._save_m2m(info, instance, cleaned_input)
         cls.post_save_action(info, instance, cleaned_input)
         # Return the attribute that was created
-        return AttributeCreate(attribute=instance)
+        return AttributeCreate(attribute=ChannelContext(instance, None))
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/attribute/mutations/attribute_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_delete.py
@@ -4,6 +4,7 @@ from ....attribute import models as models
 from ....permission.enums import ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.mutations import ModelDeleteMutation, ModelWithExtRefMutation
 from ...core.types import AttributeError
 from ...core.utils import WebhookEventInfo
@@ -32,6 +33,12 @@ class AttributeDelete(ModelDeleteMutation, ModelWithExtRefMutation):
                 description="An attribute was deleted.",
             ),
         ]
+
+    @classmethod
+    def success_response(cls, instance):
+        response = super().success_response(instance)
+        response.attribute = ChannelContext(instance, None)
+        return response
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/attribute/mutations/attribute_reorder_values.py
+++ b/saleor/graphql/attribute/mutations/attribute_reorder_values.py
@@ -7,6 +7,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ...core.inputs import ReorderInput
 from ...core.mutations import BaseMutation
@@ -100,4 +101,4 @@ class AttributeReorderValues(BaseMutation):
             cls.call_event(manager.attribute_value_updated, value)
         cls.call_event(manager.attribute_updated, attribute)
 
-        return AttributeReorderValues(attribute=attribute)
+        return AttributeReorderValues(attribute=ChannelContext(attribute, None))

--- a/saleor/graphql/attribute/mutations/attribute_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_update.py
@@ -6,6 +6,7 @@ from ....attribute.error_codes import AttributeErrorCode
 from ....permission.enums import ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ...core.enums import MeasurementUnitsEnum
@@ -152,7 +153,7 @@ class AttributeUpdate(AttributeMixin, ModelWithExtRefMutation):
         cls.post_save_action(info, instance, cleaned_input)
 
         # Return the attribute that was created
-        return AttributeUpdate(attribute=instance)
+        return AttributeUpdate(attribute=ChannelContext(instance, None))
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/attribute/mutations/attribute_value_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_create.py
@@ -8,6 +8,7 @@ from ....core.utils import generate_unique_slug
 from ....permission.enums import ProductPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import AttributeError
 from ...core.utils import WebhookEventInfo
@@ -103,7 +104,10 @@ class AttributeValueCreate(AttributeMixin, DeprecatedModelMutation):
         instance.save()
         cls._save_m2m(info, instance, cleaned_input)
         cls.post_save_action(info, instance, cleaned_input)
-        return AttributeValueCreate(attribute=attribute, attributeValue=instance)
+        return AttributeValueCreate(
+            attribute=ChannelContext(attribute, None),
+            attributeValue=ChannelContext(instance, None),
+        )
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/attribute/mutations/attribute_value_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_delete.py
@@ -6,6 +6,7 @@ from ....permission.enums import ProductTypePermissions
 from ....product import models as product_models
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.mutations import ModelDeleteMutation, ModelWithExtRefMutation
 from ...core.types import AttributeError
 from ...core.utils import WebhookEventInfo
@@ -72,5 +73,6 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
     @classmethod
     def success_response(cls, instance):
         response = super().success_response(instance)
-        response.attribute = instance.attribute
+        response.attribute = ChannelContext(instance.attribute, None)
+        response.attributeValue = ChannelContext(instance, None)
         return response

--- a/saleor/graphql/attribute/mutations/attribute_value_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_update.py
@@ -7,6 +7,7 @@ from ....permission.enums import ProductTypePermissions
 from ....product import models as product_models
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import AttributeError
 from ...core.utils import WebhookEventInfo
@@ -87,7 +88,8 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
     @classmethod
     def success_response(cls, instance):
         response = super().success_response(instance)
-        response.attribute = instance.attribute
+        response.attribute = ChannelContext(instance.attribute, None)
+        response.attributeValue = ChannelContext(instance, None)
         return response
 
     @classmethod

--- a/saleor/graphql/attribute/schema.py
+++ b/saleor/graphql/attribute/schema.py
@@ -3,6 +3,7 @@ import graphene
 from ...attribute import models
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
+from ..core.context import ChannelContext, ChannelQsContext
 from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.fields import BaseField, FilterConnectionField
@@ -69,14 +70,18 @@ class AttributeQueries(graphene.ObjectType):
         )
         if search:
             qs = filter_attribute_search(qs, None, search)
+        qs = ChannelQsContext(qs=qs, channel_slug=None)
         return create_connection_slice(qs, info, kwargs, AttributeCountableConnection)
 
     def resolve_attribute(
         self, info: ResolveInfo, *, id=None, slug=None, external_reference=None
     ):
-        return resolve_by_global_id_slug_or_ext_ref(
+        attribute = resolve_by_global_id_slug_or_ext_ref(
             info, models.Attribute, id, slug, external_reference
         )
+        if attribute:
+            return ChannelContext(node=attribute, channel_slug=None)
+        return None
 
 
 class AttributeMutations(graphene.ObjectType):

--- a/saleor/graphql/attribute/tests/queries/test_attribute_query.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_query.py
@@ -64,36 +64,56 @@ def test_get_single_attribute_by_slug_as_customer(
 
 
 QUERY_ATTRIBUTE = """
-    query($id: ID!, $query: String) {
-        attribute(id: $id) {
-            id
-            slug
-            name
-            inputType
-            entityType
-            type
-            unit
-            choices(first: 10, filter: {search: $query}) {
-                edges {
-                    node {
-                        slug
-                        inputType
-                        value
-                        file {
-                            url
-                            contentType
-                        }
-                    }
-                }
-            }
-            valueRequired
-            visibleInStorefront
-            filterableInStorefront
-            filterableInDashboard
-            availableInGrid
-            storefrontSearchPosition
+query ($id: ID!, $query: String) {
+  attribute(id: $id) {
+    id
+    slug
+    name
+    inputType
+    entityType
+    type
+    unit
+    choices(first: 10, filter: {search: $query}) {
+      edges {
+        node {
+          slug
+          inputType
+          value
+          file {
+            url
+            contentType
+          }
         }
+      }
     }
+    valueRequired
+    visibleInStorefront
+    filterableInStorefront
+    filterableInDashboard
+    availableInGrid
+    storefrontSearchPosition
+    translation(languageCode: PL) {
+      id
+      name
+    }
+    withChoices
+    productTypes(first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+    productVariantTypes(first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+    externalReference
+  }
+}
 """
 
 
@@ -417,9 +437,11 @@ def test_get_single_swatch_attribute_by_staff(
                 "slug": value.slug,
                 "value": value.value,
                 "inputType": value.input_type.upper(),
-                "file": {"url": value.file_url, "contentType": value.content_type}
-                if value.file_url
-                else None,
+                "file": (
+                    {"url": value.file_url, "contentType": value.content_type}
+                    if value.file_url
+                    else None
+                ),
             }
         }
         attribute_value_data.append(data)
@@ -439,9 +461,29 @@ QUERY_ATTRIBUTES = """
                     choices(first: 10) {
                         edges {
                             node {
+                            id
+                            name
+                            slug
+                            inputType
+                            value
+                            file {
+                                url
+                                contentType
+                            }
+                            translation(languageCode: PL) {
                                 id
                                 name
-                                slug
+                                translatableContent {
+                                id
+                                }
+                            }
+                            reference
+                            richText
+                            plainText
+                            boolean
+                            date
+                            dateTime
+                            externalReference
                             }
                         }
                     }

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -13,7 +13,11 @@ from ..core.connection import (
     create_connection_slice,
     filter_connection_queryset,
 )
-from ..core.context import ChannelContext, get_database_connection_name
+from ..core.context import (
+    ChannelContext,
+    ChannelQsContext,
+    get_database_connection_name,
+)
 from ..core.descriptions import (
     ADDED_IN_322,
     DEFAULT_DEPRECATION_REASON,
@@ -30,9 +34,9 @@ from ..core.types import (
     DateTimeRangeInput,
     File,
     IntRangeInput,
-    ModelObjectType,
     NonNullList,
 )
+from ..core.types.context import ChannelContextType, ChannelContextTypeForObjectType
 from ..decorators import check_attribute_required_permissions
 from ..meta.types import ObjectWithMetadata
 from ..page.dataloaders import PageByIdLoader
@@ -59,13 +63,15 @@ def get_reference_pk(attribute, root: models.AttributeValue) -> None | int:
     return reference_pk
 
 
-class AttributeValue(ModelObjectType[models.AttributeValue]):
+class AttributeValue(ChannelContextType[models.AttributeValue]):
     id = graphene.GlobalID(required=True, description="The ID of the attribute value.")
     name = graphene.String(description=AttributeValueDescriptions.NAME)
     slug = graphene.String(description=AttributeValueDescriptions.SLUG)
     value = graphene.String(description=AttributeValueDescriptions.VALUE)
     translation = TranslationField(
-        AttributeValueTranslation, type_name="attribute value"
+        AttributeValueTranslation,
+        type_name="attribute value",
+        resolver=ChannelContextType.resolve_translation,
     )
     input_type = AttributeInputTypeEnum(description=AttributeDescriptions.INPUT_TYPE)
     reference = graphene.ID(description="The ID of the referenced object.")
@@ -96,22 +102,27 @@ class AttributeValue(ModelObjectType[models.AttributeValue]):
     )
 
     class Meta:
+        default_resolver = ChannelContextType.resolver_with_context
         description = "Represents a value of an attribute."
         interfaces = [graphene.relay.Node]
         model = models.AttributeValue
 
     @staticmethod
-    def resolve_referenced_object(root: models.AttributeValue, info: ResolveInfo):
+    def resolve_referenced_object(
+        root: ChannelContext[models.AttributeValue], info: ResolveInfo
+    ):
+        attr_value = root.node
+
         def prepare_referenced_object(attribute):
             if not attribute:
                 return None
-            reference_pk = get_reference_pk(attribute, root)
+            reference_pk = get_reference_pk(attribute, attr_value)
 
             if reference_pk is None:
                 return None
 
             def wrap_with_channel_context(_object):
-                return ChannelContext(node=_object, channel_slug=None)
+                return ChannelContext(node=_object, channel_slug=root.channel_slug)
 
             if attribute.entity_type == AttributeEntityType.PRODUCT:
                 return (
@@ -131,61 +142,76 @@ class AttributeValue(ModelObjectType[models.AttributeValue]):
 
         return (
             AttributesByAttributeId(info.context)
-            .load(root.attribute_id)
+            .load(attr_value.attribute_id)
             .then(prepare_referenced_object)
         )
 
-    @staticmethod
-    def resolve_input_type(root: models.AttributeValue, info: ResolveInfo):
+    def resolve_input_type(
+        root: ChannelContext[models.AttributeValue], info: ResolveInfo
+    ):
+        attr_value = root.node
         return (
             AttributesByAttributeId(info.context)
-            .load(root.attribute_id)
+            .load(attr_value.attribute_id)
             .then(lambda attribute: attribute.input_type)
         )
 
     @staticmethod
-    def resolve_file(root: models.AttributeValue, _info: ResolveInfo) -> None | File:
-        if not root.file_url:
+    def resolve_file(
+        root: ChannelContext[models.AttributeValue], _info: ResolveInfo
+    ) -> None | File:
+        attr_value = root.node
+        if not attr_value.file_url:
             return None
-        return File(url=root.file_url, content_type=root.content_type)
+        return File(url=attr_value.file_url, content_type=attr_value.content_type)
 
     @staticmethod
-    def resolve_reference(root: models.AttributeValue, info: ResolveInfo):
+    def resolve_reference(
+        root: ChannelContext[models.AttributeValue], info: ResolveInfo
+    ):
+        attr_value = root.node
+
         def prepare_reference(attribute) -> None | str:
-            reference_pk = get_reference_pk(attribute, root)
+            reference_pk = get_reference_pk(attribute, attr_value)
             if reference_pk is None:
                 return None
             return graphene.Node.to_global_id(attribute.entity_type, reference_pk)
 
         return (
             AttributesByAttributeId(info.context)
-            .load(root.attribute_id)
+            .load(attr_value.attribute_id)
             .then(prepare_reference)
         )
 
     @staticmethod
-    def resolve_date_time(root: models.AttributeValue, info: ResolveInfo):
+    def resolve_date_time(
+        root: ChannelContext[models.AttributeValue], info: ResolveInfo
+    ):
+        attr_value = root.node
+
         def _resolve_date(attribute):
             if attribute.input_type == AttributeInputType.DATE_TIME:
-                return root.date_time
+                return attr_value.date_time
             return None
 
         return (
             AttributesByAttributeId(info.context)
-            .load(root.attribute_id)
+            .load(attr_value.attribute_id)
             .then(_resolve_date)
         )
 
     @staticmethod
-    def resolve_date(root: models.AttributeValue, info: ResolveInfo):
+    def resolve_date(root: ChannelContext[models.AttributeValue], info: ResolveInfo):
+        attr_value = root.node
+
         def _resolve_date(attribute):
             if attribute.input_type == AttributeInputType.DATE:
-                return root.date_time
+                return attr_value.date_time
             return None
 
         return (
             AttributesByAttributeId(info.context)
-            .load(root.attribute_id)
+            .load(attr_value.attribute_id)
             .then(_resolve_date)
         )
 
@@ -196,7 +222,7 @@ class AttributeValueCountableConnection(CountableConnection):
         node = AttributeValue
 
 
-class Attribute(ModelObjectType[models.Attribute]):
+class Attribute(ChannelContextType[models.Attribute]):
     id = graphene.GlobalID(required=True, description="The ID of the attribute.")
     input_type = AttributeInputTypeEnum(description=AttributeDescriptions.INPUT_TYPE)
     entity_type = AttributeEntityTypeEnum(
@@ -279,7 +305,11 @@ class Attribute(ModelObjectType[models.Attribute]):
         required=True,
         deprecation_reason=DEFAULT_DEPRECATION_REASON,
     )
-    translation = TranslationField(AttributeTranslation, type_name="attribute")
+    translation = TranslationField(
+        AttributeTranslation,
+        type_name="attribute",
+        resolver=ChannelContextType.resolve_translation,
+    )
     with_choices = graphene.Boolean(
         description=AttributeDescriptions.WITH_CHOICES, required=True
     )
@@ -304,6 +334,7 @@ class Attribute(ModelObjectType[models.Attribute]):
     )
 
     class Meta:
+        default_resolver = ChannelContextType.resolver_with_context
         description = (
             "Custom attribute of a product. Attributes can be assigned to products and "
             "variants at the product type level."
@@ -312,67 +343,89 @@ class Attribute(ModelObjectType[models.Attribute]):
         model = models.Attribute
 
     @staticmethod
-    def resolve_choices(root: models.Attribute, info: ResolveInfo, **kwargs):
-        if root.input_type in AttributeInputType.TYPES_WITH_CHOICES:
-            qs = root.values.using(get_database_connection_name(info.context)).all()
+    def resolve_choices(
+        root: ChannelContext[models.Attribute], info: ResolveInfo, **kwargs
+    ):
+        attr = root.node
+        if attr.input_type in AttributeInputType.TYPES_WITH_CHOICES:
+            qs = attr.values.using(get_database_connection_name(info.context)).all()
         else:
             qs = models.AttributeValue.objects.none()
 
-        qs = filter_connection_queryset(
-            qs, kwargs, allow_replica=info.context.allow_replica
+        channel_context_qs = ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
+        channel_context_qs = filter_connection_queryset(
+            channel_context_qs, kwargs, allow_replica=info.context.allow_replica
         )
         return create_connection_slice(
-            qs, info, kwargs, AttributeValueCountableConnection
+            channel_context_qs, info, kwargs, AttributeValueCountableConnection
         )
 
     @staticmethod
     @check_attribute_required_permissions()
-    def resolve_value_required(root: models.Attribute, _info: ResolveInfo):
-        return root.value_required
+    def resolve_value_required(
+        root: ChannelContext[models.Attribute], _info: ResolveInfo
+    ):
+        return root.node.value_required
 
     @staticmethod
     @check_attribute_required_permissions()
-    def resolve_visible_in_storefront(root: models.Attribute, _info: ResolveInfo):
-        return root.visible_in_storefront
+    def resolve_visible_in_storefront(
+        root: ChannelContext[models.Attribute], _info: ResolveInfo
+    ):
+        return root.node.visible_in_storefront
 
     @staticmethod
     @check_attribute_required_permissions()
-    def resolve_filterable_in_storefront(root: models.Attribute, _info: ResolveInfo):
-        return root.filterable_in_storefront
+    def resolve_filterable_in_storefront(
+        root: ChannelContext[models.Attribute], _info: ResolveInfo
+    ):
+        return root.node.filterable_in_storefront
 
     @staticmethod
     @check_attribute_required_permissions()
-    def resolve_filterable_in_dashboard(root: models.Attribute, _info: ResolveInfo):
-        return root.filterable_in_dashboard
+    def resolve_filterable_in_dashboard(
+        root: ChannelContext[models.Attribute], _info: ResolveInfo
+    ):
+        return root.node.filterable_in_dashboard
 
     @staticmethod
     @check_attribute_required_permissions()
-    def resolve_storefront_search_position(root: models.Attribute, _info: ResolveInfo):
-        return root.storefront_search_position
+    def resolve_storefront_search_position(
+        root: ChannelContext[models.Attribute], _info: ResolveInfo
+    ):
+        return root.node.storefront_search_position
 
     @staticmethod
     @check_attribute_required_permissions()
-    def resolve_available_in_grid(root: models.Attribute, _info: ResolveInfo):
-        return root.available_in_grid
+    def resolve_available_in_grid(
+        root: ChannelContext[models.Attribute], _info: ResolveInfo
+    ):
+        return root.node.available_in_grid
 
     @staticmethod
-    def resolve_with_choices(root: models.Attribute, _info: ResolveInfo):
-        return root.input_type in AttributeInputType.TYPES_WITH_CHOICES
+    def resolve_with_choices(
+        root: ChannelContext[models.Attribute], _info: ResolveInfo
+    ):
+        return root.node.input_type in AttributeInputType.TYPES_WITH_CHOICES
 
     @staticmethod
-    def resolve_product_types(root: models.Attribute, info: ResolveInfo, **kwargs):
+    def resolve_product_types(
+        root: ChannelContext[models.Attribute], info: ResolveInfo, **kwargs
+    ):
         from ..product.types import ProductTypeCountableConnection
 
-        qs = root.product_types.using(get_database_connection_name(info.context)).all()
+        qs = root.node.product_types.using(
+            get_database_connection_name(info.context)
+        ).all()
         return create_connection_slice(qs, info, kwargs, ProductTypeCountableConnection)
 
     @staticmethod
     def resolve_product_variant_types(
-        root: models.Attribute, info: ResolveInfo, **kwargs
+        root: ChannelContext[models.Attribute], info: ResolveInfo, **kwargs
     ):
         from ..product.types import ProductTypeCountableConnection
 
-        qs = root.product_variant_types.using(
+        qs = root.node.product_variant_types.using(
             get_database_connection_name(info.context)
         ).all()
         return create_connection_slice(qs, info, kwargs, ProductTypeCountableConnection)
@@ -405,7 +458,7 @@ class AssignedVariantAttribute(BaseObjectType):
         doc_category = DOC_CATEGORY_ATTRIBUTES
 
 
-class SelectedAttribute(BaseObjectType):
+class SelectedAttribute(ChannelContextTypeForObjectType):
     attribute = graphene.Field(
         Attribute,
         default_value=None,

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from django.conf import settings
 from django.db.models import QuerySet
-from django.db.models.base import Model
 from django.http import HttpRequest
 from django.utils.functional import empty
 
@@ -85,11 +84,8 @@ class SyncWebhookControlContext(BaseContext[N]):
         self.allow_sync_webhooks = allow_sync_webhooks
 
 
-C = TypeVar("C", bound=Model)
-
-
 @dataclass
-class ChannelContext(BaseContext[C]):
+class ChannelContext(BaseContext[N]):
     channel_slug: str | None
 
 

--- a/saleor/graphql/core/types/context.py
+++ b/saleor/graphql/core/types/context.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, cast
+from typing import Generic, TypeVar, cast
 
 from django.db.models import Model
 from graphene.types.resolver import get_default_resolver
@@ -6,12 +6,13 @@ from graphene.types.resolver import get_default_resolver
 from ...translations.resolvers import resolve_translation
 from .. import ResolveInfo
 from ..context import ChannelContext
+from .base import BaseObjectType
 from .model import ModelObjectType
 
-T = TypeVar("T", bound=Model)
+N = TypeVar("N", bound=Model)
 
 
-class ChannelContextTypeForObjectType(ModelObjectType[T]):
+class ChannelContextTypeForObjectType(Generic[N], BaseObjectType):
     """A Graphene type that supports resolvers' root as ChannelContext objects."""
 
     class Meta:
@@ -19,28 +20,31 @@ class ChannelContextTypeForObjectType(ModelObjectType[T]):
 
     @staticmethod
     def resolver_with_context(
-        attname, default_value, root: ChannelContext, info: ResolveInfo, **args
+        attname, default_value, root: ChannelContext[N], info: ResolveInfo, **args
     ):
         resolver = get_default_resolver()
         return resolver(attname, default_value, root.node, info, **args)
 
     @staticmethod
-    def resolve_id(root: ChannelContext[T], _info: ResolveInfo):
-        return root.node.pk
-
-    @staticmethod
     def resolve_translation(
-        root: ChannelContext[T], info: ResolveInfo, *, language_code
+        root: ChannelContext[N], info: ResolveInfo, *, language_code
     ):
         # Resolver for TranslationField; needs to be manually specified.
         return resolve_translation(root.node, info, language_code=language_code)
 
 
-class ChannelContextType(ChannelContextTypeForObjectType[T]):
+T = TypeVar("T", bound=Model)
+
+
+class ChannelContextType(ChannelContextTypeForObjectType[T], ModelObjectType[T]):
     """A Graphene type that supports resolvers' root as ChannelContext objects."""
 
     class Meta:
         abstract = True
+
+    @staticmethod
+    def resolve_id(root: ChannelContext[T], _info: ResolveInfo):
+        return root.node.pk
 
     @classmethod
     def is_type_of(cls, root: ChannelContext[T] | T, _info: ResolveInfo) -> bool:
@@ -55,5 +59,4 @@ class ChannelContextType(ChannelContextTypeForObjectType[T]):
             model = root._meta.model
         else:
             model = cast(type[Model], root._meta.model._meta.concrete_model)
-
         return model == cls._meta.model

--- a/saleor/graphql/decorators.py
+++ b/saleor/graphql/decorators.py
@@ -5,6 +5,7 @@ from functools import wraps
 from graphene import ResolveInfo
 
 from ..attribute import AttributeType
+from ..attribute.models import Attribute
 from ..core.exceptions import PermissionDenied
 from ..permission.auth_filters import is_app, is_staff_user
 from ..permission.enums import (
@@ -19,6 +20,7 @@ from ..permission.utils import (
     one_of_permissions_or_auth_filter_required,
 )
 from ..permission.utils import permission_required as core_permission_required
+from .core.context import ChannelContext
 from .utils import get_user_or_app_from_context
 
 
@@ -119,7 +121,8 @@ def check_attribute_required_permissions():
     different permissions need to be checked.
     """
 
-    def check_perms(context, attribute):
+    def check_perms(context, root: ChannelContext[Attribute]):
+        attribute = root.node
         requestor = get_user_or_app_from_context(context)
         permissions: list[BasePermissionEnum]
         if attribute.type == AttributeType.PAGE_TYPE:

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -2,6 +2,7 @@ import graphene
 from django.core.exceptions import ValidationError
 from graphql.error.base import GraphQLError
 
+from ....attribute import models as attribute_models
 from ....checkout import models as checkout_models
 from ....core import models
 from ....core.db.connection import allow_writer
@@ -256,8 +257,11 @@ class BaseMetadataMutation(BaseMutation):
             | product_models.Product
             | product_models.ProductVariant
             | shipping_models.ShippingMethod
-            | shipping_models.ShippingZone,
+            | shipping_models.ShippingZone
+            | attribute_models.Attribute
+            | attribute_models.AttributeValue,
         )
+
         use_channel_context = use_channel_context or (
             # For old sales migrated into promotions
             isinstance(instance, Promotion) and instance.old_sale_id

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -2,6 +2,7 @@ import sys
 from collections import defaultdict
 from dataclasses import asdict
 from decimal import Decimal
+from typing import cast
 
 import graphene
 from graphene import relay
@@ -584,27 +585,55 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
         info,
         variant_selection: str | None = None,
     ):
-        def apply_variant_selection_filter(selected_attributes):
+        def apply_variant_selection_filter(
+            selected_attributes,
+        ) -> list[SelectedAttribute]:
             if not variant_selection or variant_selection == VariantAttributeScope.ALL:
-                return selected_attributes
+                return [
+                    SelectedAttribute(
+                        attribute=ChannelContext(
+                            selected_att["attribute"], root.channel_slug
+                        ),
+                        values=[
+                            ChannelContext(value, root.channel_slug)
+                            for value in selected_att["values"]
+                        ],
+                    )
+                    for selected_att in selected_attributes
+                ]
             attributes = [
                 (selected_att["attribute"], selected_att["variant_selection"])
                 for selected_att in selected_attributes
             ]
+            attributes = cast(list[tuple[attribute_models.Attribute, bool]], attributes)
             variant_selection_attrs = [
                 attr for attr, _ in get_variant_selection_attributes(attributes)
             ]
 
             if variant_selection == VariantAttributeScope.VARIANT_SELECTION:
-                return [
-                    selected_attribute
-                    for selected_attribute in selected_attributes
-                    if selected_attribute["attribute"] in variant_selection_attrs
+                attributes_to_return = [
+                    selected_att
+                    for selected_att in selected_attributes
+                    if selected_att["attribute"] in variant_selection_attrs
                 ]
+            else:
+                attributes_to_return = [
+                    selected_att
+                    for selected_att in selected_attributes
+                    if selected_att["attribute"] not in variant_selection_attrs
+                ]
+
             return [
-                selected_attribute
-                for selected_attribute in selected_attributes
-                if selected_attribute["attribute"] not in variant_selection_attrs
+                SelectedAttribute(
+                    attribute=ChannelContext(
+                        selected_att["attribute"], root.channel_slug
+                    ),
+                    values=[
+                        ChannelContext(value, root.channel_slug)
+                        for value in selected_att["values"]
+                    ],
+                )
+                for selected_att in attributes_to_return
             ]
 
         return (
@@ -1300,12 +1329,33 @@ class Product(ChannelContextType[models.Product]):
     @staticmethod
     def resolve_attribute(root: ChannelContext[models.Product], info, slug):
         def get_selected_attribute_by_slug(
-            attributes: list[SelectedAttribute],
+            attributes: (
+                list[
+                    dict[
+                        str,
+                        attribute_models.Attribute
+                        | list[attribute_models.AttributeValue],
+                    ]
+                ]
+                | None
+            ),
         ) -> SelectedAttribute | None:
-            return next(
-                (atr for atr in attributes if atr["attribute"].slug == slug),
-                None,
-            )
+            if attributes is None:
+                return None
+
+            for atr in attributes:
+                attribute = atr["attribute"]
+                attribute = cast(attribute_models.Attribute, attribute)
+                if attribute.slug == slug:
+                    values = atr["values"]
+                    values = cast(list[attribute_models.AttributeValue], values)
+                    return SelectedAttribute(
+                        attribute=ChannelContext(attribute, root.channel_slug),
+                        values=[
+                            ChannelContext(value, root.channel_slug) for value in values
+                        ],
+                    )
+            return None
 
         requestor = get_user_or_app_from_context(info.context)
         if (
@@ -1326,18 +1376,53 @@ class Product(ChannelContextType[models.Product]):
 
     @staticmethod
     def resolve_attributes(root: ChannelContext[models.Product], info):
+        def wrap_with_channel_context(
+            attributes: (
+                list[
+                    dict[
+                        str,
+                        attribute_models.Attribute
+                        | list[attribute_models.AttributeValue],
+                    ]
+                ]
+                | None
+            ),
+        ) -> list[SelectedAttribute] | None:
+            if attributes is None:
+                return None
+
+            response = []
+            for attr_data in attributes:
+                attribute = attr_data["attribute"]
+                attribute = cast(attribute_models.Attribute, attribute)
+                values = attr_data["values"]
+                values = cast(list[attribute_models.AttributeValue], values)
+                response.append(
+                    SelectedAttribute(
+                        attribute=ChannelContext(attribute, root.channel_slug),
+                        values=[
+                            ChannelContext(value, root.channel_slug) for value in values
+                        ],
+                    )
+                )
+            return response
+
         requestor = get_user_or_app_from_context(info.context)
         if (
             requestor
             and requestor.is_active
             and requestor.has_perm(ProductPermissions.MANAGE_PRODUCTS)
         ):
-            return SelectedAttributesAllByProductIdLoader(info.context).load(
-                root.node.id
+            return (
+                SelectedAttributesAllByProductIdLoader(info.context)
+                .load(root.node.id)
+                .then(wrap_with_channel_context)
             )
-        return SelectedAttributesVisibleInStorefrontByProductIdLoader(
-            info.context
-        ).load(root.node.id)
+        return (
+            SelectedAttributesVisibleInStorefrontByProductIdLoader(info.context)
+            .load(root.node.id)
+            .then(wrap_with_channel_context)
+        )
 
     @staticmethod
     def resolve_media_by_id(root: ChannelContext[models.Product], info, *, id):
@@ -1784,7 +1869,7 @@ class ProductType(ModelObjectType[models.ProductType]):
     @staticmethod
     def resolve_product_attributes(root: models.ProductType, info):
         def unpack_attributes(attributes):
-            return [attr for attr, *_ in attributes]
+            return [ChannelContext(attr, None) for attr, *_ in attributes]
 
         requestor = get_user_or_app_from_context(info.context)
         if (
@@ -1812,12 +1897,14 @@ class ProductType(ModelObjectType[models.ProductType]):
     ):
         def apply_variant_selection_filter(attributes):
             if not variant_selection or variant_selection == VariantAttributeScope.ALL:
-                return [attr for attr, *_ in attributes]
+                return [ChannelContext(attr, None) for attr, *_ in attributes]
             variant_selection_attrs = get_variant_selection_attributes(attributes)
             if variant_selection == VariantAttributeScope.VARIANT_SELECTION:
-                return [attr for attr, *_ in variant_selection_attrs]
+                return [
+                    ChannelContext(attr, None) for attr, *_ in variant_selection_attrs
+                ]
             return [
-                attr
+                ChannelContext(attr, None)
                 for attr, variant_selection in attributes
                 if (attr, variant_selection) not in variant_selection_attrs
             ]
@@ -1849,17 +1936,26 @@ class ProductType(ModelObjectType[models.ProductType]):
         def apply_variant_selection_filter(attributes):
             if not variant_selection or variant_selection == VariantAttributeScope.ALL:
                 return [
-                    {"attribute": attr, "variant_selection": variant_selection}
+                    {
+                        "attribute": ChannelContext(attr, None),
+                        "variant_selection": variant_selection,
+                    }
                     for attr, variant_selection in attributes
                 ]
             variant_selection_attrs = get_variant_selection_attributes(attributes)
             if variant_selection == VariantAttributeScope.VARIANT_SELECTION:
                 return [
-                    {"attribute": attr, "variant_selection": variant_selection}
+                    {
+                        "attribute": ChannelContext(attr, None),
+                        "variant_selection": variant_selection,
+                    }
                     for attr, variant_selection in variant_selection_attrs
                 ]
             return [
-                {"attribute": attr, "variant_selection": variant_selection}
+                {
+                    "attribute": ChannelContext(attr, None),
+                    "variant_selection": variant_selection,
+                }
                 for attr, variant_selection in attributes
                 if (attr, variant_selection) not in variant_selection_attrs
             ]
@@ -1919,6 +2015,7 @@ class ProductType(ModelObjectType[models.ProductType]):
         )
         if search:
             qs = filter_attribute_search(qs, None, search)
+        qs = ChannelQsContext(qs=qs, channel_slug=None)
         return create_connection_slice(qs, info, kwargs, AttributeCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/translations/mutations/attribute_translate.py
+++ b/saleor/graphql/translations/mutations/attribute_translate.py
@@ -3,6 +3,7 @@ import graphene
 from ....attribute import models as attribute_models
 from ....permission.enums import SitePermissions
 from ...attribute.types import Attribute
+from ...core.context import ChannelContext
 from ...core.enums import LanguageCodeEnum
 from ...core.types import TranslationError
 from .utils import BaseTranslateMutation, NameTranslationInput
@@ -29,3 +30,9 @@ class AttributeTranslate(BaseTranslateMutation):
         error_type_class = TranslationError
         error_type_field = "translation_errors"
         permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
+
+    @classmethod
+    def perform_mutation(cls, *args, **kwargs):
+        response = super().perform_mutation(*args, **kwargs)
+        response.attribute = ChannelContext(response.attribute, None)
+        return response

--- a/saleor/graphql/translations/mutations/attribute_value_translate.py
+++ b/saleor/graphql/translations/mutations/attribute_value_translate.py
@@ -6,6 +6,7 @@ from ....attribute import models as attribute_models
 from ....core.utils.editorjs import clean_editor_js
 from ....permission.enums import SitePermissions
 from ...attribute.types import AttributeValue
+from ...core.context import ChannelContext
 from ...core.descriptions import RICH_CONTENT
 from ...core.enums import LanguageCodeEnum
 from ...core.fields import JSONString
@@ -50,3 +51,9 @@ class AttributeValueTranslate(BaseTranslateMutation):
             elif instance.attribute.input_type == AttributeInputType.PLAIN_TEXT:
                 input_data["name"] = truncatechars(input_data["plain_text"], 250)
         return input_data
+
+    @classmethod
+    def perform_mutation(cls, *args, **kwargs):
+        response = super().perform_mutation(*args, **kwargs)
+        response.attributeValue = ChannelContext(response.attributeValue, None)
+        return response

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -21,11 +21,7 @@ from ...shipping import models as shipping_models
 from ...site import models as site_models
 from ..attribute.dataloaders import AttributesByAttributeId, AttributeValueByIdLoader
 from ..core.context import ChannelContext, get_database_connection_name
-from ..core.descriptions import (
-    ADDED_IN_321,
-    DEPRECATED_IN_3X_TYPE,
-    RICH_CONTENT,
-)
+from ..core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_TYPE, RICH_CONTENT
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import JSONString, PermissionsField
 from ..core.tracing import traced_resolver
@@ -173,7 +169,7 @@ class AttributeTranslatableContent(ModelObjectType[attribute_models.Attribute]):
 
     @staticmethod
     def resolve_attribute(root: attribute_models.Attribute, _info):
-        return root
+        return ChannelContext(node=root, channel_slug=None)
 
     @staticmethod
     def resolve_attribute_id(root: attribute_models.Attribute, _info):
@@ -219,7 +215,7 @@ class AttributeValueTranslatableContent(
 
     @staticmethod
     def resolve_attribute_value(root: attribute_models.AttributeValue, _info):
-        return root
+        return ChannelContext(node=root, channel_slug=None)
 
     @staticmethod
     def resolve_attribute(root: attribute_models.AttributeValue, info):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -360,7 +360,7 @@ class AttributeBase(AbstractType):
     @staticmethod
     def resolve_attribute(root, _info: ResolveInfo):
         _, attribute = root
-        return attribute
+        return ChannelContext(attribute, None)
 
 
 class AttributeCreated(SubscriptionObjectType, AttributeBase):
@@ -395,8 +395,8 @@ class AttributeValueBase(AbstractType):
 
     @staticmethod
     def resolve_attribute_value(root, _info: ResolveInfo):
-        _, attribute = root
-        return attribute
+        _, attribute_value = root
+        return ChannelContext(attribute_value, None)
 
 
 class AttributeValueCreated(SubscriptionObjectType, AttributeValueBase):


### PR DESCRIPTION
I want to merge this change because it wraps the Attribute, and AttributeValue with the `ChannelContext`. 
It was required to pass the input `channel_slug` to the `AttributeValue.referencedObjects field

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
