### PR TITLE
Fill voucher code when calling `orderCreateFromCheckout` mutation.

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1252,6 +1252,9 @@ def _create_order_from_checkout(
 
     # voucher
     voucher = checkout_info.voucher
+    voucher_code = (
+        checkout_info.voucher_code.code if checkout_info.voucher_code else None
+    )
 
     # shipping
     undiscounted_base_shipping_price = base_checkout_undiscounted_delivery_price(
@@ -1301,6 +1304,7 @@ def _create_order_from_checkout(
         total=taxed_total,  # money field not supported by mypy_django_plugin
         shipping_tax_rate=shipping_tax_rate,
         voucher=voucher,
+        voucher_code=voucher_code,
         checkout_token=str(checkout_info.checkout.token),
         origin=OrderOrigin.CHECKOUT,
         channel=checkout_info.channel,

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -785,6 +785,7 @@ def test_order_from_checkout_with_voucher(
     assert order_discount.type == DiscountType.VOUCHER
     assert order_discount.voucher == voucher_percentage
     assert order_discount.voucher_code == code.code
+    assert order.voucher_code == code.code
 
     code.refresh_from_db()
     assert code.used == voucher_used_count + 1


### PR DESCRIPTION
I want to merge this change because of filling the voucher code when calling `orderCreateFromCheckout` mutation.

Port #16775

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
