### PR TITLE
Allow defining reference types during attribute bulk update

### DIFF
--- a/saleor/attribute/lock_objects.py
+++ b/saleor/attribute/lock_objects.py
@@ -12,10 +12,10 @@ def attribute_value_qs_select_for_update() -> QuerySet[AttributeValue]:
 def attribute_reference_product_types_qs_select_for_update() -> QuerySet:
     return Attribute.reference_product_types.through.objects.order_by(
         "pk"
-    ).select_for_update(of=("self"))
+    ).select_for_update(of=["self"])
 
 
 def attribute_reference_page_types_qs_select_for_update() -> QuerySet:
     return Attribute.reference_page_types.through.objects.order_by(
         "pk"
-    ).select_for_update(of=("self"))
+    ).select_for_update(of=["self"])

--- a/saleor/attribute/lock_objects.py
+++ b/saleor/attribute/lock_objects.py
@@ -1,9 +1,21 @@
 from django.db.models import QuerySet
 
-from .models.base import AttributeValue
+from .models.base import Attribute, AttributeValue
 
 
 def attribute_value_qs_select_for_update() -> QuerySet[AttributeValue]:
     return AttributeValue.objects.order_by("sort_order", "pk").select_for_update(
         of=(["self"])
     )
+
+
+def attribute_reference_product_types_qs_select_for_update() -> QuerySet:
+    return Attribute.reference_product_types.through.objects.order_by(
+        "pk"
+    ).select_for_update(of=("self"))
+
+
+def attribute_reference_page_types_qs_select_for_update() -> QuerySet:
+    return Attribute.reference_page_types.through.objects.order_by(
+        "pk"
+    ).select_for_update(of=("self"))

