### PR TITLE
Prevent sending sync webhook if the previous one timed out recently

### DIFF
--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -61,7 +61,7 @@ from ...payment.utils import (
 )
 from ...settings import WEBHOOK_SYNC_TIMEOUT
 from ...thumbnail.models import Thumbnail
-from ...webhook.const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
+from ...webhook.const import WEBHOOK_CACHE_DEFAULT_TTL
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...webhook.payloads import (
     generate_checkout_payload,
@@ -2801,7 +2801,7 @@ class WebhookPlugin(BasePlugin):
                     self.allow_replica,
                     subscribable_object=list_payment_method_data,
                     request_timeout=WEBHOOK_SYNC_TIMEOUT,
-                    cache_timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+                    cache_timeout=WEBHOOK_CACHE_DEFAULT_TTL,
                     requestor=self.requestor,
                 )
                 if response_data:

--- a/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
+++ b/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
@@ -6,7 +6,7 @@ import graphene
 from ....core.models import EventDelivery
 from ....payment.interface import ListStoredPaymentMethodsRequestData
 from ....settings import WEBHOOK_SYNC_TIMEOUT
-from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
+from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TTL
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.tests.subscription_webhooks.subscription_queries import (
     LIST_STORED_PAYMENT_METHODS as LIST_STORED_PAYMENT_METHODS_SUBSCRIPTION,
@@ -79,7 +79,7 @@ def test_list_stored_payment_methods_with_static_payload(
     mocked_cache_set.assert_called_once_with(
         expected_cache_key,
         webhook_list_stored_payment_methods_response,
-        timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+        timeout=WEBHOOK_CACHE_DEFAULT_TTL,
     )
 
     assert response
@@ -238,7 +238,7 @@ def test_list_stored_payment_methods_with_subscription_payload(
     mocked_cache_set.assert_called_once_with(
         expected_cache_key,
         webhook_list_stored_payment_methods_response,
-        timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+        timeout=WEBHOOK_CACHE_DEFAULT_TTL,
     )
 
     assert response

--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -13,7 +13,7 @@ from ....payment.interface import (
     PaymentMethodTokenizationResult,
 )
 from ....settings import WEBHOOK_SYNC_TIMEOUT
-from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
+from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TTL
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
 from ....webhook.transport.utils import (
@@ -495,7 +495,7 @@ def test_expected_result_invalidates_cache_for_app(
     mocked_cache_set.assert_called_once_with(
         expected_cache_key,
         list_stored_payment_methods_response,
-        timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+        timeout=WEBHOOK_CACHE_DEFAULT_TTL,
     )
 
     # when

--- a/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
@@ -12,7 +12,7 @@ from ....payment.interface import (
     PaymentMethodTokenizationResult,
 )
 from ....settings import WEBHOOK_SYNC_TIMEOUT
-from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
+from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TTL
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
 from ....webhook.transport.utils import (
@@ -512,7 +512,7 @@ def test_expected_result_invalidates_cache_for_app(
     mocked_cache_set.assert_called_once_with(
         expected_cache_key,
         list_stored_payment_methods_response,
-        timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+        timeout=WEBHOOK_CACHE_DEFAULT_TTL,
     )
 
     # when

--- a/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
@@ -12,7 +12,7 @@ from ....payment.interface import (
     StoredPaymentMethodRequestDeleteResult,
 )
 from ....settings import WEBHOOK_SYNC_TIMEOUT
-from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
+from ....webhook.const import WEBHOOK_CACHE_DEFAULT_TTL
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
 from ....webhook.transport.utils import (
@@ -436,7 +436,7 @@ def test_stored_payment_method_request_delete_invalidates_cache_for_app(
     mocked_cache_set.assert_called_once_with(
         expected_cache_key,
         list_stored_payment_methods_response,
-        timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+        timeout=WEBHOOK_CACHE_DEFAULT_TTL,
     )
 
     # when

--- a/saleor/webhook/const.py
+++ b/saleor/webhook/const.py
@@ -1,5 +1,9 @@
 CACHE_EXCLUDED_SHIPPING_TIME = 60 * 3
-WEBHOOK_CACHE_DEFAULT_TIMEOUT: int = 5 * 60  # 5 minutes
+WEBHOOK_CACHE_DEFAULT_TTL: int = 5 * 60  # 5 minutes
+SYNC_WEBHOOK_TIMEOUT_CACHE_TTL: int = 1  # 1 second
+SYNC_WEBHOOK_TIMEOUT_SENTINEL = (
+    "TIMED_OUT"  # Arbitrary value to indicate webhook timeout in cache
+)
 APP_ID_PREFIX = "app"
 
 MAX_FILTERABLE_CHANNEL_SLUGS_LIMIT = 500


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
