### PR TITLE
Remove incorrect call to logic that is supposed run when manually marking order as paid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.22.0 [Unreleased]
 
 ### Breaking changes
+- The following changes were implemented to orders with a zero total amount:
+  - No manual charge (`Transaction` or `Payment`) object will be created.
+  - The `OrderEvents.ORDER_MARKED_AS_PAID` event will no longer be emitted.
 
 ### GraphQL API
 - You can now filter and search orders using the new `where` and `search` fields on the `pages` query.

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -41,7 +41,7 @@ from ..graphql.checkout.utils import (
     prepare_insufficient_stock_checkout_validation_error,
 )
 from ..order import OrderOrigin, OrderStatus
-from ..order.actions import mark_order_as_paid_with_payment, order_created
+from ..order.actions import order_created
 from ..order.fetch import OrderInfo, OrderLineInfo
 from ..order.models import Order, OrderLine
 from ..order.notifications import send_order_confirmation
@@ -1200,14 +1200,6 @@ def complete_checkout_post_payment_part(
                 payment=payment,
             )
             raise ValidationError(code=e.code, message=e.message) from e
-
-        # if the order total value is 0 it is paid from the definition
-        if order.total.net.amount == 0:
-            if (
-                order.channel.order_mark_as_paid_strategy
-                == MarkAsPaidStrategy.PAYMENT_FLOW
-            ):
-                mark_order_as_paid_with_payment(order, user, app, manager)
 
     return order, action_required, action_data
 

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -1313,8 +1313,9 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
         )
 
     order.refresh_from_db()
+    assert order.charge_status == OrderChargeStatus.FULL
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
     (
-        order_marked_as_paid,
         order_placed_event,
         order_fully_paid,
         order_confirmed_event,
@@ -1331,18 +1332,6 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
     assert order_placed_event.date
     # should not have any additional parameters
     assert not order_placed_event.parameters
-
-    # Ensure the correct order event was created
-    # is the event the expected type
-    assert order_marked_as_paid.type == OrderEvents.ORDER_MARKED_AS_PAID
-    # is the user anonymous/ the customer
-    assert order_marked_as_paid.user == checkout_user
-    # is the associated backref order valid
-    assert order_marked_as_paid.order is order
-    # ensure a date was set
-    assert order_marked_as_paid.date
-    # should not have any additional parameters
-    assert not order_marked_as_paid.parameters
 
     expected_order_payload = {
         "order": get_default_order_payload(order, checkout.redirect_url),


### PR DESCRIPTION
Migration guide: https://github.com/saleor/saleor-docs/pull/1656

Changelog mentions operations that are no longer executed. There are more operations that were triggered inside `mark_order_as_paid_with_payment` but they're still in fact taking place.

- Updating order charge and authorize status: these statuses are up to date, it's been checked inside modified test.
- Emitting events for `WebhookEventAsyncType.ORDER_FULLY_PAID` and `WebhookEventAsyncType.ORDER_UPDATED` which are still being emitted but in a different place (deep inside https://github.com/saleor/saleor/blob/8993031b40f89e4c51441885099d235020d17160/saleor/checkout/complete_checkout.py#L892).