--- a/saleor/attribute/tests/fixtures/attribute.py
+++ b/saleor/attribute/tests/fixtures/attribute.py
@@ -577,8 +577,8 @@ def swatch_attribute(db):
 @pytest.fixture
 def product_type_page_reference_attribute(db):
     return Attribute.objects.create(
-        slug="page-reference",
-        name="Page reference",
+        slug="product-page-reference",
+        name="Product page reference",
         type=AttributeType.PRODUCT_TYPE,
         input_type=AttributeInputType.REFERENCE,
         entity_type=AttributeEntityType.PAGE,

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -243,6 +243,19 @@ class AttributeBulkUpdate(BaseMutation):
                 cleaned_inputs_map[attribute_index] = None
                 continue
 
+            try:
+                AttributeMixin.validate_reference_types_limit(attribute_data.fields)
+            except ValidationError as e:
+                index_error_map[attribute_index].append(
+                    AttributeBulkUpdateError(
+                        path="referenceTypes",
+                        message=e.messages[0],
+                        code=AttributeBulkUpdateErrorCode.INVALID.value,
+                    )
+                )
+                cleaned_inputs_map[attribute_index] = None
+                continue
+
             cleaned_input = cls.clean_attribute_input(
                 info,
                 attribute_data,

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from dataclasses import dataclass, field
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -9,9 +10,13 @@ from graphene.utils.str_converters import to_camel_case
 from graphql.error import GraphQLError
 from text_unidecode import unidecode
 
-from ....attribute import models
+from ....attribute import AttributeEntityType, models
 from ....attribute.error_codes import AttributeBulkUpdateErrorCode
-from ....attribute.lock_objects import attribute_value_qs_select_for_update
+from ....attribute.lock_objects import (
+    attribute_reference_page_types_qs_select_for_update,
+    attribute_reference_product_types_qs_select_for_update,
+    attribute_value_qs_select_for_update,
+)
 from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.utils import get_webhooks_for_event
@@ -38,6 +43,15 @@ from ..enums import AttributeTypeEnum
 from ..types import Attribute
 from .attribute_bulk_create import DEPRECATED_ATTR_FIELDS, clean_values
 from .attribute_update import AttributeUpdateInput
+from .mixins import AttributeMixin
+
+
+@dataclass
+class ReferenceTypeUpdateData:
+    create_product_reference_types: list[tuple[int, int]] = field(default_factory=list)
+    create_page_reference_types: list[tuple[int, int]] = field(default_factory=list)
+    delete_product_reference_types: list[tuple[int, int]] = field(default_factory=list)
+    delete_page_reference_types: list[tuple[int, int]] = field(default_factory=list)
 
 
 class AttributeBulkUpdateResult(BaseObjectType):
@@ -295,6 +309,26 @@ class AttributeBulkUpdate(BaseMutation):
         return values_existing_external_refs, duplicated_values_external_ref
 
     @classmethod
+    def get_existing_reference_types(cls, cleaned_inputs_map: dict) -> dict[int, set]:
+        existing_reference_types = defaultdict(set)
+        ReferenceProductType = models.Attribute.reference_product_types.through
+        ReferencePageType = models.Attribute.reference_page_types.through
+        attr_ids = [
+            cleaned_input["instance"].pk
+            for cleaned_input in cleaned_inputs_map.values()
+            if cleaned_input and "instance" in cleaned_input
+        ]
+        for attr_id, product_type_id in ReferenceProductType.objects.filter(
+            attribute_id__in=attr_ids
+        ).values_list("attribute_id", "producttype_id"):
+            existing_reference_types[attr_id].add(product_type_id)
+        for attr_id, page_type_id in ReferencePageType.objects.filter(
+            attribute_id__in=attr_ids
+        ).values_list("attribute_id", "pagetype_id"):
+            existing_reference_types[attr_id].add(page_type_id)
+        return existing_reference_types
+
+    @classmethod
     def clean_attribute_input(
         cls,
         info: ResolveInfo,
@@ -344,6 +378,20 @@ class AttributeBulkUpdate(BaseMutation):
         attribute_data["fields"] = DeprecatedModelMutation.clean_input(
             info, None, attribute_data.fields, input_cls=AttributeUpdateInput
         )
+
+        try:
+            AttributeMixin.clean_reference_types(
+                attribute_data["fields"], attr.entity_type, attr.input_type
+            )
+        except ValidationError as e:
+            index_error_map[attribute_index].append(
+                AttributeBulkUpdateError(
+                    path="referenceTypes",
+                    message=e.messages[0],
+                    code=AttributeBulkUpdateErrorCode.INVALID.value,
+                )
+            )
+            return None
 
         if remove_values:
             cleaned_remove_values = cls.clean_remove_values(
@@ -412,6 +460,7 @@ class AttributeBulkUpdate(BaseMutation):
         cleaned_inputs_map: dict[int, dict],
         error_policy: str,
         index_error_map: dict[int, list[AttributeBulkUpdateError]],
+        existing_reference_types_map: dict[int, set],
     ) -> list[dict]:
         instances_data_and_errors_list: list[dict] = []
 
@@ -446,12 +495,18 @@ class AttributeBulkUpdate(BaseMutation):
                     )
                     continue
 
+            reference_types_update_data = cls.create_reference_types(
+                attr,
+                existing_reference_types_map.get(attr.pk, set()),
+                fields,
+            )
             data = {
                 "instance": attr,
                 "errors": index_error_map[index],
                 "remove_values": remove_values,
                 "add_values": [],
                 "attribute_updated": True if fields else False,
+                "reference_types_updated": reference_types_update_data,
             }
 
             if add_values:
@@ -495,6 +550,38 @@ class AttributeBulkUpdate(BaseMutation):
                             )
                         )
         return values
