### PR TITLE
Add Assigned attribtues for references

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -20,7 +20,7 @@ from ..graphql.notifications.schema import ExternalNotificationMutations
 from .account.schema import AccountMutations, AccountQueries
 from .app.schema import AppMutations, AppQueries
 from .attribute.schema import AttributeMutations, AttributeQueries
-from .attribute.types import SELECTED_ATTRIBUTE_MAP
+from .attribute.types import ASSIGNED_ATTRIBUTE_TYPES
 from .channel.schema import ChannelMutations, ChannelQueries
 from .checkout.schema import CheckoutMutations, CheckoutQueries
 from .core.enums import unit_enums
@@ -177,9 +177,7 @@ GraphQLWebhookEventsInfoDirective = graphql.GraphQLDirective(
 schema = build_federated_schema(
     Query,
     mutation=Mutation,
-    types=unit_enums
-    + list(WEBHOOK_TYPES_MAP.values())
-    + list(SELECTED_ATTRIBUTE_MAP.values()),
+    types=unit_enums + list(WEBHOOK_TYPES_MAP.values()) + ASSIGNED_ATTRIBUTE_TYPES,
     subscription=Subscription,
     directives=graphql.specified_directives
     + [GraphQLDocDirective, GraphQLWebhookEventsInfoDirective],

--- a/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
+++ b/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
@@ -1,5 +1,6 @@
 import graphene
 
+from .....attribute import AttributeInputType
 from .....attribute.models.base import AttributeValue, AttributeValueTranslation
 from .....attribute.utils import associate_attribute_values_to_instance
 from ....tests.utils import get_graphql_content
@@ -378,3 +379,612 @@ def test_assigned_file_attribute(staff_api_client, page, file_attribute):
         content["data"]["page"]["attributes"][0]["value"]["contentType"]
         == attr_value.content_type
     )
+
+
+ASSIGNED_SINGLE_PAGE_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      __typename
+      ...on AssignedSinglePageReferenceAttribute{
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_single_page_reference_attribute(
+    staff_api_client,
+    page,
+    page_list,
+    page_type_page_reference_attribute,
+):
+    # given
+    referenced_page = page_list[0]
+    expected_reference_slug = "referenced-page-slug"
+    referenced_page.slug = expected_reference_slug
+    referenced_page.save(update_fields=["slug"])
+
+    page_type_page_reference_attribute.input_type = AttributeInputType.SINGLE_REFERENCE
+    page_type_page_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_page_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_page_reference_attribute,
+        name=referenced_page.title,
+        slug=f"{page.pk}_{referenced_page.pk}",
+        reference_page_id=referenced_page.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_page_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_SINGLE_PAGE_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert data["__typename"] == "Page"
+    assert data["slug"] == expected_reference_slug
+
+
+ASSIGNED_SINGLE_PRODUCT_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      __typename
+      ...on AssignedSingleProductReferenceAttribute{
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_single_product_reference_attribute(
+    staff_api_client,
+    page,
+    product,
+    page_type_product_reference_attribute,
+):
+    # given
+    referenced_product = product
+    expected_reference_slug = "referenced-product-slug"
+    referenced_product.slug = expected_reference_slug
+    referenced_product.save(update_fields=["slug"])
+
+    page_type_product_reference_attribute.input_type = (
+        AttributeInputType.SINGLE_REFERENCE
+    )
+    page_type_product_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_product_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_product_reference_attribute,
+        slug=f"{page.pk}_{referenced_product.pk}",
+        reference_product_id=referenced_product.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_product_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_SINGLE_PRODUCT_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert data["__typename"] == "Product"
+    assert data["slug"] == expected_reference_slug
+
+
+ASSIGNED_SINGLE_PRODUCT_VARIANT_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      __typename
+      ...on AssignedSingleProductVariantReferenceAttribute{
+        value{
+          __typename
+          sku
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_single_product_variant_reference_attribute(
+    staff_api_client,
+    page,
+    variant,
+    page_type_variant_reference_attribute,
+):
+    # given
+    referenced_variant = variant
+    expected_reference_sku = "referenced-variant-sku"
+    referenced_variant.sku = expected_reference_sku
+    referenced_variant.save(update_fields=["sku"])
+
+    page_type_variant_reference_attribute.input_type = (
+        AttributeInputType.SINGLE_REFERENCE
+    )
+    page_type_variant_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_variant_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_variant_reference_attribute,
+        slug=f"{page.pk}_{referenced_variant.pk}",
+        reference_variant_id=referenced_variant.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_variant_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_SINGLE_PRODUCT_VARIANT_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert data["__typename"] == "ProductVariant"
+    assert data["sku"] == expected_reference_sku
+
+
+ASSIGNED_SINGLE_CATEGORY_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      __typename
+      ...on AssignedSingleCategoryReferenceAttribute{
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_single_category_reference_attribute(
+    staff_api_client,
+    page,
+    category,
+    page_type_category_reference_attribute,
+):
+    # given
+    referenced_category = category
+    expected_reference_slug = "referenced-category-slug"
+    referenced_category.slug = expected_reference_slug
+    referenced_category.save(update_fields=["slug"])
+
+    page_type_category_reference_attribute.input_type = (
+        AttributeInputType.SINGLE_REFERENCE
+    )
+    page_type_category_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_category_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_category_reference_attribute,
+        slug=f"{page.pk}_{referenced_category.pk}",
+        reference_category_id=referenced_category.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_category_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_SINGLE_CATEGORY_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert data["__typename"] == "Category"
+    assert data["slug"] == expected_reference_slug
+
+
+ASSIGNED_SINGLE_COLLECTION_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      __typename
+      ...on AssignedSingleCollectionReferenceAttribute{
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_single_collection_reference_attribute(
+    staff_api_client,
+    page,
+    collection,
+    page_type_collection_reference_attribute,
+):
+    # given
+    referenced_collection = collection
+    expected_reference_slug = "referenced-collection-slug"
+    referenced_collection.slug = expected_reference_slug
+    referenced_collection.save(update_fields=["slug"])
+
+    page_type_collection_reference_attribute.input_type = (
+        AttributeInputType.SINGLE_REFERENCE
+    )
+    page_type_collection_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_collection_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_collection_reference_attribute,
+        slug=f"{page.pk}_{referenced_collection.pk}",
+        reference_collection_id=referenced_collection.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_collection_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_SINGLE_COLLECTION_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert data["__typename"] == "Collection"
+    assert data["slug"] == expected_reference_slug
+
+
+ASSIGNED_MULTIPLE_PAGE_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      ...on AssignedMultiPageReferenceAttribute{
+        __typename
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_multi_page_reference_attribute(
+    staff_api_client,
+    page,
+    page_list,
+    page_type_page_reference_attribute,
+):
+    # given
+    referenced_page = page_list[0]
+    expected_reference_slug = "referenced-page-slug"
+    referenced_page.slug = expected_reference_slug
+    referenced_page.save(update_fields=["slug"])
+
+    page_type_page_reference_attribute.input_type = AttributeInputType.REFERENCE
+    page_type_page_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_page_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_page_reference_attribute,
+        name=referenced_page.title,
+        slug=f"{page.pk}_{referenced_page.pk}",
+        reference_page_id=referenced_page.pk,
+    )
+    associate_attribute_values_to_instance(
+        page, {page_type_page_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_MULTIPLE_PAGE_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert len(data) == 1
+    single_page_data = data[0]
+    assert single_page_data["__typename"] == "Page"
+    assert single_page_data["slug"] == expected_reference_slug
+
+
+ASSIGNED_MULTIPLE_PRODUCT_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      ...on AssignedMultiProductReferenceAttribute{
+        __typename
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_multi_product_reference_attribute(
+    staff_api_client,
+    page,
+    product,
+    page_type_product_reference_attribute,
+):
+    # given
+    referenced_product = product
+    expected_reference_slug = "referenced-product-slug"
+    referenced_product.slug = expected_reference_slug
+    referenced_product.save(update_fields=["slug"])
+
+    page_type_product_reference_attribute.input_type = AttributeInputType.REFERENCE
+    page_type_product_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_product_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_product_reference_attribute,
+        slug=f"{page.pk}_{referenced_product.pk}",
+        reference_product_id=referenced_product.pk,
+    )
+
+    associate_attribute_values_to_instance(
+        page, {page_type_product_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_MULTIPLE_PRODUCT_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert len(data) == 1
+    single_page_data = data[0]
+    assert single_page_data["__typename"] == "Product"
+    assert single_page_data["slug"] == expected_reference_slug
+
+
+ASSIGNED_MULTIPLE_PRODUCT_VARIANT_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      ...on AssignedMultiProductVariantReferenceAttribute{
+        __typename
+        value{
+          __typename
+          sku
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_multi_product_variant_reference_attribute(
+    staff_api_client,
+    page,
+    variant,
+    page_type_variant_reference_attribute,
+):
+    # given
+    referenced_variant = variant
+    expected_reference_sku = "referenced-variant-sku"
+    referenced_variant.sku = expected_reference_sku
+    referenced_variant.save(update_fields=["sku"])
+
+    page_type_variant_reference_attribute.input_type = AttributeInputType.REFERENCE
+    page_type_variant_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_variant_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_variant_reference_attribute,
+        slug=f"{page.pk}_{referenced_variant.pk}",
+        reference_variant_id=referenced_variant.pk,
+    )
+
+    associate_attribute_values_to_instance(
+        page, {page_type_variant_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_MULTIPLE_PRODUCT_VARIANT_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert len(data) == 1
+    single_page_data = data[0]
+    assert single_page_data["__typename"] == "ProductVariant"
+    assert single_page_data["sku"] == expected_reference_sku
+
+
+ASSIGNED_MULTIPLE_CATEGORY_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      ...on AssignedMultiCategoryReferenceAttribute{
+        __typename
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_multi_category_reference_attribute(
+    staff_api_client,
+    page,
+    category,
+    page_type_category_reference_attribute,
+):
+    # given
+    referenced_category = category
+    expected_reference_slug = "referenced-category-slug"
+    referenced_category.slug = expected_reference_slug
+    referenced_category.save(update_fields=["slug"])
+
+    page_type_category_reference_attribute.input_type = AttributeInputType.REFERENCE
+    page_type_category_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_category_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_category_reference_attribute,
+        slug=f"{page.pk}_{referenced_category.pk}",
+        reference_category_id=referenced_category.pk,
+    )
+
+    associate_attribute_values_to_instance(
+        page, {page_type_category_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_MULTIPLE_CATEGORY_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert len(data) == 1
+    single_page_data = data[0]
+    assert single_page_data["__typename"] == "Category"
+    assert single_page_data["slug"] == expected_reference_slug
+
+
+ASSIGNED_MULTIPLE_COLLECTION_REFERENCE_ATTRIBUTE_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    attributes {
+      ...on AssignedMultiCollectionReferenceAttribute{
+        __typename
+        value{
+          __typename
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_multi_collection_reference_attribute(
+    staff_api_client,
+    page,
+    collection,
+    page_type_collection_reference_attribute,
+):
+    # given
+    referenced_collection = collection
+    expected_reference_slug = "referenced-collection-slug"
+    referenced_collection.slug = expected_reference_slug
+    referenced_collection.save(update_fields=["slug"])
+
+    page_type_collection_reference_attribute.input_type = AttributeInputType.REFERENCE
+    page_type_collection_reference_attribute.save()
+    page_type = page.page_type
+    page_type.page_attributes.set([page_type_collection_reference_attribute])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=page_type_collection_reference_attribute,
+        slug=f"{page.pk}_{referenced_collection.pk}",
+        reference_collection_id=referenced_collection.pk,
+    )
+
+    associate_attribute_values_to_instance(
+        page, {page_type_collection_reference_attribute.pk: [attr_value]}
+    )
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_MULTIPLE_COLLECTION_REFERENCE_ATTRIBUTE_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["page"]["attributes"]) == 1
+
+    data = content["data"]["page"]["attributes"][0]["value"]
+    assert len(data) == 1
+    single_page_data = data[0]
+    assert single_page_data["__typename"] == "Collection"
+    assert single_page_data["slug"] == expected_reference_slug

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -956,11 +956,6 @@ class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
         channel_slug = root.attribute.channel_slug
         attr_value = root.values[0].node
 
-        def _wrap_with_channel_context(
-            collection: product_models.Collection,
-        ) -> ChannelContext[product_models.Collection]:
-            return ChannelContext(node=collection, channel_slug=channel_slug)
-
         return (
             CollectionByIdLoader(info.context)
             .load(attr_value.reference_collection_id)
@@ -976,7 +971,7 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.page.types.Page",
         description="List of referenced pages.",
-        required=False,
+        required=True,
     )
 
     class Meta:
@@ -1013,7 +1008,7 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.Product",
         description="List of referenced products.",
-        required=False,
+        required=True,
     )
 
     class Meta:
@@ -1051,7 +1046,7 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.ProductVariant",
         description="List of referenced product variants.",
-        required=False,
+        required=True,
     )
 
     class Meta:
@@ -1091,7 +1086,7 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.Category",
         description="List of referenced categories.",
-        required=False,
+        required=True,
     )
 
     class Meta:
@@ -1115,7 +1110,7 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.Collection",
         description="List of referenced collections.",
-        required=False,
+        required=True,
     )
 
     class Meta:

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -1,13 +1,17 @@
+from typing import cast
+
 import graphene
 from promise import Promise
 
-from ...attribute import AttributeInputType, models
+from ...attribute import AttributeEntityType, AttributeInputType, models
+from ...page import models as page_models
 from ...permission.enums import (
     PagePermissions,
     PageTypePermissions,
     ProductPermissions,
     ProductTypePermissions,
 )
+from ...product import models as product_models
 from ..core import ResolveInfo
 from ..core.connection import (
     CountableConnection,
@@ -41,7 +45,12 @@ from ..core.types.context import ChannelContextType
 from ..decorators import check_attribute_required_permissions
 from ..meta.types import ObjectWithMetadata
 from ..page.dataloaders import PageByIdLoader
-from ..product.dataloaders.products import ProductByIdLoader, ProductVariantByIdLoader
+from ..product.dataloaders.products import (
+    CategoryByIdLoader,
+    CollectionByIdLoader,
+    ProductByIdLoader,
+    ProductVariantByIdLoader,
+)
 from ..translations.dataloaders import (
     AttributeValueTranslationByIdAndLanguageCodeLoader,
 )
@@ -665,7 +674,13 @@ class SelectedAttribute(graphene.Interface):
 
     @staticmethod
     def resolve_type(instance: SelectedAttributeData, _info):
-        attr_type = SELECTED_ATTRIBUTE_MAP.get(
+        if instance.attribute.node.input_type == AttributeInputType.SINGLE_REFERENCE:
+            entity_type = cast(str, instance.attribute.node.entity_type)
+            return ASSIGNED_SINGLE_REFERENCE_MAP.get(entity_type)
+        if instance.attribute.node.input_type == AttributeInputType.REFERENCE:
+            entity_type = cast(str, instance.attribute.node.entity_type)
+            return ASSIGNED_MULTI_REFERENCE_MAP.get(entity_type)
+        attr_type = ASSIGNED_ATTRIBUTE_MAP.get(
             instance.attribute.node.input_type,
         )
         if not attr_type:
@@ -807,9 +822,360 @@ class AssignedFileAttribute(BaseObjectType):
         return File(url=attr_value.file_url, content_type=attr_value.content_type)
 
 
-SELECTED_ATTRIBUTE_MAP = {
+class AssignedSinglePageReferenceAttribute(BaseObjectType):
+    value = graphene.Field(
+        "saleor.graphql.page.types.Page",
+        description="Referenced page.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents single page reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[ChannelContext[page_models.Page]] | None:
+        if not root.values:
+            return None
+
+        channel_slug = root.attribute.channel_slug
+        attr_value = root.values[0].node
+
+        def _wrap_with_channel_context(
+            page: page_models.Page,
+        ) -> ChannelContext[page_models.Page]:
+            return ChannelContext(node=page, channel_slug=channel_slug)
+
+        return (
+            PageByIdLoader(info.context)
+            .load(attr_value.reference_page_id)
+            .then(_wrap_with_channel_context)
+        )
+
+
+class AssignedSingleProductReferenceAttribute(BaseObjectType):
+    value = graphene.Field(
+        "saleor.graphql.product.types.Product",
+        description="Referenced product.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents single product reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[ChannelContext[product_models.Product]] | None:
+        if not root.values:
+            return None
+
+        channel_slug = root.attribute.channel_slug
+        attr_value = root.values[0].node
+
+        def _wrap_with_channel_context(
+            product: product_models.Product,
+        ) -> ChannelContext[product_models.Product]:
+            return ChannelContext(node=product, channel_slug=channel_slug)
+
+        return (
+            ProductByIdLoader(info.context)
+            .load(attr_value.reference_product_id)
+            .then(_wrap_with_channel_context)
+        )
+
+
+class AssignedSingleProductVariantReferenceAttribute(BaseObjectType):
+    value = graphene.Field(
+        "saleor.graphql.product.types.ProductVariant",
+        description="Referenced product variant.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = (
+            "Represents single product variant reference attribute." + ADDED_IN_322
+        )
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[ChannelContext[product_models.ProductVariant]] | None:
+        if not root.values:
+            return None
+
+        channel_slug = root.attribute.channel_slug
+        attr_value = root.values[0].node
+
+        def _wrap_with_channel_context(
+            product_variant: product_models.ProductVariant,
+        ) -> ChannelContext[product_models.ProductVariant]:
+            return ChannelContext(node=product_variant, channel_slug=channel_slug)
+
+        return (
+            ProductVariantByIdLoader(info.context)
+            .load(attr_value.reference_variant_id)
+            .then(_wrap_with_channel_context)
+        )
+
+
+class AssignedSingleCategoryReferenceAttribute(BaseObjectType):
+    value = graphene.Field(
+        "saleor.graphql.product.types.Category",
+        description="Referenced category.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents single category reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[product_models.Category] | None:
+        if not root.values:
+            return None
+        attr_value = root.values[0].node
+        return CategoryByIdLoader(info.context).load(attr_value.reference_category_id)
+
+
+class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
+    value = graphene.Field(
+        "saleor.graphql.product.types.Collection",
+        description="Referenced collection.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents single collection reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[ChannelContext[product_models.Collection]] | None:
+        if not root.values:
+            return None
+
+        channel_slug = root.attribute.channel_slug
+        attr_value = root.values[0].node
+
+        def _wrap_with_channel_context(
+            collection: product_models.Collection,
+        ) -> ChannelContext[product_models.Collection]:
+            return ChannelContext(node=collection, channel_slug=channel_slug)
+
+        return (
+            CollectionByIdLoader(info.context)
+            .load(attr_value.reference_collection_id)
+            .then(_wrap_with_channel_context)
+        )
+
+
+class AssignedMultiPageReferenceAttribute(BaseObjectType):
+    value = NonNullList(
+        "saleor.graphql.page.types.Page",
+        description="List of referenced pages.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents multi page reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[list[ChannelContext[page_models.Page]]]:
+        if not root.values:
+            return Promise.resolve([])
+
+        channel_slug = root.attribute.channel_slug
+        attr_values = [value.node for value in root.values]
+
+        def _wrap_with_channel_context(
+            pages: list[page_models.Page],
+        ) -> list[ChannelContext[page_models.Page]]:
+            if not pages:
+                return []
+            return [
+                ChannelContext(node=page, channel_slug=channel_slug) for page in pages
+            ]
+
+        return (
+            PageByIdLoader(info.context)
+            .load_many([value.reference_page_id for value in attr_values])
+            .then(_wrap_with_channel_context)
+        )
+
+
+class AssignedMultiProductReferenceAttribute(BaseObjectType):
+    value = NonNullList(
+        "saleor.graphql.product.types.Product",
+        description="List of referenced products.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents multi product reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[list[ChannelContext[product_models.Product]]]:
+        if not root.values:
+            return Promise.resolve([])
+
+        channel_slug = root.attribute.channel_slug
+        attr_values = [value.node for value in root.values]
+
+        def _wrap_with_channel_context(
+            products: list[product_models.Product],
+        ) -> list[ChannelContext[product_models.Product]]:
+            if not products:
+                return []
+            return [
+                ChannelContext(node=product, channel_slug=channel_slug)
+                for product in products
+            ]
+
+        return (
+            ProductByIdLoader(info.context)
+            .load_many([value.reference_product_id for value in attr_values])
+            .then(_wrap_with_channel_context)
+        )
+
+
+class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
+    value = NonNullList(
+        "saleor.graphql.product.types.ProductVariant",
+        description="List of referenced product variants.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = (
+            "Represents multi product variant reference attribute." + ADDED_IN_322
+        )
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[list[ChannelContext[product_models.ProductVariant]]]:
+        if not root.values:
+            return Promise.resolve([])
+
+        channel_slug = root.attribute.channel_slug
+        attr_values = [value.node for value in root.values]
+
+        def _wrap_with_channel_context(
+            variants: list[product_models.ProductVariant],
+        ) -> list[ChannelContext[product_models.ProductVariant]]:
+            if not variants:
+                return []
+            return [
+                ChannelContext(node=variant, channel_slug=channel_slug)
+                for variant in variants
+            ]
+
+        return (
+            ProductVariantByIdLoader(info.context)
+            .load_many([value.reference_variant_id for value in attr_values])
+            .then(_wrap_with_channel_context)
+        )
+
+
+class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
+    value = NonNullList(
+        "saleor.graphql.product.types.Category",
+        description="List of referenced categories.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents multi category reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[list[product_models.Category]]:
+        if not root.values:
+            return Promise.resolve([])
+        attr_values = [value.node for value in root.values]
+
+        return CategoryByIdLoader(info.context).load_many(
+            [value.reference_category_id for value in attr_values]
+        )
+
+
+class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
+    value = NonNullList(
+        "saleor.graphql.product.types.Collection",
+        description="List of referenced collections.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents multi collection reference attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> Promise[list[ChannelContext[product_models.Collection]]]:
+        if not root.values:
+            return Promise.resolve([])
+
+        channel_slug = root.attribute.channel_slug
+        attr_values = [value.node for value in root.values]
+
+        def _wrap_with_channel_context(
+            collections: list[product_models.Collection],
+        ) -> list[ChannelContext[product_models.Collection]]:
+            if not collections:
+                return []
+            return [
+                ChannelContext(node=collection, channel_slug=channel_slug)
+                for collection in collections
+            ]
+
+        return (
+            CollectionByIdLoader(info.context)
+            .load_many([value.reference_collection_id for value in attr_values])
+            .then(_wrap_with_channel_context)
+        )
+
+
+ASSIGNED_SINGLE_REFERENCE_MAP = {
+    AttributeEntityType.PAGE: AssignedSinglePageReferenceAttribute,
+    AttributeEntityType.PRODUCT: AssignedSingleProductReferenceAttribute,
+    AttributeEntityType.PRODUCT_VARIANT: AssignedSingleProductVariantReferenceAttribute,
+    AttributeEntityType.CATEGORY: AssignedSingleCategoryReferenceAttribute,
+    AttributeEntityType.COLLECTION: AssignedSingleCollectionReferenceAttribute,
+}
+ASSIGNED_MULTI_REFERENCE_MAP = {
+    AttributeEntityType.PAGE: AssignedMultiPageReferenceAttribute,
+    AttributeEntityType.PRODUCT: AssignedMultiProductReferenceAttribute,
+    AttributeEntityType.PRODUCT_VARIANT: AssignedMultiProductVariantReferenceAttribute,
+    AttributeEntityType.CATEGORY: AssignedMultiCategoryReferenceAttribute,
+    AttributeEntityType.COLLECTION: AssignedMultiCollectionReferenceAttribute,
+}
+ASSIGNED_ATTRIBUTE_MAP = {
     AttributeInputType.NUMERIC: AssignedNumericAttribute,
     AttributeInputType.RICH_TEXT: AssignedTextAttribute,
     AttributeInputType.PLAIN_TEXT: AssignedPlainTextAttribute,
     AttributeInputType.FILE: AssignedFileAttribute,
 }
+ASSIGNED_ATTRIBUTE_TYPES = (
+    list(ASSIGNED_ATTRIBUTE_MAP.values())
+    + list(ASSIGNED_SINGLE_REFERENCE_MAP.values())
+    + list(ASSIGNED_MULTI_REFERENCE_MAP.values())
+)

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -843,15 +843,10 @@ class AssignedSinglePageReferenceAttribute(BaseObjectType):
         channel_slug = root.attribute.channel_slug
         attr_value = root.values[0].node
 
-        def _wrap_with_channel_context(
-            page: page_models.Page,
-        ) -> ChannelContext[page_models.Page]:
-            return ChannelContext(node=page, channel_slug=channel_slug)
-
         return (
             PageByIdLoader(info.context)
             .load(attr_value.reference_page_id)
-            .then(_wrap_with_channel_context)
+            .then(lambda page: ChannelContext(node=page, channel_slug=channel_slug))
         )
 
 
@@ -876,15 +871,12 @@ class AssignedSingleProductReferenceAttribute(BaseObjectType):
         channel_slug = root.attribute.channel_slug
         attr_value = root.values[0].node
 
-        def _wrap_with_channel_context(
-            product: product_models.Product,
-        ) -> ChannelContext[product_models.Product]:
-            return ChannelContext(node=product, channel_slug=channel_slug)
-
         return (
             ProductByIdLoader(info.context)
             .load(attr_value.reference_product_id)
-            .then(_wrap_with_channel_context)
+            .then(
+                lambda product: ChannelContext(node=product, channel_slug=channel_slug)
+            )
         )
 
 
@@ -911,15 +903,14 @@ class AssignedSingleProductVariantReferenceAttribute(BaseObjectType):
         channel_slug = root.attribute.channel_slug
         attr_value = root.values[0].node
 
-        def _wrap_with_channel_context(
-            product_variant: product_models.ProductVariant,
-        ) -> ChannelContext[product_models.ProductVariant]:
-            return ChannelContext(node=product_variant, channel_slug=channel_slug)
-
         return (
             ProductVariantByIdLoader(info.context)
             .load(attr_value.reference_variant_id)
-            .then(_wrap_with_channel_context)
+            .then(
+                lambda product_variant: ChannelContext(
+                    node=product_variant, channel_slug=channel_slug
+                )
+            )
         )
 
 
@@ -973,7 +964,11 @@ class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
         return (
             CollectionByIdLoader(info.context)
             .load(attr_value.reference_collection_id)
-            .then(_wrap_with_channel_context)
+            .then(
+                lambda collection: ChannelContext(
+                    node=collection, channel_slug=channel_slug
+                )
+            )
         )
 
 

--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -289,6 +289,71 @@ PAGES_QUERY = """
                                 contentType
                             }
                         }
+                        ...on AssignedSinglePageReferenceAttribute{
+                            page_ref: value{
+                                __typename
+                                slug
+                            }
+                        }
+                        ...on AssignedSingleProductReferenceAttribute{
+                            product_ref: value{
+                                __typename
+                                slug
+                            }
+                        }
+                        ...on AssignedSingleProductVariantReferenceAttribute{
+                            variant_ref: value{
+                                __typename
+                                sku
+                            }
+                        }
+                        ...on AssignedSingleCategoryReferenceAttribute{
+                            category_ref: value{
+                                __typename
+                                slug
+                            }
+                        }
+                        ...on AssignedSingleCollectionReferenceAttribute{
+                            collection_ref: value{
+                                __typename
+                                slug
+                            }
+                        }
+                        ...on AssignedMultiPageReferenceAttribute{
+                            __typename
+                            pages: value{
+                                __typename
+                                slug
+                            }
+                        }
+                        ...on AssignedMultiProductReferenceAttribute{
+                            __typename
+                            producs: value{
+                                __typename
+                                slug
+                            }
+                        }
+                        ...on AssignedMultiProductVariantReferenceAttribute{
+                            __typename
+                            variants: value{
+                                __typename
+                                sku
+                            }
+                        }
+                        ...on AssignedMultiCategoryReferenceAttribute{
+                            __typename
+                            categories: value{
+                                __typename
+                                slug
+                            }
+                        }
+                        ...on AssignedMultiCollectionReferenceAttribute{
+                            __typename
+                            collections: value{
+                                __typename
+                                slug
+                            }
+                        }
                     }
                 }
             }

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -56,6 +56,71 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
                   contentType
                 }
               }
+              ...on AssignedSinglePageReferenceAttribute{
+                page_ref: value{
+                  __typename
+                  slug
+                }
+              }
+              ...on AssignedSingleProductReferenceAttribute{
+                product_ref: value{
+                __typename
+                slug
+                }
+              }
+              ...on AssignedSingleProductVariantReferenceAttribute{
+                variant_ref: value{
+                  __typename
+                  sku
+                }
+              }
+              ...on AssignedSingleCategoryReferenceAttribute{
+                category_ref: value{
+                  __typename
+                  slug
+                }
+              }
+              ...on AssignedSingleCollectionReferenceAttribute{
+                collection_ref: value{
+                  __typename
+                  slug
+                }
+              }
+              ...on AssignedMultiPageReferenceAttribute{
+                __typename
+                pages: value{
+                  __typename
+                  slug
+                }
+              }
+              ...on AssignedMultiProductReferenceAttribute{
+                __typename
+                producs: value{
+                  __typename
+                  slug
+                }
+              }
+              ...on AssignedMultiProductVariantReferenceAttribute{
+                __typename
+                variants: value{
+                  __typename
+                  sku
+                }
+              }
+              ...on AssignedMultiCategoryReferenceAttribute{
+                __typename
+                categories: value{
+                  __typename
+                  slug
+                }
+              }
+              ...on AssignedMultiCollectionReferenceAttribute{
+                __typename
+                collections: value{
+                  __typename
+                  slug
+                }
+              }
             }
             variants {
               attributes {
@@ -83,6 +148,71 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
                 ...on AssignedFileAttribute{
                   file: value {
                     contentType
+                  }
+                }
+                ...on AssignedSinglePageReferenceAttribute{
+                  page_ref: value{
+                    __typename
+                    slug
+                  }
+                }
+                ...on AssignedSingleProductReferenceAttribute{
+                  product_ref: value{
+                  __typename
+                  slug
+                  }
+                }
+                ...on AssignedSingleProductVariantReferenceAttribute{
+                  variant_ref: value{
+                    __typename
+                    sku
+                  }
+                }
+                ...on AssignedSingleCategoryReferenceAttribute{
+                  category_ref: value{
+                    __typename
+                    slug
+                  }
+                }
+                ...on AssignedSingleCollectionReferenceAttribute{
+                  collection_ref: value{
+                    __typename
+                    slug
+                  }
+                }
+                ...on AssignedMultiPageReferenceAttribute{
+                  __typename
+                  pages: value{
+                    __typename
+                    slug
+                  }
+                }
+                ...on AssignedMultiProductReferenceAttribute{
+                  __typename
+                  producs: value{
+                    __typename
+                    slug
+                  }
+                }
+                ...on AssignedMultiProductVariantReferenceAttribute{
+                  __typename
+                  variants: value{
+                    __typename
+                    sku
+                  }
+                }
+                ...on AssignedMultiCategoryReferenceAttribute{
+                  __typename
+                  categories: value{
+                    __typename
+                    slug
+                  }
+                }
+                ...on AssignedMultiCollectionReferenceAttribute{
+                  __typename
+                  collections: value{
+                    __typename
+                    slug
                   }
                 }
               }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -34537,6 +34537,166 @@ type AssignedFileAttribute implements SelectedAttribute {
   value: File
 }
 
+"""
+Represents single page reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedSinglePageReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """Referenced page."""
+  value: Page
+}
+
+"""
+Represents single product reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedSingleProductReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """Referenced product."""
+  value: Product
+}
+
+"""
+Represents single product variant reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedSingleProductVariantReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """Referenced product variant."""
+  value: ProductVariant
+}
+
+"""
+Represents single category reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedSingleCategoryReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """Referenced category."""
+  value: Category
+}
+
+"""
+Represents single collection reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedSingleCollectionReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """Referenced collection."""
+  value: Collection
+}
+
+"""
+Represents multi page reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedMultiPageReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """List of referenced pages."""
+  value: [Page!]
+}
+
+"""
+Represents multi product reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedMultiProductReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """List of referenced products."""
+  value: [Product!]
+}
+
+"""
+Represents multi product variant reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedMultiProductVariantReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """List of referenced product variants."""
+  value: [ProductVariant!]
+}
+
+"""
+Represents multi category reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedMultiCategoryReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """List of referenced categories."""
+  value: [Category!]
+}
+
+"""
+Represents multi collection reference attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedMultiCollectionReferenceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """List of referenced collections."""
+  value: [Collection!]
+}
+
 """_Any value scalar as defined by Federation spec."""
 scalar _Any
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -34630,7 +34630,7 @@ type AssignedMultiPageReferenceAttribute implements SelectedAttribute {
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
   """List of referenced pages."""
-  value: [Page!]
+  value: [Page!]!
 }
 
 """
@@ -34646,7 +34646,7 @@ type AssignedMultiProductReferenceAttribute implements SelectedAttribute {
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
   """List of referenced products."""
-  value: [Product!]
+  value: [Product!]!
 }
 
 """
@@ -34662,7 +34662,7 @@ type AssignedMultiProductVariantReferenceAttribute implements SelectedAttribute 
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
   """List of referenced product variants."""
-  value: [ProductVariant!]
+  value: [ProductVariant!]!
 }
 
 """
@@ -34678,7 +34678,7 @@ type AssignedMultiCategoryReferenceAttribute implements SelectedAttribute {
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
   """List of referenced categories."""
-  value: [Category!]
+  value: [Category!]!
 }
 
 """
@@ -34694,7 +34694,7 @@ type AssignedMultiCollectionReferenceAttribute implements SelectedAttribute {
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
   """List of referenced collections."""
-  value: [Collection!]
+  value: [Collection!]!
 }
 
 """_Any value scalar as defined by Federation spec."""


### PR DESCRIPTION
I want to merge this change because it adds a new assigned refernce types. The new types will provide the possibility to directly fetch the reference details. Something like this:
<img width="503" height="559" alt="image" src="https://github.com/user-attachments/assets/b50219f3-262d-4c00-8c2d-585b5047abae" />

The PR intorduces the new types for references pointing to `Page`, `Product`, `ProductVariant`, `Category`, `Collection`. Including different types for multiple and single references

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
