### PR TITLE
Remove obsolete `valueNames`  attribute filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Increased query cost for attribute-related operations due to the addition of `AttributeValue.referencedObject`.
 
 ### GraphQL API
-
-- Added support for filtering products by attribute value names. The `AttributeInput` now includes a `valueNames` field, enabling filtering by the names of attribute values, in addition to the existing filtering by value slugs.
 - You can now filter and search orders using the new `where` and `search` fields on the `pages` query.
   - Use `where` to define complex conditions with `AND`/`OR` logic and operators like `eq`, `oneOf`, `range`.
   - Use `search` to perform full-text search across relevant fields.

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -544,16 +544,6 @@ class AttributeInput(BaseInputObjectType):
             "with deprecated fields of `AttributeInput`. "
         ),
     )
-    value_names = NonNullList(
-        graphene.String,
-        required=False,
-        description=(
-            "Names corresponding to the attributeValues associated with the Attribute. "
-            "When specified, it filters the results to include only records with "
-            "one of the matching values."
-        )
-        + ADDED_IN_322,
-    )
     values = NonNullList(
         graphene.String,
         required=False,

--- a/saleor/graphql/product/tests/queries/test_products_query_with_where.py
+++ b/saleor/graphql/product/tests/queries/test_products_query_with_where.py
@@ -744,52 +744,6 @@ def test_products_filter_by_attributes_value_slug(
     assert returned_ids == {product1_id, product2_id}
 
 
-def test_products_filter_by_attributes_value_name(
-    api_client,
-    product_list,
-    channel_USD,
-):
-    # given
-    product_type = ProductType.objects.create(
-        name="Custom Type",
-        slug="custom-type",
-        has_variants=True,
-        is_shipping_required=True,
-        kind=ProductTypeKind.NORMAL,
-    )
-    attribute = Attribute.objects.create(slug="new_attr", name="Attr")
-    attribute.product_types.add(product_type)
-    attr_value = AttributeValue.objects.create(
-        attribute=attribute, name="First", slug="first"
-    )
-    product = product_list[0]
-    product.product_type = product_type
-    product.save()
-    associate_attribute_values_to_instance(
-        product,
-        {attribute.pk: [attr_value]},
-    )
-
-    variables = {
-        "channel": channel_USD.slug,
-        "where": {
-            "attributes": [{"slug": attribute.slug, "valueNames": [attr_value.name]}],
-        },
-    }
-
-    # when
-    response = api_client.post_graphql(PRODUCTS_WHERE_QUERY, variables)
-    content = get_graphql_content(response)
-
-    # then
-    product_id = graphene.Node.to_global_id("Product", product.id)
-    products = content["data"]["products"]["edges"]
-
-    assert len(products) == 1
-    assert products[0]["node"]["id"] == product_id
-    assert products[0]["node"]["name"] == product.name
-
-
 def test_products_filter_by_attributes_empty_list(
     api_client,
     product_list,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7780,13 +7780,6 @@ input AttributeInput @doc(category: "Attributes") {
   value: AssignedAttributeValueInput
 
   """
-  Names corresponding to the attributeValues associated with the Attribute. When specified, it filters the results to include only records with one of the matching values.
-  
-  Added in Saleor 3.22.
-  """
-  valueNames: [String!]
-
-  """
   Slugs identifying the attributeValues associated with the Attribute. When specified, it filters the results to include only records with one of the matching values. Requires `slug` to be provided.
   """
   values: [String!] @deprecated(reason: "Use `value` instead.")


### PR DESCRIPTION
I want to merge this change because it removes the field `valueNames` introduced in https://github.com/saleor/saleor/pull/17740. **These field has not beed released yet**, this is why I just removing it.
The filter over value's names is provided as unify and more cleaner approach. You can do:
```graphql
  productVariants(first:10, channel:"default-channel", where:{
    attributes:[
      {value: {name: {oneOf:["First name", "Second name"]}}}
    ]
  }){
```
(The same input structure is added to `products`, `productVariants` and `pages`)


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
