### PR TITLE
Add ability to filter orders by the warehouses used to fulfill them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - Filter by associated payment method name and type.
     - Filter by associated billing and shipping address phone number and country code.
     - Filter by associated transactionItems metadata.
+    - Filter by warehouse used to fulfill the order.
 - You can now filter and search orders using the new `where` and `search` fields on the `orders` query.
   - Use `where` to define complex conditions with `AND`/`OR` logic and operators like `eq`, `oneOf`, `range`.
   - Use `search` to perform full-text search across relevant fields.

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -1,10 +1,11 @@
+from collections.abc import Mapping
 from uuid import UUID
 
 import django_filters
 import graphene
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.db.models import Exists, OuterRef, Q, Value
+from django.db.models import Exists, OuterRef, Q, QuerySet, Value
 from django.utils import timezone
 from graphql.error import GraphQLError
 
@@ -12,11 +13,12 @@ from ...core.postgres import FlatConcat
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
 from ...invoice.models import Invoice
-from ...order.models import Fulfillment, Order, OrderEvent, OrderLine
+from ...order.models import Fulfillment, FulfillmentLine, Order, OrderEvent, OrderLine
 from ...order.search import search_orders
 from ...payment import ChargeStatus, PaymentMethodType
 from ...payment.models import TransactionItem
 from ...product.models import ProductVariant
+from ...warehouse.models import Stock, Warehouse
 from ..account.filters import AddressFilterInput, filter_address
 from ..channel.filters import get_currency_from_filter_data
 from ..core.doc_category import DOC_CATEGORY_ORDERS
@@ -288,6 +290,39 @@ def filter_has_fulfillments(qs, value):
     return qs.filter(~Exists(fulfillments))
 
 
+def filter_fulfillments_by_warehouse_details(
+    value: Mapping[str, Mapping[str, list[str] | str]], qs: QuerySet[Fulfillment]
+) -> QuerySet[Fulfillment]:
+    if not value:
+        return qs.none()
+
+    warehouse_qs = None
+    if warehouse_id_filter := value.get("id"):
+        warehouse_qs = filter_where_by_id_field(
+            Warehouse.objects.using(qs.db), "id", warehouse_id_filter, "Warehouse"
+        )
+    if warehouse_slug_filter := value.get("slug"):
+        warehouse_qs = warehouse_qs or Warehouse.objects.using(qs.db)
+        warehouse_qs = filter_where_by_value_field(
+            warehouse_qs, "slug", warehouse_slug_filter
+        )
+    if warehouse_external_reference := value.get("external_reference"):
+        warehouse_qs = warehouse_qs or Warehouse.objects.using(qs.db)
+        warehouse_qs = filter_where_by_value_field(
+            warehouse_qs, "external_reference", warehouse_external_reference
+        )
+    if warehouse_qs is None:
+        return qs.none()
+
+    stocks_qs = Stock.objects.using(qs.db).filter(
+        Exists(warehouse_qs.filter(id=OuterRef("warehouse_id")))
+    )
+    fulfillment_lines_qs = FulfillmentLine.objects.using(qs.db).filter(
+        Exists(stocks_qs.filter(id=OuterRef("stock_id")))
+    )
+    return qs.filter(Exists(fulfillment_lines_qs.filter(fulfillment_id=OuterRef("id"))))
+
+
 def filter_fulfillments(qs, value):
     if not value:
         return qs.none()
@@ -300,8 +335,14 @@ def filter_fulfillments(qs, value):
                 Fulfillment.objects.using(qs.db), "status", status_value
             )
         if metadata_value := input_data.get("metadata"):
-            fulfillment_qs = filter_where_metadata(
-                fulfillment_qs or Fulfillment.objects.using(qs.db), None, metadata_value
+            if fulfillment_qs is None:
+                fulfillment_qs = Fulfillment.objects.using(qs.db)
+            fulfillment_qs = filter_where_metadata(fulfillment_qs, None, metadata_value)
+        if warehouse_value := input_data.get("warehouse"):
+            if fulfillment_qs is None:
+                fulfillment_qs = Fulfillment.objects.using(qs.db)
+            fulfillment_qs = filter_fulfillments_by_warehouse_details(
+                value=warehouse_value, qs=fulfillment_qs
             )
         if fulfillment_qs is not None:
             lookup &= Q(Exists(fulfillment_qs.filter(order_id=OuterRef("id"))))
@@ -430,11 +471,34 @@ class FulfillmentStatusEnumFilterInput(BaseInputObjectType):
         description = "Filter by fulfillment status."
 
 
+class FulfillmentWarehouseFilterInput(BaseInputObjectType):
+    id = GlobalIDFilterInput(
+        description="Filter fulfillments by warehouse ID.",
+        required=False,
+    )
+    slug = StringFilterInput(
+        description="Filter fulfillments by warehouse slug.",
+        required=False,
+    )
+    external_reference = StringFilterInput(
+        description="Filter fulfillments by warehouse external reference.",
+        required=False,
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
+        description = "Filter input for fulfillment warehouses."
+
+
 class FulfillmentFilterInput(BaseInputObjectType):
     status = FulfillmentStatusEnumFilterInput(
         description="Filter by fulfillment status."
     )
     metadata = MetadataFilterInput(description="Filter by metadata fields.")
+    warehouse = FulfillmentWarehouseFilterInput(
+        description="Filter by fulfillment warehouse.",
+        required=False,
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -302,12 +302,14 @@ def filter_fulfillments_by_warehouse_details(
             Warehouse.objects.using(qs.db), "id", warehouse_id_filter, "Warehouse"
         )
     if warehouse_slug_filter := value.get("slug"):
-        warehouse_qs = warehouse_qs or Warehouse.objects.using(qs.db)
+        if warehouse_qs is None:
+            warehouse_qs = Warehouse.objects.using(qs.db)
         warehouse_qs = filter_where_by_value_field(
             warehouse_qs, "slug", warehouse_slug_filter
         )
     if warehouse_external_reference := value.get("external_reference"):
-        warehouse_qs = warehouse_qs or Warehouse.objects.using(qs.db)
+        if warehouse_qs is None:
+            warehouse_qs = Warehouse.objects.using(qs.db)
         warehouse_qs = filter_where_by_value_field(
             warehouse_qs, "external_reference", warehouse_external_reference
         )

--- a/saleor/graphql/order/tests/queries/test_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_where.py
@@ -2175,6 +2175,10 @@ def test_orders_filter_fulfillment_warehouse_external_reference(
                 ]
             }
         },
+        {
+            "slug": {"oneOf": ["non-existing-warehouse"]},
+            "externalReference": {"eq": "existing-warehouse-ref"},
+        },
     ],
 )
 def test_orders_filter_fulfillment_warehouse_non_existing(
@@ -2187,7 +2191,14 @@ def test_orders_filter_fulfillment_warehouse_non_existing(
     # given
     permission_group_manage_orders.user_set.add(staff_api_client.user)
 
+    fulfillment = fulfilled_order.fulfillments.first()
+
     assert FulfillmentLine.objects.count() > 1
+
+    existing_warehouse = fulfillment.lines.first().stock.warehouse
+    existing_warehouse.slug = "existing-warehouse-slug"
+    existing_warehouse.external_reference = "existing-warehouse-ref"
+    existing_warehouse.save()
 
     variables = {
         "where": {"fulfillments": [{"warehouse": where_warehouse_non_existing_input}]}

--- a/saleor/graphql/order/tests/queries/test_order_with_where.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_where.py
@@ -17,13 +17,17 @@ from .....order import (
     OrderEvents,
     OrderStatus,
 )
-from .....order.models import Order, OrderEvent, OrderLine
+from .....order.models import FulfillmentLine, Order, OrderEvent, OrderLine
 from .....order.search import prepare_order_search_vector_value
+from .....warehouse.models import Stock
+from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content, get_graphql_content_from_response
 
 
 @pytest.fixture
-def orders_with_fulfillments(order_list):
+def orders_with_fulfillments(
+    order_list, warehouses, order_lines_generator, product_variant_list
+):
     statuses = [
         FulfillmentStatus.FULFILLED,
         FulfillmentStatus.REFUNDED,
@@ -34,11 +38,43 @@ def orders_with_fulfillments(order_list):
         {"foo": "zaz"},
         {},
     ]
+    variant_1 = product_variant_list[0]
+    variant_2 = product_variant_list[1]
+    variant_1_quantity = 10
+    variant_2_quantity = 5
+    stock_1, stock_2 = Stock.objects.bulk_create(
+        [
+            Stock(
+                product_variant=variant_1,
+                warehouse=warehouses[0],
+                quantity=variant_1_quantity * len(order_list),
+            ),
+            Stock(
+                product_variant=variant_2,
+                warehouse=warehouses[1],
+                quantity=variant_2_quantity * len(order_list),
+            ),
+        ]
+    )
     for order, status, metadata in zip(
         order_list, statuses, metadata_values, strict=True
     ):
-        order.fulfillments.create(
+        fulfillment = order.fulfillments.create(
             tracking_number="123", status=status, metadata=metadata
+        )
+        line_1, line_2 = order_lines_generator(
+            order,
+            [variant_1, variant_2],
+            [10, 20],
+            [variant_1_quantity, variant_2_quantity],
+            create_allocations=False,
+        )
+
+        fulfillment.lines.create(
+            order_line=line_1, quantity=line_1.quantity, stock=stock_1
+        )
+        fulfillment.lines.create(
+            order_line=line_2, quantity=line_2.quantity, stock=stock_2
         )
     return order_list
 
@@ -1974,6 +2010,292 @@ def test_orders_filter_fulfillment_status_oneof_metadata_oneof(
         str(orders_with_fulfillments[0].number),
         str(orders_with_fulfillments[1].number),
     }
+
+
+def test_orders_filter_fulfillment_warehouse_id_eq(
+    orders_with_fulfillments,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    expected_order = fulfilled_order
+    fulfillment = expected_order.fulfillments.first()
+    warehouse = fulfillment.lines.first().stock.warehouse
+
+    variables = {
+        "where": {
+            "fulfillments": [
+                {"warehouse": {"id": {"eq": to_global_id_or_none(warehouse)}}}
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 1
+    order_number_from_api = orders[0]["node"]["number"]
+    assert order_number_from_api == str(expected_order.number)
+
+
+def test_orders_filter_fulfillment_warehouse_id_one_of(
+    orders_with_fulfillments,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    expected_order = fulfilled_order
+    fulfillment = expected_order.fulfillments.first()
+    warehouse = fulfillment.lines.first().stock.warehouse
+
+    variables = {
+        "where": {
+            "fulfillments": [
+                {"warehouse": {"id": {"oneOf": [to_global_id_or_none(warehouse)]}}}
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 1
+    order_number_from_api = orders[0]["node"]["number"]
+    assert order_number_from_api == str(expected_order.number)
+
+
+@pytest.mark.parametrize(
+    "where_warehouse_slug",
+    [
+        {"slug": {"eq": "warehouse-to-get"}},
+        {"slug": {"oneOf": ["warehouse-to-get"]}},
+    ],
+)
+def test_orders_filter_fulfillment_warehouse_slug(
+    where_warehouse_slug,
+    orders_with_fulfillments,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    expected_order = fulfilled_order
+    fulfillment = expected_order.fulfillments.first()
+
+    assert FulfillmentLine.objects.count() > 1
+
+    warehouse = fulfillment.lines.first().stock.warehouse
+
+    expected_warehouse_slug = "warehouse-to-get"
+    warehouse.slug = expected_warehouse_slug
+    warehouse.save()
+
+    variables = {"where": {"fulfillments": [{"warehouse": where_warehouse_slug}]}}
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 1
+    order_number_from_api = orders[0]["node"]["number"]
+    assert order_number_from_api == str(expected_order.number)
+
+
+@pytest.mark.parametrize(
+    "where_warehouse_external_reference",
+    [
+        {"externalReference": {"eq": "warehouse-to-get"}},
+        {"externalReference": {"oneOf": ["warehouse-to-get"]}},
+    ],
+)
+def test_orders_filter_fulfillment_warehouse_external_reference(
+    where_warehouse_external_reference,
+    orders_with_fulfillments,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    expected_order = fulfilled_order
+    fulfillment = expected_order.fulfillments.first()
+
+    assert FulfillmentLine.objects.count() > 1
+
+    warehouse = fulfillment.lines.first().stock.warehouse
+
+    expected_warehouse_external_reference = "warehouse-to-get"
+    warehouse.external_reference = expected_warehouse_external_reference
+    warehouse.save()
+
+    variables = {
+        "where": {"fulfillments": [{"warehouse": where_warehouse_external_reference}]}
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 1
+    order_number_from_api = orders[0]["node"]["number"]
+    assert order_number_from_api == str(expected_order.number)
+
+
+@pytest.mark.parametrize(
+    "where_warehouse_non_existing_input",
+    [
+        {"externalReference": {"eq": "non-existing-warehouse"}},
+        {"externalReference": {"oneOf": ["non-existing-warehouse"]}},
+        {"slug": {"eq": "non-existing-warehouse"}},
+        {"slug": {"oneOf": ["non-existing-warehouse"]}},
+        {
+            "id": {
+                "eq": "V2FyZWhvdXNlOjJjMGNiODAwLTU0N2ItNDM1ZS04Y2UwLTkyYTFiOTE1ZmFkMQ=="
+            }
+        },
+        {
+            "id": {
+                "oneOf": [
+                    "V2FyZWhvdXNlOjJjMGNiODAwLTU0N2ItNDM1ZS04Y2UwLTkyYTFiOTE1ZmFkMQ=="
+                ]
+            }
+        },
+    ],
+)
+def test_orders_filter_fulfillment_warehouse_non_existing(
+    where_warehouse_non_existing_input,
+    orders_with_fulfillments,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    assert FulfillmentLine.objects.count() > 1
+
+    variables = {
+        "where": {"fulfillments": [{"warehouse": where_warehouse_non_existing_input}]}
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 0
+
+
+@pytest.mark.parametrize(
+    "where_additional_filters",
+    [
+        {"status": {"eq": FulfillmentStatus.FULFILLED.upper()}},
+        {"metadata": {"key": "notfound"}},
+    ],
+)
+def test_orders_filter_fulfillment_warehouse_with_multiple_filters_with_no_match(
+    where_additional_filters,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    expected_order = fulfilled_order
+    fulfillment = expected_order.fulfillments.first()
+    fulfillment.status = FulfillmentStatus.WAITING_FOR_APPROVAL
+    fulfillment.metadata = {"key": "value"}
+    fulfillment.save()
+
+    warehouse = fulfillment.lines.first().stock.warehouse
+
+    variables = {
+        "where": {
+            "fulfillments": [
+                {
+                    "warehouse": {"id": {"eq": to_global_id_or_none(warehouse)}},
+                    **where_additional_filters,
+                },
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 0
+
+
+@pytest.mark.parametrize(
+    "where_additional_filters",
+    [
+        {"status": {"eq": FulfillmentStatus.FULFILLED.upper()}},
+        {"metadata": {"key": "meta-key"}},
+    ],
+)
+def test_orders_filter_fulfillment_warehouse_multiple_filters(
+    where_additional_filters,
+    orders_with_fulfillments,
+    staff_api_client,
+    permission_group_manage_orders,
+    fulfilled_order,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    expected_order = fulfilled_order
+
+    fulfillment = expected_order.fulfillments.first()
+    fulfillment.status = FulfillmentStatus.FULFILLED
+    fulfillment.metadata = {"meta-key": "meta-value"}
+    fulfillment.save()
+
+    assert FulfillmentLine.objects.count() > 1
+
+    warehouse = fulfillment.lines.first().stock.warehouse
+
+    expected_warehouse_external_reference = "warehouse-to-get"
+    warehouse.external_reference = expected_warehouse_external_reference
+    warehouse.save()
+
+    variables = {
+        "where": {
+            "fulfillments": [
+                {
+                    "warehouse": {"id": {"eq": to_global_id_or_none(warehouse)}},
+                    **where_additional_filters,
+                },
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WHERE_QUERY, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 1
+    order_number_from_api = orders[0]["node"]["number"]
+    assert order_number_from_api == str(expected_order.number)
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13394,6 +13394,9 @@ input FulfillmentFilterInput @doc(category: "Orders") {
 
   """Filter by metadata fields."""
   metadata: MetadataFilterInput
+
+  """Filter by fulfillment warehouse."""
+  warehouse: FulfillmentWarehouseFilterInput
 }
 
 """Filter by fulfillment status."""
@@ -13403,6 +13406,18 @@ input FulfillmentStatusEnumFilterInput @doc(category: "Orders") {
 
   """The value included in."""
   oneOf: [FulfillmentStatus!]
+}
+
+"""Filter input for fulfillment warehouses."""
+input FulfillmentWarehouseFilterInput @doc(category: "Orders") {
+  """Filter fulfillments by warehouse ID."""
+  id: GlobalIDFilterInput
+
+  """Filter fulfillments by warehouse slug."""
+  slug: StringFilterInput
+
+  """Filter fulfillments by warehouse external reference."""
+  externalReference: StringFilterInput
 }
 
 """Filter input for order lines data."""

--- a/saleor/graphql/utils/filters.py
+++ b/saleor/graphql/utils/filters.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -113,7 +114,7 @@ ValueT = str | UUID
 
 
 def filter_where_by_value_field(
-    qs: "QuerySet", field: str, value: dict[str, ValueT | list[ValueT]]
+    qs: "QuerySet", field: str, value: Mapping[str, ValueT | Sequence[ValueT]]
 ):
     if value is None:
         return qs.none()
@@ -128,7 +129,7 @@ def filter_where_by_value_field(
 
 
 def filter_where_by_id_field(
-    qs: "QuerySet", field: str, value: dict[str, str | list[str]], type: str
+    qs: "QuerySet", field: str, value: Mapping[str, str | list[str]], type: str
 ):
     from . import resolve_global_ids_to_primary_keys
 


### PR DESCRIPTION
I want to merge this change because it adds a possibility to filter out orders by the warehouse used to fulfill the orders.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
