### PR TITLE
Fix 'update deployment status' step in TEST-ENV-DEPLOYMENT workflow

### DIFF
--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
           status: ${{ job.status }}
           env_url: https://${{ steps.set-domain.outputs.domain }}/graphql/
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
https://github.com/saleor/saleor/pull/18070 introduced an error in the workflow due to `bobheadxi/deployments` action version bump from `v0.4.2` to `v1.5.0` - `env` parameter is now mandatory. This should fix the issue and the workflow should work as it used to.