### PR TITLE
Use referenced object name for attribute-value name

### DIFF
--- a/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
+++ b/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
@@ -1,0 +1,140 @@
+import graphene
+
+from .....attribute.models.base import AttributeValue
+from .....attribute.utils import associate_attribute_values_to_instance
+from ....tests.utils import get_graphql_content
+
+PAGE_QUERY = """
+    query PageQuery($id: ID) {
+        page(id: $id) {
+            attributes {
+                values {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_attribute_value_name_when_referenced_product_was_changed(
+    staff_api_client,
+    product,
+    page,
+    page_type_product_reference_attribute,
+):
+    # given
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_product_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_product_reference_attribute,
+        name=product.name,
+        slug=f"{page.pk}_{product.pk}",
+        reference_product_id=product.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_product_reference_attribute.pk: [attr_value]}
+    )
+
+    new_product_name = "New Product Name"
+    product.name = new_product_name
+    product.save(update_fields=["name"])
+
+    # when
+    response = staff_api_client.post_graphql(
+        PAGE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+    assert len(content["data"]["page"]["attributes"][0]["values"]) == 1
+    data = content["data"]["page"]["attributes"][0]["values"][0]
+    assert data["name"] == new_product_name
+
+
+def test_attribute_value_name_when_referenced_variant_was_changed(
+    staff_api_client,
+    variant,
+    page,
+    page_type_variant_reference_attribute,
+):
+    # given
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_variant_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_variant_reference_attribute,
+        name=variant.name,
+        slug=f"{page.pk}_{variant.pk}",
+        reference_variant_id=variant.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_variant_reference_attribute.pk: [attr_value]}
+    )
+    product_name = "Product Name"
+    variant.product.name = product_name
+    variant.product.save(update_fields=["name"])
+
+    new_variant_name = "New Variant Name"
+    variant.name = new_variant_name
+    variant.save(update_fields=["name"])
+
+    # when
+    response = staff_api_client.post_graphql(
+        PAGE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+    assert len(content["data"]["page"]["attributes"][0]["values"]) == 1
+    data = content["data"]["page"]["attributes"][0]["values"][0]
+    assert data["name"] == f"{product_name}: {new_variant_name}"
+
+
+def test_attribute_value_name_when_referenced_page_was_changed(
+    staff_api_client,
+    page,
+    page_list,
+    page_type_page_reference_attribute,
+):
+    # given
+    referenced_page = page_list[0]
+
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_page_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_page_reference_attribute,
+        name=referenced_page.title,
+        slug=f"{page.pk}_{referenced_page.pk}",
+        reference_page_id=referenced_page.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_page_reference_attribute.pk: [attr_value]}
+    )
+
+    new_page_title = "New Page Title"
+    referenced_page.title = new_page_title
+    referenced_page.save(update_fields=["title"])
+
+    # when
+    response = staff_api_client.post_graphql(
+        PAGE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+    assert len(content["data"]["page"]["attributes"][0]["values"]) == 1
+    data = content["data"]["page"]["attributes"][0]["values"][0]
+    assert data["name"] == new_page_title

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -4,7 +4,7 @@ import graphene
 from django.db.models import QuerySet
 from promise import Promise
 
-from ...attribute import AttributeEntityType, AttributeInputType, models
+from ...attribute import AttributeInputType, models
 from ...permission.enums import (
     PagePermissions,
     PageTypePermissions,
@@ -129,25 +129,15 @@ class AttributeValue(ModelObjectType[models.AttributeValue]):
 
     @staticmethod
     def resolve_name(root: models.AttributeValue, info: ResolveInfo):
-        def _resolve_name(attribute):
-            if attribute.input_type == AttributeInputType.REFERENCE:
-                if attribute.entity_type == AttributeEntityType.PRODUCT:
-                    return _resolve_referenced_product_name(
-                        root.reference_product_id, info
-                    )
-                if attribute.entity_type == AttributeEntityType.PRODUCT_VARIANT:
-                    return _resolve_referenced_product_variant_name(
-                        root.reference_variant_id, info
-                    )
-                if attribute.entity_type == AttributeEntityType.PAGE:
-                    return _resolve_referenced_page_name(root.reference_page_id, info)
-            return root.name
-
-        return (
-            AttributesByAttributeId(info.context)
-            .load(root.attribute_id)
-            .then(_resolve_name)
-        )
+        if root.reference_product_id:
+            return _resolve_referenced_product_name(root.reference_product_id, info)
+        if root.reference_variant_id:
+            return _resolve_referenced_product_variant_name(
+                root.reference_variant_id, info
+            )
+        if root.reference_page_id:
+            return _resolve_referenced_page_name(root.reference_page_id, info)
+        return root.name
 
     @staticmethod
     def resolve_input_type(root: models.AttributeValue, info: ResolveInfo):

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -757,9 +757,10 @@ def test_update_page_with_product_reference_attribute_existing_value(
     page_type = page.page_type
     page_type.page_attributes.add(page_type_product_reference_attribute)
 
+    expected_name = product.name
     attr_value = AttributeValue.objects.create(
         attribute=page_type_product_reference_attribute,
-        name=page.title,
+        name=expected_name,
         slug=f"{page.pk}_{product.pk}",
         reference_product=product,
     )
@@ -797,7 +798,7 @@ def test_update_page_with_product_reference_attribute_existing_value(
             {
                 "slug": attr_value.slug,
                 "file": None,
-                "name": page.title,
+                "name": expected_name,
                 "reference": reference,
                 "plainText": None,
             }
@@ -877,9 +878,10 @@ def test_update_page_with_variant_reference_attribute_existing_value(
     page_type = page.page_type
     page_type.page_attributes.add(page_type_variant_reference_attribute)
 
+    expected_name = f"{variant.product.name}: {variant.name}"
     attr_value = AttributeValue.objects.create(
         attribute=page_type_variant_reference_attribute,
-        name=page.title,
+        name=expected_name,
         slug=f"{page.pk}_{variant.pk}",
         reference_variant=variant,
     )
@@ -917,7 +919,7 @@ def test_update_page_with_variant_reference_attribute_existing_value(
             {
                 "slug": attr_value.slug,
                 "file": None,
-                "name": page.title,
+                "name": expected_name,
                 "reference": reference,
                 "plainText": None,
             }


### PR DESCRIPTION
I want to merge this change because it fixes the issue of storing static AttributeValue.name. This meant that if the name of the referenced object was later updated, AttributeValue.name would retain the outdated value, leading to inconsistencies in displayed name.
This PR changes this, by dynamically fetch the `name` of referenced object. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
