### PR TITLE
Allow defining reference types during attribute bulk creation

### DIFF
--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -342,6 +342,19 @@ class AttributeBulkCreate(BaseMutation):
                 cleaned_inputs_map[attribute_index] = None
                 continue
 
+            try:
+                AttributeMixin.validate_reference_types_limit(attribute_data)
+            except ValidationError as e:
+                index_error_map[attribute_index].append(
+                    AttributeBulkCreateError(
+                        path="referenceTypes",
+                        message=e.messages[0],
+                        code=AttributeBulkCreateErrorCode.INVALID.value,
+                    )
+                )
+                cleaned_inputs_map[attribute_index] = None
+                continue
+
             cleaned_input = cls.clean_attribute_input(
                 info,
                 attribute_data,

--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import cast
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -6,7 +7,12 @@ from django.utils.text import slugify
 from graphene.utils.str_converters import to_camel_case
 from text_unidecode import unidecode
 
-from ....attribute import ATTRIBUTE_PROPERTIES_CONFIGURATION, AttributeInputType, models
+from ....attribute import (
+    ATTRIBUTE_PROPERTIES_CONFIGURATION,
+    AttributeEntityType,
+    AttributeInputType,
+    models,
+)
 from ....attribute.error_codes import AttributeBulkCreateErrorCode
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils import prepare_unique_slug
@@ -24,6 +30,7 @@ from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import AttributeTypeEnum
 from ..mutations.attribute_create import AttributeCreateInput, AttributeValueCreateInput
 from ..types import Attribute
+from .mixins import AttributeMixin
 
 ONLY_SWATCH_FIELDS = ["file_url", "content_type", "value"]
 DEPRECATED_ATTR_FIELDS = [
@@ -382,8 +389,9 @@ class AttributeBulkCreate(BaseMutation):
             )
             return None
 
-        input_type = cleaned_input.get("input_type")
         entity_type = cleaned_input.get("entity_type")
+        # set the db default input type if not provided
+        input_type = cleaned_input.get("input_type", AttributeInputType.DROPDOWN)
         if input_type == AttributeInputType.REFERENCE and not entity_type:
             index_error_map[attribute_index].append(
                 AttributeBulkCreateError(
@@ -413,6 +421,19 @@ class AttributeBulkCreate(BaseMutation):
                     )
                 )
                 return None
+
+        entity_type = cast(str, entity_type)
+        try:
+            AttributeMixin.clean_reference_types(cleaned_input, entity_type, input_type)
+        except ValidationError as e:
+            index_error_map[attribute_index].append(
+                AttributeBulkCreateError(
+                    path="referenceTypes",
+                    message=e.messages[0],
+                    code=AttributeBulkCreateErrorCode.INVALID.value,
+                )
+            )
+            return None
 
         # generate slug
         cleaned_input["slug"] = cls._generate_slug(cleaned_input, existing_slugs)
@@ -458,6 +479,8 @@ class AttributeBulkCreate(BaseMutation):
                 continue
 
             values: list = []
+            product_reference_types: list = []
+            page_reference_types: list = []
             values_data = cleaned_input.pop("values", None)
             instance = models.Attribute()
 
@@ -470,6 +493,8 @@ class AttributeBulkCreate(BaseMutation):
                         "instance": instance,
                         "errors": index_error_map[index],
                         "values": values,
+                        "product_reference_types": product_reference_types,
+                        "page_reference_types": page_reference_types,
                     }
                 )
             except ValidationError as exc:
@@ -486,6 +511,10 @@ class AttributeBulkCreate(BaseMutation):
                     {"instance": None, "errors": index_error_map[index]}
                 )
                 continue
+
+            cls.create_reference_types(
+                cleaned_input, instance, product_reference_types, page_reference_types
+            )
 
             if values_data:
                 cls.create_values(instance, values_data, values, index, index_error_map)
@@ -526,11 +555,39 @@ class AttributeBulkCreate(BaseMutation):
                         )
 
     @classmethod
+    def create_reference_types(
+        cls,
+        cleaned_input: dict,
+        attribute: models.Attribute,
+        product_reference_types: list,
+        page_reference_types: list,
+    ):
+        if reference_types_objects := cleaned_input.get("reference_types"):
+            if attribute.entity_type == AttributeEntityType.PAGE:
+                PageReferenceTypeModel = models.Attribute.reference_page_types.through
+                page_reference_types.extend(
+                    PageReferenceTypeModel(attribute=attribute, pagetype=reference_type)
+                    for reference_type in reference_types_objects
+                )
+            else:
+                ProductReferenceTypeModel = (
+                    models.Attribute.reference_product_types.through
+                )
+                product_reference_types.extend(
+                    ProductReferenceTypeModel(
+                        attribute=attribute, producttype=reference_type
+                    )
+                    for reference_type in reference_types_objects
+                )
+
+    @classmethod
     def save(
         cls, instances_data_with_errors_list: list[dict]
     ) -> list[models.Attribute]:
         attributes_to_create: list = []
         values_to_create: list = []
