### PR TITLE
Add AssignedNumericAttribute type for  SelectedAttribute interface

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -20,6 +20,7 @@ from ..graphql.notifications.schema import ExternalNotificationMutations
 from .account.schema import AccountMutations, AccountQueries
 from .app.schema import AppMutations, AppQueries
 from .attribute.schema import AttributeMutations, AttributeQueries
+from .attribute.types import SELECTED_ATTRIBUTE_MAP
 from .channel.schema import ChannelMutations, ChannelQueries
 from .checkout.schema import CheckoutMutations, CheckoutQueries
 from .core.enums import unit_enums
@@ -176,7 +177,9 @@ GraphQLWebhookEventsInfoDirective = graphql.GraphQLDirective(
 schema = build_federated_schema(
     Query,
     mutation=Mutation,
-    types=unit_enums + list(WEBHOOK_TYPES_MAP.values()),
+    types=unit_enums
+    + list(WEBHOOK_TYPES_MAP.values())
+    + list(SELECTED_ATTRIBUTE_MAP.values()),
     subscription=Subscription,
     directives=graphql.specified_directives
     + [GraphQLDocDirective, GraphQLWebhookEventsInfoDirective],

--- a/saleor/graphql/attribute/utils/shared.py
+++ b/saleor/graphql/attribute/utils/shared.py
@@ -11,6 +11,7 @@ from ....attribute import AttributeEntityType, AttributeInputType
 from ....attribute import models as attribute_models
 from ....page import models as page_models
 from ....product import models as product_models
+from ...core.context import ChannelContext
 from ...product.utils import get_used_attribute_values_for_variant
 
 if TYPE_CHECKING:
@@ -25,6 +26,12 @@ T_REFERENCE = (
     | product_models.Collection
     | page_models.Page
 )
+
+
+@dataclass
+class SelectedAttributeData:
+    attribute: ChannelContext[attribute_models.Attribute]
+    values: list[ChannelContext[attribute_models.AttributeValue]]
 
 
 @dataclass

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -33,6 +33,12 @@ PAGE_QUERY = """
                     id
                     slug
                 }
+                ... on AssignedNumericAttribute {
+                    attribute {
+                        id
+                    }
+                    value
+                }
             }
         }
     }
@@ -83,7 +89,11 @@ def test_query_published_page(user_api_client, page):
             else []
         )
         expected_attributes.append(
-            {"attribute": {"id": attr_id, "slug": attr.slug}, "values": values}
+            {
+                "attribute": {"id": attr_id, "slug": attr.slug},
+                "values": values,
+                "value": None,
+            }
         )
 
     for attr_data in page_data["attributes"]:
@@ -384,6 +394,7 @@ def test_page_attributes_visible_in_storefront_for_customer_is_returned(
         ):
             attr_data = attr
             attr_data.pop("values", None)
+            attr_data.pop("value", None)
             break
 
     assert attr_data == {
@@ -425,6 +436,7 @@ def test_page_attributes_visible_in_storefront_for_staff_is_always_returned(
         ):
             attr_data = attr
             attr_data.pop("values", None)
+            attr_data.pop("value", None)
             break
 
     assert attr_data == {

--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -270,6 +270,12 @@ PAGES_QUERY = """
                             id
                             slug
                         }
+                        ... on AssignedNumericAttribute {
+                            attribute {
+                                id
+                            }
+                            value
+                        }
                     }
                 }
             }

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -71,6 +71,12 @@ def test_product_details(product_with_image, api_client, count_queries, channel_
               name
               value: name
             }
+            ... on AssignedNumericAttribute {
+              attribute {
+                id
+              }
+              value
+            }
           }
           media {
             id

--- a/saleor/graphql/product/tests/benchmark/test_variant.py
+++ b/saleor/graphql/product/tests/benchmark/test_variant.py
@@ -72,6 +72,12 @@ def test_retrieve_variant_list(
               name
               value: name
             }
+            ... on AssignedNumericAttribute {
+              attribute {
+                id
+              }
+              value
+            }
           }
         }
 

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -37,6 +37,12 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
               values {
                 slug
               }
+              ... on AssignedNumericAttribute {
+                attribute {
+                    id
+                }
+                value
+              }
             }
             variants {
               attributes {
@@ -46,6 +52,12 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
                 }
                 values {
                   slug
+                }
+                ... on AssignedNumericAttribute {
+                  attribute {
+                    id
+                  }
+                  value
                 }
               }
             }

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -50,6 +50,7 @@ from ...attribute.types import (
     AttributeCountableConnection,
     SelectedAttribute,
 )
