### PR TITLE
Add ChannelContext to Page type

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -137,7 +137,11 @@ class AttributeValue(ChannelContextType[models.AttributeValue]):
                     .then(wrap_with_channel_context)
                 )
             if attribute.entity_type == AttributeEntityType.PAGE:
-                return PageByIdLoader(info.context).load(reference_pk)
+                return (
+                    PageByIdLoader(info.context)
+                    .load(reference_pk)
+                    .then(wrap_with_channel_context)
+                )
             return None
 
         return (

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -224,14 +224,16 @@ class MenuItem(ChannelContextType[models.MenuItem]):
                 and requestor.is_active
                 and requestor.has_perm(PagePermissions.MANAGE_PAGES)
             )
+
+            def resolve_page_with_channel(page):
+                if requestor_has_access_to_all or page.is_visible:
+                    return ChannelContext(node=page, channel_slug=root.channel_slug)
+                return None
+
             return (
                 PageByIdLoader(info.context)
                 .load(root.node.page_id)
-                .then(
-                    lambda page: (
-                        page if requestor_has_access_to_all or page.is_visible else None
-                    )
-                )
+                .then(resolve_page_with_channel)
             )
         return None
 

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -12,6 +12,7 @@ from ....discount import models as discount_models
 from ....discount.models import Promotion
 from ....menu import models as menu_models
 from ....order import models as order_models
+from ....page import models as page_models
 from ....product import models as product_models
 from ....shipping import models as shipping_models
 from ...core import ResolveInfo
@@ -259,7 +260,8 @@ class BaseMetadataMutation(BaseMutation):
             | shipping_models.ShippingMethod
             | shipping_models.ShippingZone
             | attribute_models.Attribute
-            | attribute_models.AttributeValue,
+            | attribute_models.AttributeValue
+            | page_models.Page,
         )
 
         use_channel_context = use_channel_context or (

--- a/saleor/graphql/page/mutations/page_create.py
+++ b/saleor/graphql/page/mutations/page_create.py
@@ -10,6 +10,7 @@ from ....permission.enums import PagePermissions
 from ...attribute.types import AttributeValueInput
 from ...attribute.utils import PageAttributeAssignmentMixin
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT, RICH_CONTENT
 from ...core.doc_category import DOC_CATEGORY_PAGES
 from ...core.fields import JSONString
@@ -134,3 +135,9 @@ class PageCreate(DeprecatedModelMutation):
         super().save(info, instance, cleaned_input)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_created, instance)
+
+    @classmethod
+    def success_response(cls, instance):
+        response = super().success_response(instance)
+        response.page = ChannelContext(instance, channel_slug=None)
+        return response

--- a/saleor/graphql/page/mutations/page_delete.py
+++ b/saleor/graphql/page/mutations/page_delete.py
@@ -7,6 +7,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....page import models
 from ....permission.enums import PagePermissions
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import PageError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -35,6 +36,7 @@ class PageDelete(ModelDeleteMutation):
             response = super().perform_mutation(_root, info, **data)
             page.page_type = page_type
             cls.call_event(manager.page_deleted, page)
+        response.page = ChannelContext(page, channel_slug=None)
         return response
 
     @staticmethod

--- a/saleor/graphql/page/mutations/page_reorder_attribute_values.py
+++ b/saleor/graphql/page/mutations/page_reorder_attribute_values.py
@@ -8,6 +8,7 @@ from ....permission.enums import PagePermissions
 from ...attribute.mutations import BaseReorderAttributeValuesMutation
 from ...attribute.types import Attribute
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.doc_category import DOC_CATEGORY_PAGES
 from ...core.inputs import ReorderInput
 from ...core.types import NonNullList, PageError
@@ -44,7 +45,7 @@ class PageReorderAttributeValues(BaseReorderAttributeValuesMutation):
     def perform_mutation(cls, _root, _info: ResolveInfo, /, **data):
         page_id = data["page_id"]
         page = cls.perform(page_id, "page", data, "attributevalues", PageErrorCode)
-        return PageReorderAttributeValues(page=page)
+        return PageReorderAttributeValues(page=ChannelContext(page, channel_slug=None))
 
     @classmethod
     def perform(

--- a/saleor/graphql/page/mutations/page_update.py
+++ b/saleor/graphql/page/mutations/page_update.py
@@ -4,6 +4,7 @@ from ....page import models
 from ....permission.enums import PagePermissions
 from ...attribute.utils import PageAttributeAssignmentMixin
 from ...core import ResolveInfo
+from ...core.context import ChannelContext
 from ...core.types import PageError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Page
@@ -38,3 +39,9 @@ class PageUpdate(PageCreate):
         super(PageCreate, cls).save(info, instance, cleaned_input)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_updated, instance)
+
+    @classmethod
+    def success_response(cls, instance):
+        response = super().success_response(instance)
+        response.page = ChannelContext(instance, channel_slug=None)
+        return response

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -2,6 +2,7 @@ import graphene
 
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
+from ..core.context import ChannelContext, ChannelQsContext
 from ..core.descriptions import ADDED_IN_321, ADDED_IN_322, DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.enums import LanguageCodeEnum
@@ -83,7 +84,10 @@ class PageQueries(graphene.ObjectType):
     def resolve_page(
         _root, info: ResolveInfo, *, id=None, slug=None, slug_language_code=None
     ):
-        return resolve_page(info, id, slug, slug_language_code)
+        page = resolve_page(info, id, slug, slug_language_code)
+        if not page:
+            return None
+        return ChannelContext(page, channel_slug=None)
 
     @staticmethod
     def resolve_pages(_root, info: ResolveInfo, **kwargs):
@@ -91,6 +95,7 @@ class PageQueries(graphene.ObjectType):
         search = kwargs.get("search") or kwargs.get("filter", {}).get("search")
         if search:
             qs = search_pages(qs, search)
+        qs = ChannelQsContext(qs, channel_slug=None)
         qs = filter_connection_queryset(
             qs, kwargs, allow_replica=info.context.allow_replica
         )

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -656,12 +656,15 @@ class PageTranslatableContent(ModelObjectType[page_models.Page]):
 
     @staticmethod
     def resolve_page(root: page_models.Page, info):
-        return (
+        page = (
             page_models.Page.objects.using(get_database_connection_name(info.context))
             .visible_to_user(info.context.user)
             .filter(pk=root.id)
             .first()
         )
+        if not page:
+            return None
+        return ChannelContext(page, channel_slug=None)
 
     @staticmethod
     def resolve_content_json(root: page_models.Page, _info):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1530,7 +1530,7 @@ class PageBase(AbstractType):
     @staticmethod
     def resolve_page(root, _info: ResolveInfo):
         _, page = root
-        return page
+        return ChannelContext(page, channel_slug=None)
 
 
 class PageCreated(SubscriptionObjectType, PageBase):


### PR DESCRIPTION
I want to merge this change because it wraps the Page type with ChannelContext

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
