### PR TITLE
Skip `EventDelivery` when app is disabled

### DIFF
--- a/saleor/webhook/transport/tests/test_utils.py
+++ b/saleor/webhook/transport/tests/test_utils.py
@@ -230,7 +230,25 @@ def test_get_delivery_for_webhook_inactive_webhook(event_delivery, caplog):
     event_delivery.refresh_from_db()
     assert event_delivery.status == EventDeliveryStatus.FAILED
     assert caplog.records[0].message == (
-        f"Event delivery id: {event_delivery.pk} webhook is disabled."
+        f"Event delivery id: {event_delivery.pk} app/webhook is disabled."
+    )
+    assert not_found is False
+
+
+def test_get_delivery_for_webhook_inactive_app(event_delivery, caplog):
+    # given
+    event_delivery.webhook.app.is_active = False
+    event_delivery.webhook.app.save(update_fields=["is_active"])
+
+    # when
+    delivery, not_found = get_delivery_for_webhook(event_delivery.pk)
+
+    # then
+    assert delivery is None
+    event_delivery.refresh_from_db()
+    assert event_delivery.status == EventDeliveryStatus.FAILED
+    assert caplog.records[0].message == (
+        f"Event delivery id: {event_delivery.pk} app/webhook is disabled."
     )
     assert not_found is False
 
@@ -248,7 +266,7 @@ def test_get_multiple_deliveries_for_webhooks(event_deliveries):
     assert set(deliveries.keys()) == set(ids)
 
 
-def test_get_multiple_deliveries_for_webhooks_with_inactive(
+def test_get_multiple_deliveries_for_webhooks_with_inactive_webhook(
     any_webhook, event_deliveries
 ):
     # given
@@ -258,6 +276,42 @@ def test_get_multiple_deliveries_for_webhooks_with_inactive(
 
     any_webhook.is_active = False
     any_webhook.save(update_fields=["is_active"])
+    inactive_delivery.webhook = any_webhook
+    inactive_delivery.save(update_fields=["webhook"])
+
+    # when
+    deliveries, _ = get_multiple_deliveries_for_webhooks(ids)
+
+    # then
+    assert len(deliveries) == len(all_deliveries) - 1
+    assert set(deliveries.keys()) == set(ids) - {inactive_delivery.pk}
+
+    inactive_delivery.refresh_from_db()
+    assert inactive_delivery.status == EventDeliveryStatus.FAILED
+
+
+def test_get_multiple_deliveries_for_webhooks_with_inactive_app(
+    any_webhook, event_deliveries, external_app
+):
+    # given
+    all_deliveries = EventDelivery.objects.all()
+    assert len(all_deliveries) == 3
+
+    ids = [event_delivery.pk for event_delivery in all_deliveries]
+    inactive_delivery = all_deliveries[0]
+
+    # Assign inactive app to single delivery
+    external_app.is_active = False
+    external_app.save(update_fields=["is_active"])
+    any_webhook.app = external_app
+    any_webhook.save()
+    inactive_delivery.webhook = any_webhook
+    inactive_delivery.save()
+
+    assert any_webhook.is_active
+    assert all_deliveries[1].webhook.app != any_webhook.app
+    assert all_deliveries[2].webhook.app != any_webhook.app
+
     inactive_delivery.webhook = any_webhook
     inactive_delivery.save(update_fields=["webhook"])
 

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -444,10 +444,10 @@ def get_multiple_deliveries_for_webhooks(
         logger.warning("Event delivery id: %r not found", not_found_delivery_id)
 
     for delivery in deliveries:
-        if delivery.webhook.is_active:
+        if delivery.webhook.is_active and delivery.webhook.app.is_active:
             active_deliveries[delivery.pk] = delivery
         else:
-            logger.info("Event delivery id: %r webhook is disabled.", delivery.pk)
+            logger.info("Event delivery id: %r app/webhook is disabled.", delivery.pk)
             inactive_delivery_ids.add(delivery.pk)
 
     if inactive_delivery_ids:


### PR DESCRIPTION
I want to merge this change because it skips the event-deliveries when app is not active. 

Skipping changelog as this will be ported to previously released versions

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
