### PR TITLE
Remove `attribute.values`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - You can now filter and search attribute choices using the new `where` and `search` fields on the `attribute.choices` query.
 - Filtering products by `category` now also includes subcategories. The filter will return products that belong to the specified categories as well as their subcategories.
 - Deprecated `Transaction.gatewayResponse` field. Please migrate to Transaction API and Apps.
-- Extend the `Attribute` type with a `values` field, allowing you to retrieve all values assigned to a specific attribute.
 - Add new `single-reference` attribute. You can now create a reference attribute that points to only one object (unlike the existing `reference` type, which supports multiple references).
 Like `reference`, the `single-reference` type can target entities defined in the `AttributeEntityTypeEnum`.
 - Extended support for filtering `products` by associated attributes

--- a/saleor/graphql/attribute/dataloaders.py
+++ b/saleor/graphql/attribute/dataloaders.py
@@ -1,10 +1,7 @@
 from collections import defaultdict
 
-from django.db.models import F, Window
-from django.db.models.functions import RowNumber
-
 from ...attribute.models import Attribute, AttributeValue
-from ..core.dataloaders import DataLoader, DataLoaderWithLimit
+from ..core.dataloaders import DataLoader
 
 
 class AttributeValuesByAttributeIdLoader(DataLoader[int, list[AttributeValue]]):
@@ -14,33 +11,6 @@ class AttributeValuesByAttributeIdLoader(DataLoader[int, list[AttributeValue]]):
         attribute_values = AttributeValue.objects.using(
             self.database_connection_name
         ).filter(attribute_id__in=keys)
-        attribute_to_attributevalues = defaultdict(list)
-        for attribute_value in attribute_values.iterator(chunk_size=1000):
-            attribute_to_attributevalues[attribute_value.attribute_id].append(
-                attribute_value
-            )
-        return [attribute_to_attributevalues[attribute_id] for attribute_id in keys]
-
-
-class AttributeValuesByAttributeIdWithLimitLoader(
-    DataLoaderWithLimit[int, list[AttributeValue]]
-):
-    context_key = "attributevalues_by_attribute"
-
-    def batch_load(self, keys):
-        attribute_values = (
-            AttributeValue.objects.using(self.database_connection_name)
-            .filter(attribute_id__in=keys)
-            .annotate(
-                row_num=Window(
-                    expression=RowNumber(),
-                    partition_by=F("attribute_id"),
-                    order_by=F("id").asc(),
-                )
-            )
-            .filter(row_num__lte=self.limit)
-        )
-
         attribute_to_attributevalues = defaultdict(list)
         for attribute_value in attribute_values.iterator(chunk_size=1000):
             attribute_to_attributevalues[attribute_value.attribute_id].append(

--- a/saleor/graphql/core/dataloaders.py
+++ b/saleor/graphql/core/dataloaders.py
@@ -2,8 +2,6 @@ from collections import defaultdict
 from collections.abc import Iterable
 from typing import TypeVar
 
-from django.conf import settings
-from graphql import GraphQLError
 from promise import Promise
 from promise.dataloader import DataLoader as BaseLoader
 
@@ -76,31 +74,6 @@ class DataLoader[K, R](BaseLoader):
 
     def batch_load(self, keys: Iterable[K]) -> Promise[list[R]] | list[R]:
         raise NotImplementedError()
-
-
-class DataLoaderWithLimit(DataLoader[K, R]):
-    """Data loader base class that support a limit on the number of items returned."""
-
-    def __new__(cls, context: SaleorContext, limit: int = settings.NESTED_QUERY_LIMIT):
-        loader = super().__new__(cls, context)
-        cls.limit_validation(limit)
-        loader.limit = limit
-        return loader
-
-    def __init__(
-        self, context: SaleorContext, limit: int = settings.NESTED_QUERY_LIMIT
-    ) -> None:
-        if getattr(self, "limit", None) != limit:
-            self.limit_validation(limit)
-            self.limit = limit
-        super().__init__(context=context)
-
-    @staticmethod
-    def limit_validation(limit: int) -> None:
-        if limit > settings.NESTED_QUERY_LIMIT:
-            raise GraphQLError(
-                f"The limit for attribute values cannot be greater than {settings.NESTED_QUERY_LIMIT}."
-            )
 
 
 class BaseThumbnailBySizeAndFormatLoader(

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -143,12 +143,6 @@ COST_MAP = {
     },
     "Attribute": {
         "choices": {"complexity": 1, "multipliers": ["first", "last"]},
-        "values": {
-            "complexity": 1,
-            "multipliers": [
-                "limit",
-            ],
-        },
         "productTypes": {"complexity": 1, "multipliers": ["first", "last"]},
         "productVariantTypes": {"complexity": 1, "multipliers": ["first", "last"]},
     },

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6124,18 +6124,6 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
   ): AttributeValueCountableConnection
 
   """
-  List of all existing attribute values. This includes all values that have been assigned to attributes.
-  
-  Added in Saleor 3.22.
-  """
-  values(
-    """
-    Maximum number of attribute values to return. The default value is also the maximum number of values that can be fetched.
-    """
-    limit: Int = 100
-  ): [AttributeValue!]
-
-  """
   Whether the attribute requires values to be passed or not. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   valueRequired: Boolean!


### PR DESCRIPTION
We decided that is not useful at all.
Instead the top-level `attributeValues` query will be added with filters by slug, id, attribute id, external reference


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