+        product_reference_types_to_create: list = []
+        page_reference_types_to_create: list = []
         for attribute_data in instances_data_with_errors_list:
             attribute = attribute_data["instance"]
 
@@ -542,8 +599,20 @@ class AttributeBulkCreate(BaseMutation):
             if attribute_data["values"]:
                 values_to_create.extend(attribute_data["values"])
 
+            if ref_types := attribute_data["product_reference_types"]:
+                product_reference_types_to_create.extend(ref_types)
+
+            if ref_types := attribute_data["page_reference_types"]:
+                page_reference_types_to_create.extend(ref_types)
+
         models.Attribute.objects.bulk_create(attributes_to_create)
         models.AttributeValue.objects.bulk_create(values_to_create)
+        if product_reference_types_to_create:
+            ReferenceTypeModel = product_reference_types_to_create[0]._meta.model
+            ReferenceTypeModel.objects.bulk_create(product_reference_types_to_create)
+        if page_reference_types_to_create:
+            ReferenceTypeModel = page_reference_types_to_create[0]._meta.model
+            ReferenceTypeModel.objects.bulk_create(page_reference_types_to_create)
 
         return attributes_to_create
 

--- a/saleor/graphql/attribute/mutations/mixins.py
+++ b/saleor/graphql/attribute/mutations/mixins.py
@@ -194,7 +194,11 @@ class AttributeMixin:
             e.code = AttributeErrorCode.REQUIRED.value
             raise ValidationError({"slug": e}) from e
         cls._clean_attribute_settings(instance, cleaned_input)
-        cls.clean_reference_types(cleaned_input, instance)
+
+        entity_type = cleaned_input.get("entity_type") or instance.entity_type
+        input_type = cleaned_input.get("input_type") or instance.input_type
+        entity_type = cast(str, entity_type)
+        cls.clean_reference_types(cleaned_input, entity_type, input_type)
 
         return cleaned_input
 
@@ -219,18 +223,16 @@ class AttributeMixin:
             raise ValidationError(errors)
 
     @classmethod
-    def clean_reference_types(cls, cleaned_input: dict, attribute: models.Attribute):
+    def clean_reference_types(
+        cls, cleaned_input: dict, entity_type: str, input_type: str
+    ):
         """Validate reference types for reference attributes."""
         reference_types = cleaned_input.get("reference_types")
 
         if not reference_types:
             return
 
-        entity_type = cleaned_input.get("entity_type") or attribute.entity_type
-        attribute_input_type = cleaned_input.get("input_type") or attribute.input_type
-        entity_type = cast(str, entity_type)
-
-        cls._validate_reference_input_type(attribute_input_type)
+        cls._validate_reference_input_type(input_type)
         cls._validate_reference_entity_type(entity_type)
         cls._validate_reference_types(reference_types, entity_type)
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_create.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import graphene
+
 from .....attribute.error_codes import AttributeBulkCreateErrorCode
 from .....attribute.models import Attribute, AttributeValue
 from ....core.enums import ErrorPolicyEnum
 from ....tests.utils import get_graphql_content
-from ...enums import AttributeInputTypeEnum, AttributeTypeEnum
+from ...enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 
 ATTRIBUTE_BULK_CREATE_MUTATION = """
     mutation AttributeBulkCreate(
@@ -22,6 +24,17 @@ ATTRIBUTE_BULK_CREATE_MUTATION = """
                     id
                     name
                     slug
