### PR TITLE
INFRA-732 - add cron-based testenv cleanup workflow

### DIFF
--- a/.github/workflows/test-env-cleanup-cron.yml
+++ b/.github/workflows/test-env-cleanup-cron.yml
@@ -1,0 +1,57 @@
+name: TEST-ENV-CLEANUP-CRON
+# Daily cleanup of all stale environments (environments for which there is no open PR with "test deployment" label)
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  cleanup:
+    name: Remove stale test env deployments
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # needed by aws-actions/configure-aws-credentials
+      contents: read
+    steps:
+      - uses: rlespinasse/github-slug-action@955b5ba4560860f8a633bd24190941f16016e42c # v5.1.0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}:role/${{ secrets.AWS_TESTENVS_CICD_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Get branches from open PRs with "test deployment" label
+        id: get-branches
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // Get all open PRs - pagination is needed or otherwise we would retrieve only first 30
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+
+            // Select PRs with "test deployment" label and extract their source branches
+            const branches = pulls
+              .filter(pr => pr.labels.some(label => label.name === 'test deployment'))
+              .map(pr => pr.head.ref);
+
+            // Deduplicate (in case there are multiple PRs with the same source branch)
+            return [...new Set(branches)];
+
+      - name: Invoke test-env-manager lambda
+        uses: gagoar/invoke-aws-lambda@2ea0b5791eba7a9513ddf0fb7f91aa8f098b6458 # v3.4.0
+        with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+          REGION: us-east-1
+          FunctionName: test-env-manager
+          Payload: >-
+            {
+              "action": "daily-cleanup",
+              "labels_to_preserve": ${{ steps.get-branches.outputs.result }}
+            }
+          LogType: Tail

--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: rlespinasse/github-slug-action@955b5ba4560860f8a633bd24190941f16016e42c # v5.1.0
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
@@ -25,7 +25,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Invoke deployment lambda
-        uses: gagoar/invoke-aws-lambda@v3.3.0
+        uses: gagoar/invoke-aws-lambda@2ea0b5791eba7a9513ddf0fb7f91aa8f098b6458 # v3.4.0
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -41,7 +41,7 @@ jobs:
           LogType: Tail
 
       - name: Mark deployment as deactivated
-        uses: bobheadxi/deployments@v0.4.2
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
         with:
           step: deactivate-env
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I am working on migrating the testenvs from prod to dev account and we noticed that the cleanup mechanism is not working consistently. There are cases where cleanup did not trigger/finish succesfully leaving myriad of resources behind, which will hang forever as there is no proper way to clean them up. Some of the artifacts are hanging since few years now.

I adding daily-cleanup that will remove all stale resources in a loop every night

The general approach to daily cron cleanup will be
1. Retrieve list of open PRs with `test deployment` label and construct a list of `branches_to_preserve`
2. Pass this list of branches to our new `CleanupManager`
3. Cleanup manager will remove stale environments (so all environments minus these which are on the preserver list) in a loop

# Before this PR is merged, changes in `test-env-manager` lambda need to me merged and applied, see: https://github.com/saleor/saleor-cloud-infra/pull/3167


