### PR TITLE
Extend product filtering capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extend the `Attribute` type with a `values` field, allowing you to retrieve all values assigned to a specific attribute.
 - Add new `single-reference` attribute. You can now create a reference attribute that points to only one object (unlike the existing `reference` type, which supports multiple references).
 Like `reference`, the `single-reference` type can target entities defined in the `AttributeEntityTypeEnum`.
+- Extended support for filtering `products` by associated attributes
+  - Attribute slug is now optional when filtering by attribute values
+  - Added support for filtering by associated reference objects (e.g., `products`, `pages`, `variants`)
 
 ### Webhooks
 - Transaction webhooks responsible for processing payments can now return payment method details`, which will be associated with the corresponding transaction. See [docs](https://docs.saleor.io/developer/extending/webhooks/synchronous-events/transaction#response-4) to learn more.

--- a/saleor/graphql/attribute/shared_filters.py
+++ b/saleor/graphql/attribute/shared_filters.py
@@ -5,7 +5,12 @@ from django.db.models import Exists, OuterRef, Q, QuerySet
 from graphql import GraphQLError
 
 from ...attribute import AttributeInputType
-from ...attribute.models import AssignedPageAttributeValue, Attribute, AttributeValue
+from ...attribute.models import (
+    AssignedPageAttributeValue,
+    AssignedProductAttributeValue,
+    Attribute,
+    AttributeValue,
+)
 from ...page import models as page_models
 from ...product import models as product_models
 from ..core.filters import DecimalFilterInput
@@ -85,8 +90,10 @@ CONTAINS_TYPING = dict[Literal["contains_any", "contains_all"], list[str]]
 class SharedContainsFilterParams(TypedDict):
     attr_id: int | None
     db_connection_name: str
-    assigned_attr_model: type[AssignedPageAttributeValue]
-    assigned_id_field_name: Literal["page_id"]
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ]
+    assigned_id_field_name: Literal["page_id", "product_id"]
     identifier_field_name: Literal["slug", "id", "sku"]
 
 
@@ -94,8 +101,10 @@ def filter_by_contains_referenced_object_ids(
     attr_id: int | None,
     attr_value: CONTAINS_TYPING,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     """Build a filter expression for objects referencing other entities by global IDs.
 
@@ -193,8 +202,10 @@ def _filter_contains_single_expression(
     attr_value_reference_field_name: Literal[
         "reference_page_id", "reference_product_id", "reference_variant_id"
     ],
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     single_reference_qs = AttributeValue.objects.using(db_connection_name).filter(
         Exists(reference_objs.filter(id=OuterRef(attr_value_reference_field_name))),
@@ -215,8 +226,10 @@ def _filter_contains_all_condition(
     attr_id: int | None,
     db_connection_name: str,
     contains_all: list[str],
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
     identifier_field_name: Literal["slug", "id", "sku"],
     referenced_model: type[
         page_models.Page | product_models.Product | product_models.ProductVariant
@@ -257,8 +270,10 @@ def _filter_contains_any_condition(
     attr_id: int | None,
     db_connection_name: str,
     contains_any: list[str],
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
     identifier_field_name: Literal["slug", "id", "sku"],
     referenced_model: type[
         page_models.Page | product_models.Product | product_models.ProductVariant
@@ -294,8 +309,10 @@ def filter_by_contains_referenced_pages(
     attr_id: int | None,
     attr_value: CONTAINS_TYPING,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     """Build a filter expression for referenced pages.
 
@@ -339,8 +356,10 @@ def filter_by_contains_referenced_products(
     attr_id: int | None,
     attr_value: CONTAINS_TYPING,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     """Build a filter expression for referenced products.
 
@@ -385,8 +404,10 @@ def filter_by_contains_referenced_variants(
     attr_id: int | None,
     attr_value: CONTAINS_TYPING,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     """Build a filter expression for referenced product variants.
 
@@ -432,8 +453,10 @@ def filter_by_slug_or_name(
     attr_id: int | None,
     attr_value: dict,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     attribute_values = AttributeValue.objects.using(db_connection_name).filter(
         **{"attribute_id": attr_id} if attr_id else {}
@@ -457,8 +480,10 @@ def filter_by_numeric_attribute(
     attr_id: int | None,
     numeric_value,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     qs_by_numeric = AttributeValue.objects.using(db_connection_name).filter(
         attribute__input_type=AttributeInputType.NUMERIC,
@@ -481,8 +506,10 @@ def filter_by_boolean_attribute(
     attr_id: int | None,
     boolean_value,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     qs_by_boolean = AttributeValue.objects.using(db_connection_name).filter(
         attribute__input_type=AttributeInputType.BOOLEAN,
@@ -500,8 +527,10 @@ def filter_by_date_attribute(
     attr_id: int | None,
     date_value,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     qs_by_date = AttributeValue.objects.using(db_connection_name).filter(
         attribute__input_type=AttributeInputType.DATE,
@@ -523,8 +552,10 @@ def filter_by_date_time_attribute(
     attr_id: int | None,
     date_time_value,
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     qs_by_date_time = AttributeValue.objects.using(db_connection_name).filter(
         attribute__input_type=AttributeInputType.DATE_TIME,
@@ -542,12 +573,14 @@ def filter_by_date_time_attribute(
     return Exists(assigned_attr_value)
 
 
-def filter_objects_by_attributes(
-    qs: QuerySet[page_models.Page],
+def filter_objects_by_attributes[T: (page_models.Page, product_models.Product)](
+    qs: QuerySet[T],
     value: list[dict],
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
-):
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
+) -> QuerySet[T]:
     attribute_slugs = {
         attr_filter["slug"] for attr_filter in value if "slug" in attr_filter
     }
@@ -651,8 +684,10 @@ def filter_objects_by_reference_attributes(
         CONTAINS_TYPING,
     ],
     db_connection_name: str,
-    assigned_attr_model: type[AssignedPageAttributeValue],
-    assigned_id_field_name: Literal["page_id"],
+    assigned_attr_model: type[
+        AssignedPageAttributeValue | AssignedProductAttributeValue
+    ],
+    assigned_id_field_name: Literal["page_id", "product_id"],
 ):
     filter_expression = Q()
 

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -55,6 +55,7 @@ from .filters import (
     AttributeValueWhereInput,
     search_attribute_values,
 )
+from .shared_filters import AssignedAttributeValueInput
 from .sorters import AttributeChoicesSortingInput
 from .utils.shared import ENTITY_TYPE_MAPPING
 
@@ -534,7 +535,15 @@ class SelectedAttribute(ChannelContextTypeForObjectType):
 
 
 class AttributeInput(BaseInputObjectType):
-    slug = graphene.String(required=True, description=AttributeDescriptions.SLUG)
+    slug = graphene.String(required=False, description=AttributeDescriptions.SLUG)
+    value = AssignedAttributeValueInput(
+        required=False,
+        description=(
+            "Filter by value of the attribute. Only one value input field is allowed. "
+            "If provided more than one, the error will be raised. Cannot be combined "
+            "with deprecated fields of `AttributeInput`. "
+        ),
+    )
     value_names = NonNullList(
         graphene.String,
         required=False,
@@ -551,26 +560,42 @@ class AttributeInput(BaseInputObjectType):
         description=(
             "Slugs identifying the attributeValues associated with the Attribute. "
             "When specified, it filters the results to include only records with "
-            "one of the matching values."
+            "one of the matching values. Requires `slug` to be provided. "
+            f" {DEPRECATED_IN_3X_INPUT} Use `value` instead."
         ),
     )
     values_range = graphene.Field(
         IntRangeInput,
         required=False,
-        description=AttributeValueDescriptions.VALUES_RANGE,
+        description=(
+            AttributeValueDescriptions.VALUES_RANGE
+            + " Requires `slug` to be provided. "
+            f"{DEPRECATED_IN_3X_INPUT} Use `value` instead."
+        ),
     )
     date_time = graphene.Field(
         DateTimeRangeInput,
         required=False,
-        description=AttributeValueDescriptions.DATE_TIME_RANGE,
+        description=(
+            AttributeValueDescriptions.DATE_TIME_RANGE
+            + " Requires `slug` to be provided. "
+            f"{DEPRECATED_IN_3X_INPUT} Use `value` instead."
+        ),
     )
     date = graphene.Field(
         DateRangeInput,
         required=False,
-        description=AttributeValueDescriptions.DATE_RANGE,
+        description=(
+            AttributeValueDescriptions.DATE_RANGE + " Requires `slug` to be provided. "
+            f"{DEPRECATED_IN_3X_INPUT} Use `value` instead."
+        ),
     )
     boolean = graphene.Boolean(
-        required=False, description=AttributeDescriptions.BOOLEAN
+        required=False,
+        description=(
+            AttributeDescriptions.BOOLEAN + " Requires `slug` to be provided. "
+            f"{DEPRECATED_IN_3X_INPUT} Use `value` instead."
+        ),
     )
 
     class Meta:

--- a/saleor/graphql/product/tests/queries/products_filtrations/shared.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/shared.py
@@ -1,0 +1,26 @@
+PRODUCTS_WHERE_QUERY = """
+    query($where: ProductWhereInput!, $channel: String) {
+      products(first: 10, where: $where, channel: $channel) {
+        edges {
+          node {
+            id
+            name
+            slug
+          }
+        }
+      }
+    }
+"""
+PRODUCTS_FILTER_QUERY = """
+    query($where: ProductFilterInput!, $channel: String) {
+      products(first: 10, filter: $where, channel: $channel) {
+        edges {
+          node {
+            id
+            name
+            slug
+          }
+        }
+      }
+    }
+"""

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes.py
@@ -1,0 +1,166 @@
+import graphene
+import pytest
+
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+def test_products_query_with_attribute_slug(
+    query, staff_api_client, product_list, size_attribute, channel_USD
+):
+    # given
+    product_list[0].product_type.product_attributes.add(size_attribute)
+    product_attr_value = size_attribute.values.first()
+
+    associate_attribute_values_to_instance(
+        product_list[0], {size_attribute.pk: [product_attr_value]}
+    )
+
+    variables = {
+        "where": {"attributes": [{"slug": size_attribute.slug}]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == 1
+    assert products_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Product", product_list[0].pk
+    )
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("attribute_input", "expected_count"),
+    [
+        ({"value": {"slug": {"eq": "test-slug-1"}}}, 1),
+        ({"value": {"slug": {"oneOf": ["test-slug-1", "test-slug-2"]}}}, 2),
+        ({"slug": "size_attribute", "value": {"slug": {"eq": "test-slug-1"}}}, 1),
+        (
+            {
+                "slug": "size_attribute",
+                "value": {"slug": {"oneOf": ["test-slug-1", "test-slug-2"]}},
+            },
+            2,
+        ),
+    ],
+)
+def test_products_query_with_attribute_value_slug(
+    query,
+    attribute_input,
+    expected_count,
+    staff_api_client,
+    product_list,
+    size_attribute,
+    channel_USD,
+):
+    # given
+    size_attribute.slug = "size_attribute"
+    size_attribute.save()
+
+    product_list[0].product_type.product_attributes.add(size_attribute)
+
+    attr_value_1 = size_attribute.values.first()
+    attr_value_1.slug = "test-slug-1"
+    attr_value_1.save()
+
+    attr_value_2 = size_attribute.values.last()
+    attr_value_2.slug = "test-slug-2"
+    attr_value_2.save()
+
+    associate_attribute_values_to_instance(
+        product_list[0], {size_attribute.pk: [attr_value_1]}
+    )
+
+    associate_attribute_values_to_instance(
+        product_list[1], {size_attribute.pk: [attr_value_2]}
+    )
+
+    variables = {
+        "where": {"attributes": [attribute_input]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("attribute_input", "expected_count"),
+    [
+        ({"value": {"name": {"eq": "test-name-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["test-name-1", "test-name-2"]}}}, 2),
+        ({"slug": "size_attribute", "value": {"name": {"eq": "test-name-1"}}}, 1),
+        (
+            {
+                "slug": "size_attribute",
+                "value": {"name": {"oneOf": ["test-name-1", "test-name-2"]}},
+            },
+            2,
+        ),
+    ],
+)
+def test_products_query_with_attribute_value_name(
+    query,
+    attribute_input,
+    expected_count,
+    staff_api_client,
+    product_list,
+    size_attribute,
+    channel_USD,
+):
+    # given
+    size_attribute.slug = "size_attribute"
+    size_attribute.save()
+
+    product_list[0].product_type.product_attributes.add(size_attribute)
+
+    attr_value_1 = size_attribute.values.first()
+    attr_value_1.name = "test-name-1"
+    attr_value_1.save()
+
+    attr_value_2 = size_attribute.values.last()
+    attr_value_2.name = "test-name-2"
+    attr_value_2.save()
+
+    associate_attribute_values_to_instance(
+        product_list[0], {size_attribute.pk: [attr_value_1]}
+    )
+
+    associate_attribute_values_to_instance(
+        product_list[1], {size_attribute.pk: [attr_value_2]}
+    )
+
+    variables = {
+        "where": {"attributes": [attribute_input]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_boolean.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_boolean.py
@@ -1,0 +1,83 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "boolean_input",
+    [
+        {"value": {"boolean": True}},
+        {"value": {"name": {"eq": "True-name"}}},
+        {"value": {"slug": {"eq": "true_slug"}}},
+        {"value": {"name": {"oneOf": ["True-name", "True-name-2"]}}},
+        {"value": {"slug": {"oneOf": ["true_slug"]}}},
+        {"slug": "b_s", "value": {"boolean": True}},
+        {"slug": "b_s", "value": {"name": {"eq": "True-name"}}},
+        {"slug": "b_s", "value": {"slug": {"eq": "true_slug"}}},
+        {"slug": "b_s", "value": {"name": {"oneOf": ["True-name", "True-name-2"]}}},
+        {"slug": "b_s", "value": {"slug": {"oneOf": ["true_slug"]}}},
+    ],
+)
+def test_products_query_with_attribute_value_boolean(
+    query,
+    boolean_input,
+    staff_api_client,
+    product_type,
+    product_list,
+    boolean_attribute,
+    channel_USD,
+):
+    # given
+    boolean_attribute.slug = "b_s"
+    boolean_attribute.type = "PRODUCT_TYPE"
+    boolean_attribute.save()
+
+    second_attribute = Attribute.objects.create(
+        slug="s_boolean",
+        name="Boolean",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.BOOLEAN,
+    )
+
+    product_type.product_attributes.set([boolean_attribute, second_attribute])
+
+    true_value = boolean_attribute.values.filter(boolean=True).first()
+    true_value.name = "True-name"
+    true_value.slug = "true_slug"
+    true_value.save()
+
+    associate_attribute_values_to_instance(
+        product_list[0], {boolean_attribute.pk: [true_value]}
+    )
+
+    value_for_second_attr = AttributeValue.objects.create(
+        attribute=second_attribute,
+        name=f"{second_attribute.name}: Yes",
+        slug=f"{second_attribute.id}_false",
+        boolean=False,
+    )
+    associate_attribute_values_to_instance(
+        product_list[1], {second_attribute.pk: [value_for_second_attr]}
+    )
+
+    variables = {"where": {"attributes": [boolean_input]}, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == 1
+    assert products_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Product", product_list[0].pk
+    )

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_date.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_date.py
@@ -1,0 +1,102 @@
+import datetime
+
+import pytest
+
+from ......attribute import AttributeInputType, AttributeType
+from ......attribute.models import Attribute
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("date_input", "expected_count"),
+    [
+        ({"slug": "date", "value": {"date": {"gte": "2021-01-01"}}}, 1),
+        ({"slug": "date", "value": {"name": {"eq": "date-name-1"}}}, 1),
+        ({"slug": "date", "value": {"slug": {"eq": "date-slug-1"}}}, 1),
+        (
+            {
+                "slug": "date",
+                "value": {"name": {"oneOf": ["date-name-1", "date-name-2"]}},
+            },
+            1,
+        ),
+        (
+            {
+                "slug": "date",
+                "value": {"slug": {"oneOf": ["date-slug-1", "date-slug-2"]}},
+            },
+            1,
+        ),
+        (
+            {
+                "slug": "date",
+                "value": {"date": {"gte": "2021-01-02", "lte": "2021-01-03"}},
+            },
+            1,
+        ),
+        ({"value": {"date": {"gte": "2021-01-01"}}}, 2),
+        ({"value": {"name": {"eq": "date-name-1"}}}, 1),
+        ({"value": {"slug": {"eq": "date-slug-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["date-name-1", "date-name-2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["date-slug-1", "date-slug-2"]}}}, 2),
+        ({"value": {"date": {"gte": "2021-01-01", "lte": "2021-01-02"}}}, 1),
+    ],
+)
+def test_products_query_with_attribute_value_date(
+    query,
+    date_input,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    date_attribute,
+    channel_USD,
+):
+    # given
+    date_attribute.type = "PRODUCT_TYPE"
+    date_attribute.slug = "date"
+    date_attribute.save()
+
+    second_date_attribute = Attribute.objects.create(
+        slug="second_date",
+        name="Second date",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.DATE,
+    )
+    product_type.product_attributes.set([date_attribute, second_date_attribute])
+
+    attr_value_1 = date_attribute.values.first()
+    attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
+    attr_value_1.name = "date-name-1"
+    attr_value_1.slug = "date-slug-1"
+    attr_value_1.save()
+
+    associate_attribute_values_to_instance(
+        product_list[0], {date_attribute.pk: [attr_value_1]}
+    )
+
+    second_attr_value = second_date_attribute.values.create(
+        date_time=datetime.datetime(2021, 1, 2, tzinfo=datetime.UTC),
+        name="date-name-2",
+        slug="date-slug-2",
+    )
+
+    associate_attribute_values_to_instance(
+        product_list[1], {second_date_attribute.pk: [second_attr_value]}
+    )
+
+    variables = {"where": {"attributes": [date_input]}, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_datetime.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_datetime.py
@@ -1,0 +1,131 @@
+import datetime
+
+import pytest
+
+from ......attribute import AttributeInputType, AttributeType
+from ......attribute.models import Attribute
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("date_time_input", "expected_count"),
+    [
+        ({"slug": "dt", "value": {"name": {"eq": "datetime-name-1"}}}, 1),
+        ({"slug": "dt", "value": {"slug": {"eq": "datetime-slug-1"}}}, 1),
+        (
+            {
+                "slug": "dt",
+                "value": {"name": {"oneOf": ["datetime-name-1", "datetime-name-2"]}},
+            },
+            2,
+        ),
+        (
+            {
+                "slug": "dt",
+                "value": {"slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]}},
+            },
+            2,
+        ),
+        ({"slug": "dt", "value": {"dateTime": {"gte": "2021-01-01T00:00:00Z"}}}, 2),
+        (
+            {
+                "slug": "dt",
+                "value": {
+                    "dateTime": {
+                        "gte": "2021-01-01T00:00:00Z",
+                        "lte": "2021-01-02T00:00:00Z",
+                    }
+                },
+            },
+            1,
+        ),
+        ({"value": {"name": {"eq": "datetime-name-1"}}}, 1),
+        ({"value": {"slug": {"eq": "datetime-slug-1"}}}, 1),
+        ({"value": {"name": {"oneOf": ["datetime-name-1", "datetime-name-2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["datetime-slug-1", "datetime-slug-2"]}}}, 2),
+        ({"value": {"dateTime": {"gte": "2021-01-01T00:00:00Z"}}}, 3),
+        (
+            {
+                "value": {
+                    "dateTime": {
+                        "gte": "2021-01-01T00:00:00Z",
+                        "lte": "2021-01-02T00:00:00Z",
+                    }
+                }
+            },
+            2,
+        ),
+    ],
+)
+def test_products_query_with_attribute_value_date_time(
+    query,
+    date_time_input,
+    expected_count,
+    staff_api_client,
+    product_type,
+    product_list,
+    date_time_attribute,
+    channel_USD,
+):
+    # given
+    date_time_attribute.slug = "dt"
+    date_time_attribute.type = "PRODUCT_TYPE"
+    date_time_attribute.save()
+
+    second_date_attribute = Attribute.objects.create(
+        slug="second_dt",
+        name="Second dt",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.DATE_TIME,
+    )
+
+    product_type.product_attributes.set([date_time_attribute, second_date_attribute])
+
+    attr_value_1 = date_time_attribute.values.first()
+    attr_value_1.date_time = datetime.datetime(2021, 1, 3, tzinfo=datetime.UTC)
+    attr_value_1.name = "datetime-name-1"
+    attr_value_1.slug = "datetime-slug-1"
+    attr_value_1.save()
+
+    associate_attribute_values_to_instance(
+        product_list[0], {date_time_attribute.pk: [attr_value_1]}
+    )
+
+    second_attr_value = date_time_attribute.values.last()
+    second_attr_value.date_time = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+    second_attr_value.name = "datetime-name-2"
+    second_attr_value.slug = "datetime-slug-2"
+    second_attr_value.save()
+
+    associate_attribute_values_to_instance(
+        product_list[1], {date_time_attribute.pk: [second_attr_value]}
+    )
+
+    value_for_second_attr = second_date_attribute.values.create(
+        date_time=datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC),
+        name="second-datetime-name",
+        slug="second-datetime-slug",
+    )
+
+    associate_attribute_values_to_instance(
+        product_list[2], {second_date_attribute.pk: [value_for_second_attr]}
+    )
+
+    variables = {
+        "where": {"attributes": [date_time_input]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_numeric.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_attributes_numeric.py
@@ -1,0 +1,91 @@
+import pytest
+
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("numeric_input", "expected_count"),
+    [
+        ({"slug": "num-slug", "value": {"numeric": {"eq": 1.2}}}, 1),
+        ({"slug": "num-slug", "value": {"numeric": {"oneOf": [1.2, 2]}}}, 2),
+        (
+            {"slug": "num-slug", "value": {"numeric": {"range": {"gte": 1, "lte": 2}}}},
+            2,
+        ),
+        ({"slug": "num-slug", "value": {"name": {"eq": "1.2"}}}, 1),
+        ({"slug": "num-slug", "value": {"slug": {"eq": "1.2"}}}, 1),
+        ({"slug": "num-slug", "value": {"name": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"slug": "num-slug", "value": {"slug": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"value": {"numeric": {"eq": 1.2}}}, 1),
+        ({"value": {"numeric": {"oneOf": [1.2, 2]}}}, 2),
+        ({"value": {"numeric": {"range": {"gte": 1, "lte": 2}}}}, 2),
+        ({"value": {"numeric": {"range": {"gte": 1}}}}, 3),
+        ({"value": {"name": {"eq": "1.2"}}}, 1),
+        ({"value": {"slug": {"eq": "1.2"}}}, 1),
+        ({"value": {"name": {"oneOf": ["1.2", "2"]}}}, 2),
+        ({"value": {"slug": {"oneOf": ["1.2", "2"]}}}, 2),
+    ],
+)
+def test_products_query_with_attribute_value_numeric(
+    query,
+    numeric_input,
+    expected_count,
+    staff_api_client,
+    product_type,
+    product_list,
+    numeric_attribute_without_unit,
+    numeric_attribute,
+    channel_USD,
+):
+    # given
+    numeric_attribute_without_unit.slug = "num-slug"
+    numeric_attribute_without_unit.type = "PRODUCT_TYPE"
+    numeric_attribute_without_unit.save()
+
+    product_type.product_attributes.set(
+        [numeric_attribute_without_unit, numeric_attribute]
+    )
+
+    attr_value_1 = numeric_attribute_without_unit.values.first()
+    attr_value_1.name = "1.2"
+    attr_value_1.slug = "1.2"
+    attr_value_1.numeric = 1.2
+    attr_value_1.save()
+
+    attr_value_2 = numeric_attribute_without_unit.values.last()
+    attr_value_2.name = "2"
+    attr_value_2.slug = "2"
+    attr_value_2.numeric = 2
+    attr_value_2.save()
+
+    second_attr_value = numeric_attribute.values.first()
+
+    associate_attribute_values_to_instance(
+        product_list[0],
+        {
+            numeric_attribute_without_unit.pk: [attr_value_1],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_list[1], {numeric_attribute_without_unit.pk: [attr_value_2]}
+    )
+    associate_attribute_values_to_instance(
+        product_list[2], {numeric_attribute.pk: [second_attr_value]}
+    )
+
+    variables = {"where": {"attributes": [numeric_input]}, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_multiple_arguments.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_multiple_arguments.py
@@ -1,0 +1,262 @@
+import pytest
+
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_filter",
+    [
+        # Non-existing attribute slug
+        [{"slug": "non-existing-attribute"}],
+        # Existing attribute with non-existing value name
+        [{"slug": "tag", "value": {"name": {"eq": "Non-existing Name"}}}],
+        [{"value": {"name": {"eq": "Non-existing Name"}}}],
+        # Existing numeric attribute with out-of-range value
+        [{"slug": "count", "value": {"numeric": {"eq": 999}}}],
+        [{"value": {"numeric": {"eq": 999}}}],
+        # Existing boolean attribute with no matching boolean value
+        [{"slug": "boolean", "value": {"boolean": False}}],
+        [{"value": {"boolean": False}}],
+        # Multiple attributes where one doesn't exist
+        [
+            {"slug": "size", "value": {"slug": {"eq": "large"}}},
+            {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
+        ],
+        [
+            {"value": {"slug": {"eq": "large"}}},
+            {"slug": "non-existing-attr", "value": {"slug": {"eq": "some-value"}}},
+        ],
+    ],
+)
+def test_products_query_with_non_matching_records(
+    query,
+    attribute_filter,
+    staff_api_client,
+    product_list,
+    size_attribute,
+    tag_page_attribute,
+    boolean_attribute,
+    numeric_attribute_without_unit,
+    date_attribute,
+    date_time_attribute,
+    channel_USD,
+):
+    # given
+    tag_attribute = tag_page_attribute
+    tag_attribute.type = "PRODUCT_TYPE"
+    tag_attribute.save()
+
+    product_type = product_list[0].product_type
+    product_type.product_attributes.set(
+        [
+            size_attribute,
+            tag_attribute,
+            boolean_attribute,
+            numeric_attribute_without_unit,
+            date_attribute,
+            date_time_attribute,
+        ]
+    )
+
+    size_value = size_attribute.values.get(slug="small")
+    tag_value = tag_attribute.values.get(name="About")
+    boolean_value = boolean_attribute.values.filter(boolean=True).first()
+    numeric_value = numeric_attribute_without_unit.values.first()
+    date_time_value = date_time_attribute.values.first()
+    date_value = date_attribute.values.first()
+
+    date_attribute.slug = "date"
+    date_attribute.save()
+    date_time_attribute.slug = "date_time"
+    date_time_attribute.save()
+
+    associate_attribute_values_to_instance(
+        product_list[0],
+        {
+            size_attribute.pk: [size_value],
+            tag_attribute.pk: [tag_value],
+            boolean_attribute.pk: [boolean_value],
+            numeric_attribute_without_unit.pk: [numeric_value],
+            date_attribute.pk: [date_value],
+            date_time_attribute.pk: [date_time_value],
+        },
+    )
+
+    variables = {
+        "where": {"attributes": attribute_filter},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == 0
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("attribute_where_input", "expected_count_result"),
+    [
+        (
+            [
+                {"slug": "size", "value": {"slug": {"eq": "big"}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
+                {"slug": "color", "value": {"slug": {"oneOf": ["red"]}}},
+                {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "size", "value": {"slug": {"eq": "big"}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "size", "value": {"slug": {"eq": "big"}}},
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {"slug": "tag", "value": {"name": {"eq": "About"}}},
+                {"slug": "size", "value": {"slug": {"eq": "big"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "size", "value": {"slug": {"eq": "small"}}},
+                {"slug": "tag", "value": {"name": {"eq": "Help"}}},
+                {"slug": "boolean", "value": {"boolean": False}},
+            ],
+            0,
+        ),
+        (
+            [
+                {
+                    "slug": "color",
+                    "value": {"slug": {"oneOf": ["red", "blue"]}},
+                },
+                {"slug": "size", "value": {"slug": {"eq": "big"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "size", "value": {"slug": {"eq": "big"}}},
+                {"slug": "color", "value": {"name": {"eq": "Red"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "size", "value": {"slug": {"eq": "big"}}},
+                {"slug": "tag", "value": {"name": {"eq": "About"}}},
+                {"slug": "color", "value": {"slug": {"eq": "red"}}},
+            ],
+            1,
+        ),
+        (
+            [
+                {"slug": "size", "value": {"slug": {"oneOf": ["big", "small"]}}},
+                {"slug": "tag", "value": {"name": {"oneOf": ["About", "Help"]}}},
+            ],
+            2,
+        ),
+        (
+            [
+                {"slug": "size", "value": {"slug": {"oneOf": ["big", "small"]}}},
+                {"slug": "boolean", "value": {"boolean": True}},
+            ],
+            1,
+        ),
+        ([{"value": {"slug": {"oneOf": ["red", "blue"]}}}], 3),
+        (
+            [
+                {"value": {"slug": {"oneOf": ["big", "small"]}}},
+                {"value": {"boolean": True}},
+            ],
+            1,
+        ),
+    ],
+)
+def test_products_query_with_multiple_attribute_filters(
+    query,
+    attribute_where_input,
+    expected_count_result,
+    staff_api_client,
+    product_list,
+    size_attribute,
+    tag_page_attribute,
+    color_attribute,
+    boolean_attribute,
+    channel_USD,
+):
+    # given
+    tag_attribute = tag_page_attribute
+    tag_attribute.slug = "tag"
+    tag_attribute.type = "PRODUCT_TYPE"
+    tag_attribute.save()
+
+    product_type = product_list[0].product_type
+    product_type.product_attributes.set(
+        [size_attribute, tag_attribute, color_attribute, boolean_attribute]
+    )
+
+    size_value = size_attribute.values.get(slug="big")
+    tag_value = tag_attribute.values.get(name="About")
+    color_value = color_attribute.values.get(slug="red")
+    second_color_value = color_attribute.values.get(slug="blue")
+
+    boolean_value = boolean_attribute.values.filter(boolean=True).first()
+
+    associate_attribute_values_to_instance(
+        product_list[0],
+        {
+            size_attribute.pk: [size_value],
+            tag_attribute.pk: [tag_value],
+            color_attribute.pk: [color_value],
+            boolean_attribute.pk: [boolean_value],
+        },
+    )
+
+    tag_value_2 = tag_attribute.values.get(name="Help")
+    size_value_small = size_attribute.values.get(slug="small")
+
+    associate_attribute_values_to_instance(
+        product_list[1],
+        {
+            size_attribute.pk: [size_value_small],
+            tag_attribute.pk: [tag_value_2],
+            color_attribute.pk: [second_color_value],
+        },
+    )
+
+    variables = {
+        "where": {"attributes": attribute_where_input},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count_result

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_pages.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_pages.py
@@ -1,0 +1,352 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from ......page.models import Page
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_reference_to_pages(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_type,
+    product_list,
+    page_type,
+    product_type_page_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_page_reference_attribute)
+
+    reference_page_1_slug = "referenced-page-1"
+    reference_page_2_slug = "referenced-page-2"
+    referenced_page_1, referenced_page_2 = Page.objects.bulk_create(
+        [
+            Page(
+                title="Referenced Page 1",
+                slug=reference_page_1_slug,
+                page_type=page_type,
+                is_published=True,
+            ),
+            Page(
+                title="Referenced Page 2",
+                slug=reference_page_2_slug,
+                page_type=page_type,
+                is_published=True,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_page_reference_attribute,
+                name=f"Page {referenced_page_1.pk}",
+                slug=f"page-{referenced_page_1.pk}",
+                reference_page=referenced_page_1,
+            ),
+            AttributeValue(
+                attribute=product_type_page_reference_attribute,
+                name=f"Page {referenced_page_2.pk}",
+                slug=f"page-{referenced_page_2.pk}",
+                reference_page=referenced_page_2,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_page_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {product_type_page_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "page-reference",
+                    "value": {
+                        "reference": {
+                            "pageSlugs": {
+                                filter_type: [
+                                    reference_page_1_slug,
+                                    reference_page_2_slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attribute_value_reference_to_pages(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    page_type,
+    product_type_page_reference_attribute,
+    channel_USD,
+):
+    # given
+    second_page_reference_attribute = Attribute.objects.create(
+        slug="second-page-reference",
+        name="Page reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PAGE,
+    )
+    product_type.product_attributes.add(
+        product_type_page_reference_attribute,
+        second_page_reference_attribute,
+    )
+
+    reference_1 = "referenced-page-1"
+    reference_2 = "referenced-page-2"
+    referenced_page_1, referenced_page_2 = Page.objects.bulk_create(
+        [
+            Page(
+                title="Referenced Page 1",
+                slug=reference_1,
+                page_type=page_type,
+                is_published=True,
+            ),
+            Page(
+                title="Referenced Page 2",
+                slug=reference_2,
+                page_type=page_type,
+                is_published=True,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_page_reference_attribute,
+                name=f"Page {referenced_page_1.pk}",
+                slug=f"page-{referenced_page_1.pk}",
+                reference_page=referenced_page_1,
+            ),
+            AttributeValue(
+                attribute=second_page_reference_attribute,
+                name=f"Page {referenced_page_2.pk}",
+                slug=f"page-{referenced_page_2.pk}",
+                reference_page=referenced_page_2,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_page_reference_attribute.pk: [attribute_value_1],
+            second_page_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {second_page_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "pageSlugs": {filter_type: [reference_1, reference_2]}
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_referenced_page_ids(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    page_type,
+    product_type_page_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_page_reference_attribute)
+
+    referenced_first_page, referenced_second_page, referenced_third_page = (
+        Page.objects.bulk_create(
+            [
+                Page(
+                    title="Referenced Page",
+                    slug="referenced-page",
+                    page_type=page_type,
+                    is_published=True,
+                ),
+                Page(
+                    title="Referenced Page",
+                    slug="referenced-page2",
+                    page_type=page_type,
+                    is_published=True,
+                ),
+                Page(
+                    title="Referenced Page",
+                    slug="referenced-page3",
+                    page_type=page_type,
+                    is_published=True,
+                ),
+            ]
+        )
+    )
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_page_reference_attribute,
+                    name=f"Page {referenced_first_page.pk}",
+                    slug=f"page-{referenced_first_page.pk}",
+                    reference_page=referenced_first_page,
+                ),
+                AttributeValue(
+                    attribute=product_type_page_reference_attribute,
+                    name=f"Page {referenced_second_page.pk}",
+                    slug=f"page-{referenced_second_page.pk}",
+                    reference_page=referenced_second_page,
+                ),
+                AttributeValue(
+                    attribute=product_type_page_reference_attribute,
+                    name=f"Page {referenced_third_page.pk}",
+                    slug=f"page-{referenced_third_page.pk}",
+                    reference_page=referenced_third_page,
+                ),
+            ]
+        )
+    )
+    first_product_with_all_ids = product_list[0]
+    second_product_with_all_ids = product_list[1]
+    product_with_single_id = product_list[2]
+    associate_attribute_values_to_instance(
+        first_product_with_all_ids,
+        {
+            product_type_page_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_with_all_ids,
+        {
+            product_type_page_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_with_single_id,
+        {product_type_page_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(referenced_first_page)
+    referenced_second_global_id = to_global_id_or_none(referenced_second_page)
+    referenced_third_global_id = to_global_id_or_none(referenced_third_page)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_page_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_products.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_products.py
@@ -1,0 +1,353 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from ......product.models import Product
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_products_query_with_attr_slug_and_attribute_value_reference_to_products(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    product_type_product_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_product_reference_attribute)
+
+    ref_product_1, ref_product_2 = Product.objects.bulk_create(
+        [
+            Product(
+                name="Reference Product 1",
+                slug="ref-1",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 2",
+                slug="ref-2",
+                product_type=product_type,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_product_reference_attribute,
+                name=f"Product {ref_product_1.pk}",
+                slug=f"product-{ref_product_1.pk}",
+                reference_product=ref_product_1,
+            ),
+            AttributeValue(
+                attribute=product_type_product_reference_attribute,
+                name=f"Product {ref_product_2.pk}",
+                slug=f"product-{ref_product_2.pk}",
+                reference_product=ref_product_2,
+            ),
+        ]
+    )
+
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_product_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {product_type_product_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "product-reference",
+                    "value": {
+                        "reference": {
+                            "productSlugs": {
+                                filter_type: [ref_product_1.slug, ref_product_2.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+    assert products_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Product", product_list[0].pk
+    )
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_products_query_with_attribute_value_reference_to_products(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    product_type_product_reference_attribute,
+    channel_USD,
+):
+    # given
+    second_product_reference_attribute = Attribute.objects.create(
+        slug="second-product-reference",
+        name="Product reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PRODUCT,
+    )
+
+    product_type.product_attributes.add(
+        product_type_product_reference_attribute,
+        second_product_reference_attribute,
+    )
+
+    ref_product_1, ref_product_2 = Product.objects.bulk_create(
+        [
+            Product(
+                name="Reference Product 1",
+                slug="ref-1",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 2",
+                slug="ref-2",
+                product_type=product_type,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_product_reference_attribute,
+                name=f"Product {ref_product_1.pk}",
+                slug=f"product-{ref_product_1.pk}",
+                reference_product=ref_product_1,
+            ),
+            AttributeValue(
+                attribute=second_product_reference_attribute,
+                name=f"Product {ref_product_2.pk}",
+                slug=f"product-{ref_product_2.pk}",
+                reference_product=ref_product_2,
+            ),
+        ]
+    )
+
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_product_reference_attribute.pk: [attribute_value_1],
+            second_product_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {second_product_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "productSlugs": {
+                                filter_type: [ref_product_1.slug, ref_product_2.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+    assert products_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Product", product_list[0].pk
+    )
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_referenced_product_ids(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    product_type_product_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(
+        product_type_product_reference_attribute,
+    )
+    # Create additional products to use as references
+    ref_product_1, ref_product_2, ref_product_3 = Product.objects.bulk_create(
+        [
+            Product(
+                name="Reference Product 1",
+                slug="ref-1",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 2",
+                slug="ref-2",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 3",
+                slug="ref-3",
+                product_type=product_type,
+            ),
+        ]
+    )
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_product_reference_attribute,
+                    name=f"Product {ref_product_1.pk}",
+                    slug=f"product-{ref_product_1.pk}",
+                    reference_product=ref_product_1,
+                ),
+                AttributeValue(
+                    attribute=product_type_product_reference_attribute,
+                    name=f"Product {ref_product_2.pk}",
+                    slug=f"product-{ref_product_2.pk}",
+                    reference_product=ref_product_2,
+                ),
+                AttributeValue(
+                    attribute=product_type_product_reference_attribute,
+                    name=f"Product {ref_product_3.pk}",
+                    slug=f"product-{ref_product_3.pk}",
+                    reference_product=ref_product_3,
+                ),
+            ]
+        )
+    )
+    first_product_with_all_ids = product_list[0]
+    second_product_with_all_ids = product_list[1]
+    product_with_single_id = product_list[2]
+
+    associate_attribute_values_to_instance(
+        first_product_with_all_ids,
+        {
+            product_type_product_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_with_all_ids,
+        {
+            product_type_product_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_with_single_id,
+        {
+            product_type_product_reference_attribute.pk: [
+                first_attr_value,
+            ],
+        },
+    )
+    ref_1_global_id = to_global_id_or_none(ref_product_1)
+    ref_2_global_id = to_global_id_or_none(ref_product_2)
+    ref_3_global_id = to_global_id_or_none(ref_product_3)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_product_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    ref_1_global_id,
+                                    ref_2_global_id,
+                                    ref_3_global_id,
+                                ]
+                            }
+                        }
+                    },
+                },
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_variants.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_variants.py
@@ -1,0 +1,326 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attribute_value_reference_to_product_variants(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    product_type_variant_reference_attribute,
+    product_variant_list,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_variant_reference_attribute)
+    second_variant_reference_attribute = Attribute.objects.create(
+        slug="second-product-reference",
+        name="Product reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PRODUCT_VARIANT,
+    )
+
+    first_variant_sku = "test-variant-1"
+    second_variant_sku = "test-variant-2"
+
+    first_variant = product_variant_list[0]
+    first_variant.sku = first_variant_sku
+    first_variant.save()
+
+    second_variant = product_variant_list[1]
+    second_variant.sku = second_variant_sku
+    second_variant.save()
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_variant_reference_attribute,
+                name=f"Variant {first_variant.pk}",
+                slug=f"variant-{first_variant.pk}",
+                reference_variant=first_variant,
+            ),
+            AttributeValue(
+                attribute=second_variant_reference_attribute,
+                name=f"Variant {second_variant.pk}",
+                slug=f"variant-{second_variant.pk}",
+                reference_variant=second_variant,
+            ),
+        ]
+    )
+
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_variant_reference_attribute.pk: [attribute_value_1],
+            second_variant_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {second_variant_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "productVariantSkus": {
+                                filter_type: [
+                                    first_variant_sku,
+                                    second_variant_sku,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+    assert products_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Product", product_list[0].pk
+    )
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_reference_to_product_variants(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    product_type_variant_reference_attribute,
+    product_variant_list,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_variant_reference_attribute)
+
+    first_variant_sku = "test-variant-1"
+    second_variant_sku = "test-variant-2"
+
+    first_variant = product_variant_list[0]
+    first_variant.sku = first_variant_sku
+    first_variant.save()
+
+    second_variant = product_variant_list[1]
+    second_variant.sku = second_variant_sku
+    second_variant.save()
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_variant_reference_attribute,
+                name=f"Variant {first_variant.pk}",
+                slug=f"variant-{first_variant.pk}",
+                reference_variant=first_variant,
+            ),
+            AttributeValue(
+                attribute=product_type_variant_reference_attribute,
+                name=f"Variant {second_variant.pk}",
+                slug=f"variant-{second_variant.pk}",
+                reference_variant=second_variant,
+            ),
+        ]
+    )
+
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_variant_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {product_type_variant_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "variant-reference",
+                    "value": {
+                        "reference": {
+                            "productVariantSkus": {
+                                filter_type: [
+                                    first_variant_sku,
+                                    second_variant_sku,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+    assert products_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Product", product_list[0].pk
+    )
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_products_query_with_attr_slug_attribute_value_referenced_variant_ids(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    product_type_variant_reference_attribute,
+    product_variant_list,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(
+        product_type_variant_reference_attribute,
+    )
+
+    first_variant = product_variant_list[0]
+    second_variant = product_variant_list[1]
+    third_variant = product_variant_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_variant_reference_attribute,
+                    name=f"Variant {first_variant.pk}",
+                    slug=f"variant-{first_variant.pk}",
+                    reference_variant=first_variant,
+                ),
+                AttributeValue(
+                    attribute=product_type_variant_reference_attribute,
+                    name=f"Variant {second_variant.pk}",
+                    slug=f"variant-{second_variant.pk}",
+                    reference_variant=second_variant,
+                ),
+                AttributeValue(
+                    attribute=product_type_variant_reference_attribute,
+                    name=f"Variant {third_variant.pk}",
+                    slug=f"variant-{third_variant.pk}",
+                    reference_variant=third_variant,
+                ),
+            ]
+        )
+    )
+    first_product_with_all_ids = product_list[0]
+    second_product_with_all_ids = product_list[1]
+    product_with_single_id = product_list[2]
+    associate_attribute_values_to_instance(
+        first_product_with_all_ids,
+        {
+            product_type_variant_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_with_all_ids,
+        {
+            product_type_variant_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_with_single_id,
+        {product_type_variant_reference_attribute.pk: [first_attr_value]},
+    )
+    referenced_first_global_id = to_global_id_or_none(first_variant)
+    referenced_second_global_id = to_global_id_or_none(second_variant)
+    referenced_third_global_id = to_global_id_or_none(third_variant)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_variant_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_validation.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_validation.py
@@ -1,0 +1,459 @@
+import pytest
+
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [{"numeric": None}, {"name": None}, {"slug": None}, {"boolean": False}],
+)
+def test_products_query_failed_filter_validation_for_numeric_with_slug_input(
+    query,
+    attribute_value_filter,
+    staff_api_client,
+    numeric_attribute_without_unit,
+    product_type,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "numeric"
+    numeric_attribute_without_unit.slug = attr_slug_input
+    numeric_attribute_without_unit.save()
+
+    product_type.product_attributes.add(numeric_attribute_without_unit)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [{"boolean": None}, {"name": None}, {"slug": None}, {"numeric": {"eq": 1.2}}],
+)
+def test_products_query_failed_filter_validation_for_boolean_with_slug_input(
+    query,
+    attribute_value_filter,
+    staff_api_client,
+    boolean_attribute,
+    product_type,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "boolean"
+    boolean_attribute.slug = attr_slug_input
+    boolean_attribute.save()
+
+    product_type.product_attributes.add(boolean_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"dateTime": None},
+        {"name": None},
+        {"slug": None},
+        {"numeric": {"eq": 1.2}},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
+    ],
+)
+def test_products_query_failed_filter_validation_for_date_attribute_with_slug_input(
+    query,
+    attribute_value_filter,
+    staff_api_client,
+    date_attribute,
+    product_type,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "date"
+    date_attribute.slug = attr_slug_input
+    date_attribute.save()
+
+    product_type.product_attributes.add(date_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"dateTime": None},
+        {"name": None},
+        {"slug": None},
+        {"numeric": {"eq": 1.2}},
+        {"date": None},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
+    ],
+)
+def test_products_query_failed_filter_validation_for_datetime_attribute_with_slug_input(
+    query,
+    attribute_value_filter,
+    staff_api_client,
+    date_time_attribute,
+    product_type,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "date_time"
+    date_time_attribute.slug = attr_slug_input
+    date_time_attribute.save()
+
+    product_type.product_attributes.add(date_time_attribute)
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"slug": None, "value": None},
+        {"slug": None, "value": {"name": {"eq": "name"}}},
+    ],
+)
+def test_products_query_failed_filter_validation_null_in_input(
+    query,
+    attribute_value_filter,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    variables = {
+        "where": {"attributes": [attribute_value_filter]},
+        "channel": channel_USD.slug,
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {"slug": None},
+        {"name": None},
+        {
+            "slug": {"eq": "true_slug"},
+            "name": {"eq": "name"},
+        },
+        {
+            "slug": {"oneOf": ["true_slug"]},
+            "name": {"oneOf": ["name"]},
+        },
+    ],
+)
+def test_products_query_failed_filter_validation_for_basic_value_fields_with_attr_slug(
+    query,
+    attribute_value_filter,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "product-size"
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
+        },
+        "channel": channel_USD.slug,
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+def test_products_query_failed_filter_validation_for_duplicated_attr_slug(
+    query,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "product-size"
+
+    variables = {
+        "where": {
+            "attributes": [
+                {"slug": attr_slug_input},
+                {"slug": attr_slug_input},
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {},
+        {"reference": {}},
+        {"reference": None},
+        {"reference": {"referencedIds": {"containsAll": []}}},
+        {"reference": {"pageSlugs": {"containsAll": []}}},
+        {"reference": {"productSlugs": {"containsAll": []}}},
+        {"reference": {"productVariantSkus": {"containsAll": []}}},
+        {"reference": {"pageSlugs": {"containsAny": []}}},
+        {"reference": {"productSlugs": {"containsAny": []}}},
+        {"reference": {"productVariantSkus": {"containsAny": []}}},
+        {"reference": {"referencedIds": {"containsAny": []}}},
+        {"reference": {"pageSlugs": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"productSlugs": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"productVariantSkus": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"referencedIds": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"referencedIds": {"containsAll": None}}},
+        {"reference": {"pageSlugs": {"containsAll": None}}},
+        {"reference": {"productSlugs": {"containsAll": None}}},
+        {"reference": {"productVariantSkus": {"containsAll": None}}},
+        {"reference": {"pageSlugs": {"containsAny": None}}},
+        {"reference": {"productSlugs": {"containsAny": None}}},
+        {"reference": {"productVariantSkus": {"containsAny": None}}},
+        {"reference": {"referencedIds": {"containsAny": None}}},
+    ],
+)
+def test_products_query_failed_filter_validation_for_reference_attribute_with_slug_input(
+    query,
+    attribute_value_filter,
+    staff_api_client,
+    product_type,
+    product_type_product_reference_attribute,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "reference-product"
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": attr_slug_input,
+                    "value": attribute_value_filter,
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_filter_input",
+    [
+        {"values": ["test-slug"]},
+        {"valuesRange": {"gte": 1}},
+        {"dateTime": {"gte": "2023-01-01T00:00:00Z"}},
+        {"date": {"gte": "2023-01-01"}},
+        {"boolean": True},
+    ],
+)
+def test_products_query_failed_filter_validation_when_missing_attr_slug_for_deprecated_input(
+    query,
+    attribute_filter_input,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+
+    variables = {
+        "where": {
+            "attributes": [attribute_filter_input],
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_filter_input",
+    [
+        {"values": ["test-slug"]},
+        {"valuesRange": {"gte": 1}},
+        {"dateTime": {"gte": "2023-01-01T00:00:00Z"}},
+        {"date": {"gte": "2023-01-01"}},
+        {"boolean": True},
+    ],
+)
+def test_products_query_failed_filter_validation_when_multiple_inputs_with_deprecated_and_new(
+    query,
+    attribute_filter_input,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "attr-slug",
+                    "value": {"name": {"eq": "val-name"}},
+                },
+                {"slug": "attr-slug2", **attribute_filter_input},
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    "attribute_filter_input",
+    [
+        {"values": ["test-slug"]},
+        {"valuesRange": {"gte": 1}},
+        {"dateTime": {"gte": "2023-01-01T00:00:00Z"}},
+        {"date": {"gte": "2023-01-01"}},
+        {"boolean": True},
+    ],
+)
+def test_products_query_failed_filter_validation_when_providing_deprecated_and_new_input(
+    query,
+    attribute_filter_input,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    attribute_filter_input["value"] = {"name": {"eq": "val-name"}}
+    variables = {
+        "where": {"attributes": [{"slug": "attr-slug", **attribute_filter_input}]},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["products"] is None

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7764,7 +7764,12 @@ input ProductFilterInput @doc(category: "Products") {
 
 input AttributeInput @doc(category: "Attributes") {
   """Internal representation of an attribute name."""
-  slug: String!
+  slug: String
+
+  """
+  Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised. Cannot be combined with deprecated fields of `AttributeInput`.
+  """
+  value: AssignedAttributeValueInput
 
   """
   Names corresponding to the attributeValues associated with the Attribute. When specified, it filters the results to include only records with one of the matching values.
@@ -7774,31 +7779,86 @@ input AttributeInput @doc(category: "Attributes") {
   valueNames: [String!]
 
   """
-  Slugs identifying the attributeValues associated with the Attribute. When specified, it filters the results to include only records with one of the matching values.
+  Slugs identifying the attributeValues associated with the Attribute. When specified, it filters the results to include only records with one of the matching values. Requires `slug` to be provided.
   """
-  values: [String!]
-
-  """The range that the returned values should be in."""
-  valuesRange: IntRangeInput
-
-  """The date/time range that the returned values should be in."""
-  dateTime: DateTimeRangeInput
+  values: [String!] @deprecated(reason: "Use `value` instead.")
 
   """
-  The date range that the returned values should be in. In case of date/time attributes, the UTC midnight of the given date is used.
+  The range that the returned values should be in. Requires `slug` to be provided.
   """
-  date: DateRangeInput
+  valuesRange: IntRangeInput @deprecated(reason: "Use `value` instead.")
 
-  """The boolean value of the attribute."""
-  boolean: Boolean
+  """
+  The date/time range that the returned values should be in. Requires `slug` to be provided.
+  """
+  dateTime: DateTimeRangeInput @deprecated(reason: "Use `value` instead.")
+
+  """
+  The date range that the returned values should be in. In case of date/time attributes, the UTC midnight of the given date is used. Requires `slug` to be provided.
+  """
+  date: DateRangeInput @deprecated(reason: "Use `value` instead.")
+
+  """The boolean value of the attribute. Requires `slug` to be provided."""
+  boolean: Boolean @deprecated(reason: "Use `value` instead.")
 }
 
-input IntRangeInput {
-  """Value greater than or equal to."""
-  gte: Int
+input AssignedAttributeValueInput {
+  """Filter by slug assigned to AttributeValue."""
+  slug: StringFilterInput
 
-  """Value less than or equal to."""
-  lte: Int
+  """Filter by name assigned to AttributeValue."""
+  name: StringFilterInput
+
+  """Filter by numeric value for attributes of numeric type."""
+  numeric: DecimalFilterInput
+
+  """Filter by date value for attributes of date type."""
+  date: DateRangeInput
+
+  """Filter by date time value for attributes of date time type."""
+  dateTime: DateTimeRangeInput
+
+  """Filter by boolean value for attributes of boolean type."""
+  boolean: Boolean
+
+  """Filter by reference attribute value."""
+  reference: AssignedAttributeReferenceInput
+}
+
+"""Define the filtering options for decimal fields."""
+input DecimalFilterInput {
+  """The value equal to."""
+  eq: Decimal
+
+  """The value included in."""
+  oneOf: [Decimal!]
+
+  """The value in range."""
+  range: DecimalRangeInput
+}
+
+"""
+Custom Decimal implementation.
+
+Returns Decimal as a float in the API,
+parses float to the Decimal on the way back.
+"""
+scalar Decimal
+
+input DecimalRangeInput {
+  """Decimal value greater than or equal to."""
+  gte: Decimal
+
+  """Decimal value less than or equal to."""
+  lte: Decimal
+}
+
+input DateRangeInput {
+  """Start date."""
+  gte: Date
+
+  """End date."""
+  lte: Date
 }
 
 input DateTimeRangeInput {
@@ -7809,12 +7869,45 @@ input DateTimeRangeInput {
   lte: DateTime
 }
 
-input DateRangeInput {
-  """Start date."""
-  gte: Date
+input AssignedAttributeReferenceInput {
+  """
+  Returns objects with a reference pointing to an object identified by the given ID.
+  """
+  referencedIds: ContainsFilterInput
 
-  """End date."""
-  lte: Date
+  """
+  Returns objects with a reference pointing to a page identified by the given slug.
+  """
+  pageSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product identified by the given slug.
+  """
+  productSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product variant identified by the given sku.
+  """
+  productVariantSkus: ContainsFilterInput
+}
+
+"""
+Define the filtering options for fields that can contain multiple values.
+"""
+input ContainsFilterInput {
+  """The field contains at least one of the specified values."""
+  containsAny: [String!]
+
+  """The field contains all of the specified values."""
+  containsAll: [String!]
+}
+
+input IntRangeInput {
+  """Value greater than or equal to."""
+  gte: Int
+
+  """Value less than or equal to."""
+  lte: Int
 }
 
 enum StockAvailability @doc(category: "Products") {
@@ -7910,34 +8003,6 @@ input GlobalIDFilterInput {
 
   """The value included in."""
   oneOf: [ID!]
-}
-
-"""Define the filtering options for decimal fields."""
-input DecimalFilterInput {
-  """The value equal to."""
-  eq: Decimal
-
-  """The value included in."""
-  oneOf: [Decimal!]
-
-  """The value in range."""
-  range: DecimalRangeInput
-}
-
-"""
-Custom Decimal implementation.
-
-Returns Decimal as a float in the API,
-parses float to the Decimal on the way back.
-"""
-scalar Decimal
-
-input DecimalRangeInput {
-  """Decimal value greater than or equal to."""
-  gte: Decimal
-
-  """Decimal value less than or equal to."""
-  lte: Decimal
 }
 
 """Define the filtering options for date time fields."""
@@ -13014,62 +13079,6 @@ input AssignedAttributeWhereInput {
   Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised.
   """
   value: AssignedAttributeValueInput
-}
-
-input AssignedAttributeValueInput {
-  """Filter by slug assigned to AttributeValue."""
-  slug: StringFilterInput
-
-  """Filter by name assigned to AttributeValue."""
-  name: StringFilterInput
-
-  """Filter by numeric value for attributes of numeric type."""
-  numeric: DecimalFilterInput
-
-  """Filter by date value for attributes of date type."""
-  date: DateRangeInput
-
-  """Filter by date time value for attributes of date time type."""
-  dateTime: DateTimeRangeInput
-
-  """Filter by boolean value for attributes of boolean type."""
-  boolean: Boolean
-
-  """Filter by reference attribute value."""
-  reference: AssignedAttributeReferenceInput
-}
-
-input AssignedAttributeReferenceInput {
-  """
-  Returns objects with a reference pointing to an object identified by the given ID.
-  """
-  referencedIds: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a page identified by the given slug.
-  """
-  pageSlugs: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a product identified by the given slug.
-  """
-  productSlugs: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a product variant identified by the given sku.
-  """
-  productVariantSkus: ContainsFilterInput
-}
-
-"""
-Define the filtering options for fields that can contain multiple values.
-"""
-input ContainsFilterInput {
-  """The field contains at least one of the specified values."""
-  containsAny: [String!]
-
-  """The field contains all of the specified values."""
-  containsAll: [String!]
 }
 
 type PageTypeCountableConnection @doc(category: "Pages") {


### PR DESCRIPTION
> [!NOTE]  
>  PR contains a large number of changed lines, but the majority are related to tests. The core implementation was already prepared and merged in previous PRs

I want to merge this change because:
- Added `value` field to AttributeInput
  - Aligns product attribute filtering with the filtering used for pages
- Attribute slug is now optional when filtering by attribute values
```graphql
{ # Get 5 products with at least one numeric attribute with value greater than 11
  products(
    first: 5, 
    where: {
      attributes: {
        value: {numeric: {range: {gte: 11}}}
      }
    }
  ) {
    edges {
      node {
        id
      }
    }
  }
}
```
- Added support for filtering by associated reference objects (`productSlugs`, `pageSlugs`, `productVariantSkus` or list of global IDs):
```graphql
{ # Retrieve 5 products that have at least one reference attribute
  # pointing to a Page with the slug "Cotton", or "Wool"
  products(
    first: 5
    where: {
      attributes: {
        value:{
          reference:{
            pageSlugs:{
              containsAny: ["Cotton", "Wool"]
            }
          }
        }
      }
    }
  ) {
    edges {
      node {
        id
      }
    }
  }
}
```

---
```graphql
{ # Retrieve 5 products that have reference attributes pointing to 
  # Page with slug: "Cotton" and Page with slug: "Wool" 
  products(
    first: 5
    where: {
      attributes: {
        value:{
          reference:{
            pageSlugs:{
              containsAll: ["Cotton", "Wool"]
            }
          }
        }
      }
    }
  ) {
    edges {
      node {
        id
      }
    }
  }
}
```



-  Deprecate the previous `AttributeInput` fields (except one introduced in 3.22, I will cover it sepratly)
    -  Added additional validation, for previous filters (they work in the same way as previously, and the still requires slug)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
