### PR TITLE
Add page reference attributes to product search

### DIFF
--- a/saleor/core/utils/tests/test_update_mutation_manager.py
+++ b/saleor/core/utils/tests/test_update_mutation_manager.py
@@ -1,0 +1,102 @@
+from ....order import OrderStatus
+from ..update_mutation_manager import InstanceTracker
+
+
+def test_instance_tracker(product):
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(product, fields_to_track)
+
+    # when
+    product.name = product.name + "_updated"
+    modified_field = tracker.get_modified_fields()
+
+    # then
+    assert modified_field == ["name"]
+
+
+def test_instance_tracker_no_instance_on_init(product):
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(None, fields_to_track)
+
+    # when
+    tracker.instance = product
+    modified_fields = tracker.get_modified_fields()
+
+    # then
+    assert modified_fields == fields_to_track
+
+
+def test_instance_tracker_no_instance_on_init_and_on_get_modified_fields():
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(None, fields_to_track)
+
+    # when
+    modified_fields = tracker.get_modified_fields()
+
+    # then
+    assert modified_fields == []
+
+
+def test_instance_tracker_remove_instance(product):
+    # given
+    fields_to_track = ["name", "slug"]
+    tracker = InstanceTracker(product, fields_to_track)
+
+    # when
+    tracker.instance = None
+    modified_fields = tracker.get_modified_fields()
+
+    # then
+    assert modified_fields == fields_to_track
+
+
+def test_instance_tracker_foreign_relation(order_with_lines):
+    # given
+    order = order_with_lines
+    fields_to_track = ["status", "shipping_address", "billing_address"]
+    foreign_fields_to_track = ["last_name", "first_name"]
+    tracker = InstanceTracker(
+        order,
+        fields_to_track,
+        foreign_fields_to_track={"shipping_address": foreign_fields_to_track},
+    )
+
+    order.status = OrderStatus.FULFILLED
+    shipping_address = order.shipping_address
+    shipping_address.last_name = "new_last_name"
+
+    # when
+    modified_fields = tracker.get_modified_fields()
+    foreign_modified_fields = tracker.get_foreign_modified_fields()
+
+    # then
+    assert modified_fields == ["status", "shipping_address"]
+    assert foreign_modified_fields["shipping_address"] == ["last_name"]
+
+
+def test_instance_tracker_foreign_relation_new_instance(order_with_lines):
+    # given
+    order = order_with_lines
+    order.shipping_address = None
+
+    fields_to_track = ["status", "shipping_address", "billing_address"]
+    foreign_fields_to_track = ["last_name", "first_name"]
+    tracker = InstanceTracker(
+        order,
+        fields_to_track,
+        foreign_fields_to_track={"shipping_address": foreign_fields_to_track},
+    )
+
+    order.status = OrderStatus.FULFILLED
+    order.shipping_address = order.billing_address
+
+    # when
+    modified_fields = tracker.get_modified_fields()
+    foreign_modified_fields = tracker.get_foreign_modified_fields()
+
+    # then
+    assert modified_fields == ["status", "shipping_address"]
+    assert foreign_modified_fields["shipping_address"] == foreign_fields_to_track

--- a/saleor/core/utils/update_mutation_manager.py
+++ b/saleor/core/utils/update_mutation_manager.py
@@ -1,0 +1,70 @@
+from copy import deepcopy
+from typing import Any, TypeVar
+
+from django.db.models import Model
+
+T = TypeVar("T", bound=Model)
+
+
+class InstanceTracker:
+    """Instance with modifications tracker.
+
+    It is used to determine modified fields of the instance.
+    """
+
+    def __init__(
+        self,
+        instance: T | None,
+        fields_to_track: list[str],
+        foreign_fields_to_track: dict[str, list[str]] | None = None,
+    ):
+        self.instance = instance
+        self.fields_to_track = fields_to_track
+        self.initial_instance_values: dict[str, Any] = (
+            deepcopy(self.get_field_values()) if instance else {}
+        )
+        self.foreign_instance_relation: dict[str, InstanceTracker] = {}
+        self.create = instance is None
+
+        if foreign_fields_to_track:
+            for lookup, fields in foreign_fields_to_track.items():
+                foreign_instance = getattr(instance, lookup, None)
+                self.foreign_instance_relation[lookup] = InstanceTracker(
+                    foreign_instance,
+                    fields,
+                    None,
+                )
+
+    def get_field_values(self) -> dict[str, Any]:
+        """Create a dict of tracked fields with related instance values."""
+        if not self.instance:
+            return {}
+
+        return {field: getattr(self.instance, field) for field in self.fields_to_track}
+
+    def get_modified_fields(self) -> list[str]:
+        """Compare updated instance values with initial ones.
+
+        Raise exception when instance is None.
+        """
+        if not self.initial_instance_values:
+            if self.instance:
+                return self.fields_to_track
+            return []
+
+        modified_instance_values: dict[str, Any] = self.get_field_values()
+        return [
+            field
+            for field in self.initial_instance_values
+            if self.initial_instance_values.get(field)
+            != modified_instance_values.get(field)
+        ]
+
+    def get_foreign_modified_fields(self) -> dict[str, list[str]]:
+        modified_fields = {}
+        for lookup, tracker in self.foreign_instance_relation.items():
+            tracker.instance = getattr(self.instance, lookup, None)
+            foreign_modified = tracker.get_modified_fields()
+            if foreign_modified:
+                modified_fields[lookup] = foreign_modified
+        return modified_fields

