### PR TITLE
Optional slug attribute for use in Page.where filter

### DIFF
--- a/saleor/graphql/page/tests/queries/test_pages_with_where.py
+++ b/saleor/graphql/page/tests/queries/test_pages_with_where.py
@@ -3,7 +3,8 @@ import datetime
 import graphene
 import pytest
 
-from .....attribute.models import AttributeValue
+from .....attribute import AttributeEntityType, AttributeInputType, AttributeType
+from .....attribute.models import Attribute, AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....page.models import Page, PageType
 from ....core.utils import to_global_id_or_none
@@ -196,14 +197,22 @@ def test_pages_query_with_attribute_slug(
 
 
 @pytest.mark.parametrize(
-    ("slug_input", "expected_count"),
+    ("attribute_input", "expected_count"),
     [
-        ({"eq": "test-slug-1"}, 1),
-        ({"oneOf": ["test-slug-1", "test-slug-2"]}, 2),
+        ({"value": {"slug": {"eq": "test-slug-1"}}}, 1),
+        ({"value": {"slug": {"oneOf": ["test-slug-1", "test-slug-2"]}}}, 2),
+        ({"slug": "size_page_attribute", "value": {"slug": {"eq": "test-slug-1"}}}, 1),
+        (
+            {
+                "slug": "size_page_attribute",
+                "value": {"slug": {"oneOf": ["test-slug-1", "test-slug-2"]}},
+            },
+            2,
+        ),
     ],
 )
 def test_pages_query_with_attribute_value_slug(
-    slug_input,
+    attribute_input,
     expected_count,
     staff_api_client,
     page_list,
@@ -211,6 +220,9 @@ def test_pages_query_with_attribute_value_slug(
     size_page_attribute,
 ):
     # given
+    size_page_attribute.slug = "size_page_attribute"
+    size_page_attribute.save()
+
     page_type.page_attributes.add(size_page_attribute)
 
     attr_value_1 = size_page_attribute.values.first()
@@ -229,13 +241,7 @@ def test_pages_query_with_attribute_value_slug(
         page_list[1], {size_page_attribute.pk: [attr_value_2]}
     )
 
-    variables = {
-        "where": {
-            "attributes": [
-                {"slug": size_page_attribute.slug, "value": {"slug": slug_input}}
-            ]
-        }
-    }
+    variables = {"where": {"attributes": [attribute_input]}}
 
     # when
     response = staff_api_client.post_graphql(
@@ -250,14 +256,22 @@ def test_pages_query_with_attribute_value_slug(
 
 
 @pytest.mark.parametrize(
-    ("name_input", "expected_count"),
+    ("attribute_input", "expected_count"),
     [
-        ({"eq": "test-name-1"}, 1),
-        ({"oneOf": ["test-name-1", "test-name-2"]}, 2),
+        ({"value": {"name": {"eq": "test-name-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["test-name-1", "test-name-2"]}}}, 2),
+        ({"slug": "size_page_attribute", "value": {"name": {"eq": "test-name-1"}}}, 1),
+        (
+            {
+                "slug": "size_page_attribute",
+                "value": {"name": {"oneOf": ["test-name-1", "test-name-2"]}},
+            },
+            2,
+        ),
     ],
 )
 def test_pages_query_with_attribute_value_name(
-    name_input,
+    attribute_input,
     expected_count,
     staff_api_client,
     page_list,
@@ -265,6 +279,9 @@ def test_pages_query_with_attribute_value_name(
     size_page_attribute,
 ):
     # given
+    size_page_attribute.slug = "size_page_attribute"
+    size_page_attribute.save()
+
     page_type.page_attributes.add(size_page_attribute)
 
     attr_value_1 = size_page_attribute.values.first()
@@ -283,13 +300,7 @@ def test_pages_query_with_attribute_value_name(
         page_list[1], {size_page_attribute.pk: [attr_value_2]}
     )
 
-    variables = {
-        "where": {
-            "attributes": [
-                {"slug": size_page_attribute.slug, "value": {"name": name_input}}
-            ]
-        }
-    }
+    variables = {"where": {"attributes": [attribute_input]}}
 
     # when
     response = staff_api_client.post_graphql(
@@ -306,13 +317,24 @@ def test_pages_query_with_attribute_value_name(
 @pytest.mark.parametrize(
     ("numeric_input", "expected_count"),
     [
-        ({"numeric": {"eq": 1.2}}, 1),
-        ({"numeric": {"oneOf": [1.2, 2]}}, 2),
-        ({"numeric": {"range": {"gte": 1, "lte": 2}}}, 2),
-        ({"name": {"eq": "1.2"}}, 1),
-        ({"slug": {"eq": "1.2"}}, 1),
-        ({"name": {"oneOf": ["1.2", "2"]}}, 2),
-        ({"slug": {"oneOf": ["1.2", "2"]}}, 2),
+        ({"slug": "num-slug", "value": {"numeric": {"eq": 1.2}}}, 1),
+        ({"slug": "num-slug", "value": {"numeric": {"oneOf": [1.2, 2]}}}, 2),
+        (
+            {"slug": "num-slug", "value": {"numeric": {"range": {"gte": 1, "lte": 2}}}},
+            2,
+        ),
+        ({"slug": "num-slug", "value": {"name": {"eq": "1.2"}}}, 1),
+        ({"slug": "num-slug", "value": {"slug": {"eq": "1.2"}}}, 1),
+        ({"slug": "num-slug", "value": {"name": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"slug": "num-slug", "value": {"slug": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"value": {"numeric": {"eq": 1.2}}}, 1),
+        ({"value": {"numeric": {"oneOf": [1.2, 2]}}}, 2),
+        ({"value": {"numeric": {"range": {"gte": 1, "lte": 2}}}}, 2),
+        ({"value": {"numeric": {"range": {"gte": 1}}}}, 3),
+        ({"value": {"name": {"eq": "1.2"}}}, 1),
+        ({"value": {"slug": {"eq": "1.2"}}}, 1),
+        ({"value": {"name": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["1.2", "2"]}}}, 2),
     ],
 )
 def test_pages_query_with_attribute_value_numeric(
@@ -322,12 +344,15 @@ def test_pages_query_with_attribute_value_numeric(
     page_list,
     page_type,
     numeric_attribute_without_unit,
+    numeric_attribute,
 ):
     # given
+    numeric_attribute_without_unit.slug = "num-slug"
     numeric_attribute_without_unit.type = "PAGE_TYPE"
     numeric_attribute_without_unit.save()
 
     page_type.page_attributes.add(numeric_attribute_without_unit)
+    page_type.page_attributes.add(numeric_attribute)
 
     attr_value_1 = numeric_attribute_without_unit.values.first()
     attr_value_1.name = "1.2"
@@ -341,24 +366,23 @@ def test_pages_query_with_attribute_value_numeric(
     attr_value_2.numeric = 2
     attr_value_2.save()
 
+    second_attr_value = numeric_attribute.values.first()
+
     associate_attribute_values_to_instance(
-        page_list[0], {numeric_attribute_without_unit.pk: [attr_value_1]}
+        page_list[0],
+        {
+            numeric_attribute_without_unit.pk: [attr_value_1],
+        },
     )
 
     associate_attribute_values_to_instance(
         page_list[1], {numeric_attribute_without_unit.pk: [attr_value_2]}
     )
+    associate_attribute_values_to_instance(
+        page_list[2], {numeric_attribute.pk: [second_attr_value]}
+    )
 
-    variables = {
-        "where": {
-            "attributes": [
-                {
-                    "slug": numeric_attribute_without_unit.slug,
-                    "value": numeric_input,
-                }
-            ]
-        }
-    }
+    variables = {"where": {"attributes": [numeric_input]}}
 
     # when
     response = staff_api_client.post_graphql(
@@ -375,22 +399,36 @@ def test_pages_query_with_attribute_value_numeric(
 @pytest.mark.parametrize(
     ("date_input", "expected_count"),
     [
-        ({"date": {"gte": "2021-01-01"}}, 2),
-        ({"name": {"eq": "date-name-1"}}, 1),
-        ({"slug": {"eq": "date-slug-1"}}, 1),
+        ({"slug": "date", "value": {"date": {"gte": "2021-01-01"}}}, 1),
+        ({"slug": "date", "value": {"name": {"eq": "date-name-1"}}}, 1),
+        ({"slug": "date", "value": {"slug": {"eq": "date-slug-1"}}}, 1),
         (
             {
-                "name": {"oneOf": ["date-name-1", "date-name-2"]},
+                "slug": "date",
+                "value": {"name": {"oneOf": ["date-name-1", "date-name-2"]}},
             },
-            2,
+            1,
         ),
         (
             {
-                "slug": {"oneOf": ["date-slug-1", "date-slug-2"]},
+                "slug": "date",
+                "value": {"slug": {"oneOf": ["date-slug-1", "date-slug-2"]}},
             },
-            2,
+            1,
         ),
-        ({"date": {"gte": "2021-01-01", "lte": "2021-01-02"}}, 1),
+        (
+            {
+                "slug": "date",
+                "value": {"date": {"gte": "2021-01-02", "lte": "2021-01-03"}},
+            },
+            1,
+        ),
+        ({"value": {"date": {"gte": "2021-01-01"}}}, 2),
+        ({"value": {"name": {"eq": "date-name-1"}}}, 1),
+        ({"value": {"slug": {"eq": "date-slug-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["date-name-1", "date-name-2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["date-slug-1", "date-slug-2"]}}}, 2),
+        ({"value": {"date": {"gte": "2021-01-01", "lte": "2021-01-02"}}}, 1),
     ],
 )
 def test_pages_query_with_attribute_value_date(
@@ -403,9 +441,17 @@ def test_pages_query_with_attribute_value_date(
 ):
     # given
     date_attribute.type = "PAGE_TYPE"
+    date_attribute.slug = "date"
     date_attribute.save()
 
+    second_date_attribute = Attribute.objects.create(
+        slug="second_date",
+        name="Second date",
+        type=AttributeType.PAGE_TYPE,
+        input_type=AttributeInputType.DATE,
+    )
     page_type.page_attributes.add(date_attribute)
+    page_type.page_attributes.add(second_date_attribute)
 
     attr_value_1 = date_attribute.values.first()
     attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
@@ -417,19 +463,17 @@ def test_pages_query_with_attribute_value_date(
         page_list[0], {date_attribute.pk: [attr_value_1]}
     )
 
-    second_attr_value = date_attribute.values.last()
-    second_attr_value.date_time = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
-    second_attr_value.name = "date-name-2"
-    second_attr_value.slug = "date-slug-2"
-    second_attr_value.save()
-
-    associate_attribute_values_to_instance(
-        page_list[1], {date_attribute.pk: [second_attr_value]}
+    second_attr_value = second_date_attribute.values.create(
+        date_time=datetime.datetime(2021, 1, 2, tzinfo=datetime.UTC),
+        name="date-name-2",
+        slug="date-slug-2",
     )
 
-    variables = {
-        "where": {"attributes": [{"slug": date_attribute.slug, "value": date_input}]}
-    }
+    associate_attribute_values_to_instance(
+        page_list[1], {second_date_attribute.pk: [second_attr_value]}
+    )
+
+    variables = {"where": {"attributes": [date_input]}}
 
     # when
     response = staff_api_client.post_graphql(
@@ -446,39 +490,50 @@ def test_pages_query_with_attribute_value_date(
 @pytest.mark.parametrize(
     ("date_time_input", "expected_count"),
     [
+        ({"slug": "dt", "value": {"name": {"eq": "datetime-name-1"}}}, 1),
+        ({"slug": "dt", "value": {"slug": {"eq": "datetime-slug-1"}}}, 1),
         (
             {
-                "name": {"eq": "datetime-name-1"},
-            },
-            1,
-        ),
-        (
-            {
-                "slug": {"eq": "datetime-slug-1"},
-            },
-            1,
-        ),
-        (
-            {
-                "name": {"oneOf": ["datetime-name-1", "datetime-name-2"]},
+                "slug": "dt",
+                "value": {"name": {"oneOf": ["datetime-name-1", "datetime-name-2"]}},
             },
             2,
         ),
         (
             {
-                "slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]},
+                "slug": "dt",
+                "value": {"slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]}},
             },
             2,
         ),
-        ({"dateTime": {"gte": "2021-01-01T00:00:00Z"}}, 2),
+        ({"slug": "dt", "value": {"dateTime": {"gte": "2021-01-01T00:00:00Z"}}}, 2),
         (
             {
-                "dateTime": {
-                    "gte": "2021-01-01T00:00:00Z",
-                    "lte": "2021-01-02T00:00:00Z",
+                "slug": "dt",
+                "value": {
+                    "dateTime": {
+                        "gte": "2021-01-01T00:00:00Z",
+                        "lte": "2021-01-02T00:00:00Z",
+                    }
+                },
+            },
+            1,
+        ),
+        ({"value": {"name": {"eq": "datetime-name-1"}}}, 1),
+        ({"value": {"slug": {"eq": "datetime-slug-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["datetime-name-1", "datetime-name-2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]}}}, 2),
+        ({"value": {"dateTime": {"gte": "2021-01-01T00:00:00Z"}}}, 3),
+        (
+            {
+                "value": {
+                    "dateTime": {
+                        "gte": "2021-01-01T00:00:00Z",
+                        "lte": "2021-01-02T00:00:00Z",
+                    }
                 }
             },
-            1,
+            2,
         ),
     ],
 )
@@ -491,10 +546,19 @@ def test_pages_query_with_attribute_value_date_time(
     date_time_attribute,
 ):
     # given
+    date_time_attribute.slug = "dt"
     date_time_attribute.type = "PAGE_TYPE"
     date_time_attribute.save()
 
+    second_date_attribute = Attribute.objects.create(
+        slug="second_dt",
+        name="Second dt",
+        type=AttributeType.PAGE_TYPE,
+        input_type=AttributeInputType.DATE_TIME,
+    )
+
     page_type.page_attributes.add(date_time_attribute)
+    page_type.page_attributes.add(second_date_attribute)
 
     attr_value_1 = date_time_attribute.values.first()
     attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
@@ -516,16 +580,17 @@ def test_pages_query_with_attribute_value_date_time(
         page_list[1], {date_time_attribute.pk: [second_attr_value]}
     )
 
-    variables = {
-        "where": {
-            "attributes": [
-                {
-                    "slug": date_time_attribute.slug,
-                    "value": date_time_input,
-                }
-            ]
-        }
-    }
+    value_for_second_attr = second_date_attribute.values.create(
+        date_time=datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC),
+        name="second-datetime-name",
+        slug="second-datetime-slug",
+    )
+
+    associate_attribute_values_to_instance(
+        page_list[2], {second_date_attribute.pk: [value_for_second_attr]}
+    )
+
+    variables = {"where": {"attributes": [date_time_input]}}
 
     # when
     response = staff_api_client.post_graphql(
@@ -542,17 +607,16 @@ def test_pages_query_with_attribute_value_date_time(
 @pytest.mark.parametrize(
     "boolean_input",
     [
-        {"boolean": True},
-        {
-            "name": {"eq": "True-name"},
-        },
-        {
-            "slug": {"eq": "true_slug"},
-        },
-        {"name": {"oneOf": ["True-name", "True-name-2"]}},
-        {
-            "slug": {"oneOf": ["true_slug"]},
-        },
+        {"value": {"boolean": True}},
+        {"value": {"name": {"eq": "True-name"}}},
+        {"value": {"slug": {"eq": "true_slug"}}},
+        {"value": {"name": {"oneOf": ["True-name", "True-name-2"]}}},
+        {"value": {"slug": {"oneOf": ["true_slug"]}}},
+        {"slug": "b_s", "value": {"boolean": True}},
+        {"slug": "b_s", "value": {"name": {"eq": "True-name"}}},
+        {"slug": "b_s", "value": {"slug": {"eq": "true_slug"}}},
+        {"slug": "b_s", "value": {"name": {"oneOf": ["True-name", "True-name-2"]}}},
+        {"slug": "b_s", "value": {"slug": {"oneOf": ["true_slug"]}}},
     ],
 )
 def test_pages_query_with_attribute_value_boolean(
@@ -563,30 +627,40 @@ def test_pages_query_with_attribute_value_boolean(
     boolean_attribute,
 ):
     # given
+    boolean_attribute.slug = "b_s"
     boolean_attribute.type = "PAGE_TYPE"
     boolean_attribute.save()
 
+    second_attribute = Attribute.objects.create(
+        slug="s_boolean",
+        name="Boolean",
+        type=AttributeType.PAGE_TYPE,
+        input_type=AttributeInputType.BOOLEAN,
+    )
+
     page_type.page_attributes.add(boolean_attribute)
+    page_type.page_attributes.add(second_attribute)
 
     true_value = boolean_attribute.values.filter(boolean=True).first()
     true_value.name = "True-name"
     true_value.slug = "true_slug"
     true_value.save()
 
-    false_value = boolean_attribute.values.filter(boolean=False).first()
-    false_value.name = "False-name"
-    false_value.slug = "false_slug"
-    false_value.save()
-
     associate_attribute_values_to_instance(
         page_list[0], {boolean_attribute.pk: [true_value]}
     )
 
+    value_for_second_attr = AttributeValue.objects.create(
+        attribute=second_attribute,
+        name=f"{second_attribute.name}: Yes",
+        slug=f"{second_attribute.id}_false",
+        boolean=False,
+    )
     associate_attribute_values_to_instance(
-        page_list[1], {boolean_attribute.pk: [false_value]}
+        page_list[1], {second_attribute.pk: [value_for_second_attr]}
     )
 
-    variables = {"where": {"attributes": [{"slug": "boolean", "value": boolean_input}]}}
+    variables = {"where": {"attributes": [boolean_input]}}
 
     # when
     response = staff_api_client.post_graphql(
@@ -606,7 +680,7 @@ def test_pages_query_with_attribute_value_boolean(
 @pytest.mark.parametrize(
     ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
 )
-def test_pages_query_with_attribute_value_reference_to_pages(
+def test_pages_query_with_attr_slug_and_attribute_value_reference_to_pages(
     filter_type,
     expected_count,
     staff_api_client,
@@ -699,7 +773,106 @@ def test_pages_query_with_attribute_value_reference_to_pages(
 @pytest.mark.parametrize(
     ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
 )
-def test_pages_query_with_attribute_value_reference_to_products(
+def test_pages_query_with_attribute_value_reference_to_pages(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_page_reference_attribute,
+):
+    # given
+    second_page_reference_attribute = Attribute.objects.create(
+        slug="second-page-reference",
+        name="Page reference",
+        type=AttributeType.PAGE_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PAGE,
+    )
+    page_type.page_attributes.add(page_type_page_reference_attribute)
+    page_type.page_attributes.add(second_page_reference_attribute)
+
+    reference_1 = "referenced-page-1"
+    reference_2 = "referenced-page-2"
+    referenced_page_1, referenced_page_2 = Page.objects.bulk_create(
+        [
+            Page(
+                title="Referenced Page 1",
+                slug=reference_1,
+                page_type=page_type,
+                is_published=True,
+            ),
+            Page(
+                title="Referenced Page 2",
+                slug=reference_2,
+                page_type=page_type,
+                is_published=True,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=page_type_page_reference_attribute,
+                name=f"Page {referenced_page_1.pk}",
+                slug=f"page-{referenced_page_1.pk}",
+                reference_page=referenced_page_1,
+            ),
+            AttributeValue(
+                attribute=second_page_reference_attribute,
+                name=f"Page {referenced_page_2.pk}",
+                slug=f"page-{referenced_page_2.pk}",
+                reference_page=referenced_page_2,
+            ),
+        ]
+    )
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            page_type_page_reference_attribute.pk: [attribute_value_1],
+            second_page_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {second_page_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "pageSlugs": {filter_type: [reference_1, reference_2]}
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attr_slug_and_attribute_value_reference_to_products(
     filter_type,
     expected_count,
     staff_api_client,
@@ -781,9 +954,201 @@ def test_pages_query_with_attribute_value_reference_to_products(
 
 
 @pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attribute_value_reference_to_products(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_product_reference_attribute,
+    product_list,
+):
+    # given
+    second_product_reference_attribute = Attribute.objects.create(
+        slug="second-product-reference",
+        name="Product reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PRODUCT,
+    )
+
+    page_type.page_attributes.add(page_type_product_reference_attribute)
+    page_type.page_attributes.add(second_product_reference_attribute)
+
+    first_product = product_list[0]
+    second_product = product_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=page_type_product_reference_attribute,
+                name=f"Product {first_product.pk}",
+                slug=f"product-{first_product.pk}",
+                reference_product=first_product,
+            ),
+            AttributeValue(
+                attribute=second_product_reference_attribute,
+                name=f"Product {second_product.pk}",
+                slug=f"product-{second_product.pk}",
+                reference_product=second_product,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            page_type_product_reference_attribute.pk: [
+                attribute_value_1,
+            ],
+            second_product_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {second_product_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "productSlugs": {
+                                filter_type: [first_product.slug, second_product.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
     ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
 )
 def test_pages_query_with_attribute_value_reference_to_product_variants(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_variant_reference_attribute,
+    product_variant_list,
+):
+    # given
+    page_type.page_attributes.add(page_type_variant_reference_attribute)
+    second_variant_reference_attribute = Attribute.objects.create(
+        slug="second-product-reference",
+        name="Product reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PRODUCT_VARIANT,
+    )
+
+    first_variant_sku = "test-variant-1"
+    second_variant_sku = "test-variant-2"
+
+    first_variant = product_variant_list[0]
+    first_variant.sku = first_variant_sku
+    first_variant.save()
+
+    second_variant = product_variant_list[1]
+    second_variant.sku = second_variant_sku
+    second_variant.save()
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=page_type_variant_reference_attribute,
+                name=f"Variant {first_variant.pk}",
+                slug=f"variant-{first_variant.pk}",
+                reference_variant=first_variant,
+            ),
+            AttributeValue(
+                attribute=second_variant_reference_attribute,
+                name=f"Variant {second_variant.pk}",
+                slug=f"variant-{second_variant.pk}",
+                reference_variant=second_variant,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            page_type_variant_reference_attribute.pk: [attribute_value_1],
+            second_variant_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {second_variant_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "productVariantSkus": {
+                                filter_type: [
+                                    first_variant_sku,
+                                    second_variant_sku,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_pages_query_with_attr_slug_and_attribute_value_reference_to_product_variants(
     filter_type,
     expected_count,
     staff_api_client,
@@ -878,7 +1243,121 @@ def test_pages_query_with_attribute_value_reference_to_product_variants(
 @pytest.mark.parametrize(
     ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
 )
-def test_pages_query_with_attribute_value_referenced_page_ids(
+def test_pages_query_with_attribute_value_referenced_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_page_reference_attribute,
+    page_type_product_reference_attribute,
+    page_type_variant_reference_attribute,
+    product,
+    variant,
+):
+    # given
+    page_type.page_attributes.add(
+        page_type_page_reference_attribute,
+    )
+
+    referenced_page = Page.objects.create(
+        title="Referenced Page",
+        slug="referenced-page",
+        page_type=page_type,
+        is_published=True,
+    )
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=page_type_page_reference_attribute,
+                    name=f"Page {referenced_page.pk}",
+                    slug=f"page-{referenced_page.pk}",
+                    reference_page=referenced_page,
+                ),
+                AttributeValue(
+                    attribute=page_type_product_reference_attribute,
+                    name=f"Product {product.pk}",
+                    slug=f"product-{product.pk}",
+                    reference_product=product,
+                ),
+                AttributeValue(
+                    attribute=page_type_variant_reference_attribute,
+                    name=f"variant {variant.pk}",
+                    slug=f"variant-{variant.pk}",
+                    reference_variant=variant,
+                ),
+            ]
+        )
+    )
+    fist_page_with_all_ids = page_list[0]
+    second_page_with_all_ids = page_list[1]
+    page_with_single_id = page_list[2]
+    associate_attribute_values_to_instance(
+        fist_page_with_all_ids,
+        {
+            page_type_page_reference_attribute.pk: [first_attr_value],
+            page_type_product_reference_attribute.pk: [second_attr_value],
+            page_type_variant_reference_attribute.pk: [third_attr_value],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_page_with_all_ids,
+        {
+            page_type_page_reference_attribute.pk: [first_attr_value],
+            page_type_product_reference_attribute.pk: [second_attr_value],
+            page_type_variant_reference_attribute.pk: [third_attr_value],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        page_with_single_id,
+        {page_type_page_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_id = to_global_id_or_none(referenced_page)
+    referenced_second_id = to_global_id_or_none(product)
+    referenced_third_id = to_global_id_or_none(variant)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_id,
+                                    referenced_second_id,
+                                    referenced_third_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(page_list) > len(pages_nodes)
+    assert len(pages_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_pages_query_with_attr_slug_and_attribute_value_referenced_page_ids(
     filter_type,
     expected_count,
     staff_api_client,
@@ -1011,7 +1490,7 @@ def test_pages_query_with_attribute_value_referenced_page_ids(
 @pytest.mark.parametrize(
     ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
 )
-def test_pages_query_with_attribute_value_referenced_variant_ids(
+def test_pages_query_with_attr_slug_attribute_value_referenced_variant_ids(
     filter_type,
     expected_count,
     staff_api_client,
@@ -1123,7 +1602,7 @@ def test_pages_query_with_attribute_value_referenced_variant_ids(
 @pytest.mark.parametrize(
     ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
 )
-def test_pages_query_with_attribute_value_referenced_product_ids(
+def test_pages_query_with_attr_slug_and_attribute_value_referenced_product_ids(
     filter_type,
     expected_count,
     staff_api_client,
@@ -1236,275 +1715,283 @@ def test_pages_query_with_attribute_value_referenced_product_ids(
 
 
 @pytest.mark.parametrize(
-    "attribute_filter",
+    "attribute_value_filter",
+    [{"numeric": None}, {"name": None}, {"slug": None}, {"boolean": False}],
+)
+def test_pages_query_failed_filter_validation_for_numeric_with_slug_input(
+    attribute_value_filter, staff_api_client, numeric_attribute_without_unit, page_type
+):
+    # given
+    attr_slug_input = "numeric"
+    numeric_attribute_without_unit.slug = attr_slug_input
+    numeric_attribute_without_unit.save()
+
+    page_type.page_attributes.add(numeric_attribute_without_unit)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [{"boolean": None}, {"name": None}, {"slug": None}, {"numeric": {"eq": 1.2}}],
+)
+def test_pages_query_failed_filter_validation_for_boolean_with_slug_input(
+    attribute_value_filter, staff_api_client, boolean_attribute, page_type
+):
+    # given
+    attr_slug_input = "boolean"
+    boolean_attribute.slug = attr_slug_input
+    boolean_attribute.save()
+
+    page_type.page_attributes.add(boolean_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
     [
-        # When input receives None
-        [{"slug": "page-size"}, {"slug": "page-size"}],
-        [{"slug": "page-size", "value": {"slug": None}}],
-        [{"slug": "page-size", "value": {"name": None}}],
-        # Cant have multiple value input fields
-        [
-            {
-                "slug": "page-size",
-                "value": {
-                    "slug": {"eq": "true_slug"},
-                    "name": {"eq": "name"},
-                },
-            }
-        ],
-        [
-            {
-                "slug": "page-size",
-                "value": {
-                    "slug": {"oneOf": ["true_slug"]},
-                    "name": {"oneOf": ["name"]},
-                },
-            }
-        ],
-        [
-            {
-                "slug": "page-size",
-                "value": {
-                    "name": {"eq": "name"},
-                },
-            },
-            {"slug": "count", "value": {"numeric": None}},
-        ],
-        # numeric attribute
-        [{"slug": "count", "value": {"numeric": None}}],
-        [{"slug": "count", "value": {"name": None}}],
-        [{"slug": "count", "value": {"slug": None}}],
-        # Numeric can't be used with non numeric fields
-        [{"slug": "count", "value": {"boolean": False}}],
-        # boolean attribute
-        [{"slug": "boolean", "value": {"boolean": None}}],
-        [{"slug": "boolean", "value": {"name": None}}],
-        [{"slug": "boolean", "value": {"slug": None}}],
-        # Boolean can't be used with non boolean fields
-        [{"slug": "boolean", "value": {"numeric": {"eq": 1.2}}}],
-        # date attribute
-        [{"slug": "date", "value": {"date": None}}],
-        [{"slug": "date", "value": {"name": None}}],
-        [{"slug": "date", "value": {"slug": None}}],
-        # Date can't be used with non date fields
-        [{"slug": "date", "value": {"numeric": {"eq": 1.2}}}],
-        # datetime attribute
-        [{"slug": "date_time", "value": {"dateTime": None}}],
-        [{"slug": "date_time", "value": {"name": None}}],
-        [{"slug": "date_time", "value": {"slug": None}}],
-        # Date time can't be used with non date time fields
-        [{"slug": "date_time", "value": {"numeric": {"eq": 1.2}}}],
-        # Reference attribute
-        [
-            {
-                "slug": "date_time",
-                "value": {
-                    "reference": {
-                        "pageSlugs": {
-                            "containsAll": [
-                                "about",
-                            ]
-                        }
-                    }
-                },
-            }
-        ],
-        [{"slug": "reference-product", "value": {}}],
-        [{"slug": "reference-product", "value": {"reference": {}}}],
-        [{"slug": "reference-product", "value": {"reference": None}}],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"referencedIds": {"containsAll": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"pageSlugs": {"containsAll": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productSlugs": {"containsAll": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productVariantSkus": {"containsAll": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"pageSlugs": {"containsAny": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productSlugs": {"containsAny": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productVariantSkus": {"containsAny": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"referencedIds": {"containsAny": []}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {
-                    "reference": {"pageSlugs": {"containsAny": [], "containsAll": []}}
-                },
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {
-                    "reference": {
-                        "productSlugs": {"containsAny": [], "containsAll": []}
-                    }
-                },
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {
-                    "reference": {
-                        "productVariantSkus": {"containsAny": [], "containsAll": []}
-                    }
-                },
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {
-                    "reference": {
-                        "referencedIds": {"containsAny": [], "containsAll": []}
-                    }
-                },
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"referencedIds": {"containsAll": None}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"pageSlugs": {"containsAll": None}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productSlugs": {"containsAll": None}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productVariantSkus": {"containsAll": None}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"pageSlugs": {"containsAny": None}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productSlugs": {"containsAny": None}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"productVariantSkus": {"containsAny": None}}},
-            }
-        ],
-        [
-            {
-                "slug": "reference-product",
-                "value": {"reference": {"referencedIds": {"containsAny": None}}},
-            }
-        ],
+        {"dateTime": None},
+        {"name": None},
+        {"slug": None},
+        {"numeric": {"eq": 1.2}},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
     ],
 )
-def test_pages_query_failed_filter_validation(
-    attribute_filter,
+def test_pages_query_failed_filter_validation_for_date_attribute_with_slug_input(
+    attribute_value_filter, staff_api_client, date_attribute, page_type
+):
+    # given
+    attr_slug_input = "date"
+    date_attribute.slug = attr_slug_input
+    date_attribute.save()
+
+    page_type.page_attributes.add(date_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"dateTime": None},
+        {"name": None},
+        {"slug": None},
+        {"numeric": {"eq": 1.2}},
+        {"date": None},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
+    ],
+)
+def test_pages_query_failed_filter_validation_for_datetime_attribute_with_slug_input(
+    attribute_value_filter, staff_api_client, date_time_attribute, page_type
+):
+    # given
+    attr_slug_input = "date_time"
+    date_time_attribute.slug = attr_slug_input
+    date_time_attribute.save()
+
+    page_type.page_attributes.add(date_time_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"slug": None, "value": None},
+        {"slug": None, "value": {"name": {"eq": "name"}}},
+    ],
+)
+def test_pages_query_failed_filter_validation_null_in_input(
+    attribute_value_filter,
     staff_api_client,
-    page_list,
+):
+    # given
+    variables = {"where": {"attributes": [attribute_value_filter]}}
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"slug": None},
+        {"name": None},
+        {
+            "slug": {"eq": "true_slug"},
+            "name": {"eq": "name"},
+        },
+        {
+            "slug": {"oneOf": ["true_slug"]},
+            "name": {"oneOf": ["name"]},
+        },
+    ],
+)
+def test_pages_query_failed_filter_validation_for_basic_value_fields_with_attr_slug(
+    attribute_value_filter,
+    staff_api_client,
+):
+    # given
+    attr_slug_input = "page-size"
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        }
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+def test_pages_query_failed_filter_validation_for_duplicated_attr_slug(
+    staff_api_client,
+):
+    # given
+    attr_slug_input = "page-size"
+
+    variables = {
+        "where": {
+            "attributes": [
+                {"slug": attr_slug_input},
+                {"slug": attr_slug_input},
+            ]
+        }
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["pages"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {},
+        {"reference": {}},
+        {"reference": None},
+        {"reference": {"referencedIds": {"containsAll": []}}},
+        {"reference": {"pageSlugs": {"containsAll": []}}},
+        {"reference": {"productSlugs": {"containsAll": []}}},
+        {"reference": {"productVariantSkus": {"containsAll": []}}},
+        {"reference": {"pageSlugs": {"containsAny": []}}},
+        {"reference": {"productSlugs": {"containsAny": []}}},
+        {"reference": {"productVariantSkus": {"containsAny": []}}},
+        {"reference": {"referencedIds": {"containsAny": []}}},
+        {"reference": {"pageSlugs": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"productSlugs": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"productVariantSkus": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"referencedIds": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"referencedIds": {"containsAll": None}}},
+        {"reference": {"pageSlugs": {"containsAll": None}}},
+        {"reference": {"productSlugs": {"containsAll": None}}},
+        {"reference": {"productVariantSkus": {"containsAll": None}}},
+        {"reference": {"pageSlugs": {"containsAny": None}}},
+        {"reference": {"productSlugs": {"containsAny": None}}},
+        {"reference": {"productVariantSkus": {"containsAny": None}}},
+        {"reference": {"referencedIds": {"containsAny": None}}},
+    ],
+)
+def test_pages_query_failed_filter_validation_for_reference_attribute_with_slug_input(
+    attribute_value_filter,
+    staff_api_client,
     page_type,
-    size_page_attribute,
-    tag_page_attribute,
-    boolean_attribute,
-    numeric_attribute_without_unit,
-    date_attribute,
-    date_time_attribute,
     page_type_product_reference_attribute,
 ):
     # given
-    boolean_attribute.type = "PAGE_TYPE"
-    boolean_attribute.save()
-    numeric_attribute_without_unit.type = "PAGE_TYPE"
-    numeric_attribute_without_unit.save()
+    attr_slug_input = "reference-product"
 
-    page_type_product_reference_attribute.slug = "reference-product"
-    page_type_product_reference_attribute.save()
-
-    page_type.page_attributes.add(
-        page_type_product_reference_attribute,
-    )
-    page_type.page_attributes.add(size_page_attribute)
-    page_type.page_attributes.add(tag_page_attribute)
-    page_type.page_attributes.add(boolean_attribute)
-    page_type.page_attributes.add(numeric_attribute_without_unit)
-    page_type.page_attributes.add(date_attribute)
-    page_type.page_attributes.add(date_time_attribute)
-
-    size_value = size_page_attribute.values.get(slug="10")
-    tag_value = tag_page_attribute.values.get(name="About")
-    boolean_value = boolean_attribute.values.filter(boolean=True).first()
-    numeric_value = numeric_attribute_without_unit.values.first()
-    date_time_value = date_time_attribute.values.first()
-    date_value = date_attribute.values.first()
-
-    date_attribute.slug = "date"
-    date_attribute.save()
-    date_time_attribute.slug = "date_time"
-    date_time_attribute.save()
-
-    associate_attribute_values_to_instance(
-        page_list[0],
-        {
-            size_page_attribute.pk: [size_value],
-            tag_page_attribute.pk: [tag_value],
-            boolean_attribute.pk: [boolean_value],
-            numeric_attribute_without_unit.pk: [numeric_value],
-            date_attribute.pk: [date_value],
-            date_time_attribute.pk: [date_time_value],
-        },
-    )
-
-    variables = {"where": {"attributes": attribute_filter}}
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": attr_slug_input,
+                    "value": attribute_value_filter,
+                }
+            ]
+        }
+    }
 
     # when
     response = staff_api_client.post_graphql(
@@ -1525,13 +2012,20 @@ def test_pages_query_failed_filter_validation(
         [{"slug": "non-existing-attribute"}],
         # Existing attribute with non-existing value name
         [{"slug": "tag", "value": {"name": {"eq": "Non-existing Name"}}}],
+        [{"value": {"name": {"eq": "Non-existing Name"}}}],
         # Existing numeric attribute with out-of-range value
         [{"slug": "count", "value": {"numeric": {"eq": 999}}}],
+        [{"value": {"numeric": {"eq": 999}}}],
         # Existing boolean attribute with no matching boolean value
         [{"slug": "boolean", "value": {"boolean": False}}],
+        [{"value": {"boolean": False}}],
         # Multiple attributes where one doesn't exist
         [
             {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
+            {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
+        ],
+        [
+            {"value": {"slug": {"eq": "10"}}},
             {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
         ],
     ],
@@ -1604,76 +2098,38 @@ def test_pages_query_with_non_matching_records(
     [
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {
-                        "slug": {"eq": "10"},
-                    },
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"oneOf": ["About", "Help"]}},
-                },
-                {
-                    "slug": "author",
-                    "value": {
-                        "slug": {"oneOf": ["test-author-1"]},
-                    },
-                },
+                {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
+                {"slug": "author", "value": {"slug": {"oneOf": ["test-author-1"]}}},
                 {"slug": "boolean", "value": {"boolean": True}},
             ],
             1,
         ),
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {
-                        "slug": {"eq": "10"},
-                    },
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"oneOf": ["About", "Help"]}},
-                },
+                {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
             ],
             1,
         ),
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
+                {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
                 {"slug": "boolean", "value": {"boolean": False}},
             ],
             0,
         ),
         (
             [
-                {
-                    "slug": "tag",
-                    "value": {
-                        "name": {"eq": "About"},
-                    },
-                },
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
+                {"slug": "tag", "value": {"name": {"eq": "About"}}},
+                {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
             ],
             1,
         ),
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "15"}},
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"eq": "Help"}},
-                },
+                {"slug": "page-size", "value": {"slug": {"eq": "15"}}},
+                {"slug": "tag", "value": {"name": {"eq": "Help"}}},
                 {"slug": "boolean", "value": {"boolean": False}},
             ],
             0,
@@ -1684,63 +2140,44 @@ def test_pages_query_with_non_matching_records(
                     "slug": "author",
                     "value": {"slug": {"oneOf": ["test-author-1", "test-author-2"]}},
                 },
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
+                {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
             ],
             1,
         ),
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
-                {
-                    "slug": "author",
-                    "value": {"name": {"eq": "Test author 1"}},
-                },
+                {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
+                {"slug": "author", "value": {"name": {"eq": "Test author 1"}}},
             ],
             1,
         ),
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"eq": "10"}},
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"eq": "About"}},
-                },
-                {
-                    "slug": "author",
-                    "value": {"slug": {"eq": "test-author-1"}},
-                },
+                {"slug": "page-size", "value": {"slug": {"eq": "10"}}},
+                {"slug": "tag", "value": {"name": {"eq": "About"}}},
+                {"slug": "author", "value": {"slug": {"eq": "test-author-1"}}},
             ],
             1,
         ),
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"oneOf": ["10", "15"]}},
-                },
-                {
-                    "slug": "tag",
-                    "value": {"name": {"oneOf": ["About", "Help"]}},
-                },
+                {"slug": "page-size", "value": {"slug": {"oneOf": ["10", "15"]}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
             ],
             2,
         ),
         (
             [
-                {
-                    "slug": "page-size",
-                    "value": {"slug": {"oneOf": ["10", "15"]}},
-                },
+                {"slug": "page-size", "value": {"slug": {"oneOf": ["10", "15"]}}},
                 {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
+        ([{"value": {"slug": {"oneOf": ["test-author-1", "test-author-2"]}}}], 2),
+        (
+            [
+                {"value": {"slug": {"oneOf": ["10", "15"]}}},
+                {"value": {"boolean": True}},
             ],
             1,
         ),
@@ -1769,6 +2206,8 @@ def test_pages_query_with_multiple_attribute_filters(
     size_value = size_page_attribute.values.get(slug="10")
     tag_value = tag_page_attribute.values.get(name="About")
     author_value = author_page_attribute.values.get(slug="test-author-1")
+    second_author_value = author_page_attribute.values.get(slug="test-author-2")
+
     boolean_value = boolean_attribute.values.filter(boolean=True).first()
 
     associate_attribute_values_to_instance(
@@ -1789,6 +2228,7 @@ def test_pages_query_with_multiple_attribute_filters(
         {
             size_page_attribute.pk: [size_value_15],
             tag_page_attribute.pk: [tag_value_2],
+            author_page_attribute.pk: [second_author_value],
         },
     )
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13008,7 +13008,7 @@ input MetadataValueFilterInput {
 
 input AttributePageWhereInput {
   """Filter by attribute slug."""
-  slug: String!
+  slug: String
 
   """
   Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised.


### PR DESCRIPTION
I want to merge this change because it removes the requirement of providing `Attribtue.slug` when filtering the pages via `where` condition. 

> [!NOTE]  
> Skipping a changelog, as the entry about new where.attribtue is already there

> [!NOTE]  
> The test file has been grown quite a lot. I will split it in multiple files in separate PR: https://github.com/saleor/saleor/pull/17997


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
