### PR TITLE
Include subcategories when filtering by product categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extend `AttributeEntityType` with `CATEGORY` and `COLLECTION`. You can now assign category and collection as a attribute reference.
 - Attribute values now expose the `referencedObject`, allowing for easier access to the linked entity.
 - You can now filter and search attribute choices using the new `where` and `search` fields on the `attribute.choices` query.
+- Filtering products by `category` now also includes subcategories. The filter will return products that belong to the specified categories as well as their subcategories.
 
 ### Webhooks
 - Transaction webhooks responsible for processing payments can now return payment method details`, which will be associated with the corresponding transaction. See [docs](https://docs.saleor.io/developer/extending/webhooks/synchronous-events/transaction#response-4) to learn more.

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -1107,6 +1107,22 @@ def where_filter_updated_at_range(qs, _, value):
     return filter_where_range_field_with_conditions(qs, "updated_at", value)
 
 
+def where_filter_by_categories(qs, value):
+    """Filter products by categories and subcategories of provided categories."""
+    if not value:
+        return qs.none()
+    eq = value.get("eq")
+    one_of = value.get("one_of")
+    pks = None
+    if eq and isinstance(eq, str):
+        _, pks = resolve_global_ids_to_primary_keys([eq], "Category", True)
+    if one_of:
+        _, pks = resolve_global_ids_to_primary_keys(one_of, "Category", True)
+    if pks:
+        return filter_products_by_categories(qs, pks)
+    return qs.none()
+
+
 class ProductWhere(MetadataWhereFilterBase):
     ids = GlobalIDMultipleChoiceWhereFilter(method=filter_by_ids("Product"))
     name = OperationObjectTypeWhereFilter(
@@ -1215,7 +1231,7 @@ class ProductWhere(MetadataWhereFilterBase):
 
     @staticmethod
     def filter_category(qs, _, value):
-        return filter_where_by_id_field(qs, "category", value, "Category")
+        return where_filter_by_categories(qs, value)
 
     @staticmethod
     def filter_collection(qs, _, value):


### PR DESCRIPTION
Include subcategories when filtering by `category` in product filter

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
