### PR TITLE
Deprecate plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,3 +123,16 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed bug when not-authenticated staff user couldn't fetch `appExtension.app` without `MANAGE_APPS`. Now apps access is available by staff users and the app itself (for app and extension it owns)
 
 - Fixed bug in user email filtering to make it case-insensitive.
+
+### Deprecations
+
+Following plugins are now marked as deprecated:
+
+- Braintree (`mirumee.payments.braintree`)
+- Razorpay (`mirumme.payments.razorpay`)
+- Sendgrid (`mirumee.notifications.sendgrid_email`)
+- Dummy (`mirumee.payments.dummy`)
+- DummyCreditCard (`mirumee.payments.dummy_credit_card`)
+- Avalara (`mirumee.taxes.avalara`)
+
+We plan to remove deprecated plugins in the future versions of Saleor. We recommend you use [Saleor apps](https://apps.saleor.io/) instead.

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -23,7 +23,7 @@ from ...core.taxes import (
 )
 from ...graphql.core.utils import to_global_id_or_none
 from ...plugins import PLUGIN_IDENTIFIER_PREFIX
-from ...plugins.avatax.plugin import AvataxPlugin
+from ...plugins.avatax.plugin import DeprecatedAvataxPlugin
 from ...plugins.avatax.tests.conftest import plugin_configuration  # noqa: F401
 from ...plugins.manager import get_plugins_manager
 from ...plugins.tests.sample_plugins import PluginSample
@@ -1107,7 +1107,7 @@ def test_fetch_checkout_data_tax_data_missing_tax_id_empty_tax_data(
 
 
 @patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_fetch_order_data_plugin_tax_data_with_negative_values(
     mock_get_tax_data,
     checkout_with_item_and_shipping,
@@ -1118,7 +1118,7 @@ def test_fetch_order_data_plugin_tax_data_with_negative_values(
     checkout = checkout_with_item_and_shipping
 
     channel = checkout.channel
-    channel.tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    channel.tax_configuration.tax_app_id = DeprecatedAvataxPlugin.PLUGIN_IDENTIFIER
     channel.tax_configuration.save(update_fields=["tax_app_id"])
 
     tax_data = {
@@ -1152,7 +1152,7 @@ def test_fetch_order_data_plugin_tax_data_with_negative_values(
 
 
 @patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_fetch_order_data_plugin_tax_data_price_overflow(
     mock_get_tax_data,
     checkout_with_item_and_shipping,
@@ -1163,7 +1163,7 @@ def test_fetch_order_data_plugin_tax_data_price_overflow(
     checkout = checkout_with_item_and_shipping
 
     channel = checkout.channel
-    channel.tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    channel.tax_configuration.tax_app_id = DeprecatedAvataxPlugin.PLUGIN_IDENTIFIER
     channel.tax_configuration.save(update_fields=["tax_app_id"])
 
     tax_data = {

--- a/saleor/core/management/commands/populatedb.py
+++ b/saleor/core/management/commands/populatedb.py
@@ -1,7 +1,6 @@
 from io import StringIO
 
 from django.apps import apps
-from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import connection
@@ -83,11 +82,7 @@ class Command(BaseCommand):
         user_password = options["user_password"]
         staff_password = options["staff_password"]
         superuser_password = options["superuser_password"]
-        settings.PLUGINS = [
-            "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
-            "saleor.payment.gateways.dummy_credit_card.plugin."
-            "DummyCreditCardGatewayPlugin",
-        ]
+
         create_images = not options["withoutimages"]
         for msg in create_channels():
             self.stdout.write(msg)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -2924,7 +2924,7 @@ def test_checkout_complete_checkout_without_lines(
 @pytest.mark.parametrize(("token", "error"), list(TOKEN_VALIDATION_MAPPING.items()))
 @patch(
     "saleor.payment.gateways.dummy_credit_card.plugin."
-    "DummyCreditCardGatewayPlugin.DEFAULT_ACTIVE",
+    "DeprecatedDummyCreditCardGatewayPlugin.DEFAULT_ACTIVE",
     True,
 )
 def test_checkout_complete_error_in_gateway_response_for_dummy_credit_card(
@@ -5827,7 +5827,7 @@ def test_checkout_complete_empty_product_translation(
 @override_settings(
     PLUGINS=[
         "saleor.plugins.webhook.plugin.WebhookPlugin",
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin",
     ]
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")

--- a/saleor/graphql/invoice/tests/test_invoice_request.py
+++ b/saleor/graphql/invoice/tests/test_invoice_request.py
@@ -36,7 +36,7 @@ INVOICE_REQUEST_MUTATION = """
 @pytest.fixture(autouse=True)
 def setup_dummy_gateways(settings):
     settings.PLUGINS = [
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin",
     ]
     return settings
 

--- a/saleor/graphql/invoice/tests/test_invoice_request_delete.py
+++ b/saleor/graphql/invoice/tests/test_invoice_request_delete.py
@@ -24,7 +24,7 @@ INVOICE_REQUEST_DELETE_MUTATION = """
 @pytest.fixture(autouse=True)
 def setup_dummy_gateways(settings):
     settings.PLUGINS = [
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin",
     ]
     return settings
 

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -182,7 +182,7 @@ def test_order_capture_by_app(
 @override_settings(
     PLUGINS=[
         "saleor.plugins.webhook.plugin.WebhookPlugin",
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin",
     ]
 )
 def test_order_capture_triggers_webhooks(

--- a/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
@@ -321,7 +321,7 @@ def test_checkout_add_payment_no_checkout_email(
 
 
 @patch(
-    "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin.CONFIGURATION_PER_CHANNEL",
+    "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin.CONFIGURATION_PER_CHANNEL",
     False,
 )
 def test_checkout_add_payment_not_supported_currency(
@@ -371,7 +371,10 @@ def test_checkout_add_payment_not_existing_gateway(
     assert data["errors"][0]["field"] == "gateway"
 
 
-@patch("saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin.DEFAULT_ACTIVE", False)
+@patch(
+    "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin.DEFAULT_ACTIVE",
+    False,
+)
 def test_checkout_add_payment_gateway_inactive(
     user_api_client, checkout_without_shipping_required, address
 ):

--- a/saleor/graphql/payment/tests/mutations/test_payment_capture.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_capture.py
@@ -183,7 +183,7 @@ def test_payment_capture_gateway_error(
 
 @patch(
     "saleor.payment.gateways.dummy_credit_card.plugin."
-    "DummyCreditCardGatewayPlugin.DEFAULT_ACTIVE",
+    "DeprecatedDummyCreditCardGatewayPlugin.DEFAULT_ACTIVE",
     True,
 )
 def test_payment_capture_gateway_dummy_credit_card_error(

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -19,7 +19,7 @@ from ...discount import DiscountValueType
 from ...graphql.core.utils import to_global_id_or_none
 from ...order.utils import get_order_country
 from ...plugins import PLUGIN_IDENTIFIER_PREFIX
-from ...plugins.avatax.plugin import AvataxPlugin
+from ...plugins.avatax.plugin import DeprecatedAvataxPlugin
 from ...plugins.avatax.tests.conftest import plugin_configuration  # noqa: F401
 from ...plugins.manager import get_plugins_manager
 from ...plugins.tests.sample_plugins import PluginSample
@@ -1700,7 +1700,7 @@ def test_fetch_order_data_tax_data_missing_tax_id_empty_tax_data(
 
 
 @patch("saleor.plugins.avatax.plugin.get_order_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_fetch_order_data_plugin_tax_data_with_negative_values(
     mock_get_tax_data,
     order_with_lines,
@@ -1711,7 +1711,7 @@ def test_fetch_order_data_plugin_tax_data_with_negative_values(
     order = order_with_lines
 
     channel = order.channel
-    channel.tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    channel.tax_configuration.tax_app_id = DeprecatedAvataxPlugin.PLUGIN_IDENTIFIER
     channel.tax_configuration.save(update_fields=["tax_app_id"])
 
     tax_data = {
@@ -1748,7 +1748,7 @@ def test_fetch_order_data_plugin_tax_data_with_negative_values(
 
 
 @patch("saleor.plugins.avatax.plugin.get_order_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_fetch_order_data_plugin_tax_data_price_overflow(
     mock_get_tax_data,
     order_with_lines,
@@ -1759,7 +1759,7 @@ def test_fetch_order_data_plugin_tax_data_price_overflow(
     order = order_with_lines
 
     channel = order.channel
-    channel.tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    channel.tax_configuration.tax_app_id = DeprecatedAvataxPlugin.PLUGIN_IDENTIFIER
     channel.tax_configuration.save(update_fields=["tax_app_id"])
 
     tax_data = {

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -21,7 +21,12 @@ if TYPE_CHECKING:
     from . import GatewayResponse, PaymentData, TokenConfig
 
 
-class BraintreeGatewayPlugin(BasePlugin):
+class DeprecatedBraintreeGatewayPlugin(BasePlugin):
+    """Deprecated.
+
+    This plugin is deprecated and will be removed in future version.
+    """
+
     PLUGIN_ID = "mirumee.payments.braintree"
     PLUGIN_NAME = GATEWAY_NAME
     CONFIGURATION_PER_CHANNEL = True

--- a/saleor/payment/gateways/dummy/plugin.py
+++ b/saleor/payment/gateways/dummy/plugin.py
@@ -20,7 +20,12 @@ if TYPE_CHECKING:
     from ...interface import GatewayResponse, PaymentData, TokenConfig
 
 
-class DummyGatewayPlugin(BasePlugin):
+class DeprecatedDummyGatewayPlugin(BasePlugin):
+    """Deprecated.
+
+    This plugin is deprecated and will be removed in future version.
+    """
+
     PLUGIN_ID = "mirumee.payments.dummy"
     PLUGIN_NAME = GATEWAY_NAME
     DEFAULT_ACTIVE = True

--- a/saleor/payment/gateways/dummy/tests/test_dummy.py
+++ b/saleor/payment/gateways/dummy/tests/test_dummy.py
@@ -8,7 +8,9 @@ from .... import ChargeStatus, PaymentError, TransactionKind, gateway
 
 @pytest.fixture(autouse=True)
 def setup_dummy_gateway(settings):
-    settings.PLUGINS = ["saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin"]
+    settings.PLUGINS = [
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin"
+    ]
     return settings
 
 

--- a/saleor/payment/gateways/dummy_credit_card/plugin.py
+++ b/saleor/payment/gateways/dummy_credit_card/plugin.py
@@ -20,7 +20,12 @@ if TYPE_CHECKING:
     from ...interface import GatewayResponse, PaymentData, TokenConfig
 
 
-class DummyCreditCardGatewayPlugin(BasePlugin):
+class DeprecatedDummyCreditCardGatewayPlugin(BasePlugin):
+    """Deprecated.
+
+    This plugin is deprecated and will be removed in future version.
+    """
+
     PLUGIN_ID = "mirumee.payments.dummy_credit_card"
     PLUGIN_NAME = GATEWAY_NAME
     DEFAULT_ACTIVE = False

--- a/saleor/payment/gateways/dummy_credit_card/tests/test_dummy_credit_card.py
+++ b/saleor/payment/gateways/dummy_credit_card/tests/test_dummy_credit_card.py
@@ -14,7 +14,7 @@ from .. import (
     refund,
     void,
 )
-from ..plugin import DummyCreditCardGatewayPlugin
+from ..plugin import DeprecatedDummyCreditCardGatewayPlugin
 
 NO_LONGER_ACTIVE = "This payment is no longer active."
 CANNOT_BE_AUTHORIZED_AGAIN = "Charged transactions cannot be authorized again."
@@ -27,9 +27,9 @@ CANNOT_CHARGE_MORE_THAN_UNCAPTURED = "Unable to charge more than un-captured amo
 
 @pytest.fixture(autouse=True)
 def setup_dummy_credit_card_gateway(settings):
-    DummyCreditCardGatewayPlugin.DEFAULT_ACTIVE = True
+    DeprecatedDummyCreditCardGatewayPlugin.DEFAULT_ACTIVE = True
     settings.PLUGINS = [
-        "saleor.payment.gateways.dummy_credit_card.plugin.DummyCreditCardGatewayPlugin"
+        "saleor.payment.gateways.dummy_credit_card.plugin.DeprecatedDummyCreditCardGatewayPlugin"
     ]
     return settings
 
@@ -437,7 +437,7 @@ def test_process_payment_pre_authorized(
     dummy_gateway_config.auto_capture = False
     monkeypatch.setattr(
         "saleor.payment.gateways.dummy_credit_card.plugin."
-        "DummyCreditCardGatewayPlugin._get_gateway_config",
+        "DeprecatedDummyCreditCardGatewayPlugin._get_gateway_config",
         lambda _: dummy_gateway_config,
     )
 
@@ -466,7 +466,7 @@ def test_process_payment_pre_authorized_and_capture(
     dummy_gateway_config.auto_capture = True
     monkeypatch.setattr(
         "saleor.payment.gateways.dummy_credit_card.plugin."
-        "DummyCreditCardGatewayPlugin._get_gateway_config",
+        "DeprecatedDummyCreditCardGatewayPlugin._get_gateway_config",
         lambda _: dummy_gateway_config,
     )
 
@@ -495,7 +495,7 @@ def test_process_payment_pre_authorized_and_capture_error(
     dummy_gateway_config.auto_capture = True
     monkeypatch.setattr(
         "saleor.payment.gateways.dummy_credit_card.plugin."
-        "DummyCreditCardGatewayPlugin._get_gateway_config",
+        "DeprecatedDummyCreditCardGatewayPlugin._get_gateway_config",
         lambda _: dummy_gateway_config,
     )
 

--- a/saleor/payment/gateways/razorpay/plugin.py
+++ b/saleor/payment/gateways/razorpay/plugin.py
@@ -11,7 +11,12 @@ if TYPE_CHECKING:
     from . import GatewayResponse, PaymentData
 
 
-class RazorpayGatewayPlugin(BasePlugin):
+class DeprecatedRazorpayGatewayPlugin(BasePlugin):
+    """Deprecated.
+
+    This plugin is deprecated and will be removed in future version.
+    """
+
     PLUGIN_NAME = GATEWAY_NAME
     PLUGIN_ID = "mirumee.payments.razorpay"
     DEFAULT_CONFIGURATION = [

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -690,7 +690,7 @@ def test_is_currency_supported(
     manager = get_plugins_manager(allow_replica=False)
     dummy_gateway_config.supported_currencies = "USD, EUR"
     monkeypatch.setattr(
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin._get_gateway_config",
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin._get_gateway_config",
         lambda _: dummy_gateway_config,
     )
 

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -76,9 +76,14 @@ def _get_prices_entered_with_tax_for_order(order: "Order"):
     return tax_configuration.prices_entered_with_tax
 
 
-class AvataxPlugin(BasePlugin):
-    PLUGIN_NAME = "Avalara"
+class DeprecatedAvataxPlugin(BasePlugin):
+    """Deprecated.
+
+    This plugin is deprecated and will be removed in future version.
+    """
+
     PLUGIN_ID = "mirumee.taxes.avalara"
+    PLUGIN_NAME = "Avalara"
     # identifier used in tax configuration
     PLUGIN_IDENTIFIER = PLUGIN_IDENTIFIER_PREFIX + PLUGIN_ID
 

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from ....account.models import Address
 from ...models import PluginConfiguration
 from .. import AvataxConfiguration
-from ..plugin import AvataxPlugin
+from ..plugin import DeprecatedAvataxPlugin
 
 
 @pytest.fixture(scope="module")
@@ -36,7 +36,7 @@ def plugin_configuration(db, channel_USD):
         channel = channel or channel_USD
         data = {
             "active": active,
-            "name": AvataxPlugin.PLUGIN_NAME,
+            "name": DeprecatedAvataxPlugin.PLUGIN_NAME,
             "channel": channel,
             "configuration": [
                 {"name": "Username or account", "value": username},
@@ -53,7 +53,7 @@ def plugin_configuration(db, channel_USD):
             ],
         }
         configuration = PluginConfiguration.objects.create(
-            identifier=AvataxPlugin.PLUGIN_ID, **data
+            identifier=DeprecatedAvataxPlugin.PLUGIN_ID, **data
         )
         return configuration
 

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -56,7 +56,7 @@ from .. import (
     get_order_tax_data,
     taxes_need_new_fetch,
 )
-from ..plugin import AvataxPlugin, logger
+from ..plugin import DeprecatedAvataxPlugin, logger
 
 
 def order_set_shipping_method(order, shipping_method):
@@ -86,7 +86,7 @@ def assign_tax_code_to_object_meta(obj: "TaxClass", tax_code: str):
         ("30.00", "36.90", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total(
     expected_net,
     expected_gross,
@@ -140,7 +140,7 @@ def test_calculate_checkout_line_total(
         ("15.00", "18.45", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_with_promotion(
     expected_net,
     expected_gross,
@@ -192,7 +192,7 @@ def test_calculate_checkout_line_total_with_promotion(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_with_variant_on_promotion(
     checkout_with_item_on_promotion,
     shipping_zone,
@@ -248,7 +248,7 @@ def test_calculate_checkout_line_total_with_variant_on_promotion(
         ("25.00", "30.75", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_with_order_promotion(
     expected_net,
     expected_gross,
@@ -300,7 +300,7 @@ def test_calculate_checkout_line_total_with_order_promotion(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_gift_promotion_line(
     checkout_with_item_and_gift_promotion,
     ship_to_pl_address,
@@ -346,7 +346,7 @@ def test_calculate_checkout_line_total_gift_promotion_line(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_with_voucher(
     checkout_with_item,
     shipping_zone,
@@ -409,7 +409,7 @@ def test_calculate_checkout_line_total_with_voucher(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_with_voucher_once_per_order(
     checkout_with_item,
     shipping_zone,
@@ -469,7 +469,7 @@ def test_calculate_checkout_line_total_with_voucher_once_per_order(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_with_variant_on_promotion_and_voucher(
     checkout_with_item_on_promotion,
     shipping_zone,
@@ -528,7 +528,7 @@ def test_calculate_checkout_line_total_with_variant_on_promotion_and_voucher(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_total_with_variant_on_promotion_and_voucher_only_once(
     checkout_with_item_on_promotion,
     shipping_zone,
@@ -595,7 +595,7 @@ def test_calculate_checkout_line_total_with_variant_on_promotion_and_voucher_onl
         ("30.00", "36.90", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_without_sku_total(
     expected_net,
     expected_gross,
@@ -655,7 +655,7 @@ def test_calculate_checkout_line_without_sku_total(
         ("15.00", "18.45", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_without_sku_total_with_promotion(
     expected_net,
     expected_gross,
@@ -713,7 +713,7 @@ def test_calculate_checkout_line_without_sku_total_with_promotion(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_total(
     order_line,
     address,
@@ -775,7 +775,7 @@ def test_calculate_order_line_total(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_without_sku_total(
     order_line,
     address,
@@ -833,7 +833,7 @@ def test_calculate_order_line_without_sku_total(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_total_with_discount(
     order_line,
     address,
@@ -908,7 +908,7 @@ def test_calculate_order_line_total_with_discount(
         ("20.00", "24.60", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_total_entire_order_voucher(
     expected_net,
     expected_gross,
@@ -998,7 +998,7 @@ def test_calculate_order_line_total_entire_order_voucher(
         ("30.00", "36.90", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_total_shipping_voucher(
     expected_net,
     expected_gross,
@@ -1079,7 +1079,7 @@ def test_calculate_order_line_total_shipping_voucher(
     )
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_total_order_not_valid(
     order_line,
     address,
@@ -1124,7 +1124,7 @@ def test_calculate_order_line_total_order_not_valid(
     assert total == expected_total_price
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping_order_not_valid(
     order_line,
     address,
@@ -1182,7 +1182,7 @@ def test_calculate_order_shipping_order_not_valid(
         ("32.04", "38.99", "3.0", True),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_uses_default_calculation(
     expected_net,
     expected_gross,
@@ -1248,7 +1248,7 @@ def test_calculate_checkout_total_uses_default_calculation(
         ("21.99", "26.73", "5.0", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_uses_default_calculation_with_promotion(
     expected_net,
     expected_gross,
@@ -1319,7 +1319,7 @@ def test_calculate_checkout_total_uses_default_calculation_with_promotion(
         ("32.04", "38.99", "3.0", True),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total(
     expected_net,
     expected_gross,
@@ -1342,7 +1342,8 @@ def test_calculate_checkout_total(
         lambda _: {"PS081282": "desc", TAX_CODE_NON_TAXABLE_PRODUCT: "desc"},
     )
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
+        lambda *_: False,
     )
     manager = get_plugins_manager(allow_replica=False)
     checkout_with_item.shipping_address = ship_to_pl_address
@@ -1386,7 +1387,7 @@ def test_calculate_checkout_total(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_with_order_promotion(
     checkout_with_item_and_order_discount,
     shipping_zone,
@@ -1404,7 +1405,8 @@ def test_calculate_checkout_total_with_order_promotion(
         lambda _: {"PS081282": "desc", TAX_CODE_NON_TAXABLE_PRODUCT: "desc"},
     )
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
+        lambda *_: False,
     )
     manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = ship_to_pl_address
@@ -1449,7 +1451,7 @@ def test_calculate_checkout_total_with_order_promotion(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_with_gift_promotion(
     checkout_with_item_and_gift_promotion,
     shipping_zone,
@@ -1466,7 +1468,8 @@ def test_calculate_checkout_total_with_gift_promotion(
         lambda _: {"PS081282": "desc", TAX_CODE_NON_TAXABLE_PRODUCT: "desc"},
     )
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
+        lambda *_: False,
     )
     manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = ship_to_pl_address
@@ -1518,7 +1521,7 @@ def test_calculate_checkout_total_with_gift_promotion(
         # ("21.99", "26.73", "5.0", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_with_promotion(
     expected_net,
     expected_gross,
@@ -1542,7 +1545,8 @@ def test_calculate_checkout_total_with_promotion(
         lambda _: {"PS081282": "desc", TAX_CODE_NON_TAXABLE_PRODUCT: "desc"},
     )
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
+        lambda *_: False,
     )
     manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item_on_promotion
@@ -1598,7 +1602,7 @@ def test_calculate_checkout_total_with_promotion(
         ("3493", "4297", "3.0", True),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_for_JPY(
     expected_net,
     expected_gross,
@@ -1620,7 +1624,8 @@ def test_calculate_checkout_total_for_JPY(
         lambda _: {"PS081282": "desc", TAX_CODE_NON_TAXABLE_PRODUCT: "desc"},
     )
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
+        lambda *_: False,
     )
     manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = ship_to_pl_address
@@ -1671,7 +1676,7 @@ def test_calculate_checkout_total_for_JPY(
         ("4280", "5264", "5.0", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_for_JPY_with_promotion(
     expected_net,
     expected_gross,
@@ -1693,7 +1698,8 @@ def test_calculate_checkout_total_for_JPY_with_promotion(
         lambda _: {"PS081282": "desc", TAX_CODE_NON_TAXABLE_PRODUCT: "desc"},
     )
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
+        lambda *_: False,
     )
     manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = ship_to_pl_address
@@ -1782,7 +1788,7 @@ def test_calculate_checkout_total_for_JPY_with_promotion(
         ("10.00", "12.30", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_voucher_on_entire_order(
     expected_net,
     expected_gross,
@@ -1835,7 +1841,7 @@ def test_calculate_checkout_total_voucher_on_entire_order(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_voucher_on_entire_order_applied_once_per_order(
     checkout_with_item,
     voucher_percentage,
@@ -1906,7 +1912,7 @@ def test_calculate_checkout_total_voucher_on_entire_order_applied_once_per_order
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_voucher_on_entire_order_product_without_taxes(
     checkout_with_item,
     voucher_percentage,
@@ -1973,7 +1979,7 @@ def test_calculate_checkout_total_voucher_on_entire_order_product_without_taxes(
         ("30.00", "36.90", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_voucher_on_shipping(
     expected_net,
     expected_gross,
@@ -2024,7 +2030,7 @@ def test_calculate_checkout_total_voucher_on_shipping(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_total_not_charged_product_and_shipping_with_0_price(
     checkout_with_item,
     shipping_zone,
@@ -2038,7 +2044,8 @@ def test_calculate_checkout_total_not_charged_product_and_shipping_with_0_price(
         lambda _: {"PS081282": "desc"},
     )
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
+        lambda *_: False,
     )
     manager = get_plugins_manager(allow_replica=False)
     checkout_with_item.shipping_address = ship_to_pl_address
@@ -2080,7 +2087,7 @@ def test_calculate_checkout_total_not_charged_product_and_shipping_with_0_price(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_shipping(
     checkout_with_item_on_promotion,
     shipping_zone,
@@ -2125,7 +2132,7 @@ def test_calculate_checkout_shipping(
         ("50.00", "61.50", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_subtotal(
     expected_net,
     expected_gross,
@@ -2174,7 +2181,7 @@ def test_calculate_checkout_subtotal(
         ("20.33", "25.00", True),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_subtotal_with_promotion(
     expected_net,
     expected_gross,
@@ -2232,7 +2239,7 @@ def test_calculate_checkout_subtotal_with_promotion(
     )
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_subtotal_for_product_without_tax(
     checkout,
     stock,
@@ -2282,7 +2289,7 @@ def test_calculate_checkout_subtotal_for_product_without_tax(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize("prices_entered_with_tax", [True, False])
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_subtotal_voucher_on_entire_order(
     prices_entered_with_tax,
     checkout_with_item,
@@ -2338,7 +2345,7 @@ def test_calculate_checkout_subtotal_voucher_on_entire_order(
         ("30.00", "36.90", False),
     ],
 )
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_subtotal_voucher_on_shipping(
     expected_net,
     expected_gross,
@@ -2390,7 +2397,7 @@ def test_calculate_checkout_subtotal_voucher_on_shipping(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
@@ -2411,7 +2418,7 @@ def test_calculate_order_shipping(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_total(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
@@ -2432,7 +2439,7 @@ def test_calculate_order_total(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_total_for_JPY(
     order_line_JPY,
     shipping_zone_JPY,
@@ -2462,7 +2469,7 @@ def test_calculate_order_total_for_JPY(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_total_order_promotion(
     order_with_lines_and_order_promotion,
     shipping_zone,
@@ -2487,7 +2494,7 @@ def test_calculate_order_total_order_promotion(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_total_gift_promotion(
     order_with_lines_and_gift_promotion,
     shipping_zone,
@@ -2512,7 +2519,7 @@ def test_calculate_order_total_gift_promotion(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping_entire_order_voucher(
     order_line, shipping_zone, voucher, site_settings, address, plugin_configuration
 ):
@@ -2559,7 +2566,7 @@ def test_calculate_order_shipping_entire_order_voucher(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping_free_shipping_voucher(
     order_line,
     shipping_zone,
@@ -2618,7 +2625,7 @@ def test_calculate_order_shipping_free_shipping_voucher(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping_voucher_on_shipping(
     order_line,
     shipping_zone,
@@ -2676,7 +2683,7 @@ def test_calculate_order_shipping_voucher_on_shipping(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping_zero_shipping_amount(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
@@ -2701,7 +2708,7 @@ def test_calculate_order_shipping_zero_shipping_amount(
     assert price == TaxedMoney(net=Money("0.00", "USD"), gross=Money("0.00", "USD"))
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping_base_shipping_price_0(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
@@ -2725,7 +2732,7 @@ def test_calculate_order_shipping_base_shipping_price_0(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_shipping_not_shippable_order(
     order_line, site_settings, address, plugin_configuration
 ):
@@ -2752,7 +2759,7 @@ def test_calculate_order_shipping_not_shippable_order(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_unit(
     order_line,
     shipping_zone,
@@ -2797,7 +2804,7 @@ def test_calculate_order_line_unit(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_unit_in_JPY(
     order_line_JPY,
     shipping_zone_JPY,
@@ -2844,7 +2851,7 @@ def test_calculate_order_line_unit_in_JPY(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_order_line_unit_with_discount(
     order_line,
     shipping_zone,
@@ -2894,7 +2901,7 @@ def test_calculate_order_line_unit_with_discount(
 
 @pytest.mark.vcr
 @pytest.mark.parametrize("charge_taxes", [True, False])
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price(
     charge_taxes,
     checkout_with_item,
@@ -2942,7 +2949,7 @@ def test_calculate_checkout_line_unit_price(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_in_JPY(
     checkout_JPY_with_item,
     shipping_zone_JPY,
@@ -2980,7 +2987,7 @@ def test_calculate_checkout_line_unit_price_in_JPY(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_with_variant_on_promotion(
     checkout_with_item_on_promotion,
     shipping_zone,
@@ -3025,7 +3032,7 @@ def test_calculate_checkout_line_unit_price_with_variant_on_promotion(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_order_promotion_charge_taxes(
     checkout_with_item_and_order_discount,
     shipping_zone,
@@ -3079,7 +3086,7 @@ def test_calculate_checkout_line_unit_price_order_promotion_charge_taxes(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_order_promotion_do_not_charge_taxes(
     checkout_with_item_and_order_discount,
     shipping_zone,
@@ -3131,7 +3138,7 @@ def test_calculate_checkout_line_unit_price_order_promotion_do_not_charge_taxes(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_gift_promotion_line(
     checkout_with_item_and_gift_promotion,
     shipping_zone,
@@ -3174,7 +3181,7 @@ def test_calculate_checkout_line_unit_price_gift_promotion_line(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_with_voucher(
     checkout_with_item,
     shipping_zone,
@@ -3233,7 +3240,7 @@ def test_calculate_checkout_line_unit_price_with_voucher(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_with_voucher_once_per_order(
     checkout_with_item,
     shipping_zone,
@@ -3294,7 +3301,7 @@ def test_calculate_checkout_line_unit_price_with_voucher_once_per_order(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_with_variant_on_promotion_and_voucher(
     checkout_with_item_on_promotion,
     shipping_zone,
@@ -3353,7 +3360,7 @@ def test_calculate_checkout_line_unit_price_with_variant_on_promotion_and_vouche
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_calculate_checkout_line_unit_price_variant_on_promotion_and_voucher_only_once(
     checkout_with_item_on_promotion,
     shipping_zone,
@@ -3413,7 +3420,7 @@ def test_calculate_checkout_line_unit_price_variant_on_promotion_and_voucher_onl
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation(
     checkout_with_item_on_promotion,
     monkeypatch,
@@ -3445,7 +3452,7 @@ def test_preprocess_order_creation(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_no_lines_data(
     checkout_with_item,
     monkeypatch,
@@ -3476,7 +3483,7 @@ def test_preprocess_order_creation_no_lines_data(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_wrong_data(
     checkout_with_item,
     monkeypatch,
@@ -3504,7 +3511,7 @@ def test_preprocess_order_creation_wrong_data(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_shipping_voucher_no_tax_class_on_delivery_method(
     checkout_with_item_on_promotion,
     monkeypatch,
@@ -3545,7 +3552,7 @@ def test_preprocess_order_creation_shipping_voucher_no_tax_class_on_delivery_met
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_address_error_logging(
     checkout_with_item,
     monkeypatch,
@@ -3787,7 +3794,7 @@ def test_taxes_need_new_fetch_uses_cached_data(checkout_with_item, address):
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_line_tax_rate(
     monkeypatch,
     checkout_with_item,
@@ -3842,7 +3849,7 @@ def test_get_checkout_line_tax_rate(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_line_tax_rate_for_product_with_charge_taxes_set_to_false(
     monkeypatch,
     checkout_with_item,
@@ -3907,7 +3914,7 @@ def test_get_checkout_line_tax_rate_for_product_with_charge_taxes_set_to_false(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_line_tax_rate_for_product_type_with_non_taxable_product(
     monkeypatch,
     checkout_with_item,
@@ -3983,7 +3990,7 @@ def test_get_checkout_line_tax_rate_for_product_type_with_non_taxable_product(
     assert tax_rates[1] == Decimal("0.0")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_line_tax_rate_checkout_no_shipping_method_default_value_returned(
     monkeypatch, checkout_with_item, address, plugin_configuration, site_settings
 ):
@@ -4015,7 +4022,7 @@ def test_get_checkout_line_tax_rate_checkout_no_shipping_method_default_value_re
     assert tax_rate == Decimal("0.25")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_line_tax_rate_error_in_response(
     monkeypatch, checkout_with_item, address, plugin_configuration, shipping_zone
 ):
@@ -4051,7 +4058,7 @@ def test_get_checkout_line_tax_rate_error_in_response(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_line_tax_rate(
     monkeypatch, order_line, shipping_zone, plugin_configuration, site_settings, address
 ):
@@ -4089,7 +4096,7 @@ def test_get_order_line_tax_rate(
     assert tax_rate == Decimal("0.23")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_line_tax_rate_order_not_valid_default_value_returned(
     monkeypatch, order_line, shipping_zone, plugin_configuration
 ):
@@ -4115,7 +4122,7 @@ def test_get_order_line_tax_rate_order_not_valid_default_value_returned(
     assert tax_rate == Decimal("0.25")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_line_tax_rate_error_in_response(
     monkeypatch, order_line, shipping_zone, plugin_configuration
 ):
@@ -4151,7 +4158,7 @@ def test_get_order_line_tax_rate_error_in_response(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_shipping_tax_rate(
     checkout_with_item, address, plugin_configuration, shipping_zone, site_settings
 ):
@@ -4182,12 +4189,12 @@ def test_get_checkout_shipping_tax_rate(
     assert tax_rate == Decimal("0.23")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test__get_item_tax_rate_for_shipping_handles_multiple_tax_districts(
     avalara_response_for_checkout_with_items_and_shipping, channel_USD, checkout
 ):
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
 
     # 0.46 == sum of two tax districts
     assert Decimal("0.46") == plugin._get_item_tax_rate(
@@ -4199,12 +4206,12 @@ def test__get_item_tax_rate_for_shipping_handles_multiple_tax_districts(
     ).quantize(Decimal(".01"))
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test__get_item_tax_rate_handles_multiple_tax_districts(
     avalara_response_for_checkout_with_items_and_shipping, channel_USD, checkout
 ):
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
 
     # 0.36 == sum of two tax districts
     assert Decimal("0.36") == plugin._get_item_tax_rate(
@@ -4216,14 +4223,14 @@ def test__get_item_tax_rate_handles_multiple_tax_districts(
     ).quantize(Decimal(".01"))
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test__get_item_tax_rate_handles_tax_zero_and_rate_value(
     avalara_response_with_line_details_and_zero_tax_with_returned_rate,
     channel_USD,
     checkout,
 ):
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
 
     # 0.36 == sum of two tax districts
     assert Decimal(0) == plugin._get_item_tax_rate(
@@ -4236,7 +4243,7 @@ def test__get_item_tax_rate_handles_tax_zero_and_rate_value(
 
 
 @patch("saleor.plugins.avatax.plugin.logger", wraps=logger)
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test__get_item_tax_rate_use_default_value_when_taxable_amount_is_different(
     mocked_logger,
     avalara_response_for_checkout_with_items_and_shipping,
@@ -4252,7 +4259,7 @@ def test__get_item_tax_rate_use_default_value_when_taxable_amount_is_different(
     response["lines"][0]["details"][1]["taxableAmount"] = line_taxable_amount + 2
 
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
 
     default_rate_value = Decimal("0.66")
     object_type = "Checkout"
@@ -4300,7 +4307,7 @@ def test__get_item_tax_rate_use_default_value_when_taxable_amount_is_different(
     )
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_shipping_tax_rate_checkout_not_valid_default_value_returned(
     monkeypatch, checkout_with_item, address, plugin_configuration
 ):
@@ -4328,7 +4335,7 @@ def test_get_checkout_shipping_tax_rate_checkout_not_valid_default_value_returne
     assert tax_rate == Decimal("0.25")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_shipping_tax_rate_error_in_response(
     monkeypatch, checkout_with_item, address, plugin_configuration, shipping_zone
 ):
@@ -4361,14 +4368,14 @@ def test_get_checkout_shipping_tax_rate_error_in_response(
     assert tax_rate == Decimal("0.25")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_shipping_tax_rate_skip_plugin(
     monkeypatch, checkout_with_item, address, plugin_configuration, shipping_zone
 ):
     # given
     plugin_configuration()
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin",
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
         lambda *_: True,
     )
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
@@ -4395,7 +4402,7 @@ def test_get_checkout_shipping_tax_rate_skip_plugin(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_shipping_tax_rate(
     order_line, shipping_zone, plugin_configuration, site_settings, address
 ):
@@ -4421,7 +4428,7 @@ def test_get_order_shipping_tax_rate(
 
 
 @pytest.mark.vcr
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_shipping_tax_rate_shipping_with_tax_class(
     order_line, shipping_zone, plugin_configuration, site_settings, address
 ):
@@ -4450,7 +4457,7 @@ def test_get_order_shipping_tax_rate_shipping_with_tax_class(
     assert tax_rate == Decimal("0.23")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_shipping_tax_rate_order_not_valid_default_value_returned(
     order_line, shipping_zone, plugin_configuration
 ):
@@ -4468,7 +4475,7 @@ def test_get_order_shipping_tax_rate_order_not_valid_default_value_returned(
     assert tax_rate == Decimal("0.25")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_shipping_tax_rate_error_in_response(
     monkeypatch, order_line, shipping_zone, plugin_configuration
 ):
@@ -4495,7 +4502,7 @@ def test_get_order_shipping_tax_rate_error_in_response(
     assert tax_rate == Decimal("0.25")
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_shipping_tax_rate_skip_plugin(
     monkeypatch, order_line, shipping_zone, plugin_configuration
 ):
@@ -4503,7 +4510,7 @@ def test_get_order_shipping_tax_rate_skip_plugin(
     order = order_line.order
     plugin_configuration()
     monkeypatch.setattr(
-        "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin",
+        "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin._skip_plugin",
         lambda *_: True,
     )
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
@@ -4523,9 +4530,11 @@ def test_get_order_shipping_tax_rate_skip_plugin(
 
 
 def test_get_plugin_configuration(settings, channel_USD):
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_slug=channel_USD.slug)
+    plugin = manager.get_plugin(
+        DeprecatedAvataxPlugin.PLUGIN_ID, channel_slug=channel_USD.slug
+    )
 
     configuration_fields = [
         configuration_item["name"] for configuration_item in plugin.configuration
@@ -4541,12 +4550,12 @@ def test_get_plugin_configuration(settings, channel_USD):
 def test_save_plugin_configuration(
     api_get_request_mock, settings, channel_USD, plugin_configuration
 ):
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration()
     api_get_request_mock.return_value = {"authenticated": True}
     manager = get_plugins_manager(allow_replica=False)
     manager.save_plugin_configuration(
-        AvataxPlugin.PLUGIN_ID,
+        DeprecatedAvataxPlugin.PLUGIN_ID,
         channel_USD.slug,
         {
             "active": True,
@@ -4557,10 +4566,10 @@ def test_save_plugin_configuration(
         },
     )
     manager.save_plugin_configuration(
-        AvataxPlugin.PLUGIN_ID, channel_USD.slug, {"active": True}
+        DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug, {"active": True}
     )
     plugin_configuration = PluginConfiguration.objects.get(
-        identifier=AvataxPlugin.PLUGIN_ID
+        identifier=DeprecatedAvataxPlugin.PLUGIN_ID
     )
     assert plugin_configuration.active
 
@@ -4570,7 +4579,7 @@ def test_save_plugin_configuration_authentication_failed(
     api_get_request_mock, settings, channel_USD, plugin_configuration
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(active=False)
     api_get_request_mock.return_value = {"authenticated": False}
     manager = get_plugins_manager(allow_replica=False)
@@ -4578,7 +4587,7 @@ def test_save_plugin_configuration_authentication_failed(
     # when
     with pytest.raises(ValidationError) as e:
         manager.save_plugin_configuration(
-            AvataxPlugin.PLUGIN_ID,
+            DeprecatedAvataxPlugin.PLUGIN_ID,
             channel_USD.slug,
             {
                 "active": True,
@@ -4592,7 +4601,7 @@ def test_save_plugin_configuration_authentication_failed(
     # then
     assert e._excinfo[1].args[0] == "Authentication failed. Please check provided data."
     plugin_configuration = PluginConfiguration.objects.get(
-        identifier=AvataxPlugin.PLUGIN_ID
+        identifier=DeprecatedAvataxPlugin.PLUGIN_ID
     )
     assert not plugin_configuration.active
 
@@ -4601,16 +4610,16 @@ def test_save_plugin_configuration_cannot_be_enabled_without_config(
     settings, plugin_configuration, channel_USD
 ):
     plugin_configuration(None, None)
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     manager = get_plugins_manager(allow_replica=False)
     with pytest.raises(ValidationError):
         manager.save_plugin_configuration(
-            AvataxPlugin.PLUGIN_ID, channel_USD.slug, {"active": True}
+            DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug, {"active": True}
         )
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_order_confirmed(
     api_post_request_task_mock, order, order_line, plugin_configuration
 ):
@@ -4697,7 +4706,7 @@ def test_order_confirmed(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_with_enabled_flat_rates(
     api_post_request_task_mock,
     checkout_with_item,
@@ -4740,7 +4749,7 @@ def test_preprocess_order_creation_with_enabled_flat_rates(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_with_country_exception_for_flat_rates(
     api_post_request_task_mock,
     checkout_with_item,
@@ -4788,7 +4797,7 @@ def test_preprocess_order_creation_with_country_exception_for_flat_rates(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_order_confirmed_skip_when_flat_rate_usage(
     api_post_request_task_mock, order, plugin_configuration
 ):
@@ -4817,7 +4826,7 @@ def test_order_confirmed_skip_when_flat_rate_usage(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_order_confirmed_skip_with_country_exception_for_flat_rate(
     api_post_request_task_mock, order, order_line, plugin_configuration
 ):
@@ -4851,7 +4860,7 @@ def test_order_confirmed_skip_with_country_exception_for_flat_rate(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_order_created_no_lines(
     api_post_request_task_mock, order, plugin_configuration
 ):
@@ -4877,7 +4886,7 @@ def test_plugin_uses_configuration_from_db(
     shipping_zone,
     settings,
 ):
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     configuration = plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
 
@@ -4899,7 +4908,9 @@ def test_plugin_uses_configuration_from_db(
         {"name": "Username or account", "value": "New value"},
         {"name": "Password or license", "value": "Wrong pass"},
     ]
-    AvataxPlugin._update_config_items(field_to_update, configuration.configuration)
+    DeprecatedAvataxPlugin._update_config_items(
+        field_to_update, configuration.configuration
+    )
     configuration.save()
 
     manager = get_plugins_manager(allow_replica=False)
@@ -4909,10 +4920,10 @@ def test_plugin_uses_configuration_from_db(
 
 def test_skip_disabled_plugin(settings, plugin_configuration, channel_USD):
     plugin_configuration(username=None, password=None)
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     manager = get_plugins_manager(allow_replica=False)
-    plugin: AvataxPlugin = manager.get_plugin(
-        AvataxPlugin.PLUGIN_ID, channel_slug=channel_USD.slug
+    plugin: DeprecatedAvataxPlugin = manager.get_plugin(
+        DeprecatedAvataxPlugin.PLUGIN_ID, channel_slug=channel_USD.slug
     )
 
     assert (
@@ -4930,7 +4941,7 @@ def test_get_tax_code_from_object_meta(
         {META_CODE_KEY: "KEY", META_DESCRIPTION_KEY: "DESC"}
     )
     plugin_configuration(username=None, password=None)
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     manager = get_plugins_manager(allow_replica=False)
     tax_type = manager.get_tax_code_from_object_meta(
         product.tax_class, channel_USD.slug
@@ -5721,7 +5732,7 @@ def test_generate_request_data_from_checkout_lines_uses_tax_code_from_product_ta
     settings, channel_USD, plugin_configuration, checkout_with_item, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = checkout_with_item.lines.first()
@@ -5750,7 +5761,7 @@ def test_generate_request_data_from_checkout_lines_uses_tax_code_from_product_ty
     settings, channel_USD, plugin_configuration, checkout_with_item, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = checkout_with_item.lines.first()
@@ -5783,7 +5794,7 @@ def test_generate_request_data_from_checkout_lines_sets_different_tax_code_for_z
     settings, channel_USD, plugin_configuration, checkout_with_item, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = checkout_with_item.lines.first()
@@ -5813,7 +5824,7 @@ def test_generate_request_data_from_checkout_lines_sets_different_tax_code_only_
     settings, channel_USD, plugin_configuration, checkout_with_item, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = checkout_with_item.lines.first()
@@ -5851,7 +5862,7 @@ def test_generate_request_data_from_checkout_lines_with_collection_point(
     warehouse,
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = checkout_with_item.lines.first()
@@ -5891,7 +5902,7 @@ def test_generate_request_data_from_checkout_lines_with_shipping_method(
     shipping_method,
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = checkout_with_item.lines.first()
@@ -5932,7 +5943,7 @@ def test_generate_request_data_from_checkout_lines_adds_lines_with_taxes_disable
     tax_class_zero_rates,
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = checkout_with_item.lines.first()
@@ -5960,7 +5971,7 @@ def test_get_order_lines_data_gets_tax_code_from_product_tax_class(
     settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = order_with_lines.lines.first()
@@ -5982,7 +5993,7 @@ def test_get_order_lines_data_gets_tax_code_from_product_type_tax_class(
     settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = order_with_lines.lines.first()
@@ -6008,7 +6019,7 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
     settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = order_with_lines.lines.first()
@@ -6038,7 +6049,7 @@ def test_get_order_lines_data_with_discounted(
     settings, channel_USD, plugin_configuration, order, order_line, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     order_line.unit_price_gross_amount = Decimal(10)
@@ -6071,7 +6082,7 @@ def test_get_order_lines_data_sets_different_tax_code_only_for_zero_amount(
     settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     line = order_with_lines.lines.first()
@@ -6110,7 +6121,7 @@ def test_get_order_lines_data_adds_lines_with_taxes_disabled_for_line(
     tax_class_zero_rates,
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
 
     order_with_lines.base_shipping_price_amount = Decimal(0)
@@ -6132,7 +6143,7 @@ def test_calculate_checkout_shipping_validates_checkout(
     mocked_func, settings, channel_USD, plugin_configuration, checkout_with_item
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
     manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
@@ -6163,7 +6174,7 @@ def test_calculate_checkout_line_total_validates_checkout(
     mocked_func, settings, channel_USD, plugin_configuration, checkout_with_item
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
     manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
@@ -6195,7 +6206,7 @@ def test_calculate_checkout_line_unit_price_validates_checkout(
     mocked_func, settings, channel_USD, plugin_configuration, checkout_with_item
 ):
     # given
-    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"]
     plugin_configuration(channel=channel_USD)
     manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
@@ -6223,7 +6234,7 @@ def test_calculate_checkout_line_unit_price_validates_checkout(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_with_tax_app_id_as_plugin(
     api_post_request_task_mock,
     checkout_with_item,
@@ -6267,7 +6278,7 @@ def test_preprocess_order_creation_with_tax_app_id_as_plugin(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_preprocess_order_creation_with_country_exception_tax_app_id_plugin(
     api_post_request_task_mock,
     checkout_with_item,
@@ -6316,7 +6327,7 @@ def test_preprocess_order_creation_with_country_exception_tax_app_id_plugin(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_order_confirmed_skip_with_tax_app_id_as_plugin(
     api_post_request_task_mock, order, plugin_configuration
 ):
@@ -6346,7 +6357,7 @@ def test_order_confirmed_skip_with_tax_app_id_as_plugin(
 
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_order_confirmed_skip_with_country_exception_tax_app_id_plugin(
     api_post_request_task_mock, order, order_line, plugin_configuration
 ):
@@ -6381,7 +6392,7 @@ def test_order_confirmed_skip_with_country_exception_tax_app_id_plugin(
 
 
 @patch("saleor.plugins.avatax.plugin.get_order_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_order_tax_data_set_tax_error(
     mock_get_order_tax_data, order, order_line, plugin_configuration
 ):
@@ -6390,7 +6401,7 @@ def test_get_order_tax_data_set_tax_error(
 
     channel = order.channel
     tax_configuration = channel.tax_configuration
-    tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    tax_configuration.tax_app_id = DeprecatedAvataxPlugin.PLUGIN_IDENTIFIER
     tax_configuration.save()
     tax_configuration.country_exceptions.all().delete()
 
@@ -6412,7 +6423,7 @@ def test_get_order_tax_data_set_tax_error(
 
 
 @patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
 def test_get_checkout_tax_data_set_tax_error(
     mock_get_checkout_tax_data,
     checkout_with_item,
@@ -6427,7 +6438,7 @@ def test_get_checkout_tax_data_set_tax_error(
 
     channel = checkout_with_item.channel
     tax_configuration = channel.tax_configuration
-    tax_configuration.tax_app_id = AvataxPlugin.PLUGIN_IDENTIFIER
+    tax_configuration.tax_app_id = DeprecatedAvataxPlugin.PLUGIN_IDENTIFIER
     tax_configuration.save()
     tax_configuration.country_exceptions.all().delete()
 
@@ -6465,7 +6476,7 @@ def test_validate_plugin_tax_data_no_data(lines_info):
     tax_data = {}
 
     # when
-    error_message = AvataxPlugin.validate_tax_data(tax_data, lines_info)
+    error_message = DeprecatedAvataxPlugin.validate_tax_data(tax_data, lines_info)
 
     # then
     assert error_message == TaxDataErrorMessage.EMPTY
@@ -6494,7 +6505,7 @@ def test_validate_plugin_tax_data_with_negative_values(lines_info, caplog):
     }
 
     # when
-    error_message = AvataxPlugin.validate_tax_data(tax_data, lines_info)
+    error_message = DeprecatedAvataxPlugin.validate_tax_data(tax_data, lines_info)
 
     # then
     assert error_message == TaxDataErrorMessage.NEGATIVE_VALUE
@@ -6523,7 +6534,7 @@ def test_validate_plugin_tax_data_price_overflow(lines_info, caplog):
     }
 
     # when
-    error_message = AvataxPlugin.validate_tax_data(tax_data, lines_info)
+    error_message = DeprecatedAvataxPlugin.validate_tax_data(tax_data, lines_info)
 
     # then
     assert error_message == TaxDataErrorMessage.OVERFLOW

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -7,11 +7,11 @@ from prices import Money, TaxedMoney
 from ....checkout.fetch import fetch_checkout_lines
 from ...manager import get_plugins_manager
 from .. import CACHE_KEY, generate_request_data_from_checkout
-from ..plugin import AvataxPlugin
+from ..plugin import DeprecatedAvataxPlugin
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_total_use_cache(
     mock_cache_set,
@@ -30,7 +30,7 @@ def test_calculate_checkout_total_use_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -59,8 +59,8 @@ def test_calculate_checkout_total_use_cache(
     mock_cache_set.assert_not_called()
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 def test_calculate_checkout_total_save_avatax_response_in_cache(
     mock_validate_tax_data,
     checkout_with_items_and_shipping,
@@ -77,7 +77,7 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -105,8 +105,8 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_subtotal_use_cache(
     mock_cache_set,
@@ -125,7 +125,7 @@ def test_calculate_checkout_subtotal_use_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -154,8 +154,8 @@ def test_calculate_checkout_subtotal_use_cache(
     mock_cache_set.assert_not_called()
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     mock_validate_tax_data,
     checkout_with_items_and_shipping,
@@ -172,7 +172,7 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -200,8 +200,8 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_shipping_use_cache(
     mock_cache_set,
@@ -220,7 +220,7 @@ def test_calculate_checkout_shipping_use_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -249,8 +249,8 @@ def test_calculate_checkout_shipping_use_cache(
     mock_cache_set.assert_not_called()
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     mock_validate_tax_data,
     checkout_with_items_and_shipping,
@@ -267,7 +267,7 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -295,8 +295,8 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_line_total_use_cache(
     mock_cache_set,
@@ -315,7 +315,7 @@ def test_calculate_checkout_line_total_use_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -348,8 +348,8 @@ def test_calculate_checkout_line_total_use_cache(
     mock_cache_set.assert_not_called()
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 def test_calculate_checkout_line_save_avatax_response_in_cache(
     mock_validate_tax_data,
     checkout_with_items_and_shipping,
@@ -366,7 +366,7 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -395,8 +395,8 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_calculate_checkout_line_unit_price_use_cache(
     mock_cache_set,
@@ -415,7 +415,7 @@ def test_calculate_checkout_line_unit_price_use_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -448,8 +448,8 @@ def test_calculate_checkout_line_unit_price_use_cache(
     mock_cache_set.assert_not_called()
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     mock_validate_tax_data,
     checkout_with_items_and_shipping,
@@ -466,7 +466,7 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -501,8 +501,8 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_get_checkout_line_tax_rate_use_cache(
     mock_cache_set,
@@ -521,7 +521,7 @@ def test_get_checkout_line_tax_rate_use_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -556,8 +556,8 @@ def test_get_checkout_line_tax_rate_use_cache(
     mock_cache_set.assert_not_called()
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     mock_validate_tax_data,
     checkout_with_items_and_shipping,
@@ -574,7 +574,7 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -612,8 +612,8 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 @patch("saleor.plugins.avatax.cache.set")
 def test_get_checkout_shipping_tax_rate_use_cache(
     mock_cache_set,
@@ -632,7 +632,7 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
@@ -662,8 +662,8 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     mock_cache_set.assert_not_called()
 
 
-@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-@patch("saleor.plugins.avatax.plugin.AvataxPlugin.validate_tax_data")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+@patch("saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin.validate_tax_data")
 def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     mock_validate_tax_data,
     checkout_with_items_and_shipping,
@@ -680,7 +680,7 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager(allow_replica=False)
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
+    plugin = manager.get_plugin(DeprecatedAvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)

--- a/saleor/plugins/sendgrid/plugin.py
+++ b/saleor/plugins/sendgrid/plugin.py
@@ -97,7 +97,12 @@ EVENT_MAP = {
 HELP_TEXT_TEMPLATE = "ID of the dynamic template in Sendgrid"
 
 
-class SendgridEmailPlugin(BasePlugin):
+class DeprecatedSendgridEmailPlugin(BasePlugin):
+    """Deprecated.
+
+    This plugin is deprecated and will be removed in future version.
+    """
+
     PLUGIN_ID = "mirumee.notifications.sendgrid_email"
     PLUGIN_NAME = "Sendgrid"
     DEFAULT_ACTIVE = False

--- a/saleor/plugins/sendgrid/tests/conftest.py
+++ b/saleor/plugins/sendgrid/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ....plugins.sendgrid.plugin import SendgridEmailPlugin
+from ....plugins.sendgrid.plugin import DeprecatedSendgridEmailPlugin
 from ...manager import get_plugins_manager
 
 
@@ -27,10 +27,12 @@ def sendgrid_email_plugin(settings, channel_USD):
         send_gift_card_template_id=None,
         api_key=None,
     ):
-        settings.PLUGINS = ["saleor.plugins.sendgrid.plugin.SendgridEmailPlugin"]
+        settings.PLUGINS = [
+            "saleor.plugins.sendgrid.plugin.DeprecatedSendgridEmailPlugin"
+        ]
         manager = get_plugins_manager(allow_replica=False)
         manager.save_plugin_configuration(
-            SendgridEmailPlugin.PLUGIN_ID,
+            DeprecatedSendgridEmailPlugin.PLUGIN_ID,
             channel_USD.slug,
             {
                 "active": active,

--- a/saleor/plugins/tests/fixtures/gateway.py
+++ b/saleor/plugins/tests/fixtures/gateway.py
@@ -4,8 +4,8 @@ import pytest
 @pytest.fixture(autouse=True)
 def setup_dummy_gateways(settings):
     settings.PLUGINS = [
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
-        "saleor.payment.gateways.dummy_credit_card.plugin.DummyCreditCardGatewayPlugin",
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin",
+        "saleor.payment.gateways.dummy_credit_card.plugin.DeprecatedDummyCreditCardGatewayPlugin",
     ]
     return settings
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -844,19 +844,19 @@ GRAPHQL_QUERY_MAX_COMPLEXITY = int(
 FEDERATED_QUERY_MAX_ENTITIES = int(os.environ.get("FEDERATED_QUERY_MAX_ENTITIES", 100))
 
 BUILTIN_PLUGINS = [
-    "saleor.plugins.avatax.plugin.AvataxPlugin",
+    "saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin",
     "saleor.plugins.webhook.plugin.WebhookPlugin",
-    "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
-    "saleor.payment.gateways.dummy_credit_card.plugin.DummyCreditCardGatewayPlugin",
+    "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin",
+    "saleor.payment.gateways.dummy_credit_card.plugin.DeprecatedDummyCreditCardGatewayPlugin",
     "saleor.payment.gateways.stripe.plugin.StripeGatewayPlugin",
-    "saleor.payment.gateways.braintree.plugin.BraintreeGatewayPlugin",
-    "saleor.payment.gateways.razorpay.plugin.RazorpayGatewayPlugin",
+    "saleor.payment.gateways.braintree.plugin.DeprecatedBraintreeGatewayPlugin",
+    "saleor.payment.gateways.razorpay.plugin.DeprecatedRazorpayGatewayPlugin",
     "saleor.payment.gateways.adyen.plugin.AdyenGatewayPlugin",
     "saleor.payment.gateways.authorize_net.plugin.AuthorizeNetGatewayPlugin",
     "saleor.payment.gateways.np_atobarai.plugin.NPAtobaraiGatewayPlugin",
     "saleor.plugins.user_email.plugin.UserEmailPlugin",
     "saleor.plugins.admin_email.plugin.AdminEmailPlugin",
-    "saleor.plugins.sendgrid.plugin.SendgridEmailPlugin",
+    "saleor.plugins.sendgrid.plugin.DeprecatedSendgridEmailPlugin",
     "saleor.plugins.openid_connect.plugin.OpenIDConnectPlugin",
 ]
 

--- a/saleor/tests/e2e/checkout/shipping/test_use_external_shipping_methods_in_checkout.py
+++ b/saleor/tests/e2e/checkout/shipping/test_use_external_shipping_methods_in_checkout.py
@@ -30,7 +30,7 @@ def test_use_external_shipping_methods_in_checkout_core_1652(
     # Before
     settings.PLUGINS = [
         "saleor.plugins.webhook.plugin.WebhookPlugin",
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+        "saleor.payment.gateways.dummy.plugin.DeprecatedDummyGatewayPlugin",
     ]
     permissions = [
         permission_manage_products,


### PR DESCRIPTION
I want to merge this change because it deprecates not used plugins.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->
Following plugins are now marked as deprecated:

- Braintree (`mirumee.payments.braintree`)
- Razorpay (`mirumme.payments.razorpay`)
- Sendgrid (`mirumee.notifications.sendgrid_email`)
- Dummy (`mirumee.payments.dummy`)
- DummyCreditCard (`mirumee.payments.dummy_credit_card`)
- Avalara (`mirumee.taxes.avalara`)

We plan to remove deprecated plugins in the future versions of Saleor - as a migration path we recommend [Saleor apps](https://apps.saleor.io/) instead.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
