### PR TITLE
Fix race condition in TransactionUpdate mutation when updating checkout/order prices 

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -1,36 +1,20 @@
 import uuid
 from decimal import Decimal
-from typing import TYPE_CHECKING, cast
-from uuid import UUID
+from typing import TYPE_CHECKING
 
 import graphene
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db.models import Model
 
-from .....account.models import User
-from .....app.models import App
 from .....checkout import models as checkout_models
-from .....checkout.actions import (
-    transaction_amounts_for_checkout_updated_without_price_recalculation,
-)
 from .....core.prices import quantize_price
-from .....core.tracing import traced_atomic_transaction
-from .....order import OrderStatus
 from .....order import models as order_models
-from .....order.actions import order_transaction_updated
 from .....order.events import transaction_event as order_transaction_event
-from .....order.fetch import fetch_order_info
-from .....order.search import update_order_search_vector
-from .....order.utils import refresh_order_status, updates_amounts_for_order
 from .....payment import TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionCreateErrorCode
 from .....payment.interface import PaymentMethodDetails
-from .....payment.lock_objects import (
-    get_checkout_and_transaction_item_locked_for_update,
-    get_order_and_transaction_item_locked_for_update,
-)
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....payment.utils import (
     create_manual_adjustment_events,
@@ -56,9 +40,10 @@ from .shared import (
     get_payment_method_details,
     validate_payment_method_details_input,
 )
+from .utils import process_order_or_checkout_with_transaction
 
 if TYPE_CHECKING:
-    from .....plugins.manager import PluginsManager
+    pass
 
 
 class TransactionCreateInput(BaseInputObjectType):
@@ -344,89 +329,6 @@ class TransactionCreate(BaseMutation):
         )
 
     @classmethod
-    def process_order_with_transaction(
-        cls,
-        transaction: payment_models.TransactionItem,
-        manager: "PluginsManager",
-        user: User | None,
-        app: App | None,
-        money_data: dict[str, Decimal],
-    ):
-        order = None
-        # This is executed after we ensure that the transaction is not a checkout
-        # transaction, so we can safely cast the order_id to UUID.
-        order_id = cast(UUID, transaction.order_id)
-        with traced_atomic_transaction():
-            order, transaction = get_order_and_transaction_item_locked_for_update(
-                order_id, transaction.pk
-            )
-            update_fields = []
-            if money_data:
-                updates_amounts_for_order(order, save=False)
-                update_fields.extend(
-                    [
-                        "total_charged_amount",
-                        "charge_status",
-                        "total_authorized_amount",
-                        "authorize_status",
-                    ]
-                )
-            if (
-                order.channel.automatically_confirm_all_new_orders
-                and order.status == OrderStatus.UNCONFIRMED
-            ):
-                status_updated = refresh_order_status(order)
-                if status_updated:
-                    update_fields.append("status")
-            if update_fields:
-                update_fields.append("updated_at")
-                order.save(update_fields=update_fields)
-
-        update_order_search_vector(order)
-
-        order_info = fetch_order_info(order)
-        order_transaction_updated(
-            order_info=order_info,
-            transaction_item=transaction,
-            manager=manager,
-            user=user,
-            app=app,
-            previous_authorized_value=Decimal(0),
-            previous_charged_value=Decimal(0),
-            previous_refunded_value=Decimal(0),
-        )
-
-    @classmethod
-    def process_order_or_checkout_with_transaction(
-        cls,
-        transaction: payment_models.TransactionItem,
-        manager: "PluginsManager",
-        user: User | None,
-        app: App | None,
-        money_data: dict[str, Decimal],
-    ):
-        checkout_deleted = False
-        if transaction.checkout_id and money_data:
-            with traced_atomic_transaction():
-                locked_checkout, transaction = (
-                    get_checkout_and_transaction_item_locked_for_update(
-                        transaction.checkout_id, transaction.pk
-                    )
-                )
-                if transaction.checkout_id and locked_checkout:
-                    transaction_amounts_for_checkout_updated_without_price_recalculation(
-                        transaction, locked_checkout, manager, user, app
-                    )
-                else:
-                    checkout_deleted = True
-                    # If the checkout was deleted, we still want to update the order associated with the transaction.
-
-        if (transaction.order_id or checkout_deleted) and money_data:
-            cls.process_order_with_transaction(
-                transaction, manager, user, app, money_data
-            )
-
-    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls,
         _root,
@@ -479,12 +381,11 @@ class TransactionCreate(BaseMutation):
                 transaction=new_transaction, money_data=money_data, user=user, app=app
             )
             recalculate_transaction_amounts(new_transaction)
