### PR TITLE
Fix race condition in TransactionInitialize mutation when updating checkout/order prices

### DIFF
--- a/saleor/graphql/order/tests/benchmark/test_fulfillment_refund_and_return_products.py
+++ b/saleor/graphql/order/tests/benchmark/test_fulfillment_refund_and_return_products.py
@@ -10,7 +10,7 @@ from ....tests.utils import get_graphql_content
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_order_lines(
     mocked_refund,
     staff_api_client,
@@ -71,7 +71,7 @@ def test_fulfillment_refund_products_order_lines(
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_order_lines(
     mocked_refund,
     back_in_stock_webhook_mock,

--- a/saleor/graphql/order/tests/deprecated/test_order.py
+++ b/saleor/graphql/order/tests/deprecated/test_order.py
@@ -321,7 +321,7 @@ mutation OrderFulfillmentRefundProducts(
 """
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_order_lines_by_old_id(
     mocked_refund,
     staff_api_client,
@@ -430,7 +430,7 @@ mutation OrderFulfillmentReturnProducts(
 """
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_order_lines_by_old_line_id(
     mocked_refund,
     staff_api_client,

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_refund_products.py
@@ -80,7 +80,7 @@ def test_fulfillment_refund_products_by_user_no_channel_access(
     assert_no_permission(response)
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_with_action_requested_by_app(
     mocked_refund,
     app_api_client,
@@ -127,7 +127,7 @@ def test_fulfillment_refund_products_with_action_requested_by_app(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
 def test_fulfillment_refund_products_with_back_in_stock_webhook(
     back_in_stock_webhook_trigger,
@@ -218,7 +218,7 @@ def test_fulfillment_refund_products_order_without_payment(
     assert fulfillment is None
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_amount_and_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -287,7 +287,7 @@ def test_fulfillment_refund_products_amount_costs_for_order_with_gift_card_lines
     assert errors[0]["field"] == "amountToRefund"
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_refund_raising_payment_error(
     mocked_refund,
     staff_api_client,
@@ -321,7 +321,7 @@ def test_fulfillment_refund_products_refund_raising_payment_error(
     assert errors[0]["code"] == OrderErrorCode.CANNOT_REFUND.name
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_order_lines(
     mocked_refund,
     staff_api_client,
@@ -428,7 +428,7 @@ def test_fulfillment_refund_products_order_lines_quantity_bigger_than_unfulfille
     assert refund_fulfillment is None
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines(
     mocked_refund,
     staff_api_client,
@@ -485,7 +485,7 @@ def test_fulfillment_refund_products_fulfillment_lines(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_waiting_fulfillment_lines(
     mocked_refund,
     staff_api_client,
@@ -658,7 +658,7 @@ def test_fulfillment_refund_products_amount_bigger_than_captured_amount(
     assert refund_fulfillment is None
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines_include_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -716,7 +716,7 @@ def test_fulfillment_refund_products_fulfillment_lines_include_shipping_costs(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_order_lines_include_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -768,7 +768,7 @@ def test_fulfillment_refund_products_order_lines_include_shipping_costs(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines_custom_amount(
     mocked_refund,
     staff_api_client,
@@ -828,7 +828,7 @@ def test_fulfillment_refund_products_fulfillment_lines_custom_amount(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_order_lines_custom_amount(
     mocked_refund,
     staff_api_client,
@@ -879,7 +879,7 @@ def test_fulfillment_refund_products_order_lines_custom_amount(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
     mocked_refund,
     warehouse,
@@ -985,7 +985,7 @@ def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
 
 
 @patch("saleor.order.actions.order_refunded")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_refund_products_calls_order_refunded(
     mocked_refund,
     mocked_order_refunded,

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_return_products.py
@@ -104,7 +104,7 @@ def test_fulfillment_return_products_by_user_no_channel_access(
     assert_no_permission(response)
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_by_app(
     mocked_refund,
     app_api_client,
@@ -174,7 +174,7 @@ def test_fulfillment_return_products_order_without_payment(
     assert fulfillment is None
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_amount_and_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -253,7 +253,7 @@ def test_fulfillment_return_products_amount_order_with_gift_card(
     assert fulfillment is None
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_refund_raising_payment_error(
     mocked_refund,
     staff_api_client,
@@ -287,7 +287,7 @@ def test_fulfillment_return_products_refund_raising_payment_error(
     assert errors[0]["code"] == OrderErrorCode.CANNOT_REFUND.name
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_order_lines(
     mocked_refund,
     staff_api_client,
@@ -521,7 +521,7 @@ def test_fulfillment_return_products_order_lines_quantity_bigger_than_unfulfille
     assert return_fulfillment is None
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_order_lines_custom_amount(
     mocked_refund,
     staff_api_client,
@@ -577,7 +577,7 @@ def test_fulfillment_return_products_order_lines_custom_amount(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_fulfillment_lines(
     mocked_refund,
     staff_api_client,
@@ -711,7 +711,7 @@ def test_fulfillment_return_products_fulfillment_lines(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_gift_card_fulfillment_line(
     mocked_refund,
     staff_api_client,
@@ -878,7 +878,7 @@ def test_fulfillment_return_products_lines_with_incorrect_status(
     assert return_fulfillment is None
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_fulfillment_lines_include_shipping_costs(
     mocked_refund,
     staff_api_client,
@@ -939,7 +939,7 @@ def test_fulfillment_return_products_fulfillment_lines_include_shipping_costs(
     )
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_fulfillment_lines_and_order_lines(
     mocked_refund,
     warehouse,
@@ -1062,7 +1062,7 @@ def test_fulfillment_return_products_fulfillment_lines_and_order_lines(
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.order_refunded")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_and_replace_products_calls_order_refunded_and_webhooks(
     mocked_refund,
     mocked_order_refunded,
@@ -1153,7 +1153,7 @@ def test_fulfillment_return_and_replace_products_calls_order_refunded_and_webhoo
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.order_refunded")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_fulfillment_return_products_calls_order_refunded_and_webhooks(
     mocked_refund,
     mocked_order_refunded,

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -17,6 +17,7 @@ from .....payment.error_codes import TransactionCreateErrorCode
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....payment.utils import (
     create_manual_adjustment_events,
+    process_order_or_checkout_with_transaction,
     truncate_transaction_event_message,
 )
 from .....permission.enums import PaymentPermissions
@@ -33,7 +34,6 @@ from ...enums import TransactionActionEnum
 from ...types import TransactionItem
 from ...utils import metadata_contains_empty_key
 from ..payment.payment_check_balance import MoneyInput
-from .utils import process_order_or_checkout_with_transaction
 
 
 class TransactionCreateInput(BaseInputObjectType):

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -23,6 +23,7 @@ from .....payment.utils import (
     create_failed_transaction_event,
     get_already_existing_event,
     get_transaction_event_amount,
+    process_order_or_checkout_with_transaction,
     truncate_transaction_event_message,
 )
 from .....permission.auth_filters import AuthorizationFilters
@@ -49,7 +50,7 @@ from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import TransactionActionEnum, TransactionEventTypeEnum
 from ...types import TransactionEvent, TransactionItem
 from ...utils import check_if_requestor_has_access
-from .utils import get_transaction_item, process_order_or_checkout_with_transaction
+from .utils import get_transaction_item
 
 if TYPE_CHECKING:
     from .....app.models import App

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -15,7 +15,10 @@ from .....payment.transaction_item_calculations import (
     calculate_transaction_amount_based_on_events,
     recalculate_transaction_amounts,
 )
-from .....payment.utils import create_manual_adjustment_events
+from .....payment.utils import (
+    create_manual_adjustment_events,
+    process_order_or_checkout_with_transaction,
+)
 from .....permission.auth_filters import AuthorizationFilters
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
@@ -33,7 +36,7 @@ from .transaction_create import (
     TransactionCreateInput,
     TransactionEventInput,
 )
-from .utils import get_transaction_item, process_order_or_checkout_with_transaction
+from .utils import get_transaction_item
 
 if TYPE_CHECKING:
     from .....account.models import User
@@ -226,8 +229,6 @@ class TransactionUpdate(TransactionCreate):
                     message=transaction_event.get("message", ""),
                 )
 
-        # TransactionCreate.process_order_or_checkout_with_transaction is called to use same logic for processing
-        # order or checkout as in a transaction mutation.
         process_order_or_checkout_with_transaction(
             instance,
             manager,

--- a/saleor/graphql/payment/mutations/transaction/utils.py
+++ b/saleor/graphql/payment/mutations/transaction/utils.py
@@ -1,41 +1,16 @@
-from decimal import Decimal
-from typing import TYPE_CHECKING, Optional, cast
-from uuid import UUID
+from typing import Optional
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv46_address
 
-from .....checkout.actions import (
-    transaction_amounts_for_checkout_updated_without_price_recalculation,
-)
 from .....core.exceptions import PermissionDenied
-from .....core.tracing import traced_atomic_transaction
 from .....core.utils import get_client_ip
-from .....order import OrderStatus
-from .....order import models as order_models
-from .....order.actions import order_transaction_updated
-from .....order.fetch import fetch_order_info
-from .....order.search import update_order_search_vector
-from .....order.utils import (
-    calculate_order_granted_refund_status,
-    refresh_order_status,
-    updates_amounts_for_order,
-)
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionUpdateErrorCode
-from .....payment.lock_objects import (
-    get_checkout_and_transaction_item_locked_for_update,
-    get_order_and_transaction_item_locked_for_update,
-)
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
 from ....core.utils import from_global_id_or_error
 from ...types import TransactionItem
-
-if TYPE_CHECKING:
-    from .....account.models import User
-    from .....app.models import App
-    from .....plugins.manager import PluginsManager
 
 
 def get_transaction_item(
@@ -102,97 +77,3 @@ def clean_customer_ip_address(
             }
         )
     return customer_ip_address
-
-
-def process_order_with_transaction(
-    transaction: payment_models.TransactionItem,
-    manager: "PluginsManager",
-    user: Optional["User"],
-    app: Optional["App"],
-    previous_authorized_value: Decimal = Decimal(0),
-    previous_charged_value: Decimal = Decimal(0),
-    previous_refunded_value: Decimal = Decimal(0),
-    related_granted_refund: Optional[order_models.OrderGrantedRefund] = None,
-):
-    order = None
-    # This is executed after we ensure that the transaction is not a checkout
-    # transaction, so we can safely cast the order_id to UUID.
-    order_id = cast(UUID, transaction.order_id)
-    with traced_atomic_transaction():
-        order, transaction = get_order_and_transaction_item_locked_for_update(
-            order_id, transaction.pk
-        )
-        update_fields = []
-        updates_amounts_for_order(order, save=False)
-        update_fields.extend(
-            [
-                "total_charged_amount",
-                "charge_status",
-                "total_authorized_amount",
-                "authorize_status",
-            ]
-        )
-        if (
-            order.channel.automatically_confirm_all_new_orders
-            and order.status == OrderStatus.UNCONFIRMED
-        ):
-            status_updated = refresh_order_status(order)
-            if status_updated:
-                update_fields.append("status")
-        if update_fields:
-            update_fields.append("updated_at")
-            order.save(update_fields=update_fields)
-
-    update_order_search_vector(order)
-    order_info = fetch_order_info(order)
-    order_transaction_updated(
-        order_info=order_info,
-        transaction_item=transaction,
-        manager=manager,
-        user=user,
-        app=app,
-        previous_authorized_value=previous_authorized_value,
-        previous_charged_value=previous_charged_value,
-        previous_refunded_value=previous_refunded_value,
-    )
-    if related_granted_refund:
-        calculate_order_granted_refund_status(related_granted_refund)
-
-
-def process_order_or_checkout_with_transaction(
-    transaction: payment_models.TransactionItem,
-    manager: "PluginsManager",
-    user: Optional["User"],
-    app: Optional["App"],
-    previous_authorized_value: Decimal = Decimal(0),
-    previous_charged_value: Decimal = Decimal(0),
-    previous_refunded_value: Decimal = Decimal(0),
-    related_granted_refund: Optional[order_models.OrderGrantedRefund] = None,
-):
-    checkout_deleted = False
-    if transaction.checkout_id:
-        with traced_atomic_transaction():
-            locked_checkout, transaction = (
-                get_checkout_and_transaction_item_locked_for_update(
-                    transaction.checkout_id, transaction.pk
-                )
-            )
-            if transaction.checkout_id and locked_checkout:
-                transaction_amounts_for_checkout_updated_without_price_recalculation(
-                    transaction, locked_checkout, manager, user, app
-                )
-            else:
-                checkout_deleted = True
-                # If the checkout was deleted, we still want to update the order associated with the transaction.
-
-    if transaction.order_id or checkout_deleted:
-        process_order_with_transaction(
-            transaction,
-            manager,
-            user,
-            app,
-            previous_authorized_value,
-            previous_charged_value,
-            previous_refunded_value,
-            related_granted_refund=related_granted_refund,
-        )

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2477,7 +2477,7 @@ def test_transaction_create_create_event_message_is_empty(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
+    "saleor.payment.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -2523,7 +2523,7 @@ def test_lock_order_during_updating_order_amounts(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.payment.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(
@@ -2579,7 +2579,7 @@ def test_lock_checkout_during_updating_checkout_amounts(
     )
 
 
-def test_transaction_create_create_checkout_completed_race_condition(
+def test_transaction_create_checkout_completed_race_condition(
     app_api_client,
     permission_manage_payments,
     checkout_with_prices,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -3330,7 +3330,7 @@ def test_transaction_event_report_empty_message(
 
 
 @patch(
-    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
+    "saleor.payment.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -3394,7 +3394,7 @@ def test_lock_order_during_updating_order_amounts(
 
 
 @patch(
-    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.payment.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3395,7 +3395,7 @@ def test_transaction_update_transaction_event_empty_message(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.utils.get_order_and_transaction_item_locked_for_update",
+    "saleor.payment.utils.get_order_and_transaction_item_locked_for_update",
     wraps=get_order_and_transaction_item_locked_for_update,
 )
 def test_lock_order_during_updating_order_amounts(
@@ -3445,7 +3445,7 @@ def test_lock_order_during_updating_order_amounts(
 # Test wrapped by `transaction=True` to ensure that `selector_for_update` is called in a database transaction.
 @pytest.mark.django_db(transaction=True)
 @patch(
-    "saleor.graphql.payment.mutations.transaction.utils.get_checkout_and_transaction_item_locked_for_update",
+    "saleor.payment.utils.get_checkout_and_transaction_item_locked_for_update",
     wraps=get_checkout_and_transaction_item_locked_for_update,
 )
 def test_lock_checkout_during_updating_checkout_amounts(
@@ -3499,7 +3499,7 @@ def test_lock_checkout_during_updating_checkout_amounts(
     )
 
 
-def test_transaction_create_create_checkout_completed_race_condition(
+def test_transaction_update_checkout_completed_race_condition(
     app_api_client,
     permission_manage_payments,
     checkout_with_prices,

--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -15,7 +15,7 @@ from ..models import Fulfillment, FulfillmentLine
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_only_order_lines(
     mocked_refund,
     mocked_order_updated,
@@ -92,7 +92,7 @@ def test_create_return_fulfillment_only_order_lines(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_refund(
     mocked_refund,
     mocked_order_updated,
@@ -171,7 +171,7 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     mocked_refund,
     mocked_order_updated,
@@ -256,7 +256,7 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_replace_request(
     mocked_refund,
     mocked_order_updated,
@@ -390,7 +390,7 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines(
     mocked_refund,
     mocked_order_updated,
@@ -440,7 +440,7 @@ def test_create_return_fulfillment_only_fulfillment_lines(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     mocked_refund,
     mocked_order_updated,
@@ -550,7 +550,7 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_with_lines_already_refunded(
     mocked_refund,
     mocked_order_updated,
@@ -661,7 +661,7 @@ def test_create_return_fulfillment_with_lines_already_refunded(
 
 @patch("saleor.plugins.manager.PluginsManager.draft_order_created")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_old_ids(
     mocked_refund,
     mocked_order_updated,

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -13,7 +13,7 @@ from ..models import FulfillmentLine
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_refund_fulfillment_only_order_lines(
     mocked_refund, mocked_order_updated, order_with_lines, payment_dummy
 ):
@@ -83,7 +83,7 @@ def test_create_refund_fulfillment_only_order_lines(
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_refund_fulfillment_included_shipping_costs(
     mocked_refund, mocked_order_updated, order_with_lines, payment_dummy
 ):
@@ -145,7 +145,7 @@ def test_create_refund_fulfillment_included_shipping_costs(
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_refund_fulfillment_only_fulfillment_lines(
     mocked_refund, mocked_order_updated, fulfilled_order, payment_dummy
 ):
@@ -202,7 +202,7 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 def test_create_refund_fulfillment_custom_amount(
     mocked_refund, mocked_order_updated, fulfilled_order, payment_dummy
 ):

--- a/saleor/payment/gateways/np_atobarai/tests/conftest.py
+++ b/saleor/payment/gateways/np_atobarai/tests/conftest.py
@@ -157,7 +157,7 @@ def create_refund(payment_dummy):
             payment.captured_amount -= amount
             payment.save(update_fields=["captured_amount"])
 
-        with patch("saleor.order.actions.gateway.refund", side_effect=mocked_refund):
+        with patch("saleor.payment.gateway.refund", side_effect=mocked_refund):
             return create_refund_fulfillment(
                 user=None,
                 app=None,

--- a/saleor/payment/gateways/np_atobarai/tests/test_utils.py
+++ b/saleor/payment/gateways/np_atobarai/tests/test_utils.py
@@ -197,7 +197,7 @@ def test_create_refunded_lines_fulfillment_lines(fulfilled_order):
     }
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 @pytest.mark.parametrize("previous_refund_shipping_costs", [True, False])
 def test_create_refunded_lines_previously_refunded_order_lines(
     _mocked_refund,
@@ -243,7 +243,7 @@ def test_create_refunded_lines_previously_refunded_order_lines(
     assert lines == {line.line.variant_id: line.quantity for line in order_refund_lines}
 
 
-@patch("saleor.order.actions.gateway.refund")
+@patch("saleor.payment.gateway.refund")
 @pytest.mark.parametrize("previous_refund_shipping_costs", [True, False])
 def test_create_refunded_lines_previously_refunded_fulfillment_lines(
     _mocked_refund,

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from decimal import Decimal
 from typing import Any, Optional, Union, cast, overload
+from uuid import UUID
 
 import graphene
 from aniso8601 import parse_datetime
@@ -19,6 +20,7 @@ from ..app.models import App
 from ..channel import TransactionFlowStrategy
 from ..checkout.actions import (
     transaction_amounts_for_checkout_updated,
+    transaction_amounts_for_checkout_updated_without_price_recalculation,
     update_last_transaction_modified_at_for_checkout,
 )
 from ..checkout.fetch import fetch_checkout_info, fetch_checkout_lines
@@ -28,11 +30,14 @@ from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
 from ..core.tracing import traced_atomic_transaction
 from ..graphql.core.utils import str_to_enum
+from ..order import OrderStatus
+from ..order.actions import order_transaction_updated
 from ..order.fetch import fetch_order_info
 from ..order.models import Order, OrderGrantedRefund
 from ..order.search import update_order_search_vector
 from ..order.utils import (
     calculate_order_granted_refund_status,
+    refresh_order_status,
     update_order_authorize_data,
     updates_amounts_for_order,
 )
@@ -64,6 +69,10 @@ from .interface import (
     TransactionRequestEventResponse,
     TransactionRequestResponse,
     TransactionSessionData,
+)
+from .lock_objects import (
+    get_checkout_and_transaction_item_locked_for_update,
+    get_order_and_transaction_item_locked_for_update,
 )
 from .models import Payment, Transaction, TransactionEvent, TransactionItem
 from .transaction_item_calculations import recalculate_transaction_amounts
@@ -1215,6 +1224,100 @@ def update_order_with_transaction_details(transaction: TransactionItem):
         )
 
 
+def process_order_with_transaction(
+    transaction: TransactionItem,
+    manager: "PluginsManager",
+    user: Optional["User"],
+    app: Optional["App"],
+    previous_authorized_value: Decimal = Decimal(0),
+    previous_charged_value: Decimal = Decimal(0),
+    previous_refunded_value: Decimal = Decimal(0),
+    related_granted_refund: Optional[OrderGrantedRefund] = None,
+):
+    order = None
+    # This is executed after we ensure that the transaction is not a checkout
+    # transaction, so we can safely cast the order_id to UUID.
+    order_id = cast(UUID, transaction.order_id)
+    with traced_atomic_transaction():
+        order, transaction = get_order_and_transaction_item_locked_for_update(
+            order_id, transaction.pk
+        )
+        update_fields = []
+        updates_amounts_for_order(order, save=False)
+        update_fields.extend(
+            [
+                "total_charged_amount",
+                "charge_status",
+                "total_authorized_amount",
+                "authorize_status",
+            ]
+        )
+        if (
+            order.channel.automatically_confirm_all_new_orders
+            and order.status == OrderStatus.UNCONFIRMED
+        ):
+            status_updated = refresh_order_status(order)
+            if status_updated:
+                update_fields.append("status")
+        if update_fields:
+            update_fields.append("updated_at")
+            order.save(update_fields=update_fields)
+
+    update_order_search_vector(order)
+    order_info = fetch_order_info(order)
+    order_transaction_updated(
+        order_info=order_info,
+        transaction_item=transaction,
+        manager=manager,
+        user=user,
+        app=app,
+        previous_authorized_value=previous_authorized_value,
+        previous_charged_value=previous_charged_value,
+        previous_refunded_value=previous_refunded_value,
+    )
+    if related_granted_refund:
+        calculate_order_granted_refund_status(related_granted_refund)
+
+
+def process_order_or_checkout_with_transaction(
+    transaction: TransactionItem,
+    manager: "PluginsManager",
+    user: Optional["User"],
+    app: Optional["App"],
+    previous_authorized_value: Decimal = Decimal(0),
+    previous_charged_value: Decimal = Decimal(0),
+    previous_refunded_value: Decimal = Decimal(0),
+    related_granted_refund: Optional[OrderGrantedRefund] = None,
+):
+    checkout_deleted = False
+    if transaction.checkout_id:
+        with traced_atomic_transaction():
+            locked_checkout, transaction = (
+                get_checkout_and_transaction_item_locked_for_update(
+                    transaction.checkout_id, transaction.pk
+                )
+            )
+            if transaction.checkout_id and locked_checkout:
+                transaction_amounts_for_checkout_updated_without_price_recalculation(
+                    transaction, locked_checkout, manager, user, app
+                )
+            else:
+                checkout_deleted = True
+                # If the checkout was deleted, we still want to update the order associated with the transaction.
+
+    if transaction.order_id or checkout_deleted:
+        process_order_with_transaction(
+            transaction,
+            manager,
+            user,
+            app,
+            previous_authorized_value,
+            previous_charged_value,
+            previous_refunded_value,
+            related_granted_refund=related_granted_refund,
+        )
+
+
 def create_transaction_event_for_transaction_session(
     request_event: TransactionEvent,
     app: App,
@@ -1309,27 +1412,17 @@ def create_transaction_event_for_transaction_session(
                 "modified_at",
             ]
         )
-        if transaction_item.order_id:
-            # circular import
-            from ..order.actions import order_transaction_updated
 
-            update_order_with_transaction_details(transaction_item)
-            order = cast(Order, transaction_item.order)
-            order_info = fetch_order_info(order)
-            order_transaction_updated(
-                order_info=order_info,
-                transaction_item=transaction_item,
-                manager=manager,
-                user=None,
-                app=app,
-                previous_authorized_value=previous_authorized_value,
-                previous_charged_value=previous_charged_value,
-                previous_refunded_value=previous_refunded_value,
-            )
-        elif transaction_item.checkout_id:
-            transaction_amounts_for_checkout_updated(
-                transaction_item, manager, app=app, user=None
-            )
+        process_order_or_checkout_with_transaction(
+            transaction_item,
+            manager,
+            None,
+            app,
+            previous_authorized_value=previous_authorized_value,
+            previous_charged_value=previous_charged_value,
+            previous_refunded_value=previous_refunded_value,
+        )
+
     elif event.psp_reference and transaction_item.psp_reference != event.psp_reference:
         transaction_item.psp_reference = event.psp_reference
         transaction_item.save(update_fields=["psp_reference", "modified_at"])


### PR DESCRIPTION
I want to merge this change to fix a race condition in the TransactionInitialize mutation when updating checkout/order prices


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
