### PR TITLE
Tidy up the action versions a bit and allow for workflow_dispatch in testenvs-cron-cleanup

### DIFF
--- a/.github/workflows/migrations-perf-test.yml
+++ b/.github/workflows/migrations-perf-test.yml
@@ -13,8 +13,8 @@ jobs:
       id-token: write # needed by aws-actions/configure-aws-credentials
       contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: rlespinasse/github-slug-action@e4699e49fcf890a3172a02c56ba78d867dbb9fd5
+      - uses: actions/checkout@v4
+      - uses: rlespinasse/github-slug-action@955b5ba4560860f8a633bd24190941f16016e42c # v5.1.0
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
@@ -37,7 +37,7 @@ jobs:
           echo "PULL_ID=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
 
       - name: Invoke deployment lambda
-        uses: gagoar/invoke-aws-lambda@d3a63ccabbed6ef817604ef6320096bde576ad40
+        uses: gagoar/invoke-aws-lambda@2ea0b5791eba7a9513ddf0fb7f91aa8f098b6458 # v3.4.0
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -62,8 +62,8 @@ jobs:
       id-token: write # needed by aws-actions/configure-aws-credentials
       contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: rlespinasse/github-slug-action@e4699e49fcf890a3172a02c56ba78d867dbb9fd5
+      - uses: actions/checkout@v4
+      - uses: rlespinasse/github-slug-action@955b5ba4560860f8a633bd24190941f16016e42c # v5.1.0
 
       - name: Get pull number
         run: |
@@ -76,7 +76,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Invoke deployment lambda
-        uses: gagoar/invoke-aws-lambda@d3a63ccabbed6ef817604ef6320096bde576ad40
+        uses: gagoar/invoke-aws-lambda@2ea0b5791eba7a9513ddf0fb7f91aa8f098b6458 # v3.4.0
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-env-cleanup-cron.yml
+++ b/.github/workflows/test-env-cleanup-cron.yml
@@ -3,7 +3,8 @@ name: TEST-ENV-CLEANUP-CRON
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * *' # UTC
+  workflow_dispatch:
 
 jobs:
   cleanup:
@@ -13,8 +14,6 @@ jobs:
       id-token: write # needed by aws-actions/configure-aws-credentials
       contents: read
     steps:
-      - uses: rlespinasse/github-slug-action@955b5ba4560860f8a633bd24190941f16016e42c # v5.1.0
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
@@ -23,7 +22,7 @@ jobs:
 
       - name: Get branches from open PRs with "test deployment" label
         id: get-branches
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@v7
         with:
           script: |
             // Get all open PRs - pagination is needed or otherwise we would retrieve only first 30

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -16,8 +16,8 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: rlespinasse/github-slug-action@3.1.0
+      - uses: actions/checkout@v4
+      - uses: rlespinasse/github-slug-action@955b5ba4560860f8a633bd24190941f16016e42c # v5.1.0
 
       - name: Set domain
         id: set-domain
@@ -26,7 +26,7 @@ jobs:
           echo "domain=${{ env.GITHUB_HEAD_REF_SLUG_URL }}.api.saleor.rocks" >> $GITHUB_OUTPUT
 
       - name: Start deployment
-        uses: bobheadxi/deployments@v0.4.2
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
         id: deployment
         with:
           step: start
@@ -51,7 +51,7 @@ jobs:
           tags: ${{ env.GITHUB_HEAD_REF_SLUG_URL }},${{ github.sha }}
 
       - name: Invoke deployment lambda
-        uses: gagoar/invoke-aws-lambda@v3.3.0
+        uses: gagoar/invoke-aws-lambda@2ea0b5791eba7a9513ddf0fb7f91aa8f098b6458 # v3.4.0
         with:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -67,7 +67,7 @@ jobs:
           LogType: Tail
 
       - name: Update deployment status
-        uses: bobheadxi/deployments@v0.4.2
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
         if: always()
         with:
           step: finish

--- a/.github/workflows/test-semgrep-rules.yml
+++ b/.github/workflows/test-semgrep-rules.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .semgrep


### PR DESCRIPTION
Bumping/pinning GH action versions so we are safer/more uniformized.

Also allowing for triggering testenvs cleanup on-demand.