-        cls.process_order_or_checkout_with_transaction(
+        process_order_or_checkout_with_transaction(
             new_transaction,
             manager,
             user,
             app,
-            money_data,
         )
 
         if transaction_event:

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -1,34 +1,22 @@
-from decimal import Decimal
-from typing import TYPE_CHECKING, Optional, cast
-from uuid import UUID as UUID_TYPE
+from typing import TYPE_CHECKING, cast
 
 import graphene
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-from .....account.models import User
 from .....app.models import App
-from .....checkout.actions import (
-    transaction_amounts_for_checkout_updated_without_price_recalculation,
-)
 from .....core.exceptions import PermissionDenied
 from .....core.prices import quantize_price
 from .....core.tracing import traced_atomic_transaction
 from .....core.utils.events import call_event
 from .....order import models as order_models
-from .....order.actions import order_transaction_updated
-from .....order.fetch import fetch_order_info
-from .....order.search import update_order_search_vector
 from .....order.utils import (
     calculate_order_granted_refund_status,
-    updates_amounts_for_order,
 )
 from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment import models as payment_models
 from .....payment.interface import PaymentMethodDetails
 from .....payment.lock_objects import (
-    get_checkout_and_transaction_item_locked_for_update,
-    get_order_and_transaction_item_locked_for_update,
     transaction_item_qs_select_for_update,
 )
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
@@ -64,7 +52,7 @@ from .shared import (
     get_payment_method_details,
     validate_payment_method_details_input,
 )
-from .utils import get_transaction_item
+from .utils import get_transaction_item, process_order_or_checkout_with_transaction
 
 if TYPE_CHECKING:
     from .....plugins.manager import PluginsManager
@@ -207,7 +195,7 @@ class TransactionEventReport(DeprecatedModelMutation):
         transaction: payment_models.TransactionItem,
         transaction_event: payment_models.TransactionEvent,
         available_actions: list[str] | None = None,
-        app: Optional["App"] = None,
+        app: App | None = None,
         metadata: list[MetadataInput] | None = None,
         private_metadata: list[MetadataInput] | None = None,
         payment_details_data: PaymentMethodDetails | None = None,
@@ -302,81 +290,6 @@ class TransactionEventReport(DeprecatedModelMutation):
                     },
                 ) from e
         return quantize_price(amount, currency)
-
-    @classmethod
-    def process_order_with_transaction(
-        cls,
-        transaction: payment_models.TransactionItem,
-        manager: "PluginsManager",
-        user: User | None,
-        app: App | None,
-        previous_authorized_value: Decimal,
-        previous_charged_value: Decimal,
-        previous_refunded_value: Decimal,
-        related_granted_refund: order_models.OrderGrantedRefund | None,
-    ):
-        order = None
-        # This is executed after we ensure that the transaction is not a checkout
-        # transaction, so we can safely cast the order_id to UUID.
-        order_id = cast(UUID_TYPE, transaction.order_id)
-        with traced_atomic_transaction():
-            order, transaction = get_order_and_transaction_item_locked_for_update(
-                order_id, transaction.pk
-            )
-            updates_amounts_for_order(order)
-        update_order_search_vector(order)
-        order_info = fetch_order_info(order)
-        order_transaction_updated(
-            order_info=order_info,
-            transaction_item=transaction,
-            manager=manager,
-            user=user,
-            app=app,
-            previous_authorized_value=previous_authorized_value,
-            previous_charged_value=previous_charged_value,
-            previous_refunded_value=previous_refunded_value,
-        )
-        if related_granted_refund:
-            calculate_order_granted_refund_status(related_granted_refund)
-
-    @classmethod
-    def process_order_or_checkout_with_transaction(
-        cls,
-        transaction: payment_models.TransactionItem,
-        manager: "PluginsManager",
-        user: User | None,
-        app: App | None,
-        previous_authorized_value: Decimal,
-        previous_charged_value: Decimal,
-        previous_refunded_value: Decimal,
-        related_granted_refund: order_models.OrderGrantedRefund | None,
-    ):
-        checkout_deleted = False
-        if transaction.checkout_id:
-            with traced_atomic_transaction():
-                locked_checkout, transaction = (
-                    get_checkout_and_transaction_item_locked_for_update(
-                        transaction.checkout_id, transaction.pk
-                    )
-                )
-                if transaction.checkout_id and locked_checkout:
-                    transaction_amounts_for_checkout_updated_without_price_recalculation(
-                        transaction, locked_checkout, manager, user, app
-                    )
-                else:
-                    checkout_deleted = True
-                    # If the checkout was deleted, we still want to update the order associated with the transaction.
-        if transaction.order_id or checkout_deleted:
-            cls.process_order_with_transaction(
-                transaction,
-                manager,
-                user,
-                app,
-                previous_authorized_value,
-                previous_charged_value,
-                previous_refunded_value,
-                related_granted_refund,
-            )
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
@@ -533,7 +446,7 @@ class TransactionEventReport(DeprecatedModelMutation):
                 private_metadata=transaction_private_metadata,
                 payment_details_data=payment_details_data,
             )