+from ...attribute.utils.shared import SelectedAttributeData
 from ...channel.dataloaders import ChannelBySlugLoader
 from ...channel.utils import get_default_channel_slug_or_graphql_error
 from ...core.connection import (
@@ -590,10 +591,10 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
     ):
         def apply_variant_selection_filter(
             selected_attributes,
-        ) -> list[SelectedAttribute]:
+        ) -> list[SelectedAttributeData]:
             if not variant_selection or variant_selection == VariantAttributeScope.ALL:
                 return [
-                    SelectedAttribute(
+                    SelectedAttributeData(
                         attribute=ChannelContext(
                             selected_att["attribute"], root.channel_slug
                         ),
@@ -627,7 +628,7 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
                 ]
 
             return [
-                SelectedAttribute(
+                SelectedAttributeData(
                     attribute=ChannelContext(
                         selected_att["attribute"], root.channel_slug
                     ),
@@ -1345,7 +1346,7 @@ class Product(ChannelContextType[models.Product]):
                 ]
                 | None
             ),
-        ) -> SelectedAttribute | None:
+        ) -> SelectedAttributeData | None:
             if attributes is None:
                 return None
 
@@ -1355,7 +1356,7 @@ class Product(ChannelContextType[models.Product]):
                 if attribute.slug == slug:
                     values = atr["values"]
                     values = cast(list[attribute_models.AttributeValue], values)
-                    return SelectedAttribute(
+                    return SelectedAttributeData(
                         attribute=ChannelContext(attribute, root.channel_slug),
                         values=[
                             ChannelContext(value, root.channel_slug) for value in values
@@ -1393,7 +1394,7 @@ class Product(ChannelContextType[models.Product]):
                 ]
                 | None
             ),
-        ) -> list[SelectedAttribute] | None:
+        ) -> list[SelectedAttributeData] | None:
             if attributes is None:
                 return None
 
@@ -1404,7 +1405,7 @@ class Product(ChannelContextType[models.Product]):
                 values = attr_data["values"]
                 values = cast(list[attribute_models.AttributeValue], values)
                 response.append(
-                    SelectedAttribute(
+                    SelectedAttributeData(
                         attribute=ChannelContext(attribute, root.channel_slug),
                         values=[
                             ChannelContext(value, root.channel_slug) for value in values

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -141,6 +141,10 @@ COST_MAP = {
         "tokens": {"complexity": 1},
         "webhooks": {"complexity": 1},
     },
+    "AssignedNumericAttribute": {
+        "attribute": {"complexity": 1},
+        "values": {"complexity": 1},
+    },
     "Attribute": {
         "choices": {"complexity": 1, "multipliers": ["first", "last"]},
         "productTypes": {"complexity": 1, "multipliers": ["first", "last"]},
@@ -298,10 +302,6 @@ COST_MAP = {
     },
     "SaleChannelListing": {
         "channel": {"complexity": 1},
-    },
-    "SelectedAttribute": {
-        "attribute": {"complexity": 1},
-        "values": {"complexity": 1},
     },
     "ShippingMethodChannelListing": {
         "channel": {"complexity": 1},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7626,13 +7626,13 @@ input MetadataInput {
   value: String!
 }
 
-"""Represents a custom attribute."""
-type SelectedAttribute @doc(category: "Attributes") {
+"""Represents an assigned attribute to an object."""
+interface SelectedAttribute {
   """Name of an attribute displayed in the interface."""
   attribute: Attribute!
 
   """Values of an attribute."""
-  values: [AttributeValue!]!
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 }
 
 enum ReportingPeriod {
@@ -34465,6 +34465,22 @@ type PaymentMethodProcessTokenizationSession implements Event @doc(category: "Pa
   The ID returned by app from `PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION` webhook.
   """
   id: String!
+}
+
+"""
+Represents a numeric value of an attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedNumericAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """Numeric value of an attribute."""
+  value: Float
 }
 
 """_Any value scalar as defined by Federation spec."""


### PR DESCRIPTION
I want to merge this change because it  introduces a new GraphQL interface and type system for handling attribute assignments. The changes replaces `SelectedAttribute` type with a `SelectedAttribute` interface.  The PR also contains the implementation of `AssignedNumericAttribute` for numeric attribute.

> [!NOTE]  
> The PR targets feature-branch, as I need to change all attribute value types (right now all attribtues are treated as numeric)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
