### PR TITLE
Fix checkout.discount amount when override is set

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -73,8 +73,12 @@ class CheckoutLineInfo(LineInfo):
         if listing is not present, calculate current unit price based on
         `undiscounted_unit_price` and catalogue promotion discounts.
         """
+        if self.line.price_override is not None:
+            return Money(self.line.price_override, self.line.currency)
+
         if self.channel_listing and self.channel_listing.discounted_price is not None:
             return self.channel_listing.discounted_price
+
         catalogue_discounts = self.get_catalogue_discounts()
         total_price = self.undiscounted_unit_price * self.line.quantity
         for discount in catalogue_discounts:

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -73,6 +73,9 @@ class CheckoutLineInfo(LineInfo):
         if listing is not present, calculate current unit price based on
         `undiscounted_unit_price` and catalogue promotion discounts.
         """
+
+        # if price_override is set, it takes precedence over any other price for
+        # further calculations
         if self.line.price_override is not None:
             return Money(self.line.price_override, self.line.currency)
 

--- a/saleor/checkout/tests/test_fetch.py
+++ b/saleor/checkout/tests/test_fetch.py
@@ -217,6 +217,45 @@ def test_checkout_line_info_variant_discounted_price_when_listing_without_price(
     )
 
 
+def test_checkout_line_info_variant_discounted_price_with_price_override(
+    checkout_with_item_on_promotion,
+):
+    # given
+    checkout_line = checkout_with_item_on_promotion.lines.first()
+    channel = checkout_with_item_on_promotion.channel
+    variant = checkout_line.variant
+    variant_channel_listing = variant.channel_listings.get(channel_id=channel.id)
+    product = variant.product
+    product_type = product.product_type
+    discounts = checkout_line.discounts.all()
+    checkout_line.price_override = Decimal(5)
+    checkout_line.save(update_fields=["price_override"])
+
+    expected_discounted_variant_price = checkout_line.price_override
+    assert variant_channel_listing.discounted_price != variant_channel_listing.price
+
+    # when
+    checkout_line_info = CheckoutLineInfo(
+        line=checkout_line,
+        variant=variant,
+        channel_listing=variant_channel_listing,
+        product=product,
+        product_type=product_type,
+        collections=[],
+        tax_class=product.tax_class or product_type.tax_class,
+        discounts=discounts,
+        rules_info=[],
+        channel=channel,
+        voucher=None,
+        voucher_code=None,
+    )
+
+    # then
+    assert checkout_line_info.variant_discounted_price == Money(
+        expected_discounted_variant_price, checkout_line.currency
+    )
+
+
 def test_fetch_checkout_lines_info(checkout_with_item_on_promotion):
     # given
     lines = list(checkout_with_item_on_promotion.lines.all())

--- a/saleor/checkout/tests/test_fetch.py
+++ b/saleor/checkout/tests/test_fetch.py
@@ -1,4 +1,7 @@
+from decimal import Decimal
+
 import pytest
+from prices import Money
 
 from ...product.models import ProductChannelListing, ProductVariantChannelListing
 from ..fetch import CheckoutLineInfo, fetch_checkout_lines


### PR DESCRIPTION
Port https://github.com/saleor/saleor/pull/17972 to 3.21.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