-            cls.process_order_or_checkout_with_transaction(
+            process_order_or_checkout_with_transaction(
                 transaction,
                 manager,
                 user,
@@ -541,7 +454,7 @@ class TransactionEventReport(DeprecatedModelMutation):
                 previous_authorized_value,
                 previous_charged_value,
                 previous_refunded_value,
-                related_granted_refund,
+                related_granted_refund=related_granted_refund,
             )
         else:
             updated_fields = []

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -1,21 +1,11 @@
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional
 
 import graphene
 from django.core.exceptions import ValidationError
 
 from .....app.models import App
-from .....checkout.actions import transaction_amounts_for_checkout_updated
 from .....core.exceptions import PermissionDenied
-from .....order import OrderStatus
-from .....order import models as order_models
-from .....order.actions import order_transaction_updated
 from .....order.events import transaction_event as order_transaction_event
-from .....order.fetch import fetch_order_info
-from .....order.search import update_order_search_vector
-from .....order.utils import (
-    update_order_status,
-    updates_amounts_for_order,
-)
 from .....payment import models as payment_models
 from .....payment.error_codes import (
     TransactionCreateErrorCode,
@@ -47,7 +37,7 @@ from .transaction_create import (
     TransactionCreateInput,
     TransactionEventInput,
 )
-from .utils import get_transaction_item
+from .utils import get_transaction_item, process_order_or_checkout_with_transaction
 
 if TYPE_CHECKING:
     from .....account.models import User
@@ -200,42 +190,6 @@ class TransactionUpdate(TransactionCreate):
             transaction_data["app"] = app
             transaction_data["app_identifier"] = app.identifier
 
-    # TODO (ENG-295): Remove this method when this will be refactored to use
-    # the new functions `process_order_or_checkout_with_transaction`.
-    @classmethod
-    def update_order(
-        cls,
-        order: order_models.Order,
-        money_data: dict,
-        update_search_vector: bool = True,
-    ) -> None:
-        update_fields = []
-        if money_data:
-            updates_amounts_for_order(order, save=False)
-            update_fields.extend(
-                [
-                    "total_authorized_amount",
-                    "total_charged_amount",
-                    "authorize_status",
-                    "charge_status",
-                ]
-            )
-        if (
-            order.channel.automatically_confirm_all_new_orders
-            and order.status == OrderStatus.UNCONFIRMED
-        ):
-            update_order_status(order)
-
-        if update_search_vector:
-            update_order_search_vector(order, save=False)
-            update_fields.append(
-                "search_vector",
-            )
-
-        if update_fields:
-            update_fields.append("updated_at")
-            order.save(update_fields=update_fields)
-
     @classmethod
     def perform_mutation(
         cls,
@@ -260,7 +214,6 @@ class TransactionUpdate(TransactionCreate):
             app=app,
         )
         money_data = {}
-        previous_transaction_psp_reference = instance.psp_reference
         previous_authorized_value = instance.authorized_value
         previous_charged_value = instance.charged_value
         previous_refunded_value = instance.refunded_value
@@ -290,9 +243,8 @@ class TransactionUpdate(TransactionCreate):
                 payment_details_data=payment_details_data,
             )
 
-        event = None
         if transaction_event:
-            event = cls.create_transaction_event(transaction_event, instance, user, app)
+            cls.create_transaction_event(transaction_event, instance, user, app)
             if instance.order:
                 order_transaction_event(
                     order=instance.order,
@@ -301,28 +253,17 @@ class TransactionUpdate(TransactionCreate):
                     reference=transaction_event.get("psp_reference"),
                     message=transaction_event.get("message", ""),
                 )
-        if instance.order_id:
-            order = cast(order_models.Order, instance.order)
-            should_update_search_vector = bool(
-                (instance.psp_reference != previous_transaction_psp_reference)
-                or (event and event.psp_reference)
-            )
-            cls.update_order(
-                order, money_data, update_search_vector=should_update_search_vector
-            )
-            order_info = fetch_order_info(order)
-            order_transaction_updated(
-                order_info=order_info,
-                transaction_item=instance,
-                manager=manager,
-                user=user,
-                app=app,
-                previous_authorized_value=previous_authorized_value,
-                previous_charged_value=previous_charged_value,
-                previous_refunded_value=previous_refunded_value,
-            )
-        if instance.checkout_id and money_data:
-            manager = get_plugin_manager_promise(info.context).get()
-            transaction_amounts_for_checkout_updated(instance, manager, user, app)
+
+        # TransactionCreate.process_order_or_checkout_with_transaction is called to use same logic for processing
+        # order or checkout as in a transaction mutation.
+        process_order_or_checkout_with_transaction(
+            instance,
+            manager,
+            user,
+            app,
+            previous_authorized_value,
+            previous_charged_value,
+            previous_refunded_value,
+        )
 
         return TransactionUpdate(transaction=instance)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2796,7 +2796,7 @@ def test_transaction_create_with_invalid_other_payment_method_details(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_create.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -2842,7 +2842,7 @@ def test_lock_order_during_updating_order_amounts(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_create.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -3341,7 +3341,7 @@ def test_transaction_event_report_empty_message(
 
 
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_event_report.get_order_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -3405,7 +3405,7 @@ def test_lock_order_during_updating_order_amounts(
 
 
 @patch(
-    "saleor.graphql.payment.mutations.transaction.transaction_event_report.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(


### PR DESCRIPTION
I want to merge this change to fix a race condition in the TransactionUpdate mutation when updating checkout/order prices

Port of https://github.com/saleor/saleor/pull/17915

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
