### PR TITLE
Fix commented tests by mistake

### DIFF
--- a/saleor/graphql/page/tests/queries/test_pages_with_where.py
+++ b/saleor/graphql/page/tests/queries/test_pages_with_where.py
@@ -830,126 +830,126 @@ def test_pages_query_with_non_matching_records(
             ],
             1,
         ),
-        # (
-        #     [
-        #         {
-        #             "slug": "page-size",
-        #             "value": {
-        #                 "slug": {"eq": "10"},
-        #             },
-        #         },
-        #         {
-        #             "slug": "tag",
-        #             "value": {"name": {"oneOf": ["About", "Help"]}},
-        #         },
-        #     ],
-        #     1,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"eq": "10"}},
-        #         },
-        #         {"slug": "boolean", "value": {"boolean": False}},
-        #     ],
-        #     0,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "tag",
-        #             "value": {
-        #                 "name": {"eq": "About"},
-        #             },
-        #         },
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"eq": "10"}},
-        #         },
-        #     ],
-        #     1,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"eq": "15"}},
-        #         },
-        #         {
-        #             "slug": "tag",
-        #             "value": {"name": {"eq": "Help"}},
-        #         },
-        #         {"slug": "boolean", "value": {"boolean": False}},
-        #     ],
-        #     0,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "author",
-        #             "value": {"slug": {"oneOf": ["test-author-1", "test-author-2"]}},
-        #         },
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"eq": "10"}},
-        #         },
-        #     ],
-        #     1,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"eq": "10"}},
-        #         },
-        #         {
-        #             "slug": "author",
-        #             "value": {"name": {"eq": "Test author 1"}},
-        #         },
-        #     ],
-        #     1,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"eq": "10"}},
-        #         },
-        #         {
-        #             "slug": "tag",
-        #             "value": {"name": {"eq": "About"}},
-        #         },
-        #         {
-        #             "slug": "author",
-        #             "value": {"slug": {"eq": "test-author-1"}},
-        #         },
-        #     ],
-        #     1,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"oneOf": ["10", "15"]}},
-        #         },
-        #         {
-        #             "slug": "tag",
-        #             "value": {"name": {"oneOf": ["About", "Help"]}},
-        #         },
-        #     ],
-        #     2,
-        # ),
-        # (
-        #     [
-        #         {
-        #             "slug": "page-size",
-        #             "value": {"slug": {"oneOf": ["10", "15"]}},
-        #         },
-        #         {"slug": "boolean", "value": {"boolean": True}},
-        #     ],
-        #     1,
-        # ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {
+                        "slug": {"eq": "10"},
+                    },
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"oneOf": ["About", "Help"]}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {
+                    "slug": "tag",
+                    "value": {
+                        "name": {"eq": "About"},
+                    },
+                },
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "15"}},
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"eq": "Help"}},
+                },
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {
+                    "slug": "author",
+                    "value": {"slug": {"oneOf": ["test-author-1", "test-author-2"]}},
+                },
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+                {
+                    "slug": "author",
+                    "value": {"name": {"eq": "Test author 1"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"eq": "10"}},
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"eq": "About"}},
+                },
+                {
+                    "slug": "author",
+                    "value": {"slug": {"eq": "test-author-1"}},
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"oneOf": ["10", "15"]}},
+                },
+                {
+                    "slug": "tag",
+                    "value": {"name": {"oneOf": ["About", "Help"]}},
+                },
+            ],
+            2,
+        ),
+        (
+            [
+                {
+                    "slug": "page-size",
+                    "value": {"slug": {"oneOf": ["10", "15"]}},
+                },
+                {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
     ],
 )
 def test_pages_query_with_multiple_attribute_filters(


### PR DESCRIPTION
I want to merge this change because it uncomments the parametrize inputs commented by mistake

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
