### PR TITLE
Add validation when setting reference value in bulk mutations

### DIFF
--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -58,6 +58,7 @@ PRODUCT_BULK_CREATE_MUTATION = """
                         }
                         values{
                            value
+                           reference
                         }
                     }
                     channelListings{
@@ -873,6 +874,207 @@ def test_product_bulk_create_with_single_reference_attributes(
         data["results"][1]["product"]["attributes"][0]["attribute"]["slug"]
         == attribute.slug
     )
+
+
+def test_product_bulk_create_with_reference_attributes_and_reference_types_defined(
+    staff_api_client,
+    product_type,
+    product_type_page_single_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    product,
+    variant,
+    category,
+    permission_manage_products,
+):
+    # given
+    product_type.product_attributes.clear()
+    product_type.product_attributes.add(
+        product_type_page_single_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    product_type_page_single_reference_attribute.reference_page_types.add(
+        page.page_type
+    )
+    product_type_product_reference_attribute.reference_product_types.add(
+        product.product_type
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        variant.product.product_type
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_single_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    category_id = graphene.Node.to_global_id("Category", category.pk)
+
+    product_name_1 = "test name 1"
+    product_name_2 = "test name 2"
+    base_product_slug = "product-test-slug"
+
+    products = [
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name_1,
+            "slug": f"{base_product_slug}-1",
+            "attributes": [{"id": page_ref_attr_id, "reference": page_ref}],
+        },
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name_2,
+            "slug": f"{base_product_slug}-2",
+            "attributes": [{"id": product_ref_attr_id, "references": [product_ref]}],
+        },
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": "test name 3",
+            "slug": f"{base_product_slug}-3",
+            "attributes": [{"id": variant_ref_attr_id, "references": [variant_ref]}],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_BULK_CREATE_MUTATION, {"products": products}
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productBulkCreate"]
+
+    # then
+    assert not data["results"][0]["errors"]
+    assert not data["results"][1]["errors"]
+    assert not data["results"][2]["errors"]
+    assert data["count"] == 3
+
+    expected_attributes = [
+        {
+            "attribute": {"slug": product_type_page_single_reference_attribute.slug},
+            "values": [{"reference": page_ref, "value": ""}],
+        },
+        {
+            "attribute": {"slug": product_type_product_reference_attribute.slug},
+            "values": [{"reference": product_ref, "value": ""}],
+        },
+        {
+            "attribute": {"slug": product_type_variant_reference_attribute.slug},
+            "values": [{"reference": variant_ref, "value": ""}],
+        },
+    ]
+
+    for i, result in enumerate(data["results"]):
+        assert expected_attributes[i] in result["product"]["attributes"]
+
+
+def test_product_bulk_create_with_reference_attributes_refs_not_in_available_choices(
+    staff_api_client,
+    product_type,
+    product_type_page_reference_attribute,
+    product_type_product_single_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    product,
+    variant,
+    category,
+    permission_manage_products,
+    product_type_with_variant_attributes,
+    page_type_list,
+):
+    # given
+    product_type.product_attributes.clear()
+    product_type.product_attributes.add(
+        product_type_page_reference_attribute,
+        product_type_product_single_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    product_type_page_reference_attribute.reference_page_types.add(page_type_list[1])
+    product_type_product_single_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_single_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    category_id = graphene.Node.to_global_id("Category", category.pk)
+
+    product_name_1 = "test name 1"
+    product_name_2 = "test name 2"
+    base_product_slug = "product-test-slug"
+
+    products = [
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name_1,
+            "slug": f"{base_product_slug}-1",
+            "attributes": [{"id": page_ref_attr_id, "references": [page_ref]}],
+        },
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name_2,
+            "slug": f"{base_product_slug}-2",
+            "attributes": [{"id": product_ref_attr_id, "reference": product_ref}],
+        },
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": "test name 3",
+            "slug": f"{base_product_slug}-3",
+            "attributes": [{"id": variant_ref_attr_id, "references": [variant_ref]}],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_BULK_CREATE_MUTATION, {"products": products}
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productBulkCreate"]
+
+    # then
+    assert len(data["results"][0]["errors"]) == 1
+    assert len(data["results"][1]["errors"]) == 1
+    assert len(data["results"][2]["errors"]) == 1
+    assert data["count"] == 0
+
+    for result in data["results"]:
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["code"] == ProductBulkCreateErrorCode.INVALID.name
+        assert result["errors"][0]["path"] == "attributes"
 
 
 def test_product_bulk_create_with_attributes_using_external_refs(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -779,6 +779,198 @@ def test_product_variant_bulk_create_with_single_reference_attribute(
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
+def test_product_variant_bulk_create_with_ref_attributes_and_reference_types_defined(
+    staff_api_client,
+    product,
+    product_type,
+    product_type_page_single_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    variant,
+    permission_manage_products,
+):
+    # given
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_single_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    product_type_page_single_reference_attribute.reference_page_types.add(
+        page.page_type
+    )
+    product_type_product_reference_attribute.reference_product_types.add(
+        product.product_type
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        variant.product.product_type
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_single_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+
+    sku1 = str(uuid4())[:12]
+    sku2 = str(uuid4())[:12]
+    sku3 = str(uuid4())[:12]
+
+    variants = [
+        {
+            "sku": sku1,
+            "attributes": [{"id": page_ref_attr_id, "reference": page_ref}],
+        },
+        {
+            "sku": sku2,
+            "attributes": [{"id": product_ref_attr_id, "references": [product_ref]}],
+        },
+        {
+            "sku": sku3,
+            "attributes": [{"id": variant_ref_attr_id, "references": [variant_ref]}],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION,
+        {"productId": product_id, "variants": variants},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkCreate"]
+
+    # then
+    assert not data["results"][0]["errors"]
+    assert not data["results"][1]["errors"]
+    assert not data["results"][2]["errors"]
+    assert data["count"] == 3
+
+    expected_attributes = [
+        {
+            "slug": product_type_page_single_reference_attribute.slug,
+            "reference": page_ref,
+        },
+        {
+            "slug": product_type_product_reference_attribute.slug,
+            "reference": product_ref,
+        },
+        {
+            "slug": product_type_variant_reference_attribute.slug,
+            "reference": variant_ref,
+        },
+    ]
+
+    for i, result in enumerate(data["results"]):
+        matching_attribute = next(
+            attr
+            for attr in result["productVariant"]["attributes"]
+            if attr["attribute"]["slug"] == expected_attributes[i]["slug"]
+        )
+        assert len(matching_attribute["values"]) == 1
+        assert (
+            matching_attribute["values"][0]["reference"]
+            == expected_attributes[i]["reference"]
+        )
+
+
+def test_product_variant_bulk_create_with_ref_attributes_refs_not_in_available_choices(
+    staff_api_client,
+    product,
+    product_type,
+    product_type_page_single_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    variant,
+    permission_manage_products,
+    product_type_with_variant_attributes,
+    page_type_list,
+):
+    # given
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_single_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    product_type_page_single_reference_attribute.reference_page_types.add(
+        page_type_list[1]
+    )
+    product_type_product_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_single_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+
+    sku1 = str(uuid4())[:12]
+    sku2 = str(uuid4())[:12]
+    sku3 = str(uuid4())[:12]
+
+    variants = [
+        {
+            "sku": sku1,
+            "attributes": [{"id": page_ref_attr_id, "reference": page_ref}],
+        },
+        {
+            "sku": sku2,
+            "attributes": [{"id": product_ref_attr_id, "references": [product_ref]}],
+        },
+        {
+            "sku": sku3,
+            "attributes": [{"id": variant_ref_attr_id, "references": [variant_ref]}],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION,
+        {"productId": product_id, "variants": variants},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkCreate"]
+
+    # then
+    assert len(data["results"][0]["errors"]) == 1
+    assert len(data["results"][1]["errors"]) == 1
+    assert len(data["results"][2]["errors"]) == 1
+    assert data["count"] == 0
+
+    for result in data["results"]:
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["code"] == ProductVariantBulkErrorCode.INVALID.name
+        assert result["errors"][0]["path"] == "attributes"
+
+
 def test_product_variant_bulk_create_with_dropdown_attribute(
     staff_api_client,
     product,

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -71,6 +71,15 @@ PRODUCT_VARIANT_BULK_UPDATE_MUTATION = """
                                 quantity
                             }
                         }
