### PR TITLE
seperated email template path with comma

### DIFF
--- a/saleor/plugins/admin_email/constants.py
+++ b/saleor/plugins/admin_email/constants.py
@@ -3,7 +3,7 @@ import os
 from django.conf import settings
 
 DEFAULT_EMAIL_TEMPLATES_PATH = os.path.join(
-    settings.PROJECT_ROOT, "saleor/plugins/admin_email/default_email_templates"
+    settings.PROJECT_ROOT, "saleor", "plugins", "admin_email", "default_email_templates"
 )
 
 STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD = "staff_order_confirmation_template"

--- a/saleor/plugins/user_email/constants.py
+++ b/saleor/plugins/user_email/constants.py
@@ -6,7 +6,7 @@ PLUGIN_ID = "mirumee.notifications.user_email"
 
 
 DEFAULT_EMAIL_TEMPLATES_PATH = os.path.join(
-    settings.PROJECT_ROOT, "saleor/plugins/user_email/default_email_templates"
+    settings.PROJECT_ROOT, "saleor", "plugins", "user_email", "default_email_templates"
 )
 
 ACCOUNT_CONFIRMATION_TEMPLATE_FIELD = "account_confirmation"


### PR DESCRIPTION
I want to merge this change because it builds the correct path using the system's path separator.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
