### PR TITLE
[PoC] Fix issues with undiscounted price on promotion rule change

### DIFF
--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -946,6 +946,7 @@ def _handle_gift_reward(
             line_info for line_info in lines_info if line_info.line.pk == line.id
         )
         line_info.line = line
+        line_info.undiscounted_unit_price = line_discount.line.undiscounted_unit_price  # type:ignore[union-attr]
         line_info.discounts = [line_discount]
 
 


### PR DESCRIPTION
I want to merge this change because it fixes the issue with unit price and variant not showing up correctly on 1st fetch of checkout lines.

This is a concept, it solves the problem though. There is an issue with tests despite using proper decorator to mark the context which should be fixed first before merging.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
