### PR TITLE
Add fractional amount to the Money type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extend the `Attribute` type with a `values` field, allowing you to retrieve all values assigned to a specific attribute.
 - Add new `single-reference` attribute. You can now create a reference attribute that points to only one object (unlike the existing `reference` type, which supports multiple references).
 Like `reference`, the `single-reference` type can target entities defined in the `AttributeEntityTypeEnum`.
+- Added `fractionalAmount` and `fractionDigits` fields to the `Money` type. These fields allow monetary values to be represented as a pair of integers, which is often required when integrating with payment service providers.
 
 ### Webhooks
 - Transaction webhooks responsible for processing payments can now return payment method details`, which will be associated with the corresponding transaction. See [docs](https://docs.saleor.io/developer/extending/webhooks/synchronous-events/transaction#response-4) to learn more.

--- a/saleor/graphql/core/types/money.py
+++ b/saleor/graphql/core/types/money.py
@@ -1,4 +1,5 @@
 import graphene
+from babel.numbers import get_currency_precision
 
 from ....core.prices import quantize_price
 from ...core.doc_category import DOC_CATEGORY_TAXES
@@ -8,6 +9,14 @@ from ...core.types import BaseObjectType
 class Money(graphene.ObjectType):
     currency = graphene.String(description="Currency code.", required=True)
     amount = graphene.Float(description="Amount of money.", required=True)
+    fractional_amount = graphene.Int(
+        description="Amount of money represented as an integer in the smallest currency unit.",
+        required=True,
+    )
+    fraction_digits = graphene.Int(
+        description="Number of digits after the decimal point in the currency.",
+        required=True,
+    )
 
     class Meta:
         description = "Represents amount of money in specific currency."
@@ -15,6 +24,15 @@ class Money(graphene.ObjectType):
     @staticmethod
     def resolve_amount(root, _info):
         return quantize_price(root.amount, root.currency)
+
+    @staticmethod
+    def resolve_fractional_amount(root, _info):
+        precision = get_currency_precision(root.currency)
+        return int(quantize_price(root.amount, root.currency) * (10**precision))
+
+    @staticmethod
+    def resolve_fraction_digits(root, _info):
+        return get_currency_precision(root.currency)
 
 
 class MoneyRange(graphene.ObjectType):

--- a/saleor/graphql/core/types/tests/test_money.py
+++ b/saleor/graphql/core/types/tests/test_money.py
@@ -1,0 +1,14 @@
+from decimal import Decimal
+
+from prices import Money
+
+from ..money import Money as MoneyObject
+
+
+def test_money_object():
+    money = Money(Decimal("12.950000"), "USD")
+    resolve_info = None
+
+    assert MoneyObject.resolve_amount(money, resolve_info) == Decimal("12.95")
+    assert MoneyObject.resolve_fractional_amount(money, resolve_info) == 1295
+    assert MoneyObject.resolve_fraction_digits(money, resolve_info) == 2

--- a/saleor/graphql/core/types/tests/test_money.py
+++ b/saleor/graphql/core/types/tests/test_money.py
@@ -5,10 +5,19 @@ from prices import Money
 from ..money import Money as MoneyObject
 
 
-def test_money_object():
+def test_money_object_usd():
     money = Money(Decimal("12.950000"), "USD")
     resolve_info = None
 
     assert MoneyObject.resolve_amount(money, resolve_info) == Decimal("12.95")
     assert MoneyObject.resolve_fractional_amount(money, resolve_info) == 1295
     assert MoneyObject.resolve_fraction_digits(money, resolve_info) == 2
+
+
+def test_money_object_jpy():
+    money = Money(Decimal(1234), "JPY")
+    resolve_info = None
+
+    assert MoneyObject.resolve_amount(money, resolve_info) == Decimal(1234)
+    assert MoneyObject.resolve_fractional_amount(money, resolve_info) == 1234
+    assert MoneyObject.resolve_fraction_digits(money, resolve_info) == 0

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3781,6 +3781,14 @@ type Money {
 
   """Amount of money."""
   amount: Float!
+
+  """
+  Amount of money represented as an integer in the smallest currency unit.
+  """
+  fractionalAmount: Int!
+
+  """Number of digits after the decimal point in the currency."""
+  fractionDigits: Int!
 }
 
 """


### PR DESCRIPTION
This should ease the job for payment gateway implementers as payment gateways typically expect amounts to be passed in fractional amounts.

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