--- a/saleor/graphql/account/mutations/account/account_address_create.py
+++ b/saleor/graphql/account/mutations/account/account_address_create.py
@@ -100,7 +100,7 @@ class AccountAddressCreate(
         return AccountAddressCreate(user=user, address=address)
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         user = cleaned_input.pop("user")
         super().save(info, instance, cleaned_input)
         remove_the_oldest_user_address_if_address_limit_is_reached(user)

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -97,7 +97,13 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
 
     @classmethod
     @traced_atomic_transaction()
-    def save(cls, info: ResolveInfo, instance: models.User, cleaned_input):
+    def save(
+        cls,
+        info: ResolveInfo,
+        instance: models.User,
+        cleaned_input,
+        instance_tracker=None,
+    ):
         manager = get_plugin_manager_promise(info.context).get()
 
         cls.save_default_addresses(cleaned_input=cleaned_input, user_instance=instance)

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -99,7 +99,7 @@ class CustomerCreate(BaseCustomerCreate):
 
     @classmethod
     @traced_atomic_transaction()
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         addresses_to_set_on_user = []
         if default_shipping_address := cleaned_input.get(SHIPPING_ADDRESS_FIELD):
             addresses_to_set_on_user.append(default_shipping_address)

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -166,7 +166,7 @@ class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
 
     @classmethod
     @traced_atomic_transaction()
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         manager = get_plugin_manager_promise(info.context).get()
 
         cls.save_default_addresses(

--- a/saleor/graphql/app/mutations/app_create.py
+++ b/saleor/graphql/app/mutations/app_create.py
@@ -90,7 +90,7 @@ class AppCreate(DeprecatedModelMutation):
         return response
 
     @classmethod
-    def save(cls, info, instance, cleaned_input):
+    def save(cls, info, instance, cleaned_input, instance_tracker=None):
         instance.save()
         if not instance.identifier:
             instance.identifier = graphene.Node.to_global_id("App", instance.pk)

--- a/saleor/graphql/app/mutations/app_retry_install.py
+++ b/saleor/graphql/app/mutations/app_retry_install.py
@@ -38,7 +38,9 @@ class AppRetryInstall(DeprecatedModelMutation):
         ]
 
     @classmethod
-    def save(cls, _info: ResolveInfo, instance, _cleaned_input, /):
+    def save(
+        cls, _info: ResolveInfo, instance, _cleaned_input, /, instance_tracker=None
+    ):
         instance.status = JobStatus.PENDING
         instance.save()
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -462,7 +462,13 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
         return cleaned_input
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance: models.Checkout, cleaned_input):
+    def save(
+        cls,
+        info: ResolveInfo,
+        instance: models.Checkout,
+        cleaned_input,
+        instance_tracker=None,
+    ):
         with traced_atomic_transaction():
             # Create the checkout object
             instance.save()

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -388,7 +388,7 @@ class DraftOrderCreate(
             )
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         manager = get_plugin_manager_promise(info.context).get()
         app = get_app_promise(info.context).get()
 

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -71,7 +71,7 @@ class OrderLineUpdate(
         return cleaned_input
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         manager = get_plugin_manager_promise(info.context).get()
 
         order_is_unconfirmed = instance.order.is_unconfirmed()

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -1,12 +1,14 @@
 import graphene
 from django.core.exceptions import ValidationError
-from django.db.models.expressions import Exists, OuterRef
+from django.db import transaction
+from django.db.models import Exists, OuterRef
 
 from ...attribute import AttributeInputType
 from ...attribute import models as attribute_models
 from ...core.tracing import traced_atomic_transaction
 from ...page import models
 from ...permission.enums import PagePermissions, PageTypePermissions
+from ...product.lock_objects import product_qs_select_for_update
 from ...product.models import Product
 from ...webhook.event_types import WebhookEventAsyncType
 from ...webhook.utils import get_webhooks_for_event
@@ -47,9 +49,20 @@ class PageBulkDelete(ModelBulkDeleteMutation):
     @classmethod
     def update_products_search_index(cls, instance_pks):
         # Mark products that use these page instances as references as dirty
-        Product.objects.filter(
-            attributevalues__value__reference_page__id__in=instance_pks
-        ).update(search_index_dirty=True)
+        with transaction.atomic():
+            locked_ids = (
+                product_qs_select_for_update()
+                .filter(
+                    Exists(
+                        attribute_models.AssignedProductAttributeValue.objects.filter(
+                            product_id=OuterRef("id"),
+                            value__reference_page_id__in=instance_pks,
+                        )
+                    )
+                )
+                .values_list("id", flat=True)
+            )
+            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)
 
     @classmethod
     def delete_assigned_attribute_values(cls, instance_pks):
@@ -123,9 +136,20 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
     def update_products_search_index(cls, instance_pks):
         # Mark products that use pages belonging to these page types as reference as
         # dirty
-        Product.objects.filter(
-            attributevalues__value__reference_page__page_type_id__in=instance_pks
-        ).update(search_index_dirty=True)
+        with transaction.atomic():
+            locked_ids = (
+                product_qs_select_for_update()
+                .filter(
+                    Exists(
+                        attribute_models.AssignedProductAttributeValue.objects.filter(
+                            product_id=OuterRef("id"),
+                            value__reference_page__page_type_id__in=instance_pks,
+                        )
+                    )
+                )
+                .values_list("id", flat=True)
+            )
+            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/page/mutations/page_create.py
+++ b/saleor/graphql/page/mutations/page_create.py
@@ -130,7 +130,7 @@ class PageCreate(DeprecatedModelMutation):
                 PageAttributeAssignmentMixin.save(instance, attributes)
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         super().save(info, instance, cleaned_input)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_created, instance)

--- a/saleor/graphql/page/mutations/page_delete.py
+++ b/saleor/graphql/page/mutations/page_delete.py
@@ -48,7 +48,10 @@ class PageDelete(ModelDeleteMutation):
                 .filter(
                     Exists(
                         attribute_models.AssignedProductAttributeValue.objects.filter(
-                            value__reference_page=instance, product_id=OuterRef("id")
+                            value__in=attribute_models.AttributeValue.objects.filter(
+                                reference_page=instance
+                            ),
+                            product_id=OuterRef("id"),
                         )
                     )
                 )

--- a/saleor/graphql/page/mutations/page_delete.py
+++ b/saleor/graphql/page/mutations/page_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.db import transaction
 from django.db.models.expressions import Exists, OuterRef
 
 from ....attribute import AttributeInputType
@@ -6,6 +7,7 @@ from ....attribute import models as attribute_models
 from ....core.tracing import traced_atomic_transaction
 from ....page import models
 from ....permission.enums import PagePermissions
+from ....product.lock_objects import product_qs_select_for_update
 from ....product.models import Product
 from ...core import ResolveInfo
 from ...core.mutations import ModelDeleteMutation
@@ -40,9 +42,19 @@ class PageDelete(ModelDeleteMutation):
     @classmethod
     def update_products_search_index(cls, instance):
         # Mark products that use this instance as reference as dirty
