### PR TITLE
Add AssignedTextAttribute

### DIFF
--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -276,6 +276,10 @@ PAGES_QUERY = """
                             }
                             value
                         }
+                        ...on AssignedTextAttribute{
+                            text:value
+                            text_translation: translation(languageCode:FR)
+                        }
                     }
                 }
             }

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -43,6 +43,10 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
                 }
                 value
               }
+              ...on AssignedTextAttribute{
+                text: value
+                text_translation: translation(languageCode:FR)
+              }
             }
             variants {
               attributes {
@@ -58,6 +62,10 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
                     id
                   }
                   value
+                }
+                ...on AssignedTextAttribute{
+                  text: value
+                  text_translation: translation(languageCode:FR)
                 }
               }
             }

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -144,6 +144,13 @@ COST_MAP = {
     "AssignedNumericAttribute": {
         "attribute": {"complexity": 1},
         "values": {"complexity": 1},
+        "value": {"complexity": 1},
+    },
+    "AssignedTextAttribute": {
+        "attribute": {"complexity": 1},
+        "values": {"complexity": 1},
+        "value": {"complexity": 1},
+        "translation": {"complexity": 1},
     },
     "Attribute": {
         "choices": {"complexity": 1, "multipliers": ["first", "last"]},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -34483,6 +34483,25 @@ type AssignedNumericAttribute implements SelectedAttribute {
   value: Float
 }
 
+"""
+Represents text attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedTextAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """Rich text content."""
+  value: JSON
+
+  """Translation of the rich text content."""
+  translation(languageCode: LanguageCodeEnum!): JSON
+}
+
 """_Any value scalar as defined by Federation spec."""
 scalar _Any
 


### PR DESCRIPTION
I want to merge this change because it adds `AssignedTextAttribute`. It covers the RICH_TEXT attribute. Returns the `.rich_text` and the translation

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