+
+    @classmethod
+    def create_reference_types(
+        cls,
+        attribute: models.Attribute,
+        existing_reference_types: set[int],
+        cleaned_input: dict,
+    ) -> ReferenceTypeUpdateData:
+        if "reference_types" not in cleaned_input:
+            return ReferenceTypeUpdateData()
+        reference_type_ids = [
+            ref_type.id for ref_type in cleaned_input["reference_types"]
+        ]
+        to_create = set(reference_type_ids) - existing_reference_types
+        to_delete = existing_reference_types - set(reference_type_ids)
+        if attribute.entity_type == AttributeEntityType.PAGE:
+            return ReferenceTypeUpdateData(
+                create_page_reference_types=[
+                    (attribute.pk, reference_type) for reference_type in to_create
+                ],
+                delete_page_reference_types=[
+                    (attribute.pk, reference_type) for reference_type in to_delete
+                ],
+            )
+        return ReferenceTypeUpdateData(
+            create_product_reference_types=[
+                (attribute.pk, reference_type) for reference_type in to_create
+            ],
+            delete_product_reference_types=[
+                (attribute.pk, reference_type) for reference_type in to_delete
+            ],
+        )
 
     @classmethod
     def get_attributes(
@@ -559,6 +646,10 @@ class AttributeBulkUpdate(BaseMutation):
         values_to_create: list = []
         values_to_remove: list = []
         updated_attributes: list = []
+        create_product_reference_types: list = []
+        create_page_reference_types: list = []
+        delete_product_reference_types_lookup: Q = Q()
+        delete_page_reference_types_lookup: Q = Q()
 
         for attribute_data in instances_data_with_errors_list:
             attribute = attribute_data["instance"]
@@ -573,6 +664,16 @@ class AttributeBulkUpdate(BaseMutation):
 
             values_to_remove.extend(attribute_data["remove_values"])
             values_to_create.extend(attribute_data["add_values"])
+
+            delete_product_ref, delete_page_ref = (
+                cls._prepare_reference_types_for_saving(
+                    attribute_data["reference_types_updated"],
+                    create_product_reference_types,
+                    create_page_reference_types,
+                )
+            )
+            delete_product_reference_types_lookup |= delete_product_ref
+            delete_page_reference_types_lookup |= delete_page_ref
 
         with transaction.atomic():
             models.Attribute.objects.bulk_update(
@@ -597,8 +698,89 @@ class AttributeBulkUpdate(BaseMutation):
 
             models.AttributeValue.objects.bulk_create(values_to_create)
 
+            cls._save_reference_types(
+                create_product_reference_types,
+                create_page_reference_types,
+                delete_product_reference_types_lookup,
+                delete_page_reference_types_lookup,
+            )
+
         updated_attributes.extend(attributes_to_update)
         return updated_attributes, values_to_remove, values_to_create
+
+    @classmethod
+    def _prepare_reference_types_for_saving(
+        cls,
+        reference_update_data: ReferenceTypeUpdateData,
+        create_product_reference_types: list,
+        create_page_reference_types: list,
+    ) -> tuple[Q, Q]:
+        ModelProductReferenceType = models.Attribute.reference_product_types.through
+        ModelPageReferenceType = models.Attribute.reference_page_types.through
+        create_product_reference_types.extend(
+            ModelProductReferenceType(
+                attribute_id=attr_id,
+                producttype_id=product_type_id,
+            )
+            for attr_id, product_type_id in reference_update_data.create_product_reference_types
+        )
+        create_page_reference_types.extend(
+            ModelPageReferenceType(
+                attribute_id=attr_id,
+                pagetype_id=page_type_id,
+            )
+            for attr_id, page_type_id in reference_update_data.create_page_reference_types
+        )
+
+        delete_product_reference_types_lookup = Q()
+        delete_page_reference_types_lookup = Q()
+        for (
+            attr_id,
+            product_type_id,
+        ) in reference_update_data.delete_product_reference_types:
+            delete_product_reference_types_lookup |= Q(
+                attribute_id=attr_id,
+                producttype_id=product_type_id,
+            )
+        for attr_id, page_type_id in reference_update_data.delete_page_reference_types:
+            delete_page_reference_types_lookup |= Q(
+                attribute_id=attr_id,
+                pagetype_id=page_type_id,
+            )
+        return delete_product_reference_types_lookup, delete_page_reference_types_lookup
+
+    @classmethod
+    def _save_reference_types(
+        cls,
+        create_product_reference_types: list,
+        create_page_reference_types: list,
+        delete_product_reference_types_lookup: Q,
+        delete_page_reference_types_lookup: Q,
+    ):
+        ModelProductReferenceType = models.Attribute.reference_product_types.through
+        ModelPageReferenceType = models.Attribute.reference_page_types.through
+
+        if create_product_reference_types:
+            ModelProductReferenceType.objects.bulk_create(
+                create_product_reference_types
+            )
+        if create_page_reference_types:
+            ModelPageReferenceType.objects.bulk_create(create_page_reference_types)
+
+        if delete_product_reference_types_lookup:
+            locked_ref_product_types = (
+                attribute_reference_product_types_qs_select_for_update().filter(
+                    delete_product_reference_types_lookup
+                )
+            )
+            locked_ref_product_types.delete()
+        if delete_page_reference_types_lookup:
+            locked_ref_page_types = (
+                attribute_reference_page_types_qs_select_for_update().filter(
+                    delete_page_reference_types_lookup
+                )
+            )
+            locked_ref_page_types.delete()
 
     @classmethod
     def post_save_actions(
@@ -629,8 +811,15 @@ class AttributeBulkUpdate(BaseMutation):
         cleaned_inputs_map = cls.clean_attributes(
             info, data["attributes"], index_error_map
         )
+        existing_reference_types_map = cls.get_existing_reference_types(
+            cleaned_inputs_map
+        )
         instances_data_with_errors_list = cls.update_attributes(
-            info, cleaned_inputs_map, error_policy, index_error_map
+            info,
+            cleaned_inputs_map,
+            error_policy,
+            index_error_map,
+            existing_reference_types_map,
         )
 
         # check if errors occurred

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -781,19 +781,23 @@ class AttributeBulkUpdate(BaseMutation):
             ModelPageReferenceType.objects.bulk_create(create_page_reference_types)
 
         if delete_product_reference_types_lookup:
-            locked_ref_product_types = (
+            _locked_ref_product_types = list(
                 attribute_reference_product_types_qs_select_for_update().filter(
                     delete_product_reference_types_lookup
                 )
             )
-            locked_ref_product_types.delete()
+            ModelProductReferenceType.objects.filter(
+                delete_product_reference_types_lookup
+            ).delete()
         if delete_page_reference_types_lookup:
-            locked_ref_page_types = (
+            _locked_ref_page_types = list(
                 attribute_reference_page_types_qs_select_for_update().filter(
                     delete_page_reference_types_lookup
                 )
             )
-            locked_ref_page_types.delete()
+            ModelPageReferenceType.objects.filter(
+                delete_page_reference_types_lookup
+            ).delete()
 
     @classmethod
     def post_save_actions(

--- a/saleor/graphql/attribute/mutations/mixins.py
+++ b/saleor/graphql/attribute/mutations/mixins.py
@@ -194,7 +194,6 @@ class AttributeMixin:
             e.code = AttributeErrorCode.REQUIRED.value
             raise ValidationError({"slug": e}) from e
         cls._clean_attribute_settings(instance, cleaned_input)
-
         entity_type = cleaned_input.get("entity_type") or instance.entity_type
         input_type = cleaned_input.get("input_type") or instance.input_type
         entity_type = cast(str, entity_type)

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
@@ -23,6 +23,17 @@ ATTRIBUTE_BULK_UPDATE_MUTATION = """
                     id
                     name
                     slug
+                    entityType
+                    referenceTypes {
+                        ... on ProductType {
+                            id
+                            slug
+                        }
+                        ... on PageType {
+                            id
+                            slug
+                        }
+                    }
                     choices(first: 10) {
                         edges {
                             node {
@@ -880,3 +891,93 @@ def test_attribute_bulk_update_add_value_missing_name(
     assert errors[0]["code"] == AttributeBulkUpdateErrorCode.REQUIRED.name
     assert errors[1]["path"] == "addValues.1.name"
     assert errors[1]["code"] == AttributeBulkUpdateErrorCode.REQUIRED.name
+
+
+def test_attribute_bulk_update_reference_types(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_page_types_and_attributes,
+    product_type_product_single_reference_attribute,
+    product_type_variant_single_reference_attribute,
+    product_type_page_reference_attribute,
+    page_type_page_reference_attribute,
+    page_type_list,
+    product_type,
+):
+    # given
+    product_type_variant_single_reference_attribute.reference_product_types.add(
+        product_type
+    )
+    product_type_page_reference_attribute.reference_page_types.add(page_type_list[0])
+    page_type_page_reference_attribute.reference_page_types.add(page_type_list[1])
+
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.id)
+    page_type_ids = [
+        graphene.Node.to_global_id("PageType", page_type.id)
+        for page_type in page_type_list
+    ]
+    attributes = [
+        # set reference types
+        {
+            "id": graphene.Node.to_global_id(
+                "Attribute", product_type_product_single_reference_attribute.id
+            ),
+            "fields": {"referenceTypes": [product_type_id]},
+        },
+        # clear product reference types
+        {
+            "id": graphene.Node.to_global_id(
+                "Attribute", product_type_variant_single_reference_attribute.id
+            ),
+            "fields": {"referenceTypes": []},
+        },
+        # change reference types
+        {
+            "id": graphene.Node.to_global_id(
+                "Attribute", product_type_page_reference_attribute.id
+            ),
+            "fields": {"referenceTypes": page_type_ids[1:]},
+        },
+        # clear page reference types
+        {
+            "id": graphene.Node.to_global_id(
+                "Attribute", page_type_page_reference_attribute.id
+            ),
+            "fields": {"referenceTypes": []},
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes,
+        permission_manage_page_types_and_attributes,
+    )
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_BULK_UPDATE_MUTATION,
+        {"attributes": attributes},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["attributeBulkUpdate"]
+
+    # then
+    assert len(attributes) == 4
+    assert not data["results"][0]["errors"]
+    assert not data["results"][1]["errors"]
+    assert not data["results"][2]["errors"]
+    assert not data["results"][3]["errors"]
+    assert data["count"] == 4
+    assert len(data["results"][0]["attribute"]["referenceTypes"]) == 1
+    assert len(data["results"][1]["attribute"]["referenceTypes"]) == 0
+    assert (
+        len(data["results"][2]["attribute"]["referenceTypes"])
+        == len(page_type_list) - 1
+    )
+    assert len(data["results"][3]["attribute"]["referenceTypes"]) == 0
+
+    assert data["results"][0]["attribute"]["referenceTypes"][0]["id"] == product_type_id
+    assert {
+        ref_type["id"] for ref_type in data["results"][2]["attribute"]["referenceTypes"]
+    } == set(page_type_ids[1:])
+
+
+# TODO: add test with invalid reference types

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
@@ -979,6 +979,23 @@ def test_attribute_bulk_update_reference_types(
         ref_type["id"] for ref_type in data["results"][2]["attribute"]["referenceTypes"]
     } == set(page_type_ids[1:])
 
+    product_type_product_single_reference_attribute.refresh_from_db()
+    assert (
+        product_type_product_single_reference_attribute.reference_product_types.count()
+        == 1
+    )
+    product_type_variant_single_reference_attribute.refresh_from_db()
+    assert (
+        product_type_variant_single_reference_attribute.reference_product_types.count()
+        == 0
+    )
+    product_type_page_reference_attribute.refresh_from_db()
+    assert product_type_page_reference_attribute.reference_page_types.count() == len(
+        page_type_ids[1:]
+    )
+    page_type_page_reference_attribute.refresh_from_db()
+    assert page_type_page_reference_attribute.reference_page_types.count() == 0
+
 
 @patch("saleor.graphql.attribute.mutations.mixins.REFERENCE_TYPES_LIMIT", 1)
 def test_attribute_bulk_update_invalid_reference_types(

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_pages.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_pages.py
@@ -83,7 +83,7 @@ def test_products_query_with_attr_slug_and_attribute_value_reference_to_pages(
         "where": {
             "attributes": [
                 {
-                    "slug": "page-reference",
+                    "slug": "product-page-reference",
                     "value": {
                         "reference": {
                             "pageSlugs": {

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_references_pages.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_references_pages.py
@@ -81,7 +81,7 @@ def test_product_variants_query_with_attr_slug_and_attribute_value_reference_to_
         "where": {
             "attributes": [
                 {
-                    "slug": "page-reference",
+                    "slug": "product-page-reference",
                     "value": {
                         "reference": {
                             "pageSlugs": {

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -452,6 +452,7 @@ LOGGING = {
     },
 }
 
+
 AUTH_USER_MODEL = "account.User"
 
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
Allow setting `referenceTypes` for reference attributes in `AttributeBulkUpdate`


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
