### PR TITLE
Fix deprecation warning in the test.

### DIFF
--- a/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -556,7 +557,10 @@ def test_account_reset_password_no_channel_provided_one_channel(
     }
 
     # when
-    response = api_client.post_graphql(REQUEST_PASSWORD_RESET_MUTATION, variables)
+    # Catch deprecation warning for missing channel slug
+    # This is to ensure that the warning is not raised in the test output.
+    with warnings.catch_warnings(record=True):
+        response = api_client.post_graphql(REQUEST_PASSWORD_RESET_MUTATION, variables)
     content = get_graphql_content(response)
 
     # then


### PR DESCRIPTION
I want to merge this change because it fixes the deprecation warning in the test.


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
