### PR TITLE
Allow filtering nested objects by passing a list

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -668,18 +668,18 @@ def filter_where_events(qs, _, value: list | None):
 
         event_qs = None
         if filter_value := input_data.get("date"):
-            events = filter_where_by_range_field(
+            event_qs = filter_where_by_range_field(
                 OrderEvent.objects.using(qs.db), "date", filter_value
             )
         if filter_value := input_data.get("type"):
-            events = filter_where_by_value_field(
+            event_qs = filter_where_by_value_field(
                 event_qs or OrderEvent.objects.using(qs.db), "type", filter_value
             )
-        if events is not None:
-            lookup &= Q(Exists(events.filter(order_id=OuterRef("id"))))
+        if event_qs is not None:
+            lookup &= Q(Exists(event_qs.filter(order_id=OuterRef("id"))))
     if lookup:
         return qs.filter(lookup)
-    return qs
+    return qs.none()
 
 
 def filter_where_billing_address(qs, _, value):

--- a/saleor/graphql/order/tests/queries/test_draft_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_draft_order_with_where.py
@@ -1289,41 +1289,87 @@ def test_draft_orders_filter_by_product_type_none(
     ("event_input", "expected_indexes"),
     [
         (
-            {
-                "date": {"gte": "2025-01-01T00:00:00Z"},
-                "type": {"eq": OrderEvents.NOTE_ADDED.upper()},
-            },
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"eq": OrderEvents.NOTE_ADDED.upper()},
+                }
+            ],
             [0, 1, 2],
         ),
         (
-            {
-                "date": {"gte": "2025-01-01T00:00:00Z"},
-                "type": {"eq": OrderEvents.ORDER_FULLY_PAID.upper()},
-            },
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"eq": OrderEvents.ORDER_FULLY_PAID.upper()},
+                }
+            ],
             [0, 1],
         ),
         (
-            {
-                "date": {"gte": "2026-01-01T00:00:00Z"},
-            },
+            [
+                {
+                    "date": {"gte": "2026-01-01T00:00:00Z"},
+                }
+            ],
             [],
         ),
         (
-            {
-                "date": {"gte": "2020-01-01T00:00:00Z"},
-            },
+            [
+                {
+                    "date": {"gte": "2020-01-01T00:00:00Z"},
+                }
+            ],
             [0, 1, 2],
         ),
         (
-            {
-                "type": {
-                    "oneOf": [
-                        OrderEvents.NOTE_ADDED.upper(),
-                        OrderEvents.ORDER_FULLY_PAID.upper(),
-                    ]
-                },
-            },
+            [
+                {
+                    "type": {
+                        "oneOf": [
+                            OrderEvents.NOTE_ADDED.upper(),
+                            OrderEvents.ORDER_FULLY_PAID.upper(),
+                        ]
+                    },
+                }
+            ],
             [0, 1, 2],
+        ),
+        (
+            [
+                {
+                    "type": {"eq": OrderEvents.NOTE_ADDED.upper()},
+                },
+                {
+                    "type": {"eq": OrderEvents.ORDER_FULLY_PAID.upper()},
+                },
+            ],
+            [0, 1],
+        ),
+        (
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"oneOf": [OrderEvents.NOTE_ADDED.upper()]},
+                },
+                {
+                    "date": {"gte": "2025-02-01T00:00:00Z"},
+                    "type": {"oneOf": [OrderEvents.ORDER_FULLY_PAID.upper()]},
+                },
+            ],
+            [0, 1],
+        ),
+        (
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"eq": OrderEvents.NOTE_ADDED.upper()},
+                },
+                {
+                    "date": {"gte": "2025-02-02T00:00:00Z"},
+                },
+            ],
+            [0, 1],
         ),
     ],
 )