-        Product.objects.filter(attributevalues__value__reference_page=instance).update(
-            search_index_dirty=True
-        )
+        with transaction.atomic():
+            locked_ids = (
+                product_qs_select_for_update()
+                .filter(
+                    Exists(
+                        attribute_models.AssignedProductAttributeValue.objects.filter(
+                            value__reference_page=instance, product_id=OuterRef("id")
+                        )
+                    )
+                )
+                .values_list("id", flat=True)
+            )
+            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)
 
     @staticmethod
     def delete_assigned_attribute_values(instance):

--- a/saleor/graphql/page/mutations/page_type_delete.py
+++ b/saleor/graphql/page/mutations/page_type_delete.py
@@ -6,6 +6,7 @@ from ....attribute import models as attribute_models
 from ....core.tracing import traced_atomic_transaction
 from ....page import models
 from ....permission.enums import PageTypePermissions
+from ....product.models import Product
 from ...core import ResolveInfo
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import PageError
@@ -32,7 +33,18 @@ class PageTypeDelete(ModelDeleteMutation):
         page_type_pk = cls.get_global_id_or_error(id, only_type=PageType, field="pk")
         with traced_atomic_transaction():
             cls.delete_assigned_attribute_values(page_type_pk)
+            cls.update_products_search_index(page_type_pk)
             return super().perform_mutation(_root, info, id=id)
+
+    @classmethod
+    def update_products_search_index(cls, instance):
+        # Mark products that use pages belonging to this page type as reference as dirty
+        page_ids = models.Page.objects.filter(page_type=instance).values_list(
+            "id", flat=True
+        )
+        Product.objects.filter(
+            attributevalues__value__reference_page__id__in=page_ids
+        ).update(search_index_dirty=True)
 
     @staticmethod
     def delete_assigned_attribute_values(instance_pk):

--- a/saleor/graphql/page/mutations/page_type_delete.py
+++ b/saleor/graphql/page/mutations/page_type_delete.py
@@ -50,8 +50,10 @@ class PageTypeDelete(ModelDeleteMutation):
                 .filter(
                     Exists(
                         attribute_models.AssignedProductAttributeValue.objects.filter(
-                            value__reference_page_id__in=page_ids,
                             product_id=OuterRef("id"),
+                            value__in=attribute_models.AttributeValue.objects.filter(
+                                reference_page_id__in=page_ids
+                            ),
                         )
                     )
                 )

--- a/saleor/graphql/page/mutations/page_update.py
+++ b/saleor/graphql/page/mutations/page_update.py
@@ -57,10 +57,6 @@ class PageUpdate(PageCreate):
 
     @classmethod
     def update_products_search_index(cls, instance):
-        # Update `name` of AttributeValue instances
-        attribute_values_qs = instance.references.all()
-        attribute_values_qs.update(name=instance.title)
-
         # Mark products that use this instance as reference as dirty
         Product.objects.filter(attributevalues__value__reference_page=instance).update(
             search_index_dirty=True

--- a/saleor/graphql/page/mutations/page_update.py
+++ b/saleor/graphql/page/mutations/page_update.py
@@ -68,7 +68,10 @@ class PageUpdate(PageCreate):
                 .filter(
                     Exists(
                         attribute_models.AssignedProductAttributeValue.objects.filter(
-                            value__reference_page=instance, product_id=OuterRef("id")
+                            value__in=attribute_models.AttributeValue.objects.filter(
+                                reference_page=instance
+                            ),
+                            product_id=OuterRef("id"),
                         )
                     )
                 )

--- a/saleor/graphql/page/mutations/page_update.py
+++ b/saleor/graphql/page/mutations/page_update.py
@@ -1,8 +1,12 @@
 import graphene
+from django.db import transaction
+from django.db.models import Exists, OuterRef
 
+from ....attribute import models as attribute_models
 from ....core.utils.update_mutation_manager import InstanceTracker
 from ....page import models
 from ....permission.enums import PagePermissions
+from ....product.lock_objects import product_qs_select_for_update
 from ....product.models import Product
 from ...attribute.utils import PageAttributeAssignmentMixin
 from ...core import ResolveInfo
@@ -58,6 +62,16 @@ class PageUpdate(PageCreate):
     @classmethod
     def update_products_search_index(cls, instance):
         # Mark products that use this instance as reference as dirty
-        Product.objects.filter(attributevalues__value__reference_page=instance).update(
-            search_index_dirty=True
-        )
+        with transaction.atomic():
+            locked_ids = (
+                product_qs_select_for_update()
+                .filter(
+                    Exists(
+                        attribute_models.AssignedProductAttributeValue.objects.filter(
+                            value__reference_page=instance, product_id=OuterRef("id")
+                        )
+                    )
+                )
+                .values_list("id", flat=True)
+            )
+            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)

--- a/saleor/graphql/page/mutations/page_update.py
+++ b/saleor/graphql/page/mutations/page_update.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ....core.utils.update_mutation_manager import InstanceTracker
 from ....page import models
 from ....permission.enums import PagePermissions
 from ....product.models import Product
@@ -25,6 +26,9 @@ class PageUpdate(PageCreate):
         permissions = (PagePermissions.MANAGE_PAGES,)
         error_type_class = PageError
         error_type_field = "page_errors"
+        instance_tracker_fields = [
+            "title",
+        ]
 
     @classmethod
     def clean_attributes(cls, attributes: dict, page_type: models.PageType):
@@ -35,11 +39,21 @@ class PageUpdate(PageCreate):
         return cleaned_attributes
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(
+        cls,
+        info: ResolveInfo,
+        instance,
+        cleaned_input,
+        instance_tracker: InstanceTracker | None = None,
+    ):
         super(PageCreate, cls).save(info, instance, cleaned_input)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_updated, instance)
-        cls.update_products_search_index(instance)
+
+        if instance_tracker is not None:
+            modified_instance_fields = instance_tracker.get_modified_fields()
+            if "title" in modified_instance_fields:
+                cls.update_products_search_index(instance)
 
     @classmethod
     def update_products_search_index(cls, instance):

--- a/saleor/graphql/page/tests/mutations/test_page_bulk_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_bulk_delete.py
@@ -3,6 +3,7 @@ import pytest
 
 from .....attribute.models import AttributeValue
 from .....page.models import Page
+from .....product.search import update_products_search_vector
 from ....attribute.utils import associate_attribute_values_to_instance
 from ....tests.utils import get_graphql_content
 