+                        attributes{
+                            attribute{
+                            slug
+                            }
+                            values{
+                            value
+                            reference
+                            }
+                        }
                         preorder {
                             globalThreshold
                             endDate
@@ -802,6 +811,183 @@ def test_product_variant_bulk_update_attributes(
     assert data["count"] == 1
     for rule in get_active_catalogue_promotion_rules():
         assert rule.variants_dirty
+
+
+def test_product_variant_bulk_update_with_ref_attributes_and_reference_types_defined(
+    staff_api_client,
+    product,
+    product_type,
+    product_type_page_single_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    variant,
+    permission_manage_products,
+):
+    # given
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_single_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    product_type_page_single_reference_attribute.reference_page_types.add(
+        page.page_type
+    )
+    product_type_product_reference_attribute.reference_product_types.add(
+        product.product_type
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        variant.product.product_type
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_single_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variants = [
+        {
+            "id": variant_id,
+            "attributes": [{"id": page_ref_attr_id, "reference": page_ref}],
+        },
+        {
+            "id": variant_id,
+            "attributes": [{"id": product_ref_attr_id, "references": [product_ref]}],
+        },
+        {
+            "id": variant_id,
+            "attributes": [{"id": variant_ref_attr_id, "references": [variant_ref]}],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION,
+        {"productId": product_id, "variants": variants},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkUpdate"]
+
+    # then
+    assert not data["results"][0]["errors"]
+    assert not data["results"][1]["errors"]
+    assert not data["results"][2]["errors"]
+    assert data["count"] == 3
+
+    expected_attributes = [
+        {
+            "attribute": {"slug": product_type_page_single_reference_attribute.slug},
+            "values": [{"reference": page_ref, "value": ""}],
+        },
+        {
+            "attribute": {"slug": product_type_product_reference_attribute.slug},
+            "values": [{"reference": product_ref, "value": ""}],
+        },
+        {
+            "attribute": {"slug": product_type_variant_reference_attribute.slug},
+            "values": [{"reference": variant_ref, "value": ""}],
+        },
+    ]
+
+    for i, result in enumerate(data["results"]):
+        assert expected_attributes[i] in result["productVariant"]["attributes"]
+
+
+def test_product_variant_bulk_update_with_ref_attributes__refs_not_in_available_choices(
+    staff_api_client,
+    product,
+    product_type,
+    product_type_page_single_reference_attribute,
+    product_type_product_reference_attribute,
+    product_type_variant_reference_attribute,
+    page,
+    variant,
+    permission_manage_products,
+    product_type_with_variant_attributes,
+    page_type_list,
+):
+    # given
+    product_type.variant_attributes.clear()
+    product_type.variant_attributes.add(
+        product_type_page_single_reference_attribute,
+        product_type_product_reference_attribute,
+        product_type_variant_reference_attribute,
+    )
+
+    product_type_page_single_reference_attribute.reference_page_types.add(
+        page_type_list[1]
+    )
+    product_type_product_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+    product_type_variant_reference_attribute.reference_product_types.add(
+        product_type_with_variant_attributes
+    )
+
+    page_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_page_single_reference_attribute.id
+    )
+    product_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_product_reference_attribute.id
+    )
+    variant_ref_attr_id = graphene.Node.to_global_id(
+        "Attribute", product_type_variant_reference_attribute.id
+    )
+    page_ref = graphene.Node.to_global_id("Page", page.pk)
+    product_ref = graphene.Node.to_global_id("Product", product.pk)
+    variant_ref = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variants = [
+        {
+            "id": variant_id,
+            "attributes": [{"id": page_ref_attr_id, "reference": page_ref}],
+        },
+        {
+            "id": variant_id,
+            "attributes": [{"id": product_ref_attr_id, "references": [product_ref]}],
+        },
+        {
+            "id": variant_id,
+            "attributes": [{"id": variant_ref_attr_id, "references": [variant_ref]}],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION,
+        {"productId": product_id, "variants": variants},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkUpdate"]
+
+    # then
+    assert len(data["results"][0]["errors"]) == 1
+    assert len(data["results"][1]["errors"]) == 1
+    assert len(data["results"][2]["errors"]) == 1
+    assert data["count"] == 0
+
+    for result in data["results"]:
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["code"] == ProductVariantBulkErrorCode.INVALID.name
+        assert result["errors"][0]["path"] == "attributes"
 
 
 @override_settings(ENABLE_LIMITING_WEBHOOKS_FOR_IDENTICAL_PAYLOADS=True)


### PR DESCRIPTION
Add tests for:
- `ProductBulkCreate`
- `ProductVariantBulkCreate`
- `ProductVariantBulkUpdate`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
