### PR TITLE
Extend `AttributePageWhereInput` to allow filtering by assigned references

### DIFF
--- a/saleor/graphql/core/filters/where_input.py
+++ b/saleor/graphql/core/filters/where_input.py
@@ -56,6 +56,8 @@ class FilterInputDescriptions:
     ONE_OF = "The value included in."
     NOT_ONE_OF = "The value not included in."
     RANGE = "The value in range."
+    CONTAINS_ALL = "The field contains all of the specified values."
+    CONTAINS_ANY = "The field contains at least one of the specified values."
 
 
 class StringFilterInput(graphene.InputObjectType):
@@ -182,3 +184,21 @@ class MetadataFilterInput(graphene.InputObjectType):
         - `{key: "status", value: {eq: "active"}}`
           Matches objects where the metadata key "status" is set to "active".
         """
+
+
+class ContainsFilterInput(graphene.InputObjectType):
+    contains_any = NonNullList(
+        graphene.String,
+        description=FilterInputDescriptions.CONTAINS_ANY,
+        required=False,
+    )
+    contains_all = NonNullList(
+        graphene.String,
+        description=FilterInputDescriptions.CONTAINS_ALL,
+        required=False,
+    )
+
+    class Meta:
+        description = (
+            "Define the filtering options for fields that can contain multiple values."
+        )

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import django_filters
 import graphene
 from django.db.models import Exists, FloatField, OuterRef, Q
@@ -7,6 +9,13 @@ from graphql import GraphQLError
 from ...attribute import AttributeInputType
 from ...attribute.models import AssignedPageAttributeValue, Attribute, AttributeValue
 from ...page import models
+from ..attribute.filters import (
+    CONTAINS_TYPING,
+    filter_by_contains_referenced_object_ids,
+    filter_by_contains_referenced_pages,
+    filter_by_contains_referenced_products,
+    filter_by_contains_referenced_variants,
+)
 from ..core.context import ChannelQsContext
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.filters import (
@@ -22,6 +31,7 @@ from ..core.filters.where_filters import (
     OperationObjectTypeWhereFilter,
 )
 from ..core.filters.where_input import (
+    ContainsFilterInput,
     DecimalFilterInput,
     GlobalIDFilterInput,
     StringFilterInput,
@@ -212,9 +222,122 @@ def filter_pages_by_attributes(qs, value):
             attr_filter_expression &= filter_by_date_time_attribute(
                 attr.id, attr_value["date_time"], qs.db
             )
+        elif attr.input_type == AttributeInputType.REFERENCE:
+            attr_filter_expression &= filter_pages_by_reference_attributes(
+                attr.id, attr_value["reference"], qs.db
+            )
     if attr_filter_expression != Q():
         return qs.filter(attr_filter_expression)
     return qs.none()
+
+
+def filter_pages_by_reference_attributes(
+    attr_id: int | None,
+    attr_value: dict[
+        Literal[
+            "referenced_ids", "page_slugs", "product_slugs", "product_variant_skus"
+        ],
+        CONTAINS_TYPING,
+    ],
+    db_connection_name: str,
+):
+    filter_expression = Q()
+    if "referenced_ids" in attr_value:
+        filter_expression &= filter_by_contains_referenced_object_ids(
+            attr_id,
+            attr_value["referenced_ids"],
+            db_connection_name,
+            assigned_attr_model=AssignedPageAttributeValue,
+            assigned_id_field_name="page_id",
+        )
+    if "page_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_pages(
+            attr_id,
+            attr_value["page_slugs"],
+            db_connection_name,
+            identifier_field_name="slug",
+            assigned_attr_model=AssignedPageAttributeValue,
+            assigned_id_field_name="page_id",
+        )
+    if "product_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_products(
+            attr_id,
+            attr_value["product_slugs"],
+            db_connection_name,
+            identifier_field_name="slug",
+            assigned_attr_model=AssignedPageAttributeValue,
+            assigned_id_field_name="page_id",
+        )
+    if "product_variant_skus" in attr_value:
+        filter_expression &= filter_by_contains_referenced_variants(
+            attr_id,
+            attr_value["product_variant_skus"],
+            db_connection_name,
+            identifier_field_name="sku",
+            assigned_attr_model=AssignedPageAttributeValue,
+            assigned_id_field_name="page_id",
+        )
+    return filter_expression
+
+
+def validate_attribute_value_reference_input(
+    values: list[
+        dict[
+            Literal[
+                "referenced_ids", "page_slugs", "product_slugs", "product_variant_skus"
+            ],
+            CONTAINS_TYPING,
+        ]
+        | None
+    ],
+):
+    """Validate the input for reference attributes.
+
+    This function checks if the input for reference attributes is valid.
+    It raises a GraphQLError if the input is invalid.
+    """
+    duplicated_error = []
+    empty_input_value_error = set()
+    for value in values:
+        if not value:
+            raise GraphQLError(
+                message="Invalid input for reference attributes. "
+                "Provided 'value' cannot be null or empty."
+            )
+        for key in value:
+            single_key_value = value[key]
+            if (
+                "contains_all" in single_key_value
+                and "contains_any" in single_key_value
+            ):
+                duplicated_error.append(key)
+                continue
+            if (
+                "contains_all" in single_key_value
+                and not single_key_value["contains_all"]
+            ):
+                empty_input_value_error.add(key)
+                continue
+            if (
+                "contains_any" in single_key_value
+                and not single_key_value["contains_any"]
+            ):
+                empty_input_value_error.add(key)
+
+    if empty_input_value_error:
+        raise GraphQLError(
+            message=(
+                f"Invalid input for reference attributes. For fields: {', '.join(empty_input_value_error)}. "
+                f"Provided values cannot be null or empty."
+            )
+        )
+    if duplicated_error:
+        raise GraphQLError(
+            message=(
+                f"Invalid input for reference attributes. For fields: {', '.join(duplicated_error)}. "
+                "Cannot provide both 'containsAll' and 'containsAny' for the same reference filter."
+            )
+        )
 
 
 def validate_attribute_value_input(attributes: list[dict], db_connection_name: str):
@@ -222,6 +345,7 @@ def validate_attribute_value_input(attributes: list[dict], db_connection_name: s
     value_as_empty_list = []
     value_more_than_one_list = []
     invalid_input_type_list = []
+    reference_value_list = []
     if len(slug_list) != len(set(slug_list)):
         raise GraphQLError(
             message="Duplicated attribute slugs in attribute 'where' input are not allowed."
@@ -245,6 +369,8 @@ def validate_attribute_value_input(attributes: list[dict], db_connection_name: s
         if value[value_key] is None:
             value_as_empty_list.append(attr["slug"])
             continue
+        if value_key == "reference":
+            reference_value_list.append(value["reference"])
 
     if type_specific_value_list:
         attribute_input_type_map = Attribute.objects.using(db_connection_name).in_bulk(
@@ -265,6 +391,10 @@ def validate_attribute_value_input(attributes: list[dict], db_connection_name: s
                 invalid_input_type_list.append(attr_slug)
             if "boolean" == value_key and input_type != AttributeInputType.BOOLEAN:
                 invalid_input_type_list.append(attr_slug)
+            if "reference" == value_key and input_type != AttributeInputType.REFERENCE:
+                invalid_input_type_list.append(attr_slug)
+
+    validate_attribute_value_reference_input(reference_value_list)
 
     if value_as_empty_list:
         raise GraphQLError(
@@ -289,6 +419,26 @@ def validate_attribute_value_input(attributes: list[dict], db_connection_name: s
         )
 
 
+class ReferenceAttributeWhereInput(BaseInputObjectType):
+    referenced_ids = ContainsFilterInput(
+        description="Returns objects with a reference pointing to an object identified by the given ID.",
+    )
+    page_slugs = ContainsFilterInput(
+        description="Returns objects with a reference pointing to a page identified by the given slug.",
+    )
+    product_slugs = ContainsFilterInput(
+        description=(
+            "Returns objects with a reference pointing to a product identified by the given slug."
+        )
+    )
+    product_variant_skus = ContainsFilterInput(
+        description=(
+            "Returns objects with a reference pointing "
+            "to a product variant identified by the given sku."
+        )
+    )
+
+
 class AttributeValuePageInput(BaseInputObjectType):
     slug = StringFilterInput(
         description="Filter by slug assigned to AttributeValue.",
@@ -311,6 +461,10 @@ class AttributeValuePageInput(BaseInputObjectType):
     boolean = graphene.Boolean(
         required=False,
         description="Filter by boolean value for attributes of boolean type.",
+    )
+    reference = ReferenceAttributeWhereInput(
+        required=False,
+        description=("Filter by reference attribute value. "),
     )
 
 

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -464,7 +464,7 @@ class AttributeValuePageInput(BaseInputObjectType):
     )
     reference = ReferenceAttributeWhereInput(
         required=False,
-        description=("Filter by reference attribute value. "),
+        description=("Filter by reference attribute value."),
     )
 
 

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -242,6 +242,7 @@ def filter_pages_by_reference_attributes(
     db_connection_name: str,
 ):
     filter_expression = Q()
+
     if "referenced_ids" in attr_value:
         filter_expression &= filter_by_contains_referenced_object_ids(
             attr_id,
@@ -255,7 +256,6 @@ def filter_pages_by_reference_attributes(
             attr_id,
             attr_value["page_slugs"],
             db_connection_name,
-            identifier_field_name="slug",
             assigned_attr_model=AssignedPageAttributeValue,
             assigned_id_field_name="page_id",
         )
@@ -264,7 +264,6 @@ def filter_pages_by_reference_attributes(
             attr_id,
             attr_value["product_slugs"],
             db_connection_name,
-            identifier_field_name="slug",
             assigned_attr_model=AssignedPageAttributeValue,
             assigned_id_field_name="page_id",
         )
@@ -273,7 +272,6 @@ def filter_pages_by_reference_attributes(
             attr_id,
             attr_value["product_variant_skus"],
             db_connection_name,
-            identifier_field_name="sku",
             assigned_attr_model=AssignedPageAttributeValue,
             assigned_id_field_name="page_id",
         )

--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -141,7 +141,7 @@ def test_pages_query_with_filter_by_page_type(
     [
         ({"slugs": ["test-url-1"]}, 1),
         ({"slugs": ["test-url-1", "test-url-2"]}, 2),
-        ({"slugs": []}, 2),
+        ({"slugs": []}, 4),
     ],
 )
 def test_pages_with_filtering(filter_by, pages_count, staff_api_client, page_list):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13033,6 +13033,42 @@ input AttributeValuePageInput {
 
   """Filter by boolean value for attributes of boolean type."""
   boolean: Boolean
+
+  """Filter by reference attribute value."""
+  reference: ReferenceAttributeWhereInput
+}
+
+input ReferenceAttributeWhereInput {
+  """
+  Returns objects with a reference pointing to an object identified by the given ID.
+  """
+  referencedIds: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a page identified by the given slug.
+  """
+  pageSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product identified by the given slug.
+  """
+  productSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product variant identified by the given sku.
+  """
+  productVariantSkus: ContainsFilterInput
+}
+
+"""
+Define the filtering options for fields that can contain multiple values.
+"""
+input ContainsFilterInput {
+  """The field contains at least one of the specified values."""
+  containsAny: [String!]
+
+  """The field contains all of the specified values."""
+  containsAll: [String!]
 }
 
 type PageTypeCountableConnection @doc(category: "Pages") {

--- a/saleor/page/tests/fixtures/page.py
+++ b/saleor/page/tests/fixtures/page.py
@@ -63,7 +63,23 @@ def page_list(db, page_type):
         "is_published": True,
         "page_type": page_type,
     }