@@ -212,3 +213,64 @@ def test_bulk_delete_page_with_invalid_ids(
     errors = content["data"]["pageBulkDelete"]["errors"][0]
 
     assert errors["code"] == "GRAPHQL_ERROR"
+
+
+def test_page_bulk_delete_reference_attribute_sets_search_index_dirty_in_product(
+    product_type_page_reference_attribute,
+    page,
+    product,
+    staff_api_client,
+    permission_manage_pages,
+):
+    # given
+    query = PAGE_BULK_DELETE_MUTATION
+
+    # Set up page reference attribute
+    attribute = product_type_page_reference_attribute
+    product.product_type.product_attributes.add(attribute)
+    page.title = "Brand"
+    page.save(update_fields=["title"])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=attribute,
+        name=page.title,
+        slug=f"{product.pk}_{page.pk}",
+        reference_page=page,
+    )
+
+    associate_attribute_values_to_instance(product, {attribute.pk: [attr_value]})
+
+    # Ensure product search index is initially clean
+    product.search_index_dirty = False
+    product.save(update_fields=["search_index_dirty"])
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    assert page.title.lower() in product.search_vector
+
+    # when
+    page_id = graphene.Node.to_global_id("Page", page.pk)
+    variables = {"ids": [page_id]}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_pages]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageBulkDelete"]
+
+    # Check that page was deleted
+    with pytest.raises(page._meta.model.DoesNotExist):
+        page.refresh_from_db()
+
+    # Check that attribute value was deleted
+    with pytest.raises(attr_value._meta.model.DoesNotExist):
+        attr_value.refresh_from_db()
+
+    # Check that product search_index_dirty flag was set to True
+    product.refresh_from_db(fields=["search_index_dirty"])
+    assert product.search_index_dirty is True
+    assert not data["errors"]
+
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    assert page.title.lower() not in product.search_vector

--- a/saleor/graphql/page/tests/mutations/test_page_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_delete.py
@@ -8,6 +8,7 @@ from django.utils.functional import SimpleLazyObject
 
 from .....attribute.models import AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
+from .....product.search import update_products_search_vector
 from .....webhook.event_types import WebhookEventAsyncType
 from ....tests.utils import get_graphql_content
 
@@ -228,3 +229,64 @@ def test_page_delete_removes_reference_to_page(
         page_ref.refresh_from_db()
 
     assert not data["errors"]
+
+
+def test_page_delete_reference_attribute_sets_search_index_dirty_in_product(
+    product_type_page_reference_attribute,
+    page,
+    product,
+    staff_api_client,
+    permission_manage_pages,
+):
+    # given
+    query = PAGE_DELETE_MUTATION
+
+    # Set up page reference attribute
+    attribute = product_type_page_reference_attribute
+    product.product_type.product_attributes.add(attribute)
+    page.title = "Brand"
+    page.save(update_fields=["title"])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=attribute,
+        name=page.title,
+        slug=f"{product.pk}_{page.pk}",
+        reference_page=page,
+    )
+
+    associate_attribute_values_to_instance(product, {attribute.pk: [attr_value]})
+
+    # Ensure product search index is initially clean
+    product.search_index_dirty = False
+    product.save(update_fields=["search_index_dirty"])
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    assert page.title.lower() in product.search_vector
+
+    # when
+    page_id = graphene.Node.to_global_id("Page", page.pk)
+    variables = {"id": page_id}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_pages]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageDelete"]
+
+    # Check that page was deleted
+    with pytest.raises(page._meta.model.DoesNotExist):
+        page.refresh_from_db()
+
+    # Check that attribute value was deleted
+    with pytest.raises(attr_value._meta.model.DoesNotExist):
+        attr_value.refresh_from_db()
+
+    # Check that product search_index_dirty flag was set to True
+    product.refresh_from_db(fields=["search_index_dirty"])
+    assert product.search_index_dirty is True
+    assert not data["errors"]
+
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    assert page.title.lower() not in product.search_vector

--- a/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
@@ -3,8 +3,10 @@ from unittest import mock
 import graphene
 import pytest
 
+from .....attribute.models import AttributeValue
+from .....attribute.utils import associate_attribute_values_to_instance
 from .....page.models import Page
