### PR TITLE
Update query cost map for `referenceTypes` field

### DIFF
--- a/saleor/graphql/core/validators/query_cost.py
+++ b/saleor/graphql/core/validators/query_cost.py
@@ -3,6 +3,7 @@ from operator import add, mul
 from typing import Any, cast
 
 from graphql import (
+    GraphQLArgument,
     GraphQLError,
     GraphQLInterfaceType,
     GraphQLObjectType,
@@ -84,6 +85,8 @@ class CostValidator(ValidationRule):
                     report_error(self.context, e)
                     field_args = {}
 
+                field_args = self.update_empty_args_with_default(field_args, field.args)
+
                 if not self.cost_map:
                     return 0
 
@@ -122,6 +125,17 @@ class CostValidator(ValidationRule):
                 )
             total += node_cost
         return total
+
+    def update_empty_args_with_default(
+        self, field_args: dict[str, Any], args_defs: dict[str, GraphQLArgument]
+    ) -> dict[str, Any]:
+        """Update empty args with default values from argument definition."""
+        for arg_name, value in field_args.items():
+            if value is None and arg_name in args_defs:
+                arg_def = args_defs[arg_name]
+                if arg_def.default_value is not None:
+                    field_args[arg_name] = arg_def.default_value
+        return field_args
 
     def enter_operation_definition(self, node, key, parent, path, ancestors):  # pylint: disable=unused-argument
         if self.cost_map:

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -145,6 +145,7 @@ COST_MAP = {
         "choices": {"complexity": 1, "multipliers": ["first", "last"]},
         "productTypes": {"complexity": 1, "multipliers": ["first", "last"]},
         "productVariantTypes": {"complexity": 1, "multipliers": ["first", "last"]},
+        "referenceTypes": {"complexity": 1, "multipliers": ["limit"]},
     },
     "Category": {
         "ancestors": {"complexity": 1, "multipliers": ["first", "last"]},


### PR DESCRIPTION
Adjust query map. Ensure in case `null` is provided as an argument, the default value is used and query map is calculated properly.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