--- a/saleor/graphql/order/tests/queries/test_draft_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_draft_order_with_where.py
@@ -844,20 +844,41 @@ def test_draft_order_filter_by_voucher_code_empty_value(
 
 
 @pytest.mark.parametrize(
-    ("metadata", "expected_indexes"),
+    ("filter_input", "expected_indexes"),
     [
-        ({"key": "foo"}, [0, 1]),
-        ({"key": "foo", "value": {"eq": "bar"}}, [0]),
-        ({"key": "foo", "value": {"eq": "baz"}}, []),
-        ({"key": "foo", "value": {"oneOf": ["bar", "zaz"]}}, [0, 1]),
-        ({"key": "notfound"}, []),
-        ({"key": "foo", "value": {"eq": None}}, []),
-        ({"key": "foo", "value": {"oneOf": []}}, []),
+        ([{"metadata": {"key": "foo"}}], [0, 1]),
+        ([{"metadata": {"key": "foo", "value": {"eq": "bar"}}}], [0]),
+        ([{"metadata": {"key": "foo", "value": {"eq": "baz"}}}], []),
+        ([{"metadata": {"key": "foo", "value": {"oneOf": ["bar", "zaz"]}}}], [0, 1]),
+        ([{"metadata": {"key": "notfound"}}], []),
+        ([{"metadata": {"key": "foo", "value": {"eq": None}}}], []),
+        ([{"metadata": {"key": "foo", "value": {"oneOf": []}}}], []),
         (None, []),
+        (
+            [
+                {"metadata": {"key": "foo"}},
+                {"metadata": {"key": "foo", "value": {"eq": "bar"}}},
+            ],
+            [0],
+        ),
+        (
+            [
+                {"metadata": {"key": "foo"}},
+                {"metadata": {"key": "baz", "value": {"eq": "zaz"}}},
+            ],
+            [0, 1],
+        ),
+        (
+            [
+                {"metadata": {"key": "foo"}},
+                {"metadata": {"key": "foo", "value": {"eq": "baz"}}},
+            ],
+            [],
+        ),
     ],
 )
 def test_draft_orders_filter_by_lines_metadata(
-    metadata,
+    filter_input,
     expected_indexes,
     draft_order_list,
     staff_api_client,
@@ -866,8 +887,14 @@ def test_draft_orders_filter_by_lines_metadata(
     # given
     lines = []
     metadata_values = [
-        {"foo": "bar"},
-        {"foo": "zaz"},
+        {
+            "foo": "bar",
+            "baz": "zaz",
+        },
+        {
+            "foo": "zaz",
+            "baz": "zaz",
+        },
         {},
     ]
     for order, metadata_value in zip(draft_order_list, metadata_values, strict=True):
@@ -889,7 +916,7 @@ def test_draft_orders_filter_by_lines_metadata(
     OrderLine.objects.bulk_create(lines)
 
     permission_group_manage_orders.user_set.add(staff_api_client.user)
-    variables = {"where": {"lines": {"metadata": metadata}}}
+    variables = {"where": {"lines": filter_input}}
 
     # when
     response = staff_api_client.post_graphql(DRAFT_ORDERS_WHERE_QUERY, variables)

--- a/saleor/graphql/order/tests/queries/test_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_where.py
@@ -1639,6 +1639,13 @@ def test_orders_filter_by_fulfillment_status(
         ),
         (
             [
+                {"metadata": {"key": "foo"}},
+                {"metadata": {"key": "notfound"}},
+            ],
+            [],
+        ),
+        (
+            [
                 {"metadata": {"key": "foo", "value": {"eq": "bar"}}},
                 {"metadata": {"key": "baz", "value": {"eq": "zaz"}}},
             ],
@@ -1741,6 +1748,17 @@ def test_orders_filter_by_fulfillment_metadata(
                 {"status": {"eq": FulfillmentStatus.RETURNED.upper()}},
                 {"metadata": {"key": "foo", "value": {"eq": "baz"}}},
             ],
+            [],
+        ),
+        (
+            [
+                {"status": {}},
+                {"metadata": {"key": "foo"}},
+            ],
+            [0, 1],
+        ),
+        (
+            [],
             [],
         ),
     ],

--- a/saleor/graphql/order/tests/queries/test_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_where.py
@@ -2404,41 +2404,87 @@ def test_orders_filter_by_product_type_none(
     ("event_input", "expected_indexes"),
     [
         (
-            {
-                "date": {"gte": "2025-01-01T00:00:00Z"},
-                "type": {"eq": OrderEvents.PLACED.upper()},
-            },
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"eq": OrderEvents.PLACED.upper()},
+                }
+            ],
             [0, 1, 2],
         ),
         (
-            {
-                "date": {"gte": "2025-01-01T00:00:00Z"},
-                "type": {"eq": OrderEvents.ORDER_FULLY_PAID.upper()},
-            },
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"eq": OrderEvents.ORDER_FULLY_PAID.upper()},
+                }
+            ],
             [0, 1],
         ),
         (
-            {
-                "date": {"gte": "2026-01-01T00:00:00Z"},
-            },
+            [
+                {
+                    "date": {"gte": "2026-01-01T00:00:00Z"},
+                }
+            ],
             [],
         ),
         (
-            {
-                "date": {"gte": "2020-01-01T00:00:00Z"},
-            },
+            [
+                {
+                    "date": {"gte": "2020-01-01T00:00:00Z"},
+                }
+            ],
             [0, 1, 2],
         ),
         (
-            {
-                "type": {
-                    "oneOf": [
-                        OrderEvents.PLACED.upper(),
-                        OrderEvents.ORDER_FULLY_PAID.upper(),
-                    ]
-                },
-            },
+            [
+                {
+                    "type": {
+                        "oneOf": [
+                            OrderEvents.PLACED.upper(),
+                            OrderEvents.ORDER_FULLY_PAID.upper(),
+                        ]
+                    },
+                }
+            ],
             [0, 1, 2],
+        ),
+        (
+            [
+                {
+                    "type": {"eq": OrderEvents.PLACED.upper()},
+                },
+                {
+                    "type": {"eq": OrderEvents.ORDER_FULLY_PAID.upper()},
+                },
+            ],
+            [0, 1],
+        ),
+        (
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"oneOf": [OrderEvents.PLACED.upper()]},
+                },
+                {
+                    "date": {"gte": "2025-02-01T00:00:00Z"},
+                    "type": {"oneOf": [OrderEvents.ORDER_FULLY_PAID.upper()]},
+                },
+            ],
+            [0, 1],
+        ),
+        (
+            [
+                {
+                    "date": {"gte": "2025-01-01T00:00:00Z"},
+                    "type": {"eq": OrderEvents.PLACED.upper()},
+                },
+                {
+                    "date": {"gte": "2025-02-02T00:00:00Z"},
+                },
+            ],
+            [0, 1],
         ),
     ],
 )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13291,8 +13291,10 @@ input OrderWhereInput @doc(category: "Orders") {
   """Filter by the product type of related order lines."""
   productTypeId: GlobalIDFilterInput
 
-  """Filter by order events."""
-  events: OrderEventFilterInput
+  """
+  Filter by order events. Each list item specifies conditions that must be satisfied by a single event. The filter matches orders that have related objects meeting all specified groups of conditions.
+  """
+  events: [OrderEventFilterInput!]
 
   """Filter by billing address of the order."""
   billingAddress: AddressFilterInput
@@ -13539,8 +13541,10 @@ input DraftOrderWhereInput @doc(category: "Orders") {
   """Filter by the product type of related order lines."""
   productTypeId: GlobalIDFilterInput
 
-  """Filter by order events."""
-  events: OrderEventFilterInput
+  """
+  Filter by order events. Each list item specifies conditions that must be satisfied by a single event. The filter matches orders that have related objects meeting all specified groups of conditions.
+  """
+  events: [OrderEventFilterInput!]
 
   """Filter by billing address of the order."""
   billingAddress: AddressFilterInput

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13264,8 +13264,10 @@ input OrderWhereInput @doc(category: "Orders") {
   """Filter by whether the order has any fulfillments."""
   hasFulfillments: Boolean
 
-  """Filter by fulfillment data associated with the order."""
-  fulfillments: FulfillmentFilterInput
+  """
+  Filter by fulfillment data associated with the order.Each list item specifies conditions that must be satisfied by a single fulfillment. The filter matches orders that have related objects meeting all specified groups of conditions.
+  """
+  fulfillments: [FulfillmentFilterInput!]
 
   """
   Filter by line items associated with the order. Each list item specifies conditions that must be satisfied by a single line. The filter matches orders that have related objects meeting all specified groups of conditions.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13256,8 +13256,10 @@ input OrderWhereInput @doc(category: "Orders") {
   """Filter by whether the order has any invoices."""
   hasInvoices: Boolean
 
-  """Filter by invoice data associated with the order."""
-  invoices: InvoiceFilterInput
+  """
+  Filter by invoice data associated with the order. Each list item represents conditions that must be satisfied by a single invoice. The filter matches orders that have related objects meeting all specified groups of conditions.
+  """
+  invoices: [InvoiceFilterInput!]
 
   """Filter by whether the order has any fulfillments."""
   hasFulfillments: Boolean
@@ -13265,7 +13267,9 @@ input OrderWhereInput @doc(category: "Orders") {
   """Filter by fulfillment data associated with the order."""
   fulfillments: FulfillmentFilterInput
 
-  """Filter by metadata fields of order lines."""
+  """
+  Filter by line items associated with the order. Each list item specifies conditions that must be satisfied by a single line. The filter matches orders that have related objects meeting all specified groups of conditions.
+  """
   lines: [LinesFilterInput!]
 
   """Filter by number of lines in the order."""
@@ -13511,7 +13515,9 @@ input DraftOrderWhereInput @doc(category: "Orders") {
   """Filter by voucher code used in the order."""
   voucherCode: StringFilterInput
 
-  """Filter by metadata fields of order lines."""
+  """
+  Filter by line items associated with the order. Each list item specifies conditions that must be satisfied by a single line. The filter matches orders that have related objects meeting all specified groups of conditions.
+  """
   lines: [LinesFilterInput!]
 
   """Filter by number of lines in the order."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13266,7 +13266,7 @@ input OrderWhereInput @doc(category: "Orders") {
   fulfillments: FulfillmentFilterInput
 
   """Filter by metadata fields of order lines."""
-  lines: LinesFilterInput
+  lines: [LinesFilterInput!]
 
   """Filter by number of lines in the order."""
   linesCount: IntFilterInput
@@ -13512,7 +13512,7 @@ input DraftOrderWhereInput @doc(category: "Orders") {
   voucherCode: StringFilterInput
 
   """Filter by metadata fields of order lines."""
-  lines: LinesFilterInput
+  lines: [LinesFilterInput!]
 
   """Filter by number of lines in the order."""
   linesCount: IntFilterInput


### PR DESCRIPTION
Change newly added filter input for relational fields to list.
Each item in the list must match a single related object, but different items may match different objects.
The returned orders must contain objects satisfying all conditions specified in the list.

The changes applied to the following inputs from `OrderWhere` filter:
- `fulfillments`
- `events` (applies also on Draft orders)
- `lines` (applies also on Draft orders)
- `invoices`

Example [Explain](https://explain.dalibo.com/plan/h2gfgba9392hb98f) for following events filer
```
      {
          "date": {"gte": "2025-01-01T00:00:00Z"},
          "type": {"eq": OrderEvents.PLACED.upper()},
      },
      {
          "date": {"gte": "2025-07-07T00:00:00Z"},
      }
```



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
