### PR TITLE
Revert increased cost introduced in #17937

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.22.0 [Unreleased]
 
 ### Breaking changes
-- Increased query cost for attribute-related operations due to the addition of `AttributeValue.referencedObject`.
 
 ### GraphQL API
 - You can now filter and search orders using the new `where` and `search` fields on the `pages` query.

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -242,11 +242,11 @@ COST_MAP = {
         "variant": {"complexity": 1},
     },
     "Page": {
-        "attributes": {"complexity": 100},
+        "attributes": {"complexity": 1},
         "pageType": {"complexity": 1},
     },
     "PageType": {
-        "attributes": {"complexity": 100},
+        "attributes": {"complexity": 1},
         "availableAttributes": {"complexity": 1, "multipliers": ["first", "last"]},
     },
     "Payment": {
@@ -254,7 +254,7 @@ COST_MAP = {
         "transactions": {"complexity": 1},
     },
     "Product": {
-        "attributes": {"complexity": 100},
+        "attributes": {"complexity": 1},
         "category": {"complexity": 1},
         "channelListings": {"complexity": 1},
         "collections": {"complexity": 1},
@@ -267,7 +267,7 @@ COST_MAP = {
         "pricing": {"complexity": 1},
         "productType": {"complexity": 1},
         "thumbnail": {"complexity": 1},
-        "variants": {"complexity": 100},
+        "variants": {"complexity": 1},
         "productVariants": {"complexity": 1, "multipliers": ["first", "last"]},
     },
     "ProductChannelListing": {
@@ -286,7 +286,7 @@ COST_MAP = {
         "products": {"complexity": 1, "multipliers": ["first", "last"]},
     },
     "ProductVariant": {
-        "attributes": {"complexity": 100},
+        "attributes": {"complexity": 1},
         "channelListings": {"complexity": 1},
         "images": {"complexity": 1},
         "media": {"complexity": 1},


### PR DESCRIPTION
I want to merge this change because it reverts https://github.com/saleor/saleor/pull/17937/.  We need to first provide `limit` input field to list fields.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
