### PR TITLE
feat: populate external_reference field for new OIDC users

### DIFF
--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -412,6 +412,7 @@ def get_or_create_user_from_payload(
         "first_name": payload.get("given_name", ""),
         "last_name": payload.get("family_name", ""),
         "private_metadata": {oidc_metadata_key: sub},
+        "external_reference": sub,
         "password": make_password(None),
     }
     cache_key = oidc_metadata_key + ":" + sub


### PR DESCRIPTION
Add external_reference field population during OIDC user creation.
The field is set to the OIDC subject identifier (sub) value while
maintaining the existing private metadata for backward compatibility.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined
