### PR TITLE
Add MessageGroupId to webhook Celery tasks

### DIFF
--- a/saleor/app/tests/test_app_commands.py
+++ b/saleor/app/tests/test_app_commands.py
@@ -85,9 +85,9 @@ def test_creates_app_from_manifest_sends_token(monkeypatch, app_manifest):
         headers={
             "Content-Type": "application/json",
             # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-            "X-Saleor-Domain": "mirumee.com",
-            "Saleor-Domain": "mirumee.com",
-            "Saleor-Api-Url": "http://mirumee.com/graphql/",
+            "X-Saleor-Domain": "example.com",
+            "Saleor-Domain": "example.com",
+            "Saleor-Api-Url": "https://example.com/graphql/",
             "Saleor-Schema-Version": schema_version,
         },
         json={"auth_token": ANY},
@@ -153,9 +153,9 @@ def test_sends_data_to_target_url(monkeypatch):
         target_url,
         headers={
             # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-            "X-Saleor-Domain": "mirumee.com",
-            "Saleor-Domain": "mirumee.com",
-            "Saleor-Api-Url": "http://mirumee.com/graphql/",
+            "X-Saleor-Domain": "example.com",
+            "Saleor-Domain": "example.com",
+            "Saleor-Api-Url": "https://example.com/graphql/",
             "Saleor-Schema-Version": schema_version,
         },
         json={"auth_token": ANY},

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -90,9 +90,9 @@ def test_install_app_created_app(
         headers={
             "Content-Type": "application/json",
             # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-            "X-Saleor-Domain": "mirumee.com",
-            "Saleor-Domain": "mirumee.com",
-            "Saleor-Api-Url": "http://mirumee.com/graphql/",
+            "X-Saleor-Domain": "example.com",
+            "Saleor-Domain": "example.com",
+            "Saleor-Api-Url": "https://example.com/graphql/",
             "Saleor-Schema-Version": schema_version,
         },
         json={"auth_token": ANY},

--- a/saleor/attribute/tests/fixtures/attribute.py
+++ b/saleor/attribute/tests/fixtures/attribute.py
@@ -568,7 +568,7 @@ def swatch_attribute(db):
         attribute=attribute,
         name="Logo",
         slug="logo",
-        file_url="http://mirumee.com/test_media/test_file.jpeg",
+        file_url="http://example.com/test_media/test_file.jpeg",
         content_type="image/jpeg",
     )
     return attribute

--- a/saleor/checkout/tests/test_actions.py
+++ b/saleor/checkout/tests/test_actions.py
@@ -668,9 +668,7 @@ def test_call_checkout_event_triggers_sync_webhook_when_needed(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -765,9 +763,7 @@ def test_call_checkout_event_skips_tax_webhook_when_not_expired(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -886,9 +882,7 @@ def test_call_checkout_event_only_async_when_sync_missing(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.test",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -1016,9 +1010,7 @@ def test_call_checkout_info_event_triggers_sync_webhook_when_needed(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1124,9 +1116,7 @@ def test_call_checkout_info_event_skips_tax_webhook_when_not_expired(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1217,9 +1207,7 @@ def test_call_checkout_info_event_only_async_when_sync_missing(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.test",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -1346,9 +1334,7 @@ def test_transaction_amounts_for_checkout_fully_paid_triggers_sync_webhook(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1488,9 +1474,7 @@ def test_call_checkout_events_triggers_sync_webhook_when_needed(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1593,9 +1577,7 @@ def test_call_checkout_events_skips_tax_webhook_when_not_expired(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1725,9 +1707,7 @@ def test_call_checkout_events_only_async_when_sync_missing(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.test",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(

--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -217,7 +217,7 @@ def test_storages_not_setting_s3_bucket_domain(storage, settings):
     assert storage.custom_domain is None
 
 
-def test_build_absolute_uri(site_settings, settings):
+def test_build_absolute_uri():
     # Case when we are using external service for storing static files,
     # eg. Amazon s3
     url = "https://example.com/static/images/image.jpg"
@@ -225,13 +225,12 @@ def test_build_absolute_uri(site_settings, settings):
 
     # Case when static url is resolved to relative url
     logo_url = build_absolute_uri(static("images/close.svg"))
-    protocol = "https" if settings.ENABLE_SSL else "http"
-    current_url = f"{protocol}://{site_settings.site.domain}"
+    current_url = "https://example.com/"
     logo_location = urljoin(current_url, static("images/close.svg"))
     assert logo_url == logo_location
 
 
-def test_build_absolute_uri_with_host(site_settings, settings):
+def test_build_absolute_uri_with_host(settings):
     # given
     host = "test.com"
     location = "images/close.svg"
@@ -240,7 +239,7 @@ def test_build_absolute_uri_with_host(site_settings, settings):
     url = build_absolute_uri(location, host)
 
     # then
-    assert url == f"http://{host}/{location}"
+    assert url == f"https://example.com/{location}"
 
 
 @pytest.mark.parametrize(
@@ -248,9 +247,7 @@ def test_build_absolute_uri_with_host(site_settings, settings):
 )
 @pytest.mark.parametrize("enable_ssl", [True, False])
 @pytest.mark.parametrize("host", [None, "test.com"])
-def test_build_absolute_uri_with_public_url(
-    public_url, enable_ssl, host, site_settings, settings
-):
+def test_build_absolute_uri_with_public_url(public_url, enable_ssl, host, settings):
     # given
     location = "images/close.svg"
     settings.PUBLIC_URL = public_url
@@ -261,9 +258,7 @@ def test_build_absolute_uri_with_public_url(
     assert url == f"{public_url}/{location}"
 
 
-def test_build_absolute_uri_with_public_url_and_absolute_location(
-    site_settings, settings
-):
+def test_build_absolute_uri_with_public_url_and_absolute_location(settings):
     # given
     location = "https://example.com/static/images/image.jpg"
     settings.PUBLIC_URL = "https://api.example.com"
@@ -275,6 +270,7 @@ def test_build_absolute_uri_with_public_url_and_absolute_location(
 
 @pytest.mark.parametrize("enable_ssl", [True, False])
 def test_is_ssl_enabled(enable_ssl, settings):
+    settings.PUBLIC_URL = None
     # given
     settings.ENABLE_SSL = enable_ssl
     # then
@@ -295,6 +291,7 @@ def test_is_ssl_enabled_with_public_url(public_url, expected, enable_ssl, settin
 
 
 def test_get_domain(site_settings, settings):
+    settings.PUBLIC_URL = None
     assert get_domain() == site_settings.site.domain
 
 

--- a/saleor/core/tests/test_jwt.py
+++ b/saleor/core/tests/test_jwt.py
@@ -17,14 +17,13 @@ def test_create_access_token_for_app(
     staff_user,
     permission_manage_apps,
     permission_manage_products,
-    site_settings,
 ):
     # given
     staff_user.user_permissions.set(
         [permission_manage_apps, permission_manage_products]
     )
     app.permissions.add(permission_manage_products)
-    audience = f"https://{site_settings.site.domain}.com/app-123"
+    audience = "https://example.com/app-123"
     app.audience = audience
     app.save()
 
@@ -47,13 +46,12 @@ def test_create_access_token_for_app_extension_staff_user_with_more_permissions(
     permission_manage_apps,
     permission_manage_products,
     permission_manage_channels,
-    site_settings,
 ):
     # given
     staff_user.user_permissions.set(
         [permission_manage_channels, permission_manage_apps, permission_manage_products]
     )
-    audience = f"https://{site_settings.site.domain}.com/app-123"
+    audience = "https://example.com/app-123"
     app, extensions = app_with_extensions
     app.audience = audience
     app.save()
@@ -93,12 +91,11 @@ def test_create_access_token_for_app_extension_with_more_permissions(
     permission_manage_apps,
     permission_manage_products,
     permission_manage_channels,
-    site_settings,
 ):
     # given
     staff_user.user_permissions.set([permission_manage_products])
 
-    audience = f"https://{site_settings.site.domain}.com/app-123"
+    audience = "https://example.com/app-123"
     app, extensions = app_with_extensions
     app.audience = audience
     app.save()

--- a/saleor/core/tests/utils.py
+++ b/saleor/core/tests/utils.py
@@ -4,9 +4,8 @@ from ..notification.utils import LOGO_URL
 
 
 def get_site_context_payload(site):
-    domain = site.domain
     return {
         "site_name": site.name,
-        "domain": domain,
-        "logo_url": f"http://{domain}{settings.STATIC_URL}{LOGO_URL}",
+        "domain": "example.com",
+        "logo_url": f"https://example.com{settings.STATIC_URL}{LOGO_URL}",
     }

--- a/saleor/core/utils/tests/test_url.py
+++ b/saleor/core/utils/tests/test_url.py
@@ -21,12 +21,12 @@ def test_prepare_url_with_existing_query():
     assert result == f"{redirect_url}&param3=abc&param4=xyz"
 
 
-def test_get_default_storage_root_url(site_settings):
+def test_get_default_storage_root_url():
     # when
     root_url = get_default_storage_root_url()
 
     # then
-    assert root_url == f"http://{site_settings.site.domain}{settings.MEDIA_URL}"
+    assert root_url == f"https://example.com{settings.MEDIA_URL}"
 
 
 @pytest.mark.parametrize(

--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -92,7 +92,7 @@ def test_get_products_data(product, product_with_image, collection, image, chann
             "media__image": (
                 ""
                 if not product.media.all()
-                else f"http://mirumee.com{product.media.first().image.url}"
+                else f"https://example.com{product.media.first().image.url}"
             ),
         }
 
@@ -112,10 +112,10 @@ def test_get_products_data(product, product_with_image, collection, image, chann
                 "variants__media__image": (
                     ""
                     if not variant.media.all()
-                    else f"http://mirumee.com{variant.media.first().image.url}"
+                    else f"https://example.com{variant.media.first().image.url}"
                 ),
                 "variant_weight": (
-                    "{} g".foramt(int(variant.weight.value)) if variant.weight else ""
+                    f"{int(variant.weight.value)} g" if variant.weight else ""
                 ),
                 "variants__is_preorder": variant.is_preorder,
                 "variants__preorder_global_threshold": (

--- a/saleor/csv/tests/export/products_data/test_handle_relations_data.py
+++ b/saleor/csv/tests/export/products_data/test_handle_relations_data.py
@@ -229,7 +229,7 @@ def test_prepare_products_relations_data(
     )
     images = ", ".join(
         [
-            "http://mirumee.com/media/" + image.image.name
+            "https://example.com/media/" + image.image.name
             for image in product_with_image.media.all()
         ]
     )
@@ -632,7 +632,7 @@ def test_prepare_variants_relations_data(
         pk = variant.pk
         images = ", ".join(
             [
-                "http://mirumee.com/media/" + image.image.name
+                "https://example.com/media/" + image.image.name
                 for image in variant.media.all()
             ]
         )
@@ -676,7 +676,7 @@ def test_prepare_variants_relations_data_only_fields(
     pk = variant.pk
     images = ", ".join(
         [
-            "http://mirumee.com/media/" + image.image.name
+            "https://example.com/media/" + image.image.name
             for image in variant.media.all()
         ]
     )
@@ -823,13 +823,13 @@ def test_add_image_uris_to_data(product):
     result = add_image_uris_to_data(product.pk, image_path, field, input_data)
 
     # then
-    assert result[pk][field] == {"http://mirumee.com/media/" + image_path}
+    assert result[pk][field] == {"https://example.com/media/" + image_path}
 
 
 def test_add_image_uris_to_data_update_images(product):
     # given
     pk = product.pk
-    old_path = "http://mirumee.com/media/test/image0.jpg"
+    old_path = "https://example.com/media/test/image0.jpg"
     image_path = "test/path/image.jpg"
     input_data = {pk: {"product_media": {old_path}}}
     field = "product_media"
@@ -838,7 +838,7 @@ def test_add_image_uris_to_data_update_images(product):
     result = add_image_uris_to_data(product.pk, image_path, field, input_data)
 
     # then
-    assert result[pk][field] == {"http://mirumee.com/media/" + image_path, old_path}
+    assert result[pk][field] == {"https://example.com/media/" + image_path, old_path}
 
 
 def test_add_image_uris_to_data_no_image_path(product):
@@ -1009,7 +1009,7 @@ def test_add_file_attribute_info_to_data(product):
 
     # then
     expected_header = f"{slug} (product attribute)"
-    assert result[pk][expected_header] == {"http://mirumee.com/media/" + test_url}
+    assert result[pk][expected_header] == {"https://example.com/media/" + test_url}
 
 
 def test_add_rich_text_attribute_info_to_data(product):
@@ -1454,7 +1454,7 @@ def test_add_swatch_attribute_value_info_to_data(product, numeric_attribute):
 
     # then
     expected_header = f"{numeric_attribute.slug} (product attribute)"
-    assert result[pk][expected_header] == {"http://mirumee.com/media/" + test_url}
+    assert result[pk][expected_header] == {"https://example.com/media/" + test_url}
 
 
 def test_add_warehouse_info_to_data(product):

--- a/saleor/csv/tests/export/products_data/utils.py
+++ b/saleor/csv/tests/export/products_data/utils.py
@@ -64,7 +64,7 @@ def get_attribute_value(attribute, value_instance):
     if not value_instance:
         return ""
     if attribute.input_type == AttributeInputType.FILE:
-        value = "http://mirumee.com/media/" + value_instance.file_url
+        value = "https://example.com/media/" + value_instance.file_url
     elif attribute.input_type == AttributeInputType.REFERENCE:
         ref_id = value_instance.slug.split("_")[3]
         value = f"{attribute.entity_type}_{ref_id}"

--- a/saleor/graphql/account/tests/mutations/staff/test_user_avatar_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_user_avatar_update.py
@@ -37,9 +37,7 @@ def test_user_avatar_update_mutation_permission(api_client):
     assert_no_permission(response)
 
 
-def test_user_avatar_update_mutation(
-    monkeypatch, staff_api_client, media_root, site_settings
-):
+def test_user_avatar_update_mutation(monkeypatch, staff_api_client, media_root):
     query = USER_AVATAR_UPDATE_MUTATION
 
     user = staff_api_client.user
@@ -59,7 +57,7 @@ def test_user_avatar_update_mutation(
 
     assert user.avatar
     assert data["user"]["avatar"]["url"].startswith(
-        f"http://{site_settings.site.domain}/media/user-avatars/avatar"
+        "https://example.com/media/user-avatars/avatar"
     )
     img_name, format = os.path.splitext(image_file._name)
     file_name = user.avatar.name
@@ -68,9 +66,7 @@ def test_user_avatar_update_mutation(
     assert file_name.endswith(format)
 
 
-def test_user_avatar_update_mutation_image_exists(
-    staff_api_client, media_root, site_settings
-):
+def test_user_avatar_update_mutation_image_exists(staff_api_client, media_root):
     query = USER_AVATAR_UPDATE_MUTATION
 
     user = staff_api_client.user
@@ -98,6 +94,6 @@ def test_user_avatar_update_mutation_image_exists(
 
     assert user.avatar != avatar_mock
     assert data["user"]["avatar"]["url"].startswith(
-        f"http://{site_settings.site.domain}/media/user-avatars/new_image"
+        "https://example.com/media/user-avatars/new_image"
     )
     assert not user.thumbnails.exists()

--- a/saleor/graphql/account/tests/queries/test_user.py
+++ b/saleor/graphql/account/tests/queries/test_user.py
@@ -784,7 +784,7 @@ USER_AVATAR_QUERY = """
 
 
 def test_query_user_avatar_with_size_and_format_proxy_url_returned(
-    staff_api_client, media_root, permission_manage_staff, site_settings
+    staff_api_client, media_root, permission_manage_staff
 ):
     # given
     user = staff_api_client.user
@@ -807,15 +807,14 @@ def test_query_user_avatar_with_size_and_format_proxy_url_returned(
     # then
     content = get_graphql_content(response)
     data = content["data"]["user"]
-    domain = site_settings.site.domain
     assert (
         data["avatar"]["url"]
-        == f"http://{domain}/thumbnail/{user_uuid}/128/{format.lower()}/"
+        == f"https://example.com/thumbnail/{user_uuid}/128/{format.lower()}/"
     )
 
 
 def test_query_user_avatar_with_size_proxy_url_returned(
-    staff_api_client, media_root, permission_manage_staff, site_settings
+    staff_api_client, media_root, permission_manage_staff
 ):
     # given
     user = staff_api_client.user
@@ -836,14 +835,11 @@ def test_query_user_avatar_with_size_proxy_url_returned(
     # then
     content = get_graphql_content(response)
     data = content["data"]["user"]
-    assert (
-        data["avatar"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{user_uuid}/128/"
-    )
+    assert data["avatar"]["url"] == f"https://example.com/thumbnail/{user_uuid}/128/"
 
 
 def test_query_user_avatar_with_size_thumbnail_url_returned(
-    staff_api_client, media_root, permission_manage_staff, site_settings
+    staff_api_client, media_root, permission_manage_staff
 ):
     # given
     user = staff_api_client.user
@@ -869,12 +865,12 @@ def test_query_user_avatar_with_size_thumbnail_url_returned(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
+        == f"https://example.com/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_query_user_avatar_original_size_custom_format_provided_original_image_returned(
-    staff_api_client, media_root, permission_manage_staff, site_settings
+    staff_api_client, media_root, permission_manage_staff
 ):
     # given
     user = staff_api_client.user
@@ -898,12 +894,12 @@ def test_query_user_avatar_original_size_custom_format_provided_original_image_r
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://{site_settings.site.domain}/media/user-avatars/{avatar_mock.name}"
+        == f"https://example.com/media/user-avatars/{avatar_mock.name}"
     )
 
 
 def test_query_user_avatar_no_size_value(
-    staff_api_client, media_root, permission_manage_staff, site_settings
+    staff_api_client, media_root, permission_manage_staff
 ):
     # given
     user = staff_api_client.user
@@ -925,10 +921,7 @@ def test_query_user_avatar_no_size_value(
     # then
     content = get_graphql_content(response)
     data = content["data"]["user"]
-    assert (
-        data["avatar"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{user_uuid}/4096/"
-    )
+    assert data["avatar"]["url"] == f"https://example.com/thumbnail/{user_uuid}/4096/"
 
 
 def test_query_user_avatar_no_image(staff_api_client, permission_manage_staff):

--- a/saleor/graphql/app/tests/queries/test_app.py
+++ b/saleor/graphql/app/tests/queries/test_app.py
@@ -483,11 +483,10 @@ def test_app_query_access_token_with_audience(
     permission_manage_staff,
     external_app,
     webhook,
-    site_settings,
 ):
     app = external_app
     app.permissions.add(permission_manage_staff)
-    app.audience = f"https://{site_settings.site.domain}.com/app-123"
+    app.audience = "https://example.com/app-123"
     app.save()
 
     webhook = webhook
@@ -522,7 +521,6 @@ def test_app_query_logo_thumbnail_with_size_and_format_url_returned(
     format,
     staff_api_client,
     app,
-    site_settings,
     icon_image,
     media_root,
 ):
@@ -531,7 +529,6 @@ def test_app_query_logo_thumbnail_with_size_and_format_url_returned(
     app.save()
     id = graphene.Node.to_global_id("App", app.id)
     media_id = graphene.Node.to_global_id("App", app.uuid)
-    domain = site_settings.site.domain
     if thumbnail_exists:
         thumbnail = Thumbnail.objects.create(
             app=app,
@@ -539,9 +536,9 @@ def test_app_query_logo_thumbnail_with_size_and_format_url_returned(
             format=format or IconThumbnailFormat.ORIGINAL,
             image=icon_image,
         )
-        expected_url = f"http://{domain}/media/{thumbnail.image.name}"
+        expected_url = f"https://example.com/media/{thumbnail.image.name}"
     else:
-        expected_url = f"http://{domain}/thumbnail/{media_id}/128/"
+        expected_url = f"https://example.com/thumbnail/{media_id}/128/"
         if format not in [None, IconThumbnailFormat.ORIGINAL]:
             expected_url += f"{format}/"
     variables = {"id": id, "size": 120, "format": format.upper() if format else None}
@@ -565,14 +562,13 @@ def test_app_query_logo_thumbnail_with_size_and_format_url_returned(
     ],
 )
 def test_app_query_logo_thumbnail_with_zero_size_value_original_image_url_returned(
-    format, staff_api_client, app, site_settings, icon_image, media_root
+    format, staff_api_client, app, icon_image, media_root
 ):
     # given
     app.brand_logo_default = icon_image
     app.save()
     id = graphene.Node.to_global_id("App", app.id)
-    domain = site_settings.site.domain
-    expected_url = f"http://{domain}/media/{app.brand_logo_default.name}"
+    expected_url = f"https://example.com/media/{app.brand_logo_default.name}"
     variables = {"id": id, "size": 0, "format": format.upper() if format else None}
     # when
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/app/tests/queries/test_apps_installations.py
+++ b/saleor/graphql/app/tests/queries/test_apps_installations.py
@@ -79,7 +79,6 @@ def test_apps_installations_query_logo_thumbnail_with_size_and_format_url_return
     app_installation,
     staff_api_client,
     permission_manage_apps,
-    site_settings,
     icon_image,
     media_root,
 ):
@@ -87,7 +86,6 @@ def test_apps_installations_query_logo_thumbnail_with_size_and_format_url_return
     app_installation.brand_logo_default = icon_image
     app_installation.save()
     media_id = graphene.Node.to_global_id("AppInstallation", app_installation.uuid)
-    domain = site_settings.site.domain
     if thumbnail_exists:
         thumbnail = Thumbnail.objects.create(
             app_installation=app_installation,
@@ -95,9 +93,9 @@ def test_apps_installations_query_logo_thumbnail_with_size_and_format_url_return
             format=format or IconThumbnailFormat.ORIGINAL,
             image=icon_image,
         )
-        expected_url = f"http://{domain}/media/{thumbnail.image.name}"
+        expected_url = f"https://example.com/media/{thumbnail.image.name}"
     else:
-        expected_url = f"http://{domain}/thumbnail/{media_id}/128/"
+        expected_url = f"https://example.com/thumbnail/{media_id}/128/"
         if format not in [None, IconThumbnailFormat.ORIGINAL]:
             expected_url += f"{format}/"
     variables = {"size": 120, "format": format.upper() if format else None}
@@ -128,15 +126,15 @@ def test_apps_installations_query_logo_thumbnail_original_image_url_returned(
     app_installation,
     staff_api_client,
     permission_manage_apps,
-    site_settings,
     icon_image,
     media_root,
 ):
     # given
     app_installation.brand_logo_default = icon_image
     app_installation.save()
-    domain = site_settings.site.domain
-    expected_url = f"http://{domain}/media/{app_installation.brand_logo_default.name}"
+    expected_url = (
+        f"https://example.com/media/{app_installation.brand_logo_default.name}"
+    )
     variables = {"size": 0, "format": format.upper() if format else None}
     # when
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
@@ -335,7 +335,7 @@ def test_create_swatch_attribute_and_attribute_values_with_file(
 
     attribute_name = "Example numeric attribute name"
     name = "Logo"
-    file_url = "http://mirumee.com/test_media/test_logo.png"
+    file_url = "https://example.com/test_media/test_logo.png"
     content_type = "image/png"
     variables = {
         "input": {
@@ -464,7 +464,7 @@ def test_create_swatch_attribute_and_attribute_values_file_and_value_provided(
 
     attribute_name = "Example numeric attribute name"
     name = "Pink"
-    file_url = "http://mirumee.com/test_media/test_file.jpeg"
+    file_url = "https://example.com/test_media/test_file.jpeg"
     variables = {
         "input": {
             "name": attribute_name,

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -258,7 +258,7 @@ def test_create_swatch_attribute_value_with_file(
     query = CREATE_ATTRIBUTE_VALUE_MUTATION
     attribute_id = graphene.Node.to_global_id("Attribute", attribute.id)
     name = "test name"
-    file = "http://mirumee.com/test_media/test_file.jpeg"
+    file = "https://example.com/test_media/test_file.jpeg"
     content_type = "image/jpeg"
     variables = {
         "name": name,
@@ -297,7 +297,7 @@ def test_create_swatch_attribute_value_with_value_and_file(
     attribute_id = graphene.Node.to_global_id("Attribute", attribute.id)
     name = "test name"
     value = "#ffffff"
-    file_url = "http://mirumee.com/test_media/test_file.jpeg"
+    file_url = "https://example.com/test_media/test_file.jpeg"
     variables = {
         "name": name,
         "value": value,
@@ -326,7 +326,7 @@ def test_create_swatch_attribute_value_with_value_and_file(
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("fileUrl", "http://mirumee.com/test_media/test_file.jpeg"),
+        ("fileUrl", "https://example.com/test_media/test_file.jpeg"),
         ("contentType", "jpeg"),
     ],
 )

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -366,7 +366,7 @@ def test_update_swatch_attribute_value_clear_value(
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
     value = swatch_attribute.values.filter(value__isnull=False).first()
     node_id = graphene.Node.to_global_id("AttributeValue", value.id)
-    file_url = "http://mirumee.com/test_media/test_file.jpeg"
+    file_url = "https://example.com/test_media/test_file.jpeg"
     variables = {"input": {"fileUrl": file_url, **additional_field}, "id": node_id}
 
     # when
@@ -422,7 +422,7 @@ def test_update_swatch_attribute_value_clear_file_value(
 @pytest.mark.parametrize(
     ("field", "input_value"),
     [
-        ("fileUrl", "http://mirumee.com/test_media/test_file.jpeg"),
+        ("fileUrl", "https://example.com/test_media/test_file.jpeg"),
         ("contentType", "jpeg"),
     ],
 )

--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -809,7 +809,7 @@ def test_clean_variant_attribute_input_multiple_errors(
 
 @pytest.mark.parametrize("creation", [True, False])
 def test_clean_attributes_with_file_input_type_for_product(
-    creation, weight_attribute, file_attribute, product_type, site_settings
+    creation, weight_attribute, file_attribute, product_type
 ):
     # given
     file_attribute.value_required = True
@@ -818,8 +818,7 @@ def test_clean_attributes_with_file_input_type_for_product(
     weight_attribute.save(update_fields=["value_required"])
     product_type.product_attributes.add(weight_attribute, file_attribute)
 
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}test_file.jpeg"
+    file_url = f"https://example.com{settings.MEDIA_URL}test_file.jpeg"
 
     input_data = [
         {
@@ -1815,11 +1814,10 @@ def test_clean_rich_text_attributes_input_for_product_only_image_block(
     )
 
 
-def test_clean_file_url(site_settings, file_attribute):
+def test_clean_file_url(file_attribute):
     # given
     name = "Test.jpg"
-    domain = site_settings.site.domain
-    url = f"http://{domain}{settings.MEDIA_URL}{name}"
+    url = f"https://example.com{settings.MEDIA_URL}{name}"
 
     file_handler = FileAttributeHandler(
         file_attribute,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1425,9 +1425,7 @@ def test_checkout_add_voucher_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -720,9 +720,7 @@ def test_checkout_billing_address_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -2768,9 +2768,7 @@ def test_checkout_create_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -352,9 +352,7 @@ def test_checkout_customer_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -219,9 +219,7 @@ def test_checkout_customer_detach_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
@@ -181,9 +181,7 @@ def test_checkout_customer_note_update_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -1282,9 +1282,7 @@ def test_checkout_delivery_method_update_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1378,9 +1376,7 @@ def test_checkout_delivery_method_update_cc_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # Shipping sync webhooks are called twice - first call before saving the changes in
@@ -1491,9 +1487,7 @@ def test_checkout_delivery_method_update_external_shipping_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -216,9 +216,7 @@ def test_checkout_email_update_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -174,9 +174,7 @@ def test_checkout_update_language_code_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -401,9 +401,7 @@ def test_checkout_line_delete_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -399,9 +399,7 @@ def test_checkout_lines_delete_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -1184,9 +1184,7 @@ def test_checkout_shipping_address_update_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -906,9 +906,7 @@ def test_checkout_shipping_method_update_to_none_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/core/tests/test_file_upload.py
+++ b/saleor/graphql/core/tests/test_file_upload.py
@@ -119,7 +119,7 @@ def test_file_upload_by_superuser(superuser_api_client, media_root):
 
 
 def test_file_upload_file_with_the_same_name_already_exists(
-    staff_api_client, media_root, site_settings
+    staff_api_client, media_root
 ):
     # given
     image_file1, image_name1 = create_image()
@@ -143,13 +143,12 @@ def test_file_upload_file_with_the_same_name_already_exists(
     data = content["data"]["fileUpload"]
     errors = data["errors"]
 
-    domain = site_settings.site.domain
     assert not errors
     assert data["uploadedFile"]["contentType"] == "image/jpeg"
     file_url = data["uploadedFile"]["url"]
-    assert file_url != f"http://{domain}/media/{image_file._name}"
-    assert file_url != f"http://{domain}/media/{path}"
-    assert default_storage.exists(file_url.replace(f"http://{domain}/media/", ""))
+    assert file_url != f"https://example.com/media/{image_file._name}"
+    assert file_url != f"https://example.com/media/{path}"
+    assert default_storage.exists(file_url.replace("https://example.com/media/", ""))
 
 
 def test_file_upload_file_name_with_space(staff_api_client, media_root):

--- a/saleor/graphql/meta/tests/mutations/test_checkout.py
+++ b/saleor/graphql/meta/tests/mutations/test_checkout.py
@@ -424,9 +424,7 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_checkout_updated(
             "telemetry_context": ANY,
         },
         queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook con was called without saving event delivery
@@ -521,9 +519,7 @@ def test_add_metadata_for_checkout_triggers_webhooks_with_updated_metadata(
             "telemetry_context": ANY,
         },
         queue=None,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook con was called without saving event delivery

--- a/saleor/graphql/meta/tests/mutations/test_order.py
+++ b/saleor/graphql/meta/tests/mutations/test_order.py
@@ -664,9 +664,7 @@ def test_change_in_public_metadata_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -742,9 +740,7 @@ def test_change_in_private_metadata_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -1709,9 +1709,7 @@ def test_draft_order_complete_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -3780,9 +3780,7 @@ def test_draft_order_create_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -343,9 +343,7 @@ def test_draft_order_delete_do_not_trigger_sync_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
     assert not mocked_send_webhook_request_sync.called
     assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -2554,9 +2554,7 @@ def test_draft_order_update_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -2644,9 +2642,7 @@ def test_draft_order_update_triggers_webhooks_when_tax_webhook_not_needed(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_cancel.py
+++ b/saleor/graphql/order/tests/mutations/test_order_cancel.py
@@ -207,9 +207,7 @@ def test_order_cancel_skip_trigger_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -251,9 +251,7 @@ def test_order_capture_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -691,9 +691,7 @@ def test_order_confirm_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -1652,9 +1652,7 @@ def test_order_fulfill_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -375,9 +375,7 @@ def test_order_line_delete_triggers_webhooks(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_line_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_update.py
@@ -686,9 +686,7 @@ def test_order_line_update_triggers_webhooks(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -1347,9 +1347,7 @@ def test_order_lines_create_triggers_webhooks(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_note_add.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_add.py
@@ -235,9 +235,7 @@ def test_order_note_add_user_triggers_webhooks(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_note_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_update.py
@@ -279,9 +279,7 @@ def test_order_note_update_user_triggers_webhooks(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update.py
@@ -594,9 +594,7 @@ def test_order_update_triggers_webhooks(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -720,9 +720,7 @@ def test_order_update_shipping_triggers_webhooks(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 3
@@ -803,9 +801,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     assert wrapped_call_order_event.called
@@ -858,9 +854,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook_for_null_sh
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     assert wrapped_call_order_event.called
@@ -915,9 +909,7 @@ def test_editable_order_update_shipping_triggers_proper_updated_webhook_for_null
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/queries/test_order_line.py
+++ b/saleor/graphql/order/tests/queries/test_order_line.py
@@ -408,7 +408,6 @@ def test_order_query_product_image_size_and_format_given_proxy_url_returned(
     permission_group_manage_orders,
     order_line,
     product_with_image,
-    site_settings,
 ):
     # given
     order_line.variant.product = product_with_image
@@ -428,11 +427,10 @@ def test_order_query_product_image_size_and_format_given_proxy_url_returned(
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
     media_id = graphene.Node.to_global_id("ProductMedia", media.pk)
-    domain = site_settings.site.domain
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{domain}/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"https://example.com/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
@@ -441,7 +439,6 @@ def test_order_query_product_image_size_given_proxy_url_returned(
     permission_group_manage_orders,
     order_line,
     product_with_image,
-    site_settings,
 ):
     # given
     order_line.variant.product = product_with_image
@@ -462,7 +459,7 @@ def test_order_query_product_image_size_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{media_id}/128/"
+        == f"https://example.com/thumbnail/{media_id}/128/"
     )
 
 
@@ -471,7 +468,6 @@ def test_order_query_product_image_size_given_thumbnail_url_returned(
     permission_group_manage_orders,
     order_line,
     product_with_image,
-    site_settings,
 ):
     # given
     order_line.variant.product = product_with_image
@@ -496,7 +492,7 @@ def test_order_query_product_image_size_given_thumbnail_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
+        == f"https://example.com/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -505,7 +501,6 @@ def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
     permission_group_manage_orders,
     order_line,
     variant_with_image,
-    site_settings,
 ):
     # given
     order_line.variant = variant_with_image
@@ -525,11 +520,10 @@ def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
     media_id = graphene.Node.to_global_id("ProductMedia", media.pk)
-    domain = site_settings.site.domain
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{domain}/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"https://example.com/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
@@ -538,7 +532,6 @@ def test_order_query_variant_image_size_given_proxy_url_returned(
     permission_group_manage_orders,
     order_line,
     variant_with_image,
-    site_settings,
 ):
     # given
     order_line.variant = variant_with_image
@@ -559,7 +552,7 @@ def test_order_query_variant_image_size_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{media_id}/128/"
+        == f"https://example.com/thumbnail/{media_id}/128/"
     )
 
 
@@ -568,7 +561,6 @@ def test_order_query_variant_image_size_given_thumbnail_url_returned(
     permission_group_manage_orders,
     order_line,
     variant_with_image,
-    site_settings,
 ):
     # given
     order_line.variant = variant_with_image
@@ -593,7 +585,7 @@ def test_order_query_variant_image_size_given_thumbnail_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
+        == f"https://example.com/media/thumbnails/{thumbnail_mock.name}"
     )
 
 

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -389,7 +389,6 @@ def test_create_page_with_file_attribute(
     permission_manage_pages,
     page_type,
     page_file_attribute,
-    site_settings,
 ):
     # given
     page_slug = "test-slug"
@@ -406,9 +405,7 @@ def test_create_page_with_file_attribute(
     attr_value = page_file_attribute.values.first()
 
     values_count = page_file_attribute.values.count()
-    file_url = (
-        f"http://{site_settings.site.domain}{settings.MEDIA_URL}{attr_value.file_url}"
-    )
+    file_url = f"https://example.com{settings.MEDIA_URL}{attr_value.file_url}"
 
     # test creating root page
     variables = {
@@ -467,7 +464,6 @@ def test_create_page_with_file_attribute_new_attribute_value(
     permission_manage_pages,
     page_type,
     page_file_attribute,
-    site_settings,
 ):
     # given
     page_slug = "test-slug"
@@ -482,7 +478,7 @@ def test_create_page_with_file_attribute_new_attribute_value(
     file_attribute_id = graphene.Node.to_global_id("Attribute", page_file_attribute.pk)
     page_type.page_attributes.add(page_file_attribute)
     new_value = "new_test_value.txt"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{new_value}"
     new_value_content_type = "text/plain"
 
     values_count = page_file_attribute.values.count()

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -255,7 +255,7 @@ def test_update_page_only_title(staff_api_client, permission_manage_pages, page)
 
 
 def test_update_page_with_file_attribute_value(
-    staff_api_client, permission_manage_pages, page, page_file_attribute, site_settings
+    staff_api_client, permission_manage_pages, page, page_file_attribute
 ):
     # given
     query = UPDATE_PAGE_MUTATION
@@ -268,7 +268,7 @@ def test_update_page_with_file_attribute_value(
 
     page_id = graphene.Node.to_global_id("Page", page.id)
     file_name = "test.txt"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{file_name}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{file_name}"
 
     variables = {
         "id": page_id,
@@ -305,7 +305,7 @@ def test_update_page_with_file_attribute_value(
 
 
 def test_update_page_with_file_attribute_new_value_is_not_created(
-    staff_api_client, permission_manage_pages, page, page_file_attribute, site_settings
+    staff_api_client, permission_manage_pages, page, page_file_attribute
 ):
     # given
     query = UPDATE_PAGE_MUTATION
@@ -321,8 +321,7 @@ def test_update_page_with_file_attribute_new_value_is_not_created(
     )
 
     page_id = graphene.Node.to_global_id("Page", page.id)
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{existing_value.file_url}"
 
     variables = {
         "id": page_id,

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -810,7 +810,7 @@ def test_products_media_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(1):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1

--- a/saleor/graphql/product/tests/mutations/test_category_update.py
+++ b/saleor/graphql/product/tests/mutations/test_category_update.py
@@ -264,7 +264,6 @@ def test_category_update_background_image_mutation(
     category,
     permission_manage_products,
     media_root,
-    site_settings,
 ):
     # given
     staff_api_client.user.user_permissions.add(permission_manage_products)
@@ -315,7 +314,7 @@ def test_category_update_background_image_mutation(
     assert category.background_image.file
     assert data["category"]["backgroundImage"]["alt"] == image_alt
     assert data["category"]["backgroundImage"]["url"].startswith(
-        f"http://{site_settings.site.domain}/media/category-backgrounds/{image_name}"
+        f"https://example.com/media/category-backgrounds/{image_name}"
     )
 
     # ensure that thumbnails for old background image has been deleted

--- a/saleor/graphql/product/tests/mutations/test_collection_update.py
+++ b/saleor/graphql/product/tests/mutations/test_collection_update.py
@@ -182,7 +182,6 @@ def test_update_collection_with_background_image(
     collection_with_image,
     permission_manage_products,
     media_root,
-    site_settings,
 ):
     # given
     staff_api_client.user.user_permissions.add(permission_manage_products)
@@ -225,7 +224,7 @@ def test_update_collection_with_background_image(
     collection = Collection.objects.get(slug=slug)
     assert data["collection"]["backgroundImage"]["alt"] == image_alt
     assert data["collection"]["backgroundImage"]["url"].startswith(
-        f"http://{site_settings.site.domain}/media/collection-backgrounds/{image_name}"
+        f"https://example.com/media/collection-backgrounds/{image_name}"
     )
 
     # ensure that thumbnails for old background image has been deleted

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -1463,7 +1463,6 @@ def test_create_product_with_file_attribute(
     file_attribute,
     color_attribute,
     permission_manage_products,
-    site_settings,
 ):
     query = CREATE_PRODUCT_MUTATION
 
@@ -1478,8 +1477,7 @@ def test_create_product_with_file_attribute(
     product_type.product_attributes.add(file_attribute)
     file_attr_id = graphene.Node.to_global_id("Attribute", file_attribute.id)
     existing_value = file_attribute.values.first()
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{existing_value.file_url}"
 
     # test creating root product
     variables = {
@@ -2157,7 +2155,6 @@ def test_create_product_with_file_attribute_new_attribute_value(
     file_attribute,
     color_attribute,
     permission_manage_products,
-    site_settings,
 ):
     query = CREATE_PRODUCT_MUTATION
 
@@ -2172,7 +2169,7 @@ def test_create_product_with_file_attribute_new_attribute_value(
     product_type.product_attributes.add(file_attribute)
     file_attr_id = graphene.Node.to_global_id("Attribute", file_attribute.id)
     file_name = "new_test.jpg"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{file_name}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{file_name}"
 
     # test creating root product
     variables = {
@@ -2433,7 +2430,6 @@ def test_create_product_no_values_given(
     product_type,
     category,
     permission_manage_products,
-    site_settings,
 ):
     query = CREATE_PRODUCT_MUTATION
 
@@ -2447,7 +2443,7 @@ def test_create_product_no_values_given(
     color_attr_id = graphene.Node.to_global_id("Attribute", color_attr.id)
 
     file_name = "test.jpg"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{file_name}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{file_name}"
 
     # test creating root product
     variables = {

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -500,7 +500,6 @@ def test_update_product_with_file_attribute_value(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -511,7 +510,7 @@ def test_update_product_with_file_attribute_value(
     product_type.product_attributes.add(file_attribute)
 
     file_name = "new_test.jpg"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{file_name}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{file_name}"
 
     variables = {
         "productId": product_id,
@@ -561,7 +560,6 @@ def test_update_product_with_file_attribute_value_new_value_is_not_created(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -578,8 +576,7 @@ def test_update_product_with_file_attribute_value_new_value_is_not_created(
     )
 
     values_count = len(attribute_values)
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{existing_value.file_url}"
 
     variables = {
         "productId": product_id,
@@ -2517,7 +2514,6 @@ def test_update_product_with_dropdown_attribute_non_existing_value(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2563,7 +2559,6 @@ def test_update_product_with_dropdown_attribute_existing_value(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2615,7 +2610,6 @@ def test_update_product_with_dropdown_attribute_existing_value_passed_as_new_val
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2670,7 +2664,6 @@ def test_update_product_with_dropdown_attribute_null_value(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2714,7 +2707,6 @@ def test_update_product_with_multiselect_attribute_non_existing_values(
     staff_api_client,
     product_with_multiple_values_attributes,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2764,7 +2756,6 @@ def test_update_product_with_multiselect_attribute_existing_values(
     staff_api_client,
     product_with_multiple_values_attributes,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2886,7 +2877,6 @@ def test_update_product_with_selectable_attribute_by_both_id_and_value(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2940,7 +2930,6 @@ def test_update_product_with_selectable_attribute_value_required(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -2987,7 +2976,6 @@ def test_update_product_with_selectable_attribute_exceed_max_length(
     product,
     product_type,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT
@@ -3029,7 +3017,6 @@ def test_update_product_with_multiselect_attribute_by_both_id_and_value(
     staff_api_client,
     product_with_multiple_values_attributes,
     permission_manage_products,
-    site_settings,
 ):
     # given
     query = MUTATION_UPDATE_PRODUCT

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -525,7 +525,7 @@ def test_product_variant_bulk_create_with_date_attribute(
 
 
 def test_product_variant_bulk_create_with_file_attribute(
-    staff_api_client, product, file_attribute, permission_manage_products, site_settings
+    staff_api_client, product, file_attribute, permission_manage_products
 ):
     # given
     product_variant_count = ProductVariant.objects.count()
@@ -534,8 +534,7 @@ def test_product_variant_bulk_create_with_file_attribute(
     product_id = graphene.Node.to_global_id("Product", product.pk)
     attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
     existing_value = file_attribute.values.first()
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{existing_value.file_url}"
 
     sku = str(uuid4())[:12]
     variants = [
@@ -571,7 +570,6 @@ def test_product_variant_bulk_create_with_datetime_attribute(
     product,
     date_time_attribute,
     permission_manage_products,
-    site_settings,
 ):
     # given
     product_variant_count = ProductVariant.objects.count()
@@ -614,7 +612,6 @@ def test_product_variant_bulk_create_with_rich_text_attribute(
     product,
     rich_text_attribute,
     permission_manage_products,
-    site_settings,
 ):
     # given
     product_variant_count = ProductVariant.objects.count()
@@ -657,7 +654,6 @@ def test_product_variant_bulk_create_with_numeric_attribute(
     product,
     numeric_attribute,
     permission_manage_products,
-    site_settings,
 ):
     # given
     product_variant_count = ProductVariant.objects.count()
@@ -700,7 +696,6 @@ def test_product_variant_bulk_create_with_page_reference_attribute(
     product,
     product_type_page_reference_attribute,
     permission_manage_products,
-    site_settings,
     page,
 ):
     # given
@@ -746,7 +741,6 @@ def test_product_variant_bulk_create_with_single_reference_attribute(
     product,
     product_type_category_single_reference_attribute,
     permission_manage_products,
-    site_settings,
     category,
 ):
     # given

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -376,7 +376,6 @@ def test_create_variant_with_file_attribute(
     file_attribute,
     permission_manage_products,
     warehouse,
-    site_settings,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -387,8 +386,7 @@ def test_create_variant_with_file_attribute(
     product_type.variant_attributes.add(file_attribute)
     file_attr_id = graphene.Node.to_global_id("Attribute", file_attribute.id)
     existing_value = file_attribute.values.first()
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{existing_value.file_url}"
 
     values_count = file_attribute.values.count()
 
@@ -509,7 +507,6 @@ def test_create_variant_with_file_attribute_new_value(
     file_attribute,
     permission_manage_products,
     warehouse,
-    site_settings,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -520,7 +517,7 @@ def test_create_variant_with_file_attribute_new_value(
     product_type.variant_attributes.add(file_attribute)
     file_attr_id = graphene.Node.to_global_id("Attribute", file_attribute.id)
     new_value = "new_value.txt"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{new_value}"
 
     values_count = file_attribute.values.count()
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -1699,7 +1699,6 @@ def test_update_product_variant_with_current_file_attribute(
     product_with_variant_with_file_attribute,
     file_attribute,
     permission_manage_products,
-    site_settings,
 ):
     product = product_with_variant_with_file_attribute
     variant = product.variants.first()
@@ -1712,9 +1711,7 @@ def test_update_product_variant_with_current_file_attribute(
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     file_attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
-    file_url = (
-        f"http://{site_settings.site.domain}{settings.MEDIA_URL}{second_value.file_url}"
-    )
+    file_url = f"https://example.com{settings.MEDIA_URL}{second_value.file_url}"
 
     variables = {
         "id": variant_id,
@@ -1749,7 +1746,6 @@ def test_update_product_variant_with_duplicated_file_attribute(
     product_with_variant_with_file_attribute,
     file_attribute,
     permission_manage_products,
-    site_settings,
 ):
     product = product_with_variant_with_file_attribute
     variant = product.variants.first()
@@ -1775,8 +1771,7 @@ def test_update_product_variant_with_duplicated_file_attribute(
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     file_attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}{file_attr_value.file_url}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{file_attr_value.file_url}"
 
     variables = {
         "id": variant_id,
@@ -1805,7 +1800,6 @@ def test_update_product_variant_with_file_attribute_new_value_is_not_created(
     product_with_variant_with_file_attribute,
     file_attribute,
     permission_manage_products,
-    site_settings,
 ):
     product = product_with_variant_with_file_attribute
     variant = product.variants.first()
@@ -1819,8 +1813,7 @@ def test_update_product_variant_with_file_attribute_new_value_is_not_created(
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     file_attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
-    domain = site_settings.site.domain
-    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
+    file_url = f"https://example.com{settings.MEDIA_URL}{existing_value.file_url}"
 
     variables = {
         "id": variant_id,

--- a/saleor/graphql/product/tests/queries/test_category_query.py
+++ b/saleor/graphql/product/tests/queries/test_category_query.py
@@ -408,7 +408,7 @@ FETCH_CATEGORY_IMAGE_QUERY = """
 
 
 def test_category_image_query_with_size_and_format_proxy_url_returned(
-    user_api_client, non_default_category, media_root, site_settings
+    user_api_client, non_default_category, media_root
 ):
     # given
     alt_text = "Alt text for an image."
@@ -436,15 +436,14 @@ def test_category_image_query_with_size_and_format_proxy_url_returned(
 
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
-    domain = site_settings.site.domain
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{domain}/thumbnail/{category_id}/128/{format.lower()}/"
+        == f"https://example.com/thumbnail/{category_id}/128/{format.lower()}/"
     )
 
 
 def test_category_image_query_with_size_proxy_url_returned(
-    user_api_client, non_default_category, media_root, site_settings
+    user_api_client, non_default_category, media_root
 ):
     # given
     alt_text = "Alt text for an image."
@@ -472,12 +471,12 @@ def test_category_image_query_with_size_proxy_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{category_id}/{size}/"
+        == f"https://example.com/thumbnail/{category_id}/{size}/"
     )
 
 
 def test_category_image_query_with_size_thumbnail_url_returned(
-    user_api_client, non_default_category, media_root, site_settings
+    user_api_client, non_default_category, media_root
 ):
     # given
     alt_text = "Alt text for an image."
@@ -509,12 +508,12 @@ def test_category_image_query_with_size_thumbnail_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
+        == f"https://example.com/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_category_image_query_zero_size_custom_format_provided_original_image_returned(
-    user_api_client, non_default_category, media_root, site_settings
+    user_api_client, non_default_category, media_root
 ):
     # given
     alt_text = "Alt text for an image."
@@ -542,13 +541,14 @@ def test_category_image_query_zero_size_custom_format_provided_original_image_re
 
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
-    domain = site_settings.site.domain
-    expected_url = f"http://{domain}/media/category-backgrounds/{background_mock.name}"
+    expected_url = (
+        f"https://example.com/media/category-backgrounds/{background_mock.name}"
+    )
     assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_category_image_query_zero_size_value_original_image_returned(
-    user_api_client, non_default_category, media_root, site_settings
+    user_api_client, non_default_category, media_root
 ):
     # given
     alt_text = "Alt text for an image."
@@ -573,8 +573,9 @@ def test_category_image_query_zero_size_value_original_image_returned(
 
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
-    domain = site_settings.site.domain
-    expected_url = f"http://{domain}/media/category-backgrounds/{background_mock.name}"
+    expected_url = (
+        f"https://example.com/media/category-backgrounds/{background_mock.name}"
+    )
     assert data["backgroundImage"]["url"] == expected_url
 
 

--- a/saleor/graphql/product/tests/queries/test_collection_query.py
+++ b/saleor/graphql/product/tests/queries/test_collection_query.py
@@ -389,7 +389,7 @@ FETCH_COLLECTION_IMAGE_QUERY = """
 
 
 def test_collection_image_query_with_size_and_format_proxy_url_returned(
-    user_api_client, published_collection, media_root, channel_USD, site_settings
+    user_api_client, published_collection, media_root, channel_USD
 ):
     # given
     alt_text = "Alt text for an image."
@@ -419,13 +419,14 @@ def test_collection_image_query_with_size_and_format_proxy_url_returned(
 
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
-    domain = site_settings.site.domain
-    expected_url = f"http://{domain}/thumbnail/{collection_id}/128/{format.lower()}/"
+    expected_url = (
+        f"https://example.com/thumbnail/{collection_id}/128/{format.lower()}/"
+    )
     assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_collection_image_query_with_size_proxy_url_returned(
-    user_api_client, published_collection, media_root, channel_USD, site_settings
+    user_api_client, published_collection, media_root, channel_USD
 ):
     # given
     alt_text = "Alt text for an image."
@@ -454,12 +455,12 @@ def test_collection_image_query_with_size_proxy_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{collection_id}/{size}/"
+        == f"https://example.com/thumbnail/{collection_id}/{size}/"
     )
 
 
 def test_collection_image_query_with_size_thumbnail_url_returned(
-    user_api_client, published_collection, media_root, channel_USD, site_settings
+    user_api_client, published_collection, media_root, channel_USD
 ):
     # given
     alt_text = "Alt text for an image."
@@ -492,12 +493,12 @@ def test_collection_image_query_with_size_thumbnail_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
+        == f"https://example.com/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_collection_image_query_zero_size_custom_format_provided(
-    user_api_client, published_collection, media_root, channel_USD, site_settings
+    user_api_client, published_collection, media_root, channel_USD
 ):
     # given
     alt_text = "Alt text for an image."
@@ -527,14 +528,13 @@ def test_collection_image_query_zero_size_custom_format_provided(
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
     expected_url = (
-        f"http://{site_settings.site.domain}"
-        f"/media/collection-backgrounds/{background_mock.name}"
+        f"https://example.com/media/collection-backgrounds/{background_mock.name}"
     )
     assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_collection_image_query_zero_size_value_original_image_returned(
-    user_api_client, published_collection, media_root, channel_USD, site_settings
+    user_api_client, published_collection, media_root, channel_USD
 ):
     # given
     alt_text = "Alt text for an image."
@@ -561,8 +561,7 @@ def test_collection_image_query_zero_size_value_original_image_returned(
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
     expected_url = (
-        f"http://{site_settings.site.domain}"
-        f"/media/collection-backgrounds/{background_mock.name}"
+        f"https://example.com/media/collection-backgrounds/{background_mock.name}"
     )
     assert data["backgroundImage"]["url"] == expected_url
 

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -576,7 +576,7 @@ QUERY_PRODUCT_BY_ID_WITH_MEDIA = """
 
 
 def test_query_product_thumbnail_with_size_and_format_proxy_url_returned(
-    staff_api_client, product_with_image, channel_USD, site_settings
+    staff_api_client, product_with_image, channel_USD
 ):
     # given
     format = ThumbnailFormatEnum.WEBP.name
@@ -599,14 +599,13 @@ def test_query_product_thumbnail_with_size_and_format_proxy_url_returned(
         "ProductMedia", product_with_image.media.first().pk
     )
     expected_url = (
-        f"http://{site_settings.site.domain}"
-        f"/thumbnail/{product_media_id}/128/{format.lower()}/"
+        f"https://example.com/thumbnail/{product_media_id}/128/{format.lower()}/"
     )
     assert data["thumbnail"]["url"] == expected_url
 
 
 def test_query_product_thumbnail_with_size_and_proxy_url_returned(
-    staff_api_client, product_with_image, channel_USD, site_settings
+    staff_api_client, product_with_image, channel_USD
 ):
     # given
     id = graphene.Node.to_global_id("Product", product_with_image.pk)
@@ -627,12 +626,12 @@ def test_query_product_thumbnail_with_size_and_proxy_url_returned(
     )
     assert (
         data["thumbnail"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{product_media_id}/128/"
+        == f"https://example.com/thumbnail/{product_media_id}/128/"
     )
 
 
 def test_query_product_thumbnail_with_size_and_thumbnail_url_returned(
-    staff_api_client, product_with_image, channel_USD, site_settings
+    staff_api_client, product_with_image, channel_USD
 ):
     # given
     product_media = product_with_image.media.first()
@@ -658,12 +657,12 @@ def test_query_product_thumbnail_with_size_and_thumbnail_url_returned(
     data = content["data"]["product"]
     assert (
         data["thumbnail"]["url"]
-        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
+        == f"https://example.com/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_query_product_thumbnail_only_format_provided_default_size_is_used(
-    staff_api_client, product_with_image, channel_USD, site_settings
+    staff_api_client, product_with_image, channel_USD
 ):
     # given
     format = ThumbnailFormatEnum.WEBP.name
@@ -685,8 +684,7 @@ def test_query_product_thumbnail_only_format_provided_default_size_is_used(
         "ProductMedia", product_with_image.media.first().pk
     )
     expected_url = (
-        f"http://{site_settings.site.domain}"
-        f"/thumbnail/{product_media_id}/256/{format.lower()}/"
+        f"https://example.com/thumbnail/{product_media_id}/256/{format.lower()}/"
     )
     assert data["thumbnail"]["url"] == expected_url
 
@@ -1927,7 +1925,7 @@ def test_query_product_media_by_invalid_id(
 
 
 def test_query_product_media_by_id_with_size_and_format_proxy_url_returned(
-    user_api_client, product_with_image, channel_USD, site_settings
+    user_api_client, product_with_image, channel_USD
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
     media = product_with_image.media.first()
@@ -1947,15 +1945,14 @@ def test_query_product_media_by_id_with_size_and_format_proxy_url_returned(
 
     content = get_graphql_content(response)
     assert content["data"]["product"]["mediaById"]["id"]
-    domain = site_settings.site.domain
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://{domain}/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"https://example.com/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
 def test_query_product_media_by_id_with_size_proxy_url_returned(
-    user_api_client, product_with_image, channel_USD, site_settings
+    user_api_client, product_with_image, channel_USD
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
     media = product_with_image.media.first()
@@ -1975,12 +1972,12 @@ def test_query_product_media_by_id_with_size_proxy_url_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{media_id}/128/"
+        == f"https://example.com/thumbnail/{media_id}/128/"
     )
 
 
 def test_query_product_media_by_id_with_size_thumbnail_url_returned(
-    user_api_client, product_with_image, channel_USD, site_settings
+    user_api_client, product_with_image, channel_USD
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
     media = product_with_image.media.first()
@@ -2005,12 +2002,12 @@ def test_query_product_media_by_id_with_size_thumbnail_url_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
+        == f"https://example.com/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_query_product_media_by_id_zero_size_custom_format_provided(
-    user_api_client, product_with_image, channel_USD, site_settings
+    user_api_client, product_with_image, channel_USD
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
     media = product_with_image.media.first()
@@ -2032,12 +2029,12 @@ def test_query_product_media_by_id_zero_size_custom_format_provided(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://{site_settings.site.domain}/media/{media.image.name}"
+        == f"https://example.com/media/{media.image.name}"
     )
 
 
 def test_query_product_media_by_id_original_format(
-    user_api_client, product_with_image, channel_USD, site_settings
+    user_api_client, product_with_image, channel_USD
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
     media = product_with_image.media.first()
@@ -2059,12 +2056,12 @@ def test_query_product_media_by_id_original_format(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{media_id}/128/"
+        == f"https://example.com/thumbnail/{media_id}/128/"
     )
 
 
 def test_query_product_media_by_id_avif_format(
-    user_api_client, product_with_image, channel_USD, site_settings
+    user_api_client, product_with_image, channel_USD
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
     media = product_with_image.media.first()
@@ -2086,12 +2083,12 @@ def test_query_product_media_by_id_avif_format(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://{site_settings.site.domain}/thumbnail/{media_id}/128/avif/"
+        == f"https://example.com/thumbnail/{media_id}/128/avif/"
     )
 
 
 def test_query_product_media_by_id_zero_size_value_original_image_returned(
-    user_api_client, product_with_image, channel_USD, site_settings
+    user_api_client, product_with_image, channel_USD
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
     media = product_with_image.media.first()
@@ -2111,7 +2108,7 @@ def test_query_product_media_by_id_zero_size_value_original_image_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://{site_settings.site.domain}/media/{media.image.name}"
+        == f"https://example.com/media/{media.image.name}"
     )
 
 
@@ -2361,7 +2358,7 @@ def test_query_product_for_federation_as_staff_user_channel_not_active(
 
 
 def test_query_product_media_for_federation(
-    api_client, product_with_image, channel_USD, site_settings
+    api_client, product_with_image, channel_USD
 ):
     media = product_with_image.media.first()
     media_id = graphene.Node.to_global_id("ProductMedia", media.pk)
@@ -2391,7 +2388,7 @@ def test_query_product_media_for_federation(
         {
             "__typename": "ProductMedia",
             "id": media_id,
-            "url": f"http://{site_settings.site.domain}/media/products/product.jpg",
+            "url": "https://example.com/media/products/product.jpg",
         }
     ]
 

--- a/saleor/graphql/shop/tests/mutations/test_shop_domain_update.py
+++ b/saleor/graphql/shop/tests/mutations/test_shop_domain_update.py
@@ -2,7 +2,8 @@ from .....site.models import Site
 from ....tests.utils import get_graphql_content
 
 
-def test_shop_domain_update(staff_api_client, permission_manage_settings):
+def test_shop_domain_update(staff_api_client, permission_manage_settings, settings):
+    settings.PUBLIC_URL = None
     # given
     query = """
         mutation updateSettings($input: SiteDomainInput!) {

--- a/saleor/graphql/shop/tests/queries/test_shop.py
+++ b/saleor/graphql/shop/tests/queries/test_shop.py
@@ -293,7 +293,7 @@ def test_query_company_address(user_api_client, site_settings, address):
     assert company_address["postalCode"] == address.postal_code
 
 
-def test_query_domain(user_api_client, site_settings, settings):
+def test_query_domain(user_api_client, settings):
     # given
     query = """
     query {
@@ -313,8 +313,8 @@ def test_query_domain(user_api_client, site_settings, settings):
     # then
     content = get_graphql_content(response)
     data = content["data"]["shop"]
-    assert data["domain"]["host"] == site_settings.site.domain
-    assert data["domain"]["sslEnabled"] == settings.ENABLE_SSL
+    assert data["domain"]["host"] == "example.com"
+    assert data["domain"]["sslEnabled"] is True
     assert data["domain"]["url"]
 
 

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -773,5 +773,5 @@ def test_get_default_images_payload(product_with_image):
     for th_size in THUMBNAIL_SIZES:
         assert (
             images_payload[str(th_size)]
-            == f"http://mirumee.com/thumbnail/{media_id}/{th_size}/"
+            == f"https://example.com/thumbnail/{media_id}/{th_size}/"
         )

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -425,9 +425,7 @@ def test_handle_fully_paid_order_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -715,9 +713,7 @@ def test_cancel_order_dont_trigger_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -891,9 +887,7 @@ def test_order_refunded_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -992,9 +986,7 @@ def test_order_voided_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1102,9 +1094,7 @@ def test_order_fulfilled_dont_trigger_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -1189,9 +1179,7 @@ def test_order_awaits_fulfillment_approval_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1285,9 +1273,7 @@ def test_order_authorized_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -1403,9 +1389,7 @@ def test_order_charged_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -1799,9 +1783,7 @@ def test_order_transaction_updated_for_charged_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -1917,9 +1899,7 @@ def test_order_transaction_updated_for_authorized_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -2043,9 +2023,7 @@ def test_order_transaction_updated_for_refunded_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -2546,9 +2524,7 @@ def test_call_order_event_triggers_sync_webhook(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -2680,9 +2656,7 @@ def test_call_order_event_missing_filter_shipping_method_webhook(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     mocked_send_webhook_request_sync.assert_called_once()
@@ -2763,9 +2737,7 @@ def test_call_order_event_skips_tax_webhook_when_prices_are_valid(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -2853,9 +2825,7 @@ def test_call_order_event_skips_sync_webhooks_when_order_not_editable(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
     assert not mocked_send_webhook_request_sync.called
     assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
@@ -2915,9 +2885,7 @@ def test_call_order_event_skips_sync_webhooks_when_draft_order_deleted(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -3015,9 +2983,7 @@ def test_call_order_event_skips_when_sync_webhooks_missing(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.test",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_called_once_with(
@@ -3089,9 +3055,7 @@ def test_call_order_events_triggers_sync_webhook(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
     # confirm each sync webhook was called without saving event delivery
     assert mocked_send_webhook_request_sync.call_count == 2
@@ -3243,9 +3207,7 @@ def test_call_order_events_missing_filter_shipping_method_webhook(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -3338,9 +3300,7 @@ def test_call_order_events_skips_tax_webhook_when_prices_are_valid(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery
@@ -3446,9 +3406,7 @@ def test_call_order_events_skips_sync_webhooks_when_order_not_editable(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(
@@ -3519,9 +3477,7 @@ def test_call_order_events_skips_sync_webhooks_when_draft_order_deleted(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(
@@ -3634,9 +3590,7 @@ def test_call_order_events_skips_when_sync_webhooks_missing(
     mocked_send_webhook_request_async.assert_called_once_with(
         kwargs={"event_delivery_id": order_delivery.id, "telemetry_context": ANY},
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.test",
     )
     assert not mocked_send_webhook_request_sync.called
     mocked_call_event_including_protected_events.assert_has_calls(
@@ -3753,9 +3707,7 @@ def test_order_created_triggers_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -3869,9 +3821,7 @@ def test_order_confirmed_triggers_webhooks(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -451,9 +451,7 @@ def test_expire_orders_task_do_not_call_sync_webhooks(
             call(
                 kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
                 queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId="example.com:saleor.app.additional",
             )
             for delivery in order_deliveries
         ],
@@ -871,9 +869,7 @@ def test_send_order_updated(
             "telemetry_context": ANY,
         },
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.additional",
     )
 
     # confirm each sync webhook was called without saving event delivery

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"amount": {"value": "8000", "currency": "USD"}, "reference": "UGF5bWVudDoxMTM3",
       "paymentMethod": {"type": "scheme", "encryptedCardNumber": "test_4646464646464644",
       "encryptedExpiryMonth": "test_03", "encryptedExpiryYear": "test_2030", "encryptedSecurityCode":
-      "test_737"}, "returnUrl": "http://mirumee.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMTM3&checkout=dd45b15c-e50f-4734-9166-cb19b7da75d3",
+      "test_737"}, "returnUrl": "https://example.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMTM3&checkout=dd45b15c-e50f-4734-9166-cb19b7da75d3",
       "merchantAccount": "SaleorECOM", "channel": "web", "shopperEmail": "", "applicationInfo":
       {"adyenLibrary": {"name": "adyen-python-api-library", "version": "4.0.0"}}}'
     headers:

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_3ds_redirect.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_3ds_redirect.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"amount": {"value": "8000", "currency": "USD"}, "reference": "UGF5bWVudDoxMDM=",
       "paymentMethod": {"type": "scheme", "encryptedCardNumber": "test_4917610000000000",
       "encryptedExpiryMonth": "test_03", "encryptedExpiryYear": "test_2030", "encryptedSecurityCode":
-      "test_737", "brand": "visa"}, "returnUrl": "http://mirumee.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMDM%3D&checkout=08546530-4718-422c-a912-9a1642a9031c",
+      "test_737", "brand": "visa"}, "returnUrl": "https://example.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMDM%3D&checkout=08546530-4718-422c-a912-9a1642a9031c",
       "merchantAccount": "SaleorECOM", "browserInfo": {"acceptHeader": "*/*", "colorDepth":
       24, "language": "en-US", "javaEnabled": false, "screenHeight": 1080, "screenWidth":
       1920, "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML,

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_adyen_auto_capture.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_adyen_auto_capture.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"amount": {"value": "8000", "currency": "USD"}, "reference": "UGF5bWVudDoxMTUw",
       "paymentMethod": {"type": "scheme", "encryptedCardNumber": "test_4646464646464644",
       "encryptedExpiryMonth": "test_03", "encryptedExpiryYear": "test_2030", "encryptedSecurityCode":
-      "test_737"}, "returnUrl": "http://mirumee.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMTUw&checkout=d72ba46f-95ce-4971-b548-2f65c51309b6",
+      "test_737"}, "returnUrl": "https://example.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMTUw&checkout=d72ba46f-95ce-4971-b548-2f65c51309b6",
       "merchantAccount": "SaleorECOM", "channel": "web", "shopperEmail": "", "applicationInfo":
       {"adyenLibrary": {"name": "adyen-python-api-library", "version": "4.0.0"}}}'
     headers:

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_auto_capture.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_auto_capture.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"amount": {"value": "8000", "currency": "USD"}, "reference": "UGF5bWVudDoxMzY1",
       "paymentMethod": {"type": "scheme", "encryptedCardNumber": "test_4646464646464644",
       "encryptedExpiryMonth": "test_03", "encryptedExpiryYear": "test_2030", "encryptedSecurityCode":
-      "test_737"}, "returnUrl": "http://mirumee.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMzY1&checkout=4c3b18ff-b18a-43f3-a255-bc3f89607e95",
+      "test_737"}, "returnUrl": "https://example.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDoxMzY1&checkout=4c3b18ff-b18a-43f3-a255-bc3f89607e95",
       "merchantAccount": "SaleorECOM", "channel": "web", "shopperEmail": "", "applicationInfo":
       {"adyenLibrary": {"name": "adyen-python-api-library", "version": "4.0.0"}}}'
     headers:

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_klarna.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_plugin/test_process_payment_with_klarna.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"amount": {"value": "8000", "currency": "USD"}, "reference": "UGF5bWVudDo1NzU=",
-      "paymentMethod": {"type": "klarna_account"}, "returnUrl": "http://mirumee.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDo1NzU%3D&checkout=7eaddd6c-e06f-4deb-bc3e-02162cb3ac10",
+      "paymentMethod": {"type": "klarna_account"}, "returnUrl": "https://example.com/plugins/mirumee.payments.adyen/additional-actions?payment=UGF5bWVudDo1NzU%3D&checkout=7eaddd6c-e06f-4deb-bc3e-02162cb3ac10",
       "merchantAccount": "SaleorECOM", "browserInfo": {"acceptHeader": "*/*", "colorDepth":
       24, "language": "en-US", "javaEnabled": false, "screenHeight": 1080, "screenWidth":
       1920, "userAgent": ["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML,

--- a/saleor/payment/gateways/stripe/tests/test_stripe_api.py
+++ b/saleor/payment/gateways/stripe/tests/test_stripe_api.py
@@ -54,7 +54,7 @@ def test_is_secret_api_key_valid_correct_key(mocked_webhook):
 def test_subscribe_webhook_returns_webhook_object(mocked_webhook, channel_USD):
     api_key = "api_key"
     expected_url = (
-        "http://mirumee.com/plugins/channel/main/saleor.payments.stripe/webhooks/"
+        "https://example.com/plugins/channel/main/saleor.payments.stripe/webhooks/"
     )
 
     subscribe_webhook(api_key, channel_slug=channel_USD.slug)
@@ -63,7 +63,7 @@ def test_subscribe_webhook_returns_webhook_object(mocked_webhook, channel_USD):
         api_key=api_key,
         url=expected_url,
         enabled_events=WEBHOOK_EVENTS,
-        metadata={METADATA_IDENTIFIER: "mirumee.com"},
+        metadata={METADATA_IDENTIFIER: "example.com"},
     )
 
 

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2727,7 +2727,7 @@ class WebhookPlugin(BasePlugin):
         domain = get_domain()
         webhook = delivery.webhook
         app = webhook.app
-        message_group_id = f"{domain}:{app.identifier}"
+        message_group_id = f"{domain}:{app.identifier or app.id}"
         send_webhook_request_async.apply_async(
             kwargs={
                 "event_delivery_id": delivery.pk,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -20,7 +20,7 @@ from ...core.models import EventDelivery
 from ...core.notify import NotifyEventType
 from ...core.taxes import TAX_ERROR_FIELD_LENGTH, TaxData, TaxDataError, TaxType
 from ...core.telemetry import get_task_context
-from ...core.utils import build_absolute_uri
+from ...core.utils import build_absolute_uri, get_domain
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...csv.notifications import get_default_export_payload
 from ...graphql.core.context import SaleorContext
@@ -98,6 +98,7 @@ from ...webhook.response_schemas.transaction import (
 from ...webhook.response_schemas.utils.helpers import parse_validation_error
 from ...webhook.transport.asynchronous.transport import (
     WebhookPayloadData,
+    get_queue_name_for_webhook,
     send_webhook_request_async,
     trigger_webhooks_async,
     trigger_webhooks_async_for_multiple_objects,
@@ -2723,8 +2724,20 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         delivery_update(delivery, status=EventDeliveryStatus.PENDING)
-        send_webhook_request_async.delay(
-            delivery.pk, telemetry_context=get_task_context().to_dict()
+        domain = get_domain()
+        webhook = delivery.webhook
+        app = webhook.app
+        message_group_id = f"{domain}:{app.identifier}"
+        send_webhook_request_async.apply_async(
+            kwargs={
+                "event_delivery_id": delivery.pk,
+                "telemetry_context": get_task_context().to_dict(),
+            },
+            queue=get_queue_name_for_webhook(
+                webhook,
+                default_queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
+            ),
+            MessageGroupId=message_group_id,  # for AWS SQS fair queues
         )
         return previous_value
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -11,7 +11,6 @@ import graphene
 import pytest
 from celery.exceptions import MaxRetriesExceededError
 from celery.exceptions import Retry as CeleryTaskRetryError
-from django.contrib.sites.models import Site
 from django.core.serializers import serialize
 from freezegun import freeze_time
 from kombu.asynchronous.aws.sqs.connection import AsyncSQSConnection
@@ -1923,7 +1922,7 @@ def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
     mocked_webhook_send.assert_called_once_with(
         kwargs={"event_delivery_id": event_delivery.pk, "telemetry_context": ANY},
         queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
-        MessageGroupId="mirumee.com:saleor.app.test",
+        MessageGroupId="example.com:saleor.app.test",
     )
 
 
@@ -1955,7 +1954,7 @@ def test_send_webhook_request_async_with_success_response(
     # then
     mocked_send_response.assert_called_once_with(
         event_delivery.webhook.target_url,
-        "mirumee.com",
+        "example.com",
         event_delivery.webhook.secret_key,
         event_delivery.event_type,
         event_delivery.payload.get_payload().encode("utf-8"),
@@ -2366,7 +2365,7 @@ def test_send_webhook_request_async_with_request_exception(
     event_payload = event_delivery.payload
     data = event_payload.get_payload()
     webhook = event_delivery.webhook
-    domain = Site.objects.get_current().domain
+    domain = "example.com"
     message = data.encode("utf-8")
     signature = signature_for_payload(message, webhook.secret_key)
     expected_request_headers = generate_request_headers(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1910,7 +1910,7 @@ def test_sale_toggle(
     )
 
 
-@mock.patch("saleor.plugins.webhook.plugin.send_webhook_request_async.delay")
+@mock.patch("saleor.plugins.webhook.plugin.send_webhook_request_async.apply_async")
 def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -1921,7 +1921,9 @@ def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
 
     # then
     mocked_webhook_send.assert_called_once_with(
-        event_delivery.pk, telemetry_context=ANY
+        kwargs={"event_delivery_id": event_delivery.pk, "telemetry_context": ANY},
+        queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
+        MessageGroupId="mirumee.com:saleor.app.test",
     )
 
 

--- a/saleor/plugins/webhook/tests/utils.py
+++ b/saleor/plugins/webhook/tests/utils.py
@@ -8,5 +8,5 @@ def generate_request_headers(event_type, domain, signature):
         "Saleor-Event": event_type,
         "Saleor-Domain": domain,
         "Saleor-Signature": signature,
-        "Saleor-Api-Url": f"http://{domain}/graphql/",
+        "Saleor-Api-Url": f"https://{domain}/graphql/",
     }

--- a/saleor/product/tests/test_generate_and_set_variant_name.py
+++ b/saleor/product/tests/test_generate_and_set_variant_name.py
@@ -127,7 +127,7 @@ def test_generate_and_set_variant_name_only_not_variant_selection_attributes(
                 attribute=file_attribute,
                 name="test_file_3.txt",
                 slug="test_file3txt",
-                file_url="http://mirumee.com/test_media/test_file3.txt",
+                file_url="https://example.com/test_media/test_file3.txt",
                 content_type="text/plain",
             ),
         ]

--- a/saleor/site/tests/fixtures/site_settings.py
+++ b/saleor/site/tests/fixtures/site_settings.py
@@ -12,11 +12,11 @@ def site_settings(db, settings) -> SiteSettings:
     saleor.site.models.SiteSettings have a one-to-one relationship and a site
     should never exist without a matching settings object.
     """
-    site = Site.objects.get_or_create(name="mirumee.com", domain="mirumee.com")[0]
+    site = Site.objects.get_or_create(name="example.com", domain="example.com")[0]
     obj = SiteSettings.objects.get_or_create(
         site=site,
-        default_mail_sender_name="Mirumee Labs",
-        default_mail_sender_address="mirumee@example.com",
+        default_mail_sender_name="Example",
+        default_mail_sender_address="example@example.com",
     )[0]
     settings.SITE_ID = site.pk
     settings.ALLOWED_HOSTS += [site.domain]

--- a/saleor/site/tests/test_site_settings.py
+++ b/saleor/site/tests/test_site_settings.py
@@ -7,8 +7,8 @@ from ..models import SiteSettings
 
 def test_new_get_current():
     result = Site.objects.get_current()
-    assert result.name == "mirumee.com"
-    assert result.domain == "mirumee.com"
+    assert result.name == "example.com"
+    assert result.domain == "example.com"
     assert type(result.settings) is SiteSettings
 
 

--- a/saleor/tests/e2e/checkout/shipping/cassettes/test_use_external_shipping_methods_in_checkout/test_use_external_shipping_methods_in_checkout_core_1652.yaml
+++ b/saleor/tests/e2e/checkout/shipping/cassettes/test_use_external_shipping_methods_in_checkout/test_use_external_shipping_methods_in_checkout_core_1652.yaml
@@ -14,9 +14,9 @@ interactions:
       Content-Type:
       - application/json
       Saleor-Api-Url:
-      - http://mirumee.com/graphql/
+      - https://example.com/graphql/
       Saleor-Domain:
-      - mirumee.com
+      - example.com
       Saleor-Event:
       - shipping_list_methods_for_checkout
       Saleor-Signature:
@@ -63,9 +63,9 @@ interactions:
       Content-Type:
       - application/json
       Saleor-Api-Url:
-      - http://mirumee.com/graphql/
+      - https://example.com/graphql/
       Saleor-Domain:
-      - mirumee.com
+      - example.com
       Saleor-Event:
       - shipping_list_methods_for_checkout
       Saleor-Signature:

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -19,7 +19,6 @@ def test_create_page_with_each_of_attribute_types_core_0701(
     permission_manage_pages,
     shop_permissions,
     permission_manage_product_types_and_attributes,
-    site_settings,
 ):
     # Before
     permissions = [
@@ -87,7 +86,7 @@ def test_create_page_with_each_of_attribute_types_core_0701(
     expected_rich_text = json.dumps(dummy_editorjs(expected_base_text))
 
     new_value = "new_test_value.txt"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
+    file_url = f"{settings.PUBLIC_URL}{settings.MEDIA_URL}{new_value}"
     file_content_type = "text/plain"
 
     attributes = [

--- a/saleor/tests/e2e/product/test_create_product_with_all_attributes_types.py
+++ b/saleor/tests/e2e/product/test_create_product_with_all_attributes_types.py
@@ -22,7 +22,6 @@ def test_create_product_with_attributes_created_in_bulk_core_0704(
     permission_manage_pages,
     permission_manage_products,
     permission_manage_product_types_and_attributes,
-    site_settings,
 ):
     # Before
     permissions = [
@@ -83,7 +82,7 @@ def test_create_product_with_attributes_created_in_bulk_core_0704(
     expected_base_text = "Test rich attribute text"
     expected_rich_text = json.dumps(dummy_editorjs(expected_base_text))
     new_value = "new_test_value.txt"
-    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
+    file_url = f"{settings.PUBLIC_URL}{settings.MEDIA_URL}{new_value}"
     file_content_type = "text/plain"
 
     attributes = [

--- a/saleor/tests/settings.py
+++ b/saleor/tests/settings.py
@@ -23,6 +23,7 @@ POPULATE_DEFAULTS = False
 
 CELERY_TASK_ALWAYS_EAGER = True
 
+PUBLIC_URL = "https://example.com"
 SECRET_KEY = "NOTREALLY"
 
 ALLOWED_CLIENT_HOSTS = ["www.example.com"]

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -245,7 +245,7 @@ def test_serialize_headers(headers, expected):
     assert serialize_headers(headers) == expected
 
 
-def test_generate_api_call_payload(app, rf, gql_operation_factory, site_settings):
+def test_generate_api_call_payload(app, rf, gql_operation_factory):
     request = rf.post(
         "/graphql", data={"request": "data"}, content_type="application/json"
     )
@@ -271,7 +271,7 @@ def test_generate_api_call_payload(app, rf, gql_operation_factory, site_settings
             request=ApiCallRequest(
                 id=request_id,
                 method="POST",
-                url=f"http://{site_settings.site.domain}/graphql",
+                url="https://example.com/graphql",
                 time=request.request_time.timestamp(),
                 headers=[
                     ("Cookie", "***"),

--- a/saleor/webhook/tests/fixtures/webhook_data.py
+++ b/saleor/webhook/tests/fixtures/webhook_data.py
@@ -7,7 +7,7 @@ from ....webhook.observability import WebhookData
 def observability_webhook_data(observability_webhook):
     return WebhookData(
         id=observability_webhook.id,
-        saleor_domain="mirumee.com",
+        saleor_domain="example.com",
         target_url=observability_webhook.target_url,
         secret_key=observability_webhook.secret_key,
     )

--- a/saleor/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/webhook/tests/subscription_webhooks/payloads.py
@@ -31,7 +31,7 @@ def generate_account_requested_events_payload(customer_user, channel, new_email=
         }
         if channel
         else None,
-        "shop": {"domain": {"host": "mirumee.com", "url": "http://mirumee.com/"}},
+        "shop": {"domain": {"host": "example.com", "url": "https://example.com/"}},
     }
     if new_email:
         payload["newEmail"] = new_email

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1280,7 +1280,7 @@ def test_product_media_created(
         {
             "productMedia": {
                 "id": media_id,
-                "url": f"http://mirumee.com{media.image.url}",
+                "url": f"https://example.com{media.image.url}",
                 "productId": graphene.Node.to_global_id("Product", media.product_id),
             }
         }
@@ -1303,7 +1303,7 @@ def test_product_media_updated(
         {
             "productMedia": {
                 "id": media_id,
-                "url": f"http://mirumee.com{media.image.url}",
+                "url": f"https://example.com{media.image.url}",
                 "productId": graphene.Node.to_global_id("Product", media.product_id),
             }
         }
@@ -1326,7 +1326,7 @@ def test_product_media_deleted(
         {
             "productMedia": {
                 "id": media_id,
-                "url": f"http://mirumee.com{media.image.url}",
+                "url": f"https://example.com{media.image.url}",
                 "productId": graphene.Node.to_global_id("Product", media.product_id),
             }
         }

--- a/saleor/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_webhook.py
@@ -41,9 +41,7 @@ def test_trigger_webhooks_async(
                     "telemetry_context": mock.ANY,
                 },
                 queue=None,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId=f"example.com:{delivery.webhook.app.identifier or delivery.webhook.app.id}",
             )
             in mocked_send_webhook_request.mock_calls
         )
@@ -106,9 +104,7 @@ def test_trigger_webhooks_async_for_multiple_objects(
                     "telemetry_context": mock.ANY,
                 },
                 queue=None,
-                bind=True,
-                retry_backoff=10,
-                retry_kwargs={"max_retries": 5},
+                MessageGroupId=f"example.com:{delivery.webhook.app.identifier or delivery.webhook.app.id}",
             )
             in mocked_send_webhook_request.mock_calls
         )

--- a/saleor/webhook/tests/test_webhook_protocols.py
+++ b/saleor/webhook/tests/test_webhook_protocols.py
@@ -18,7 +18,7 @@ from ..transport.asynchronous import trigger_webhooks_async
 
 @pytest.mark.parametrize(
     ("queue_name", "additional_call_args"),
-    [("queue_name", {}), ("queue_name.fifo", {"MessageGroupId": "mirumee.com"})],
+    [("queue_name", {}), ("queue_name.fifo", {"MessageGroupId": "example.com"})],
 )
 def test_trigger_webhooks_with_aws_sqs(
     queue_name,
@@ -68,10 +68,10 @@ def test_trigger_webhooks_with_aws_sqs(
     expected_call_args = {
         "QueueUrl": f"https://sqs.us-east-1.amazonaws.com/account_id/{queue_name}",
         "MessageAttributes": {
-            "SaleorDomain": {"DataType": "String", "StringValue": "mirumee.com"},
+            "SaleorDomain": {"DataType": "String", "StringValue": "example.com"},
             "SaleorApiUrl": {
                 "DataType": "String",
-                "StringValue": "http://mirumee.com/graphql/",
+                "StringValue": "https://example.com/graphql/",
             },
             "EventType": {"DataType": "String", "StringValue": "order_created"},
             "Signature": {"DataType": "String", "StringValue": expected_signature},
@@ -140,10 +140,10 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
     mocked_client.send_message.assert_called_once_with(
         QueueUrl="https://sqs.us-east-1.amazonaws.com/account_id/queue_name",
         MessageAttributes={
-            "SaleorDomain": {"DataType": "String", "StringValue": "mirumee.com"},
+            "SaleorDomain": {"DataType": "String", "StringValue": "example.com"},
             "SaleorApiUrl": {
                 "DataType": "String",
-                "StringValue": "http://mirumee.com/graphql/",
+                "StringValue": "https://example.com/graphql/",
             },
             "EventType": {"DataType": "String", "StringValue": "order_created"},
             "Signature": {"DataType": "String", "StringValue": expected_signature},
@@ -191,8 +191,8 @@ def test_trigger_webhooks_with_google_pub_sub(
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
         expected_data.encode("utf-8"),
-        saleorDomain="mirumee.com",
-        saleorApiUrl="http://mirumee.com/graphql/",
+        saleorDomain="example.com",
+        saleorApiUrl="https://example.com/graphql/",
         eventType=WebhookEventAsyncType.ORDER_CREATED,
         signature=expected_signature,
     )
@@ -244,8 +244,8 @@ def test_trigger_webhooks_with_google_pub_sub_when_timout_error_raised(
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
         expected_data.encode("utf-8"),
-        saleorDomain="mirumee.com",
-        saleorApiUrl="http://mirumee.com/graphql/",
+        saleorDomain="example.com",
+        saleorApiUrl="https://example.com/graphql/",
         eventType=WebhookEventAsyncType.ORDER_CREATED,
         signature=expected_signature,
     )
@@ -284,8 +284,8 @@ def test_trigger_webhooks_with_google_pub_sub_and_secret_key(
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
         message.encode("utf-8"),
-        saleorDomain="mirumee.com",
-        saleorApiUrl="http://mirumee.com/graphql/",
+        saleorDomain="example.com",
+        saleorApiUrl="https://example.com/graphql/",
         eventType=WebhookEventAsyncType.ORDER_CREATED,
         signature=expected_signature,
     )
@@ -328,12 +328,12 @@ def test_trigger_webhooks_with_http(
         "Content-Type": "application/json",
         # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
         "X-Saleor-Event": "order_created",
-        "X-Saleor-Domain": "mirumee.com",
+        "X-Saleor-Domain": "example.com",
         "X-Saleor-Signature": expected_signature,
         "Saleor-Event": "order_created",
-        "Saleor-Domain": "mirumee.com",
+        "Saleor-Domain": "example.com",
         "Saleor-Signature": expected_signature,
-        "Saleor-Api-Url": "http://mirumee.com/graphql/",
+        "Saleor-Api-Url": "https://example.com/graphql/",
     }
 
     mock_request.assert_called_once_with(
@@ -377,12 +377,12 @@ def test_trigger_webhooks_with_http_and_secret_key(
         "Content-Type": "application/json",
         # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
         "X-Saleor-Event": "order_created",
-        "X-Saleor-Domain": "mirumee.com",
+        "X-Saleor-Domain": "example.com",
         "X-Saleor-Signature": expected_signature,
         "Saleor-Event": "order_created",
-        "Saleor-Domain": "mirumee.com",
+        "Saleor-Domain": "example.com",
         "Saleor-Signature": expected_signature,
-        "Saleor-Api-Url": "http://mirumee.com/graphql/",
+        "Saleor-Api-Url": "https://example.com/graphql/",
     }
 
     mock_request.assert_called_once_with(
@@ -424,12 +424,12 @@ def test_trigger_webhooks_with_http_and_secret_key_as_empty_string(
         "Content-Type": "application/json",
         # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
         "X-Saleor-Event": "order_created",
-        "X-Saleor-Domain": "mirumee.com",
+        "X-Saleor-Domain": "example.com",
         "X-Saleor-Signature": expected_signature,
         "Saleor-Event": "order_created",
-        "Saleor-Domain": "mirumee.com",
+        "Saleor-Domain": "example.com",
         "Saleor-Signature": expected_signature,
-        "Saleor-Api-Url": "http://mirumee.com/graphql/",
+        "Saleor-Api-Url": "https://example.com/graphql/",
     }
 
     signature_headers = jwt.get_unverified_header(expected_signature)
@@ -463,12 +463,12 @@ def test_trigger_webhooks_with_http_and_custom_headers(
     expected_headers = {
         "Content-Type": "application/json",
         "X-Saleor-Event": "order_created",
-        "X-Saleor-Domain": "mirumee.com",
+        "X-Saleor-Domain": "example.com",
         "X-Saleor-Signature": expected_signature,
         "Saleor-Event": "order_created",
-        "Saleor-Domain": "mirumee.com",
+        "Saleor-Domain": "example.com",
         "Saleor-Signature": expected_signature,
-        "Saleor-Api-Url": "http://mirumee.com/graphql/",
+        "Saleor-Api-Url": "https://example.com/graphql/",
         "X-Key": "Value",
         "Authorization-Key": "Value",
     }
@@ -536,7 +536,5 @@ def test_trigger_webhooks_async_pick_up_queue_based_on_protocol(
     mock_async_apply.assert_called_once_with(
         kwargs={"event_delivery_id": delivery.id, "telemetry_context": ANY},
         queue=expected_queue_name,
-        bind=True,
-        retry_backoff=10,
-        retry_kwargs={"max_retries": 5},
+        MessageGroupId="example.com:saleor.app.test",
     )

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -435,7 +435,7 @@ def trigger_webhooks_async_for_multiple_objects(
     domain = get_domain()
     for delivery in deliveries:
         app = delivery.webhook.app
-        message_group_id = f"{domain}:{app.identifier}"
+        message_group_id = f"{domain}:{app.identifier or app.id}"
         # TODO: switch to new `send_webhooks_async_for_app` task when we have
         # deduplication mechanism in place.
         send_webhook_request_async.apply_async(
@@ -576,7 +576,7 @@ def generate_deferred_payloads(
     for delivery in event_deliveries_for_bulk_update:
         # Trigger webhook delivery task when the payload is ready.
         app = delivery.webhook.app
-        message_group_id = f"{domain}:{app.identifier}"
+        message_group_id = f"{domain}:{app.identifier or app.id}"
         # TODO: switch to new `send_webhooks_async_for_app` task when we have
         # deduplication mechanism in place.
         send_webhook_request_async.apply_async(

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -432,7 +432,10 @@ def trigger_webhooks_async_for_multiple_objects(
             },
             bind=True,
         )
+    domain = get_domain()
     for delivery in deliveries:
+        app = delivery.webhook.app
+        message_group_id = f"{domain}:{app.identifier}"
         # TODO: switch to new `send_webhooks_async_for_app` task when we have
         # deduplication mechanism in place.
         send_webhook_request_async.apply_async(
@@ -444,9 +447,7 @@ def trigger_webhooks_async_for_multiple_objects(
                 delivery.webhook,
                 default_queue=queue or settings.WEBHOOK_CELERY_QUEUE_NAME,
             ),
-            bind=True,
-            retry_backoff=10,
-            retry_kwargs={"max_retries": 5},
+            MessageGroupId=message_group_id,  # for AWS SQS fair queues
         )
 
 
@@ -571,23 +572,23 @@ def generate_deferred_payloads(
                 EventDelivery.objects.bulk_update(
                     event_deliveries_for_bulk_update, ["payload"]
                 )
+    domain = get_domain()
     for delivery in event_deliveries_for_bulk_update:
         # Trigger webhook delivery task when the payload is ready.
+        app = delivery.webhook.app
+        message_group_id = f"{domain}:{app.identifier}"
         # TODO: switch to new `send_webhooks_async_for_app` task when we have
         # deduplication mechanism in place.
         send_webhook_request_async.apply_async(
             kwargs={
                 "event_delivery_id": delivery.pk,
-                # Propagate received telemetry context
                 "telemetry_context": telemetry_context.to_dict(),
             },
             queue=get_queue_name_for_webhook(
                 delivery.webhook,
                 default_queue=send_webhook_queue or settings.WEBHOOK_CELERY_QUEUE_NAME,
             ),
-            bind=True,
-            retry_backoff=10,
-            retry_kwargs={"max_retries": 5},
+            MessageGroupId=message_group_id,  # for AWS SQS fair queues
         )
 
 

--- a/saleor/webhook/transport/tests/test_utils.py
+++ b/saleor/webhook/transport/tests/test_utils.py
@@ -169,7 +169,7 @@ def test_send_webhook_using_aws_sqs(
             "SaleorDomain": {"DataType": "String", "StringValue": domain},
             "SaleorApiUrl": {
                 "DataType": "String",
-                "StringValue": f"http://{domain}/graphql/",
+                "StringValue": f"https://{domain}/graphql/",
             },
             "EventType": {"DataType": "String", "StringValue": event_type},
             "Signature": {"DataType": "String", "StringValue": signature},


### PR DESCRIPTION
This should enable fair queue usage with SQS, protecting apps from noisy neighbors during large spikes of events.

More on SQS fair queues: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fair-queues.html

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
