### PR TITLE
Fix missing currency on variant channel listing when created via productChannelListingUpdate

### DIFF
--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -290,7 +290,9 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
         variant_channel_listings = []
         for variant in variants:
             variant_channel_listings.append(
-                ProductVariantChannelListing(channel=channel, variant=variant)
+                ProductVariantChannelListing(
+                    channel=channel, variant=variant, currency=channel.currency_code
+                )
             )
 
         try:

--- a/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
@@ -1116,10 +1116,18 @@ def test_product_channel_listing_add_variant_as_staff_user(
     # then
     data = content["data"]["productChannelListingUpdate"]
     variant_data = data["product"]["variants"]
-
     assert not data["errors"]
     assert variant_data[0]["channelListings"][0]["channel"]["slug"] == channel_USD.slug
     assert variant_data[1]["channelListings"][0]["channel"]["slug"] == channel_USD.slug
+
+    variant_channel_listing1 = ProductVariantChannelListing.objects.get(
+        channel=channel_USD, variant=variant_1
+    )
+    variant_channel_listing2 = ProductVariantChannelListing.objects.get(
+        channel=channel_USD, variant=variant_2
+    )
+    assert variant_channel_listing1.currency == channel_USD.currency_code
+    assert variant_channel_listing2.currency == channel_USD.currency_code
 
 
 def test_product_channel_listing_add_variant_as_app(
@@ -1157,6 +1165,15 @@ def test_product_channel_listing_add_variant_as_app(
     assert not data["errors"]
     assert variant_data[0]["channelListings"][0]["channel"]["slug"] == channel_USD.slug
     assert variant_data[1]["channelListings"][0]["channel"]["slug"] == channel_USD.slug
+
+    variant_channel_listing1 = ProductVariantChannelListing.objects.get(
+        channel=channel_USD, variant=variant_1
+    )
+    variant_channel_listing2 = ProductVariantChannelListing.objects.get(
+        channel=channel_USD, variant=variant_2
+    )
+    assert variant_channel_listing1.currency == channel_USD.currency_code
+    assert variant_channel_listing2.currency == channel_USD.currency_code
 
 
 def test_product_channel_listing_remove_variant_as_staff_user(


### PR DESCRIPTION
I want to merge this change because it fixes missing currency on variant channel listing when created via productChannelListingUpdate. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
