### PR TITLE
Move product attribute related logic to product module

### DIFF
--- a/saleor/graphql/product/filters/product_attributes.py
+++ b/saleor/graphql/product/filters/product_attributes.py
@@ -1,8 +1,9 @@
 import datetime
 import math
 from collections import defaultdict
-from typing import TypedDict
+from typing import Literal, TypedDict
 
+import graphene
 from django.db.models import Exists, OuterRef, Q, QuerySet
 from graphql import GraphQLError
 
@@ -16,9 +17,21 @@ from ....attribute.models import (
 )
 from ....product.models import Product, ProductVariant
 from ...attribute.shared_filters import (
-    filter_objects_by_attributes,
+    CONTAINS_TYPING,
+    get_attribute_values_by_boolean_value,
+    get_attribute_values_by_date_time_value,
+    get_attribute_values_by_date_value,
+    get_attribute_values_by_numeric_value,
+    get_attribute_values_by_referenced_page_ids,
+    get_attribute_values_by_referenced_page_slugs,
+    get_attribute_values_by_referenced_product_ids,
+    get_attribute_values_by_referenced_product_slugs,
+    get_attribute_values_by_referenced_variant_ids,
+    get_attribute_values_by_referenced_variant_skus,
+    get_attribute_values_by_slug_or_name_value,
     validate_attribute_value_input,
 )
+from ...utils.filters import Number
 
 T_PRODUCT_FILTER_QUERIES = dict[int, list[int]]
 
@@ -316,13 +329,474 @@ def deprecated_filter_attributes(qs, value):
     return qs
 
 
