### PR TITLE
Change bump-dependencies workflow to run monthly

### DIFF
--- a/.github/workflows/bump-dependencies.yml
+++ b/.github/workflows/bump-dependencies.yml
@@ -3,7 +3,7 @@ name: Bump dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 8 * * 1' # At 08:00 on Monday.
+    - cron:  '0 8 1 * *'  # At 08:00 on day-of-month 1
 
 jobs:
   bump-dependencies:
@@ -21,15 +21,15 @@ jobs:
       - run: git status
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
         with:
-          token: ${{ secrets.TRIGGER_WORKFLOW_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: bump-dependencies
           delete-branch: true
           commit-message: Bump dependencies
           title: 'Bump dependencies'
           body: |
-            Weekly update of backend dependencies.
+            Monthly update of backend dependencies.
           labels: |
             :robot: bot
             test deployment


### PR DESCRIPTION
- Changed the workflow to run monthly, as we're not merging dependencies upgrades more often anyway (as they often require some changes, linter fixes etc) - once a month should be reasonable. This won't affect security updates that are handled separately from this workflow.
- Changed to GITHUB_TOKEN for auth instead of a custom token.
- Bumped version of the workflow.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