-from ....attribute.utils import associate_attribute_values_to_instance
+from .....product.search import update_products_search_vector
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 PAGE_TYPE_BULK_DELETE_MUTATION = """
@@ -233,3 +235,79 @@ def test_page_type_bulk_delete_by_app_with_invalid_ids(
     errors = content["data"]["pageTypeBulkDelete"]["errors"][0]
 
     assert errors["code"] == "GRAPHQL_ERROR"
+
+
+def test_page_type_bulk_delete_sets_search_index_dirty_in_product_with_page_reference(
+    staff_api_client,
+    page_type_list,
+    product,
+    product_type_page_reference_attribute,
+    permission_manage_page_types_and_attributes,
+):
+    # given
+    # Set up page reference attribute
+    attribute = product_type_page_reference_attribute
+    product.product_type.product_attributes.add(attribute)
+
+    # Use the first page type and create a page with a specific title
+    page_type = page_type_list[0]
+    page = Page.objects.filter(page_type=page_type).first()
+    page.title = "Brand"
+    page.save(update_fields=["title"])
+
+    attr_value = AttributeValue.objects.create(
+        attribute=attribute,
+        name=page.title,
+        slug=f"{product.pk}_{page.pk}",
+        reference_page=page,
+    )
+
+    associate_attribute_values_to_instance(product, {attribute.pk: [attr_value]})
+
+    # Ensure product search index is initially clean
+    product.search_index_dirty = False
+    product.save(update_fields=["search_index_dirty"])
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    assert page.title.lower() in product.search_vector
+
+    # when
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("PageType", page_type.pk)
+            for page_type in page_type_list
+        ]
+    }
+    staff_api_client.user.user_permissions.add(
+        permission_manage_page_types_and_attributes
+    )
+    response = staff_api_client.post_graphql(PAGE_TYPE_BULK_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypeBulkDelete"]
+
+    assert not data["errors"]
+    assert data["count"] == len(page_type_list)
+
+    # Check that page types were deleted
+    for page_type in page_type_list:
+        with pytest.raises(page_type._meta.model.DoesNotExist):
+            page_type.refresh_from_db()
+
+    # Check that page was deleted (cascade from page type)
+    with pytest.raises(page._meta.model.DoesNotExist):
+        page.refresh_from_db()
+
+    # Check that attribute value was deleted
+    with pytest.raises(attr_value._meta.model.DoesNotExist):
+        attr_value.refresh_from_db()
+
+    # Check that product search_index_dirty flag was set to True
+    product.refresh_from_db(fields=["search_index_dirty"])
+    assert product.search_index_dirty is True
+
+    # Verify search vector no longer contains the deleted page title
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    assert page.title.lower() not in product.search_vector

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -19,6 +19,7 @@ from .....attribute.tests.model_helpers import (
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....page.error_codes import PageErrorCode
 from .....page.models import Page
+from .....product.search import update_products_search_vector
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
 from ....tests.utils import get_graphql_content
@@ -1203,3 +1204,66 @@ def test_paginate_pages(user_api_client, page, page_type):
     content = get_graphql_content(response)
     pages_data = content["data"]["pages"]
     assert len(pages_data["edges"]) == 2
+
+
+def test_page_update_reference_attribute_sets_search_index_dirty_in_product(
+    staff_api_client,
+    page,
+    product,
+    product_type_page_reference_attribute,
+    permission_manage_pages,
+):
+    # given
+    query = UPDATE_PAGE_MUTATION
+    page_id = graphene.Node.to_global_id("Page", page.id)
+
+    old_title = "Brand"
+    page.title = old_title
+    page.save(update_fields=["title"])
+
+    # Set up page reference attribute
+    attribute = product_type_page_reference_attribute
+    attribute_value = AttributeValue.objects.create(
+        attribute=attribute,
+        name=page.title,
+        slug=f"{page.pk}_{page.id}",
+        reference_page=page,
+    )
+    product.product_type.product_attributes.add(attribute)
+    associate_attribute_values_to_instance(product, {attribute.id: [attribute_value]})
+
+    # Ensure product search index is initially clean
+    product.search_index_dirty = False
+    product.save(update_fields=["search_index_dirty"])
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    assert old_title.lower() in product.search_vector
+
+    # when
+    new_title = "Extra Brand"
+    variables = {
+        "id": page_id,
+        "input": {"title": new_title},
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_pages]
+    )
+
+    # then
+    data = get_graphql_content(response)
+    assert not data["data"]["pageUpdate"]["errors"]
+
+    # Check that page was updated
+    page.refresh_from_db()
+    assert page.title == new_title
+
+    # Check that product search_index_dirty flag was set to True
+    product.refresh_from_db()
+    update_products_search_vector([product.id])
+    product.refresh_from_db()
+    updated_search_vector = str(product.search_vector)
+
+    # Verify search vector now contains the new page title
+    assert "extra" in updated_search_vector
+    # Verify search index dirty flag is reset
+    assert product.search_index_dirty is False

--- a/saleor/graphql/product/mutations/product/product_cleaner.py
+++ b/saleor/graphql/product/mutations/product/product_cleaner.py
@@ -1,0 +1,34 @@
+from django.core.exceptions import ValidationError
+
+from .....core.utils.editorjs import clean_editor_js
+from .....product.error_codes import ProductErrorCode
+from ....core.validators import validate_slug_and_generate_if_needed
+
+
+def clean_weight(cleaned_input: dict):
+    weight = cleaned_input.get("weight")
+    if weight and weight.value < 0:
+        raise ValidationError(
+            {
+                "weight": ValidationError(
+                    "Product can't have negative weight.",
+                    code=ProductErrorCode.INVALID.value,
+                )
+            }
+        )
+
+
+def clean_slug(cleaned_input: dict, instance):
+    try:
+        validate_slug_and_generate_if_needed(instance, "name", cleaned_input)
+    except ValidationError as e:
+        e.code = ProductErrorCode.REQUIRED.value
+        raise ValidationError({"slug": e}) from e
+
+
+def clean_description(cleaned_input: dict):
+    if "description" in cleaned_input:
+        description = cleaned_input["description"]
+        cleaned_input["description_plaintext"] = (
+            clean_editor_js(description, to_string=True) if description else ""
+        )

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -199,7 +199,7 @@ class ProductCreate(DeprecatedModelMutation):
         return cleaned_input
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         with traced_atomic_transaction():
             instance.search_index_dirty = True
             instance.save()

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -3,10 +3,8 @@ from django.core.exceptions import ValidationError
 
 from .....attribute import models as attribute_models
 from .....core.tracing import traced_atomic_transaction
-from .....core.utils.editorjs import clean_editor_js
 from .....permission.enums import ProductPermissions
 from .....product import models
-from .....product.error_codes import ProductErrorCode
 from ....attribute.types import AttributeValueInput
 from ....attribute.utils import AttrValuesInput, ProductAttributeAssignmentMixin
 from ....channel import ChannelContext
@@ -20,11 +18,12 @@ from ....core.fields import JSONString
 from ....core.mutations import DeprecatedModelMutation
 from ....core.scalars import WeightScalar
 from ....core.types import BaseInputObjectType, NonNullList, ProductError, SeoInput
-from ....core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
+from ....core.validators import clean_seo_fields
 from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Product
 from ..utils import clean_tax_code
+from . import product_cleaner as cleaner
 
 
 class ProductInput(BaseInputObjectType):
@@ -137,66 +136,36 @@ class ProductCreate(DeprecatedModelMutation):
         support_private_meta_field = True
 
     @classmethod
-    def clean_attributes(
-        cls, attributes: dict, product_type: models.ProductType
-    ) -> T_INPUT_MAP:
-        attributes_qs = product_type.product_attributes.all()
-        attributes = ProductAttributeAssignmentMixin.clean_input(
-            attributes, attributes_qs
-        )
-        return attributes
-
-    @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 
-        if "description" in cleaned_input:
-            description = cleaned_input["description"]
-            cleaned_input["description_plaintext"] = (
-                clean_editor_js(description, to_string=True) if description else ""
-            )
+        cleaner.clean_description(cleaned_input)
+        cleaner.clean_weight(cleaned_input)
+        cleaner.clean_slug(cleaned_input, instance)
+        cls.clean_attributes(cleaned_input, instance)
+        clean_tax_code(cleaned_input)
+        clean_seo_fields(cleaned_input)
 
-        weight = cleaned_input.get("weight")
-        if weight and weight.value < 0:
-            raise ValidationError(
-                {
-                    "weight": ValidationError(
-                        "Product can't have negative weight.",
-                        code=ProductErrorCode.INVALID.value,
-                    )
-                }
-            )
+        return cleaned_input
 
+    @classmethod
+    def clean_attributes(cls, cleaned_input, instance):
         # Attributes are provided as list of `AttributeValueInput` objects.
         # We need to transform them into the format they're stored in the
         # `Product` model, which is HStore field that maps attribute's PK to
         # the value's PK.
-
         attributes = cleaned_input.get("attributes")
-        product_type = (
-            instance.product_type if instance.pk else cleaned_input.get("product_type")
-        )  # type: models.ProductType
-
-        try:
-            cleaned_input = validate_slug_and_generate_if_needed(
-                instance, "name", cleaned_input
-            )
-        except ValidationError as e:
-            e.code = ProductErrorCode.REQUIRED.value
-            raise ValidationError({"slug": e}) from e
-
+        product_type = cleaned_input.get("product_type")
         if attributes and product_type:
             try:
-                cleaned_input["attributes"] = cls.clean_attributes(
-                    attributes, product_type
+                attributes_qs = product_type.product_attributes.all()
+                cleaned_input["attributes"] = (
+                    ProductAttributeAssignmentMixin.clean_input(
+                        attributes, attributes_qs
+                    )
                 )
             except ValidationError as e:
                 raise ValidationError({"attributes": e}) from e
-
-        clean_tax_code(cleaned_input)
-
-        clean_seo_fields(cleaned_input)
-        return cleaned_input
 
     @classmethod
     def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -1,21 +1,28 @@
 import graphene
+from django.core.exceptions import ValidationError
 
 from .....attribute import models as attribute_models
+from .....core.tracing import traced_atomic_transaction
 from .....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
 from .....permission.enums import ProductPermissions
 from .....product import models
 from ....attribute.utils import AttrValuesInput, ProductAttributeAssignmentMixin
+from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.mutations import ModelWithExtRefMutation
 from ....core.types.common import ProductError
+from ....core.validators import clean_seo_fields
+from ....meta.inputs import MetadataInput
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Product
-from .product_create import ProductCreate, ProductInput
+from ..utils import clean_tax_code
+from . import product_cleaner as cleaner
+from .product_create import ProductInput
 
 T_INPUT_MAP = list[tuple[attribute_models.Attribute, AttrValuesInput]]
 
 
-class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
+class ProductUpdate(ModelWithExtRefMutation):
     class Arguments:
         id = graphene.ID(required=False, description="ID of a product to update.")
         external_reference = graphene.String(
@@ -37,27 +44,6 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
         support_private_meta_field = True
 
     @classmethod
-    def clean_attributes(
-        cls, attributes: dict, product_type: models.ProductType
-    ) -> T_INPUT_MAP:
-        attributes_qs = product_type.product_attributes.all()
-        attributes = ProductAttributeAssignmentMixin.clean_input(
-            attributes, attributes_qs, creation=False
-        )
-        return attributes
-
-    @classmethod
-    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
-        product = models.Product.objects.get(pk=instance.pk)
-        channel_ids = set(
-            product.channel_listings.all().values_list("channel_id", flat=True)
-        )
-        cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
-
-        manager = get_plugin_manager_promise(info.context).get()
-        cls.call_event(manager.product_updated, product)
-
-    @classmethod
     def get_instance(cls, info, **data):
         """Prefetch related fields that are needed to process the mutation."""
         # If we are updating an instance and want to update its attributes,
@@ -73,3 +59,99 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
             return cls.get_node_or_error(info, object_id, only_type="Product", qs=qs)
 
         return super().get_instance(info, **data)
+
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        cleaner.clean_description(cleaned_input)
+        cleaner.clean_weight(cleaned_input)
+        cleaner.clean_slug(cleaned_input, instance)
+        cls.clean_attributes(cleaned_input, instance)
+        clean_tax_code(cleaned_input)
+        clean_seo_fields(cleaned_input)
+
+        return cleaned_input
+
+    @classmethod
+    def clean_attributes(cls, cleaned_input, instance):
+        # Attributes are provided as list of `AttributeValueInput` objects.
+        # We need to transform them into the format they're stored in the
+        # `Product` model, which is HStore field that maps attribute's PK to
+        # the value's PK.
+        attributes = cleaned_input.get("attributes")
+        product_type = instance.product_type
+        if attributes and product_type:
+            try:
+                attributes_qs = product_type.product_attributes.all()
+                cleaned_input["attributes"] = (
+                    ProductAttributeAssignmentMixin.clean_input(
+                        attributes, attributes_qs, creation=False
+                    )
+                )
+            except ValidationError as e:
+                raise ValidationError({"attributes": e}) from e
+
+    @classmethod
+    def handle_metadata(cls, instance, cleaned_input):
+        metadata_list: list[MetadataInput] = cleaned_input.pop("metadata", None)
+        private_metadata_list: list[MetadataInput] = cleaned_input.pop(
+            "private_metadata", None
+        )
+        metadata_collection = cls.create_metadata_from_graphql_input(
+            metadata_list, error_field_name="metadata"
+        )
+        private_metadata_collection = cls.create_metadata_from_graphql_input(
+            private_metadata_list, error_field_name="private_metadata"
+        )
+        cls.validate_and_update_metadata(
+            instance, metadata_collection, private_metadata_collection
+        )
+
+    @classmethod
+    def save(cls, info: ResolveInfo, instance, cleaned_input):
+        with traced_atomic_transaction():
+            instance.search_index_dirty = True
+            instance.save()
+            attributes = cleaned_input.get("attributes")
+            if attributes:
+                ProductAttributeAssignmentMixin.save(instance, attributes)
+
+    @classmethod
+    def _save_m2m(cls, _info: ResolveInfo, instance, cleaned_data):
+        collections = cleaned_data.get("collections", None)
+        if collections is not None:
+            instance.collections.set(collections)
+
+    @classmethod
+    def _post_save_action(cls, info: ResolveInfo, instance):
+        product = models.Product.objects.get(pk=instance.pk)
+        channel_ids = set(
+            product.channel_listings.all().values_list("channel_id", flat=True)
+        )
+        cls.call_event(mark_active_catalogue_promotion_rules_as_dirty, channel_ids)
+
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.call_event(manager.product_updated, product)
+
+    @classmethod
+    def success_response(cls, instance):
+        instance = ChannelContext(node=instance, channel_slug=None)
+        return super().success_response(instance)
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        instance = cls.get_instance(info, **data)
+        data = data.get("input")
+        cleaned_input = cls.clean_input(info, instance, data)
+
+        cls.handle_metadata(instance, cleaned_input)
+
+        instance = cls.construct_instance(instance, cleaned_input)
+
+        cls.clean_instance(info, instance)
+
+        cls.save(info, instance, cleaned_input)
+        cls._save_m2m(info, instance, cleaned_input)
+        cls._post_save_action(info, instance)
+        return cls.success_response(instance)

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -109,7 +109,7 @@ class ProductUpdate(ModelWithExtRefMutation):
         )
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         with traced_atomic_transaction():
             instance.search_index_dirty = True
             instance.save()

--- a/saleor/graphql/product/mutations/product_type/product_type_update.py
+++ b/saleor/graphql/product/mutations/product_type/product_type_update.py
@@ -29,7 +29,7 @@ class ProductTypeUpdate(ProductTypeCreate):
         return data.get("kind", instance.kind)
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         variant_attr = cleaned_input.get("variant_attributes")
         if variant_attr:
             variant_attr = set(variant_attr)

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -311,7 +311,7 @@ class ProductVariantCreate(DeprecatedModelMutation):
             )
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         new_variant = instance.pk is None
         cls.set_track_inventory(info, instance, cleaned_input)
         with traced_atomic_transaction():

--- a/saleor/graphql/shipping/mutations/base.py
+++ b/saleor/graphql/shipping/mutations/base.py
@@ -402,7 +402,7 @@ class ShippingPriceMixin:
             )
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         with traced_atomic_transaction():
             super().save(info, instance, cleaned_input)  # type: ignore[misc] # mixin
 

--- a/saleor/graphql/tax/mutations/tax_class_create.py
+++ b/saleor/graphql/tax/mutations/tax_class_create.py
@@ -75,7 +75,7 @@ class TaxClassCreate(DeprecatedModelMutation):
         models.TaxClassCountryRate.objects.bulk_create(to_create)
 
     @classmethod
-    def save(cls, _info, instance, cleaned_input):
+    def save(cls, _info, instance, cleaned_input, instance_tracker=None):
         instance.save()
         create_country_rates = cleaned_input.get("create_country_rates", [])
         cls.create_country_rates(instance, create_country_rates)

--- a/saleor/graphql/tax/mutations/tax_class_update.py
+++ b/saleor/graphql/tax/mutations/tax_class_update.py
@@ -138,7 +138,7 @@ class TaxClassUpdate(DeprecatedModelMutation):
         models.TaxClassCountryRate.objects.filter(country__in=country_codes).delete()
 
     @classmethod
-    def save(cls, _info, instance, cleaned_input):
+    def save(cls, _info, instance, cleaned_input, instance_tracker=None):
         instance.save()
         update_country_rates = cleaned_input.get("update_country_rates", [])
         remove_country_rates = cleaned_input.get("remove_country_rates", [])

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -368,7 +368,7 @@ class TaxConfigurationUpdate(DeprecatedModelMutation):
         ).delete()
 
     @classmethod
-    def save(cls, _info, instance, cleaned_input):
+    def save(cls, _info, instance, cleaned_input, instance_tracker=None):
         instance.save()
         update_countries_configuration = cleaned_input.get(
             "update_countries_configuration", []

--- a/saleor/graphql/webhook/mutations/webhook_create.py
+++ b/saleor/graphql/webhook/mutations/webhook_create.py
@@ -178,7 +178,7 @@ class WebhookCreate(DeprecatedModelMutation, NotifyUserEventValidationMixin):
         return instance
 
     @classmethod
-    def save(cls, _info: ResolveInfo, instance, cleaned_input):
+    def save(cls, _info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         instance.save()
         events = set(cleaned_input.get("events", []))
         models.WebhookEvent.objects.bulk_create(

--- a/saleor/graphql/webhook/mutations/webhook_update.py
+++ b/saleor/graphql/webhook/mutations/webhook_update.py
@@ -89,7 +89,7 @@ class WebhookUpdate(WebhookCreate, NotifyUserEventValidationMixin):
         error_type_field = "webhook_errors"
 
     @classmethod
-    def save(cls, _info: ResolveInfo, instance, cleaned_input):
+    def save(cls, _info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         instance.save()
         events = set(cleaned_input.get("events", []))
         cls.validate_events(events)

--- a/saleor/product/lock_objects.py
+++ b/saleor/product/lock_objects.py
@@ -1,0 +1,7 @@
+from django.db.models import QuerySet
+
+from .models import Product
+
+
+def product_qs_select_for_update() -> QuerySet[Product]:
+    return Product.objects.order_by("pk").select_for_update(of=(["self"]))

--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -7,7 +7,7 @@ from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F, Q, Value, prefetch_related_objects
 
 from ..attribute import AttributeInputType
-from ..attribute.models import Attribute
+from ..attribute.models import Attribute, AttributeValue
 from ..core.postgres import FlatConcatSearchVector, NoValidationSearchVector
 from ..core.utils.editorjs import clean_editor_js
 from ..product.models import Product
@@ -215,15 +215,24 @@ def get_search_vectors_for_values(
             for value in values
         ]
     elif input_type == AttributeInputType.REFERENCE:
+        # for now only AttributeEntityType.PAGE is supported
         search_vectors += [
             NoValidationSearchVector(
-                Value(value.name),
+                Value(get_reference_attribute_search_value(value)),
                 config="simple",
                 weight="B",
             )
             for value in values
+            if value.reference_page_id is not None
         ]
     return search_vectors
+
+
+def get_reference_attribute_search_value(attribute_value: AttributeValue) -> str:
+    """Get search value for reference attribute."""
+    if attribute_value.reference_page:
+        return attribute_value.reference_page.title
+    return ""
 
 
 def search_products(qs, value):

--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -214,6 +214,15 @@ def get_search_vectors_for_values(
             )
             for value in values
         ]
+    elif input_type == AttributeInputType.REFERENCE:
+        search_vectors += [
+            NoValidationSearchVector(
+                Value(value.name),
+                config="simple",
+                weight="B",
+            )
+            for value in values
+        ]
     return search_vectors
 
 

--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -7,9 +7,10 @@ from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F, Q, Value, prefetch_related_objects
 
 from ..attribute import AttributeInputType
-from ..attribute.models import Attribute, AttributeValue
+from ..attribute.models import AssignedProductAttributeValue, Attribute, AttributeValue
 from ..core.postgres import FlatConcatSearchVector, NoValidationSearchVector
 from ..core.utils.editorjs import clean_editor_js
+from ..page.models import Page
 from ..product.models import Product
 
 if TYPE_CHECKING:
@@ -20,7 +21,6 @@ PRODUCT_FIELDS_TO_PREFETCH = [
     "variants__attributes__values",
     "variants__attributes__assignment__attribute",
     "attributevalues__value",
-    "attributevalues__value__reference_page",
     "product_type__attributeproduct__attribute",
 ]
 
@@ -30,12 +30,18 @@ PRODUCTS_BATCH_SIZE = 100
 # and product variants.
 
 
-def _prep_product_search_vector_index(products):
+def _prep_product_search_vector_index(
+    products, page_id_to_title_map: dict[int, str] | None = None
+):
     prefetch_related_objects(products, *PRODUCT_FIELDS_TO_PREFETCH)
 
     for product in products:
         product.search_vector = FlatConcatSearchVector(
-            *prepare_product_search_vector_value(product, already_prefetched=True)
+            *prepare_product_search_vector_value(
+                product,
+                already_prefetched=True,
+                page_id_to_title_map=page_id_to_title_map,
+            )
         )
         product.search_index_dirty = False
 
@@ -64,23 +70,35 @@ def queryset_in_batches(queryset):
 
 
 def update_products_search_vector(product_ids: Iterable[int]):
+    db_conn = settings.DATABASE_CONNECTION_REPLICA_NAME
     product_ids = list(product_ids)
-    products = (
-        Product.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
-        .filter(pk__in=product_ids)
-        .order_by("pk")
-    )
+    products = Product.objects.using(db_conn).filter(pk__in=product_ids).order_by("pk")
     for product_pks in queryset_in_batches(products):
-        products_batch = list(
-            Product.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME).filter(
-                id__in=product_pks
-            )
+        value_ids = (
+            AssignedProductAttributeValue.objects.using(db_conn)
+            .filter(product_id__in=product_pks)
+            .values_list("value_id", flat=True)
         )
-        _prep_product_search_vector_index(products_batch)
+        value_to_page_id = (
+            AttributeValue.objects.using(db_conn)
+            .filter(id__in=value_ids, reference_page_id__isnull=False)
+            .values_list("id", "reference_page_id")
+        )
+        page_id_to_title_map = dict(
+            Page.objects.using(db_conn)
+            .filter(id__in=[page_id for _, page_id in value_to_page_id])
+            .values_list("id", "title")
+        )
+
+        products_batch = list(Product.objects.using(db_conn).filter(id__in=product_pks))
+        _prep_product_search_vector_index(products_batch, page_id_to_title_map)
 
 
 def prepare_product_search_vector_value(
-    product: "Product", *, already_prefetched=False
+    product: "Product",
+    *,
+    already_prefetched=False,
+    page_id_to_title_map: dict[int, str] | None = None,
 ) -> list[NoValidationSearchVector]:
     if not already_prefetched:
         prefetch_related_objects([product], *PRODUCT_FIELDS_TO_PREFETCH)
@@ -91,7 +109,7 @@ def prepare_product_search_vector_value(
             Value(product.description_plaintext), config="simple", weight="C"
         ),
         *generate_attributes_search_vector_value(
-            product,
+            product, page_id_to_title_map=page_id_to_title_map
         ),
         *generate_variants_search_vector_value(product),
     ]
@@ -122,6 +140,8 @@ def generate_variants_search_vector_value(
 
 def generate_attributes_search_vector_value(
     product: "Product",
+    *,
+    page_id_to_title_map: dict[int, str] | None = None,
 ) -> list[NoValidationSearchVector]:
     """Prepare `search_vector` value for assigned attributes.
 