-def _filter_products_by_attributes(qs, value):
-    return filter_objects_by_attributes(
-        qs,
-        value,
-        AssignedProductAttributeValue,
-        "product_id",
+def _get_assigned_product_attribute_for_attribute_value(
+    attribute_values: QuerySet[AttributeValue],
+    db_connection_name: str,
+):
+    return Q(
+        Exists(
+            AssignedProductAttributeValue.objects.using(db_connection_name).filter(
+                Exists(attribute_values.filter(id=OuterRef("value_id"))),
+                product_id=OuterRef("id"),
+            )
+        )
     )
+
+
+def filter_by_slug_or_name(
+    attr_id: int | None,
+    attr_value: dict,
+    db_connection_name: str,
+):
+    attribute_values = get_attribute_values_by_slug_or_name_value(
+        attr_id=attr_id,
+        attr_value=attr_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_product_attribute_for_attribute_value(
+        attribute_values=attribute_values,
+        db_connection_name=db_connection_name,
+    )
+
+
+def filter_by_numeric_attribute(
+    attr_id: int | None,
+    numeric_value: dict[str, Number | list[Number] | dict[str, Number]],
+    db_connection_name: str,
+):
+    qs_by_numeric = get_attribute_values_by_numeric_value(
+        attr_id=attr_id,
+        numeric_value=numeric_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_product_attribute_for_attribute_value(
+        attribute_values=qs_by_numeric,
+        db_connection_name=db_connection_name,
+    )
+
+
+def filter_by_boolean_attribute(
+    attr_id: int | None,
+    boolean_value,
+    db_connection_name: str,
+):
+    qs_by_boolean = get_attribute_values_by_boolean_value(
+        attr_id=attr_id,
+        boolean_value=boolean_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_product_attribute_for_attribute_value(
+        qs_by_boolean,
+        db_connection_name,
+    )
+
+
+def filter_by_date_attribute(
+    attr_id: int | None,
+    date_value,
+    db_connection_name: str,
+):
+    qs_by_date = get_attribute_values_by_date_value(
+        attr_id=attr_id,
+        date_value=date_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_product_attribute_for_attribute_value(
+        qs_by_date,
+        db_connection_name,
+    )
+
+
+def filter_by_date_time_attribute(
+    attr_id: int | None,
+    date_value,
+    db_connection_name: str,
+):
+    qs_by_date_time = get_attribute_values_by_date_time_value(
+        attr_id=attr_id,
+        date_value=date_value,
+        db_connection_name=db_connection_name,
+    )
+    return _get_assigned_product_attribute_for_attribute_value(
+        qs_by_date_time,
+        db_connection_name,
+    )
+
+
+def _filter_contains_single_expression(
+    attr_id: int | None,
+    db_connection_name: str,
+    referenced_attr_values: QuerySet[AttributeValue],
+):
+    if attr_id:
+        referenced_attr_values = referenced_attr_values.filter(
+            attribute_id=attr_id,
+        )
+    return _get_assigned_product_attribute_for_attribute_value(
+        referenced_attr_values,
+        db_connection_name,
+    )
+
+
+def filter_by_contains_referenced_page_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter products based on their references to pages.
+
+    - If `contains_all` is provided, only products that reference all of the
+    specified pages will match.
+    - If `contains_any` is provided, products that reference at least one of
+    the specified pages will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for page_slug in contains_all:
+            referenced_attr_values = get_attribute_values_by_referenced_page_slugs(
+                slugs=[page_slug], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_page_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
+def filter_by_contains_referenced_product_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter products based on their references to products.
+
+    - If `contains_all` is provided, only products that reference all of the
+    specified products will match.
+    - If `contains_any` is provided, products that reference at least one of
+    the specified products will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for product_slug in contains_all:
+            referenced_attr_values = get_attribute_values_by_referenced_product_slugs(
+                slugs=[product_slug], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_product_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
+def filter_by_contains_referenced_variant_skus(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter products based on their references to variants.
+
+    - If `contains_all` is provided, only products that reference all of the
+    specified variants will match.
+    - If `contains_any` is provided, products that reference at least one of
+    the specified variants will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for variant_sku in contains_all:
+            referenced_attr_values = get_attribute_values_by_referenced_variant_skus(
+                slugs=[variant_sku], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_variant_skus(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
+def _filter_by_contains_all_referenced_object_ids(
+    variant_ids: set[int],
+    product_ids: set[int],
+    page_ids: set[int],
+    attr_id: int | None,
+    db_connection_name: str,
+) -> Q:
+    expression = Q()
+    if page_ids:
+        for page_id in page_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_page_ids(
+                ids=[page_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+    if product_ids:
+        for product_id in product_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_product_ids(
+                ids=[product_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+    if variant_ids:
+        for variant_id in variant_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_variant_ids(
+                ids=[variant_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+    return expression
+
+
+def _filter_by_contains_any_referenced_object_ids(
+    variant_ids: set[int],
+    product_ids: set[int],
+    page_ids: set[int],
+    attr_id: int | None,
+    db_connection_name: str,
+) -> Q:
+    expression = Q()
+    if page_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_page_ids(
+            ids=list(page_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    if product_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_product_ids(
+            ids=list(product_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    if variant_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_variant_ids(
+            ids=list(variant_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return expression
+
+
+def filter_by_contains_referenced_object_ids(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+) -> Q:
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    variant_ids = set()
+    product_ids = set()
+    page_ids = set()
+
+    for obj_id in contains_any or contains_all or []:
+        type_, id_ = graphene.Node.from_global_id(obj_id)
+        if type_ == "Page":
+            page_ids.add(id_)
+        elif type_ == "Product":
+            product_ids.add(id_)
+        elif type_ == "ProductVariant":
+            variant_ids.add(id_)
+
+    if contains_all:
+        return _filter_by_contains_all_referenced_object_ids(
+            variant_ids=variant_ids,
+            product_ids=product_ids,
+            page_ids=page_ids,
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+        )
+    if contains_any:
+        return _filter_by_contains_any_referenced_object_ids(
+            variant_ids=variant_ids,
+            product_ids=product_ids,
+            page_ids=page_ids,
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+        )
+    return Q()
+
+
+def filter_objects_by_reference_attributes(
+    attr_id: int | None,
+    attr_value: dict[
+        Literal[
+            "referenced_ids", "page_slugs", "product_slugs", "product_variant_skus"
+        ],
+        CONTAINS_TYPING,
+    ],
+    db_connection_name: str,
+):
+    filter_expression = Q()
+
+    if "referenced_ids" in attr_value:
+        filter_expression &= filter_by_contains_referenced_object_ids(
+            attr_id,
+            attr_value["referenced_ids"],
+            db_connection_name,
+        )
+    if "page_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_page_slugs(
+            attr_id,
+            attr_value["page_slugs"],
+            db_connection_name,
+        )
+    if "product_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_product_slugs(
+            attr_id,
+            attr_value["product_slugs"],
+            db_connection_name,
+        )
+    if "product_variant_skus" in attr_value:
+        filter_expression &= filter_by_contains_referenced_variant_skus(
+            attr_id,
+            attr_value["product_variant_skus"],
+            db_connection_name,
+        )
+    return filter_expression
+
+
+def _filter_products_by_attributes(
+    qs: QuerySet[Product], value: list[dict]
+) -> QuerySet[Product]:
+    attribute_slugs = {
+        attr_filter["slug"] for attr_filter in value if "slug" in attr_filter
+    }
+    attributes_map = {
+        attr.slug: attr
+        for attr in Attribute.objects.using(qs.db).filter(slug__in=attribute_slugs)
+    }
+    if len(attribute_slugs) != len(attributes_map.keys()):
+        # Filter over non existing attribute
+        return qs.none()
+
+    attr_filter_expression = Q()
+
+    attr_without_values_input = []
+    for attr_filter in value:
+        if "slug" in attr_filter and "value" not in attr_filter:
+            attr_without_values_input.append(attributes_map[attr_filter["slug"]])
+
+    if attr_without_values_input:
+        atr_value_qs = AttributeValue.objects.using(qs.db).filter(
+            attribute_id__in=[attr.id for attr in attr_without_values_input]
+        )
+        attr_filter_expression = _get_assigned_product_attribute_for_attribute_value(
+            atr_value_qs, qs.db
+        )
+
+    for attr_filter in value:
+        attr_value = attr_filter.get("value")
+        if not attr_value:
+            # attrs without value input are handled separately
+            continue
+
+        attr_id = None
+        if attr_slug := attr_filter.get("slug"):
+            attr = attributes_map[attr_slug]
+            attr_id = attr.id
+
+        attr_value = attr_filter["value"]
+
+        if "slug" in attr_value or "name" in attr_value:
+            attr_filter_expression &= filter_by_slug_or_name(
+                attr_id,
+                attr_value,
+                qs.db,
+            )
+        elif "numeric" in attr_value:
+            attr_filter_expression &= filter_by_numeric_attribute(
+                attr_id,
+                attr_value["numeric"],
+                qs.db,
+            )
+        elif "boolean" in attr_value:
+            attr_filter_expression &= filter_by_boolean_attribute(
+                attr_id,
+                attr_value["boolean"],
+                qs.db,
+            )
+        elif "date" in attr_value:
+            attr_filter_expression &= filter_by_date_attribute(
+                attr_id,
+                attr_value["date"],
+                qs.db,
+            )
+        elif "date_time" in attr_value:
+            attr_filter_expression &= filter_by_date_time_attribute(
+                attr_id,
+                attr_value["date_time"],
+                qs.db,
+            )
+        elif "reference" in attr_value:
+            attr_filter_expression &= filter_objects_by_reference_attributes(
+                attr_id,
+                attr_value["reference"],
+                qs.db,
+            )
+    if attr_filter_expression != Q():
+        return qs.filter(attr_filter_expression)
+    return qs.none()
 
 
 def validate_attribute_input(attributes: list[dict], db_connection_name: str):


### PR DESCRIPTION
I want to merge this change because it moves the attribute filter logic for product to attribute module. 

I didn’t modify any existing logic (existing tests confirm this). I’ve moved the shared logic from shared_attributes.py and scoped it directly to products. The prior implementation relied on a 'fake' generic abstraction, assuming that Product, Page, and Variant shared the same attribute relationships, which wasn't correct.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
