### PR TITLE
Fix `test_build_absolute_uri_with_host` test

### DIFF
--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -231,6 +231,8 @@ def test_build_absolute_uri():
 
 
 def test_build_absolute_uri_with_host(settings):
+    settings.PUBLIC_URL = None
+    settings.ENABLE_SSL = True
     # given
     host = "test.com"
     location = "images/close.svg"
@@ -239,7 +241,7 @@ def test_build_absolute_uri_with_host(settings):
     url = build_absolute_uri(location, host)
 
     # then
-    assert url == f"https://example.com/{location}"
+    assert url == f"https://{host}/{location}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previous version accidentally did not use the host fallback

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