@@ -147,7 +167,9 @@ def generate_attributes_search_vector_value(
             : settings.PRODUCT_MAX_INDEXED_ATTRIBUTE_VALUES
         ]
 
-        search_vectors += get_search_vectors_for_values(attribute, values)
+        search_vectors += get_search_vectors_for_values(
+            attribute, values, page_id_to_title_map=page_id_to_title_map
+        )
     return search_vectors
 
 
@@ -170,7 +192,9 @@ def generate_attributes_search_vector_value_with_assignment(
 
 
 def get_search_vectors_for_values(
-    attribute: Attribute, values: Union[list, "QuerySet"]
+    attribute: Attribute,
+    values: Union[list, "QuerySet"],
+    page_id_to_title_map: dict[int, str] | None = None,
 ) -> list[NoValidationSearchVector]:
     search_vectors = []
 
@@ -219,7 +243,11 @@ def get_search_vectors_for_values(
         # for now only AttributeEntityType.PAGE is supported
         search_vectors += [
             NoValidationSearchVector(
-                Value(get_reference_attribute_search_value(value)),
+                Value(
+                    get_reference_attribute_search_value(
+                        value, page_id_to_title_map=page_id_to_title_map
+                    )
+                ),
                 config="simple",
                 weight="B",
             )
@@ -229,10 +257,18 @@ def get_search_vectors_for_values(
     return search_vectors
 
 
-def get_reference_attribute_search_value(attribute_value: AttributeValue) -> str:
+def get_reference_attribute_search_value(
+    attribute_value: AttributeValue, page_id_to_title_map: dict[int, str] | None = None
+) -> str:
     """Get search value for reference attribute."""
-    if attribute_value.reference_page:
-        return attribute_value.reference_page.title
+    if attribute_value.reference_page_id:
+        if page_id_to_title_map:
+            return page_id_to_title_map.get(attribute_value.reference_page_id, "")
+        return (
+            attribute_value.reference_page.title
+            if attribute_value.reference_page
+            else ""
+        )
     return ""
 
 

--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -20,6 +20,7 @@ PRODUCT_FIELDS_TO_PREFETCH = [
     "variants__attributes__values",
     "variants__attributes__assignment__attribute",
     "attributevalues__value",
+    "attributevalues__value__reference_page",
     "product_type__attributeproduct__attribute",
 ]
 

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -308,7 +308,7 @@ def test_update_products_search_vector_task_with_static_number_of_queries(
         product_list[i].save(update_fields=["search_index_dirty"])
 
     # when & # then
-    with django_assert_num_queries(15):
+    with django_assert_num_queries(16):
         update_products_search_vector_task()
 
 


### PR DESCRIPTION
Port https://github.com/saleor/saleor/pull/18041/ to 3.21.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
