### PR TITLE
fix: handle duplicate channel listings in ProductVariantBulkUpdate

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -3,8 +3,8 @@ from typing import cast
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.db.utils import IntegrityError
 from django.db.models import F, Subquery
+from django.db.utils import IntegrityError
 from django.utils import timezone
 from graphene.utils.str_converters import to_camel_case
 
@@ -730,18 +730,18 @@ class ProductVariantBulkUpdate(BaseMutation):
 
         if error_policy == ErrorPolicyEnum.REJECT_EVERYTHING.value:
             try:
-                models.ProductVariantChannelListing.objects.bulk_create(listings_to_create)
-            except IntegrityError as exc:
-                variants_data_with_errors_list.append(
-                    ProductVariantBulkError(
-                    field="channelListings",
-                    message="Duplicate Channel Listing Detected.",
-                    code=ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.value,
-                    )
+                models.ProductVariantChannelListing.objects.bulk_create(
+                    listings_to_create
                 )
+            except IntegrityError as exc:
+                raise ValidationError(
+                    "Duplicate Channel Listing Detected.",
+                    code=ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.value,
+                ) from exc
         else:
             models.ProductVariantChannelListing.objects.bulk_create(
-            listings_to_create, ignore_conflicts=True)
+                listings_to_create, ignore_conflicts=True
+            )
         models.ProductVariantChannelListing.objects.bulk_update(
             listings_to_update,
             fields=[


### PR DESCRIPTION
This is the fix for Duplicate Channel Listing issue in product_variant_bulk_update.py file when we try to bulk create Channel Listing but it throws Internal Server Error 500 (Integrity Error)
