### PR TITLE
Trace the full span of dataloaders and report the number of objects returned

### DIFF
--- a/saleor/core/telemetry/saleor_attributes.py
+++ b/saleor/core/telemetry/saleor_attributes.py
@@ -8,10 +8,11 @@ OPERATION_NAME: Final = "operation.name"
 
 # GraphQL
 GRAPHQL_DOCUMENT_FINGERPRINT: Final = "graphql.document_fingerprint"
-GRAPHQL_OPERATION_IDENTIFIER: Final = "graphql.operation.identifier"
-GRAPHQL_OPERATION_COST: Final = "graphql.operation.cost"
-GRAPHQL_PARENT_TYPE: Final = "graphql.parent_type"
 GRAPHQL_FIELD_NAME: Final = "graphql.field_name"
+GRAPHQL_OPERATION_COST: Final = "graphql.operation.cost"
+GRAPHQL_OPERATION_IDENTIFIER: Final = "graphql.operation.identifier"
+GRAPHQL_PARENT_TYPE: Final = "graphql.parent_type"
+GRAPHQL_RESOLVER_ROW_COUNT: Final = "graphql.resolver.row_count"
 
 # Http
 SALEOR_SOURCE_SERVICE_NAME: Final = "saleor.source.service.name"


### PR DESCRIPTION
We currently only trace the initial, synchronous part of dataloaders, which often means immediately calling another dataloader. This should give us the whole duration of data fetching, and will log the number of resulting objects.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