+                    entityType
+                    referenceTypes {
+                        ... on ProductType {
+                            id
+                            slug
+                        }
+                        ... on PageType {
+                            id
+                            slug
+                        }
+                    }
                     choices(first: 10) {
                         edges {
                             node {
@@ -646,3 +659,153 @@ def test_attribute_bulk_create_dropdown_with_invalid_row_and_reject_failed_rows(
     choices = data["results"][0]["attribute"]["choices"]["edges"]
     assert choices[0]["node"]["name"] == value_1
     assert choices[0]["node"]["value"] == ""
+
+
+def test_attribute_bulk_create_with_reference_types(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    product_type,
+    page_type,
+):
+    # given
+    attribute_1_name = "Example name 1"
+    attribute_2_name = "Example name 2"
+    ref_product_type_id = graphene.Node.to_global_id("ProductType", product_type.id)
+    ref_page_type_id = graphene.Node.to_global_id("PageType", page_type.id)
+    entity_type_1 = AttributeEntityTypeEnum.PRODUCT.name
+    entity_type_2 = AttributeEntityTypeEnum.PAGE.name
+
+    attributes = [
+        {
+            "name": attribute_1_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "inputType": AttributeInputTypeEnum.REFERENCE.name,
+            "entityType": entity_type_1,
+            "referenceTypes": [ref_product_type_id],
+        },
+        {
+            "name": attribute_2_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "inputType": AttributeInputTypeEnum.SINGLE_REFERENCE.name,
+            "entityType": entity_type_2,
+            "referenceTypes": [ref_page_type_id],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes
+    )
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_BULK_CREATE_MUTATION,
+        {"attributes": attributes},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["attributeBulkCreate"]
+
+    # then
+    attributes = Attribute.objects.all()
+
+    assert not data["results"][0]["errors"]
+    assert not data["results"][1]["errors"]
+    assert data["count"] == 2
+    assert data["results"][0]["attribute"]["name"] == attribute_1_name
+    assert data["results"][1]["attribute"]["name"] == attribute_2_name
+    assert data["results"][0]["attribute"]["entityType"] == entity_type_1
+    assert data["results"][1]["attribute"]["entityType"] == entity_type_2
+    assert len(data["results"][0]["attribute"]["referenceTypes"]) == 1
+    assert len(data["results"][1]["attribute"]["referenceTypes"]) == 1
+
+    assert (
+        data["results"][0]["attribute"]["referenceTypes"][0]["id"]
+        == ref_product_type_id
+    )
+    assert (
+        data["results"][1]["attribute"]["referenceTypes"][0]["id"] == ref_page_type_id
+    )
+
+
+@patch("saleor.graphql.attribute.mutations.mixins.REFERENCE_TYPES_LIMIT", 1)
+def test_attribute_bulk_create_with_invalid_reference_types(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    product_type,
+    page_type,
+    page_type_list,
+):
+    # given
+    attribute_1_name = "Example name 1"
+    attribute_2_name = "Example name 2"
+    ref_product_type_id = graphene.Node.to_global_id("ProductType", product_type.id)
+    ref_page_type_id = graphene.Node.to_global_id("PageType", page_type.id)
+
+    attributes = [
+        {
+            "name": attribute_1_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "inputType": AttributeInputTypeEnum.REFERENCE.name,
+            "entityType": AttributeEntityTypeEnum.PRODUCT.name,
+            # should be a list of page types
+            "referenceTypes": [ref_page_type_id],
+        },
+        {
+            "name": attribute_2_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "inputType": AttributeInputTypeEnum.SINGLE_REFERENCE.name,
+            "entityType": AttributeEntityTypeEnum.PAGE.name,
+            # should be a list of product types
+            "referenceTypes": [ref_product_type_id],
+        },
+        {
+            "name": attribute_2_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "inputType": AttributeInputTypeEnum.SINGLE_REFERENCE.name,
+            "entityType": AttributeEntityTypeEnum.PAGE.name,
+            # limit exceeded
+            "referenceTypes": [
+                graphene.Node.to_global_id("PageType", p_type.id)
+                for p_type in page_type_list
+            ],
+        },
+        {
+            "name": attribute_2_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            "inputType": AttributeInputTypeEnum.SINGLE_REFERENCE.name,
+            # invalid entity type
+            "entityType": AttributeEntityTypeEnum.COLLECTION.name,
+            "referenceTypes": [ref_product_type_id],
+        },
+        {
+            "name": attribute_2_name,
+            "type": AttributeTypeEnum.PRODUCT_TYPE.name,
+            # invalid input type
+            "inputType": AttributeInputTypeEnum.DROPDOWN.name,
+            "referenceTypes": [ref_product_type_id],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes
+    )
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_BULK_CREATE_MUTATION,
+        {"attributes": attributes},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["attributeBulkCreate"]
+
+    # then
+    attributes = Attribute.objects.all()
+
+    assert data["count"] == 0
+    assert data["results"][0]["errors"]
+    assert data["results"][1]["errors"]
+    assert data["results"][2]["errors"]
+    assert data["results"][3]["errors"]
+    assert data["results"][4]["errors"]
+
+    for result in data["results"]:
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["code"] == AttributeBulkCreateErrorCode.INVALID.name
+        assert result["errors"][0]["path"] == "referenceTypes"

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_create.py
@@ -745,7 +745,7 @@ def test_attribute_bulk_create_with_invalid_reference_types(
             "type": AttributeTypeEnum.PRODUCT_TYPE.name,
             "inputType": AttributeInputTypeEnum.REFERENCE.name,
             "entityType": AttributeEntityTypeEnum.PRODUCT.name,
-            # should be a list of page types
+            # should be a list of product types
             "referenceTypes": [ref_page_type_id],
         },
         {
@@ -753,7 +753,7 @@ def test_attribute_bulk_create_with_invalid_reference_types(
             "type": AttributeTypeEnum.PRODUCT_TYPE.name,
             "inputType": AttributeInputTypeEnum.SINGLE_REFERENCE.name,
             "entityType": AttributeEntityTypeEnum.PAGE.name,
-            # should be a list of product types
+            # should be a list of page types
             "referenceTypes": [ref_product_type_id],
         },
         {


### PR DESCRIPTION
Allow setting `referenceTypes` for reference attributes in `AttributeBulkCreate`


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