-    pages = Page.objects.bulk_create([Page(**data_1), Page(**data_2)])
+    data_3 = {
+        "slug": "test3",
+        "title": "Test page3",
+        "content": dummy_editorjs("Test content."),
+        "is_published": True,
+        "page_type": page_type,
+    }
+    data_4 = {
+        "slug": "test4",
+        "title": "Test page4",
+        "content": dummy_editorjs("Test content."),
+        "is_published": True,
+        "page_type": page_type,
+    }
+    pages = Page.objects.bulk_create(
+        [Page(**data_1), Page(**data_2), Page(**data_3), Page(**data_4)]
+    )
     return pages
 
 


### PR DESCRIPTION
I want to merge this change because it adds support  to reference attributes.
It itroduces:
- `contains` structures to support approaches like contain all, or contain any
  -  `containsAll` - return the records that have all listed references
  - `containsAny` - return the records that have at least sinlge reference
- search by the slug of referenced variant, product or page

Input like below:
```graphql
{
  pages(
    first:100
    where: {
      attributes:[
        {
          slug:"ref2",
          value:{
            reference:{
              productSlugs: {
                containsAll: ["p1","p2"],
              }
            }
          }
        }
      ]
    }
  )
```
will return only pages that have relation to product with slug `p1` and `p2`

Task related to this PR: https://linear.app/saleor/issue/ENG-343/ability-to-filter-pagesproductsvariants-based-by-reference

[Explain](https://explain.dalibo.com/plan/1510g9gbgg0187c7) for query: 
```graphql
{
  pages(
    first:100
    where: {
      attributes:[
        {
          slug:"tags-6d6c2dbf",
          value:{
            reference:{
              productVariantSkus: {
                containsAny: ["tt"],
              }
            }
          }
        },
        {
          slug:"ref"
          value: {
            reference:{
              productSlugs: {
                containsAny: ["apple-juice",]
              }
            }
          }
        },
        {
          slug:"ref2"
          value: {
            reference:{
              pageSlugs: {
                containsAny: ["one",]
              }
            }
          }
        }
      ]
    }
  ){
    totalCount
    edges{
      node{
        id
      }
    }
  }
}
```


> [!NOTE]  
> Some logic is places in attribtue/filters file. It is expected. These functions are generic, and I am going to use them in queries like `products` or `pages` in next PRs.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
