### PR TITLE
Enhance variants filtering by enabling filters based on referenced objects

### DIFF
--- a/saleor/graphql/attribute/shared_filters.py
+++ b/saleor/graphql/attribute/shared_filters.py
@@ -654,6 +654,93 @@ def get_attribute_values_by_date_time_value(
     )
 
 
+def _get_attribute_values_by_referenced_page_identifiers(
+    field_name: str,
+    identifiers: list[str] | list[int],
+    db_connection_name: str,
+):
+    pages = page_models.Page.objects.using(db_connection_name).filter(
+        **{f"{field_name}__in": identifiers}
+    )
+    return AttributeValue.objects.using(db_connection_name).filter(
+        Exists(pages.filter(id=OuterRef("reference_page_id"))),
+    )
+
+
+def get_attribute_values_by_referenced_page_slugs(
+    slugs: list[str], db_connection_name: str
+) -> QuerySet[AttributeValue]:
+    return _get_attribute_values_by_referenced_page_identifiers(
+        "slug", slugs, db_connection_name
+    )
+
+
+def get_attribute_values_by_referenced_page_ids(
+    ids: list[int], db_connection_name: str
+) -> QuerySet[AttributeValue]:
+    return _get_attribute_values_by_referenced_page_identifiers(
+        "id", ids, db_connection_name
+    )
+
+
+def _get_attribute_values_by_referenced_product_identifiers(
+    field_name: str,
+    identifiers: list[str] | list[int],
+    db_connection_name: str,
+) -> QuerySet[AttributeValue]:
+    products = product_models.Product.objects.using(db_connection_name).filter(
+        **{f"{field_name}__in": identifiers}
+    )
+    return AttributeValue.objects.using(db_connection_name).filter(
+        Exists(products.filter(id=OuterRef("reference_product_id"))),
+    )
+
+
+def get_attribute_values_by_referenced_product_slugs(
+    slugs: list[str], db_connection_name: str
+) -> QuerySet[AttributeValue]:
+    return _get_attribute_values_by_referenced_product_identifiers(
+        "slug", slugs, db_connection_name
+    )
+
+
+def get_attribute_values_by_referenced_product_ids(
+    ids: list[int], db_connection_name: str
+) -> QuerySet[AttributeValue]:
+    return _get_attribute_values_by_referenced_product_identifiers(
+        "id", ids, db_connection_name
+    )
+
+
+def _get_attribute_values_by_referenced_variant_identifiers(
+    field_name: str,
+    identifiers: list[str] | list[int],
+    db_connection_name: str,
+):
+    variants = product_models.ProductVariant.objects.using(db_connection_name).filter(
+        **{f"{field_name}__in": identifiers}
+    )
+    return AttributeValue.objects.using(db_connection_name).filter(
+        Exists(variants.filter(id=OuterRef("reference_variant_id"))),
+    )
+
+
+def get_attribute_values_by_referenced_variant_skus(
+    slugs: list[str], db_connection_name: str
+) -> QuerySet[AttributeValue]:
+    return _get_attribute_values_by_referenced_variant_identifiers(
+        "sku", slugs, db_connection_name
+    )
+
+
+def get_attribute_values_by_referenced_variant_ids(
+    ids: list[int], db_connection_name: str
+) -> QuerySet[AttributeValue]:
+    return _get_attribute_values_by_referenced_variant_identifiers(
+        "id", ids, db_connection_name
+    )
+
+
 def filter_objects_by_attributes[T: (page_models.Page, product_models.Product)](
     qs: QuerySet[T],
     value: list[dict],

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_references_pages.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_references_pages.py
@@ -1,0 +1,346 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from ......page.models import Page
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_reference_to_pages(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    page_type,
+    product_type_page_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(product_type_page_reference_attribute)
+
+    reference_page_1_slug = "referenced-page-1"
+    reference_page_2_slug = "referenced-page-2"
+    referenced_page_1, referenced_page_2 = Page.objects.bulk_create(
+        [
+            Page(
+                title="Referenced Page 1",
+                slug=reference_page_1_slug,
+                page_type=page_type,
+                is_published=True,
+            ),
+            Page(
+                title="Referenced Page 2",
+                slug=reference_page_2_slug,
+                page_type=page_type,
+                is_published=True,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_page_reference_attribute,
+                name=f"Page {referenced_page_1.pk}",
+                slug=f"page-{referenced_page_1.pk}",
+                reference_page=referenced_page_1,
+            ),
+            AttributeValue(
+                attribute=product_type_page_reference_attribute,
+                name=f"Page {referenced_page_2.pk}",
+                slug=f"page-{referenced_page_2.pk}",
+                reference_page=referenced_page_2,
+            ),
+        ]
+    )
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_page_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {product_type_page_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "page-reference",
+                    "value": {
+                        "reference": {
+                            "pageSlugs": {
+                                filter_type: [
+                                    reference_page_1_slug,
+                                    reference_page_2_slug,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attribute_value_reference_to_pages(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    page_type,
+    product_type_page_reference_attribute,
+    channel_USD,
+):
+    # given
+    second_page_reference_attribute = Attribute.objects.create(
+        slug="second-page-reference",
+        name="Page reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PAGE,
+    )
+    product_type.variant_attributes.add(
+        product_type_page_reference_attribute,
+        second_page_reference_attribute,
+    )
+
+    reference_1 = "referenced-page-1"
+    reference_2 = "referenced-page-2"
+    referenced_page_1, referenced_page_2 = Page.objects.bulk_create(
+        [
+            Page(
+                title="Referenced Page 1",
+                slug=reference_1,
+                page_type=page_type,
+                is_published=True,
+            ),
+            Page(
+                title="Referenced Page 2",
+                slug=reference_2,
+                page_type=page_type,
+                is_published=True,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_page_reference_attribute,
+                name=f"Page {referenced_page_1.pk}",
+                slug=f"page-{referenced_page_1.pk}",
+                reference_page=referenced_page_1,
+            ),
+            AttributeValue(
+                attribute=second_page_reference_attribute,
+                name=f"Page {referenced_page_2.pk}",
+                slug=f"page-{referenced_page_2.pk}",
+                reference_page=referenced_page_2,
+            ),
+        ]
+    )
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_page_reference_attribute.pk: [attribute_value_1],
+            second_page_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {second_page_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "pageSlugs": {filter_type: [reference_1, reference_2]}
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_referenced_page_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    page_type,
+    product_type_page_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.variant_attributes.add(product_type_page_reference_attribute)
+
+    referenced_first_page, referenced_second_page, referenced_third_page = (
+        Page.objects.bulk_create(
+            [
+                Page(
+                    title="Referenced Page",
+                    slug="referenced-page",
+                    page_type=page_type,
+                    is_published=True,
+                ),
+                Page(
+                    title="Referenced Page",
+                    slug="referenced-page2",
+                    page_type=page_type,
+                    is_published=True,
+                ),
+                Page(
+                    title="Referenced Page",
+                    slug="referenced-page3",
+                    page_type=page_type,
+                    is_published=True,
+                ),
+            ]
+        )
+    )
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_page_reference_attribute,
+                    name=f"Page {referenced_first_page.pk}",
+                    slug=f"page-{referenced_first_page.pk}",
+                    reference_page=referenced_first_page,
+                ),
+                AttributeValue(
+                    attribute=product_type_page_reference_attribute,
+                    name=f"Page {referenced_second_page.pk}",
+                    slug=f"page-{referenced_second_page.pk}",
+                    reference_page=referenced_second_page,
+                ),
+                AttributeValue(
+                    attribute=product_type_page_reference_attribute,
+                    name=f"Page {referenced_third_page.pk}",
+                    slug=f"page-{referenced_third_page.pk}",
+                    reference_page=referenced_third_page,
+                ),
+            ]
+        )
+    )
+    first_product_variant_with_all_ids = product_variant_list[0]
+    second_product_variant_with_all_ids = product_variant_list[1]
+    product_variant_with_single_id = product_variant_list[3]
+    associate_attribute_values_to_instance(
+        first_product_variant_with_all_ids,
+        {
+            product_type_page_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_variant_with_all_ids,
+        {
+            product_type_page_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_with_single_id,
+        {product_type_page_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(referenced_first_page)
+    referenced_second_global_id = to_global_id_or_none(referenced_second_page)
+    referenced_third_global_id = to_global_id_or_none(referenced_third_page)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_page_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_references_products.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_references_products.py
@@ -1,0 +1,346 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from ......product.models import Product
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_reference_to_products(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_product_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(product_type_product_reference_attribute)
+
+    ref_product_1, ref_product_2 = Product.objects.bulk_create(
+        [
+            Product(
+                name="Reference Product 1",
+                slug="ref-1",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 2",
+                slug="ref-2",
+                product_type=product_type,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_product_reference_attribute,
+                name=f"Product {ref_product_1.pk}",
+                slug=f"product-{ref_product_1.pk}",
+                reference_product=ref_product_1,
+            ),
+            AttributeValue(
+                attribute=product_type_product_reference_attribute,
+                name=f"Product {ref_product_2.pk}",
+                slug=f"product-{ref_product_2.pk}",
+                reference_product=ref_product_2,
+            ),
+        ]
+    )
+
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_product_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {product_type_product_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "product-reference",
+                    "value": {
+                        "reference": {
+                            "productSlugs": {
+                                filter_type: [ref_product_1.slug, ref_product_2.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+    assert product_variants_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", product_variant_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_product_variants_query_with_attribute_value_reference_to_products(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_product_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    second_product_reference_attribute = Attribute.objects.create(
+        slug="second-product-reference",
+        name="Product reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PRODUCT,
+    )
+
+    product_type.variant_attributes.add(
+        product_type_product_reference_attribute,
+        second_product_reference_attribute,
+    )
+
+    ref_product_1, ref_product_2 = Product.objects.bulk_create(
+        [
+            Product(
+                name="Reference Product 1",
+                slug="ref-1",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 2",
+                slug="ref-2",
+                product_type=product_type,
+            ),
+        ]
+    )
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_product_reference_attribute,
+                name=f"Product {ref_product_1.pk}",
+                slug=f"product-{ref_product_1.pk}",
+                reference_product=ref_product_1,
+            ),
+            AttributeValue(
+                attribute=second_product_reference_attribute,
+                name=f"Product {ref_product_2.pk}",
+                slug=f"product-{ref_product_2.pk}",
+                reference_product=ref_product_2,
+            ),
+        ]
+    )
+
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_product_reference_attribute.pk: [attribute_value_1],
+            second_product_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {second_product_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "productSlugs": {
+                                filter_type: [ref_product_1.slug, ref_product_2.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+    assert product_variants_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", product_variant_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_referenced_product_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_product_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(
+        product_type_product_reference_attribute,
+    )
+    ref_product_1, ref_product_2, ref_product_3 = Product.objects.bulk_create(
+        [
+            Product(
+                name="Reference Product 1",
+                slug="ref-1",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 2",
+                slug="ref-2",
+                product_type=product_type,
+            ),
+            Product(
+                name="Reference Product 3",
+                slug="ref-3",
+                product_type=product_type,
+            ),
+        ]
+    )
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_product_reference_attribute,
+                    name=f"Product {ref_product_1.pk}",
+                    slug=f"product-{ref_product_1.pk}",
+                    reference_product=ref_product_1,
+                ),
+                AttributeValue(
+                    attribute=product_type_product_reference_attribute,
+                    name=f"Product {ref_product_2.pk}",
+                    slug=f"product-{ref_product_2.pk}",
+                    reference_product=ref_product_2,
+                ),
+                AttributeValue(
+                    attribute=product_type_product_reference_attribute,
+                    name=f"Product {ref_product_3.pk}",
+                    slug=f"product-{ref_product_3.pk}",
+                    reference_product=ref_product_3,
+                ),
+            ]
+        )
+    )
+    first_product_variant_with_all_ids = product_variant_list[0]
+    second_product_variant_with_all_ids = product_variant_list[1]
+    product_variant_with_single_id = product_variant_list[3]
+
+    associate_attribute_values_to_instance(
+        first_product_variant_with_all_ids,
+        {
+            product_type_product_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_variant_with_all_ids,
+        {
+            product_type_product_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_with_single_id,
+        {
+            product_type_product_reference_attribute.pk: [
+                first_attr_value,
+            ],
+        },
+    )
+    ref_1_global_id = to_global_id_or_none(ref_product_1)
+    ref_2_global_id = to_global_id_or_none(ref_product_2)
+    ref_3_global_id = to_global_id_or_none(ref_product_3)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_product_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    ref_1_global_id,
+                                    ref_2_global_id,
+                                    ref_3_global_id,
+                                ]
+                            }
+                        }
+                    },
+                },
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_references_variants.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_references_variants.py
@@ -1,0 +1,322 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attribute_value_reference_to_product_variants(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_variant_reference_attribute,
+    channel_USD,
+    variant,
+    variant_without_inventory_tracking,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+
+    second_variant_reference_attribute = Attribute.objects.create(
+        slug="second-product-reference",
+        name="Product reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.PRODUCT_VARIANT,
+    )
+    product_type.variant_attributes.set(
+        [product_type_variant_reference_attribute, second_variant_reference_attribute]
+    )
+
+    first_variant_sku = "test-variant-1"
+    second_variant_sku = "test-variant-2"
+
+    first_variant = variant
+    first_variant.sku = first_variant_sku
+    first_variant.save()
+
+    second_variant = variant_without_inventory_tracking
+    second_variant.sku = second_variant_sku
+    second_variant.save()
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_variant_reference_attribute,
+                name=f"Variant {first_variant.pk}",
+                slug=f"variant-{first_variant.pk}",
+                reference_variant=first_variant,
+            ),
+            AttributeValue(
+                attribute=second_variant_reference_attribute,
+                name=f"Variant {second_variant.pk}",
+                slug=f"variant-{second_variant.pk}",
+                reference_variant=second_variant,
+            ),
+        ]
+    )
+
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_variant_reference_attribute.pk: [attribute_value_1],
+            second_variant_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {second_variant_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "productVariantSkus": {
+                                filter_type: [
+                                    first_variant_sku,
+                                    second_variant_sku,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+    assert product_variants_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", product_variant_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_reference_to_product_variants(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_variant_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(product_type_variant_reference_attribute)
+
+    first_variant_sku = "test-variant-1"
+    second_variant_sku = "test-variant-2"
+
+    first_variant = product_variant_list[0]
+    first_variant.sku = first_variant_sku
+    first_variant.save()
+
+    second_variant = product_variant_list[1]
+    second_variant.sku = second_variant_sku
+    second_variant.save()
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_variant_reference_attribute,
+                name=f"Variant {first_variant.pk}",
+                slug=f"variant-{first_variant.pk}",
+                reference_variant=first_variant,
+            ),
+            AttributeValue(
+                attribute=product_type_variant_reference_attribute,
+                name=f"Variant {second_variant.pk}",
+                slug=f"variant-{second_variant.pk}",
+                reference_variant=second_variant,
+            ),
+        ]
+    )
+
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_variant_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {product_type_variant_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "variant-reference",
+                    "value": {
+                        "reference": {
+                            "productVariantSkus": {
+                                filter_type: [
+                                    first_variant_sku,
+                                    second_variant_sku,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+    assert product_variants_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", product_variant_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_product_variants_query_with_attr_slug_attribute_value_referenced_variant_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_variant_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(
+        product_type_variant_reference_attribute,
+    )
+
+    first_variant = product_variant_list[0]
+    second_variant = product_variant_list[1]
+    third_variant = product_variant_list[3]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_variant_reference_attribute,
+                    name=f"Variant {first_variant.pk}",
+                    slug=f"variant-{first_variant.pk}",
+                    reference_variant=first_variant,
+                ),
+                AttributeValue(
+                    attribute=product_type_variant_reference_attribute,
+                    name=f"Variant {second_variant.pk}",
+                    slug=f"variant-{second_variant.pk}",
+                    reference_variant=second_variant,
+                ),
+                AttributeValue(
+                    attribute=product_type_variant_reference_attribute,
+                    name=f"Variant {third_variant.pk}",
+                    slug=f"variant-{third_variant.pk}",
+                    reference_variant=third_variant,
+                ),
+            ]
+        )
+    )
+    first_product_variant_with_all_ids = product_variant_list[0]
+    second_product_variant_with_all_ids = product_variant_list[1]
+    product_variant_with_single_id = product_variant_list[3]
+    associate_attribute_values_to_instance(
+        first_product_variant_with_all_ids,
+        {
+            product_type_variant_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_variant_with_all_ids,
+        {
+            product_type_variant_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_with_single_id,
+        {product_type_variant_reference_attribute.pk: [first_attr_value]},
+    )
+    referenced_first_global_id = to_global_id_or_none(first_variant)
+    referenced_second_global_id = to_global_id_or_none(second_variant)
+    referenced_third_global_id = to_global_id_or_none(third_variant)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_variant_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_validation.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_validation.py
@@ -6,7 +6,13 @@ from .shared import PRODUCT_VARIANTS_WHERE_QUERY
 
 @pytest.mark.parametrize(
     "attribute_value_filter",
-    [{"numeric": None}, {"name": None}, {"slug": None}, {"boolean": False}],
+    [
+        {"numeric": None},
+        {"name": None},
+        {"slug": None},
+        {"boolean": False},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
+    ],
 )
 def test_product_variants_query_failed_filter_validation_for_numeric_with_slug_input(
     attribute_value_filter,
@@ -44,7 +50,13 @@ def test_product_variants_query_failed_filter_validation_for_numeric_with_slug_i
 
 @pytest.mark.parametrize(
     "attribute_value_filter",
-    [{"boolean": None}, {"name": None}, {"slug": None}, {"numeric": {"eq": 1.2}}],
+    [
+        {"boolean": None},
+        {"name": None},
+        {"slug": None},
+        {"numeric": {"eq": 1.2}},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
+    ],
 )
 def test_product_variants_query_failed_filter_validation_for_boolean_with_slug_input(
     attribute_value_filter,
@@ -87,6 +99,7 @@ def test_product_variants_query_failed_filter_validation_for_boolean_with_slug_i
         {"name": None},
         {"slug": None},
         {"numeric": {"eq": 1.2}},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
     ],
 )
 def test_product_variants_query_failed_filter_validation_for_date_attribute_with_slug_input(
@@ -131,6 +144,7 @@ def test_product_variants_query_failed_filter_validation_for_date_attribute_with
         {"slug": None},
         {"numeric": {"eq": 1.2}},
         {"date": None},
+        {"reference": {"referencedIds": {"containsAll": ["global-id-1"]}}},
     ],
 )
 def test_product_variants_query_failed_filter_validation_for_datetime_attribute_with_slug_input(
@@ -250,6 +264,60 @@ def test_product_variants_query_failed_filter_validation_for_duplicated_attr_slu
                 {"slug": attr_slug_input},
                 {"slug": attr_slug_input},
             ]
+        },
+        "channel": channel_USD.slug,
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert content["data"]["productVariants"] is None
+
+
+@pytest.mark.parametrize(
+    "attribute_value_filter",
+    [
+        {},
+        {"reference": {}},
+        {"reference": None},
+        {"reference": {"referencedIds": {"containsAll": []}}},
+        {"reference": {"pageSlugs": {"containsAll": []}}},
+        {"reference": {"productSlugs": {"containsAll": []}}},
+        {"reference": {"productVariantSkus": {"containsAll": []}}},
+        {"reference": {"pageSlugs": {"containsAny": []}}},
+        {"reference": {"productSlugs": {"containsAny": []}}},
+        {"reference": {"productVariantSkus": {"containsAny": []}}},
+        {"reference": {"referencedIds": {"containsAny": []}}},
+        {"reference": {"pageSlugs": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"productSlugs": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"productVariantSkus": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"referencedIds": {"containsAny": [], "containsAll": []}}},
+        {"reference": {"referencedIds": {"containsAll": None}}},
+        {"reference": {"pageSlugs": {"containsAll": None}}},
+        {"reference": {"productSlugs": {"containsAll": None}}},
+        {"reference": {"productVariantSkus": {"containsAll": None}}},
+        {"reference": {"pageSlugs": {"containsAny": None}}},
+        {"reference": {"productSlugs": {"containsAny": None}}},
+        {"reference": {"productVariantSkus": {"containsAny": None}}},
+        {"reference": {"referencedIds": {"containsAny": None}}},
+    ],
+)
+def test_product_variants_query_failed_filter_validation_for_reference_attribute_with_slug_input(
+    attribute_value_filter,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    attr_slug_input = "reference-product"
+
+    variables = {
+        "where": {
+            "attributes": [{"slug": attr_slug_input, "value": attribute_value_filter}]
         },
         "channel": channel_USD.slug,
     }


### PR DESCRIPTION
I want to merge this change because it adds support for filtering variants by associated reference objects (`productSlugs`, `pageSlugs`, `productVariantSkus` or list of global IDs):

```graphql
{ # Retrieve 5 variants that have at least one reference attribute
  # pointing to a Page with the slug "Cotton", or "Wool"
  productVariants(
    first: 5
    where: {
      attributes: {
        value:{
          reference:{
            pageSlugs:{
              containsAny: ["Cotton", "Wool"]
            }
          }
        }
      }
    }
  ) {
    edges {
      node {
        id
      }
    }
  }
}
```

---
```graphql
{ # Retrieve 5 variants that have reference attributes pointing to 
  # Page with slug: "Cotton" and Page with slug: "Wool" 
  productVariants(
    first: 5
    where: {
      attributes: {
        value:{
          reference:{
            pageSlugs:{
              containsAll: ["Cotton", "Wool"]
            }
          }
        }
      }
    }
  ) {
    edges {
      node {
        id
      }
    }
  }
}
```

> [!NOTE]  
> Skipping changelog as in previous PR I already mentioned that we added a new  filtration over attributes

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
