### PR TITLE
Extend tests for AssignedAttribute

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -1224,6 +1224,8 @@ class AssignedSwatchAttributeValue(BaseObjectType):
     def resolve_hex_color(
         root: models.AttributeValue, _info: ResolveInfo
     ) -> str | None:
+        if not root.value:
+            return None
         return root.value
 
     @staticmethod

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -17,46 +17,128 @@ from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
 
 CREATE_PAGE_MUTATION = """
-    mutation CreatePage(
-        $input: PageCreateInput!
-    ) {
-        pageCreate(input: $input) {
-            page {
-                id
-                title
-                content
-                slug
-                isPublished
-                publishedAt
-                pageType {
-                    id
-                }
-                attributes {
-                    attribute {
-                        slug
-                    }
-                    values {
-                        slug
-                        name
-                        reference
-                        date
-                        dateTime
-                        plainText
-                        file {
-                            url
-                            contentType
-                        }
-                    }
-                }
-            }
-            errors {
-                field
-                code
-                message
-                attributes
-            }
+mutation CreatePage($input: PageCreateInput!) {
+  pageCreate(input: $input) {
+    page {
+      id
+      title
+      content
+      slug
+      isPublished
+      publishedAt
+      pageType {
+        id
+      }
+      assignedAttributes {
+        ... on AssignedAttributeInterface {
+          attribute {
+            slug
+          }
         }
+        ... on AssignedSingleChoiceAttribute {
+          choice: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedNumericAttribute {
+          value
+        }
+        ... on AssignedFileAttribute {
+          file: value {
+            contentType
+            url
+          }
+        }
+        ... on AssignedMultiPageReferenceAttribute {
+          pages: value {
+            slug
+          }
+        }
+        ... on AssignedDateAttribute {
+          date: value
+        }
+        ... on AssignedDateTimeAttribute {
+          datetime: value
+        }
+        ... on AssignedTextAttribute {
+          text: value
+        }
+        ... on AssignedPlainTextAttribute {
+          plain_text: value
+        }
+        ... on AssignedMultiProductReferenceAttribute {
+          products: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductVariantReferenceAttribute {
+          variants: value {
+            sku
+          }
+        }
+        ... on AssignedMultiCategoryReferenceAttribute {
+          categories: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCollectionReferenceAttribute {
+          collections: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCategoryReferenceAttribute {
+          category: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCollectionReferenceAttribute {
+          collection: value {
+            slug
+          }
+        }
+        ... on AssignedSinglePageReferenceAttribute {
+          page: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductReferenceAttribute {
+          product: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductVariantReferenceAttribute {
+          variant: value {
+            sku
+          }
+        }
+      }
+      attributes {
+        attribute {
+          slug
+        }
+        values {
+          slug
+          name
+          reference
+          date
+          dateTime
+          plainText
+          file {
+            url
+            contentType
+          }
+        }
+      }
     }
+    errors {
+      field
+      code
+      message
+      attributes
+    }
+  }
+}
 """
 
 
@@ -75,9 +157,9 @@ def test_page_create_mutation(
 
     # Default attributes defined in page_type fixture
     tag_attr = page_type.page_attributes.get(name="tag")
-    tag_value_slug = tag_attr.values.first().slug
+
     tag_attr_id = graphene.Node.to_global_id("Attribute", tag_attr.id)
-    tag_value_name = tag_attr.values.first().name
+    tag_value = tag_attr.values.first()
 
     # Add second attribute
     size_attr = page_type.page_attributes.get(name="Page size")
@@ -96,7 +178,7 @@ def test_page_create_mutation(
             "slug": page_slug,
             "pageType": page_type_id,
             "attributes": [
-                {"id": tag_attr_id, "values": [tag_value_name]},
+                {"id": tag_attr_id, "values": [tag_value.name]},
                 {"id": size_attr_id, "values": [non_existent_attr_value]},
                 {
                     "id": to_global_id_or_none(numeric_attribute),
@@ -129,7 +211,26 @@ def test_page_create_mutation(
         data["page"]["attributes"][1]["values"][0]["slug"],
     )
     assert slugify(non_existent_attr_value) in values
-    assert tag_value_slug in values
+    assert tag_value.slug in values
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_size_assigned_attribute = {
+        "attribute": {"slug": size_attr.slug},
+        "choice": {
+            "name": non_existent_attr_value,
+            "slug": slugify(non_existent_attr_value),
+        },
+    }
+    expected_tag_assigned_attribute = {
+        "attribute": {"slug": tag_attr.slug},
+        "choice": {
+            "name": tag_value.name,
+            "slug": tag_value.slug,
+        },
+    }
+    assert expected_size_assigned_attribute in assigned_attributes
+    assert expected_tag_assigned_attribute in assigned_attributes
+
     assert numeric_attribute.values.filter(
         name=numeric_name, numeric=numeric_value
     ).exists()
@@ -150,8 +251,7 @@ def test_page_create_mutation_with_published_at_date(
 
     # Default attributes defined in page_type fixture
     tag_attr = page_type.page_attributes.get(name="tag")
-    tag_value_slug = tag_attr.values.first().slug
-    tag_value_name = tag_attr.values.first().name
+    tag_value = tag_attr.values.first()
     tag_attr_id = graphene.Node.to_global_id("Attribute", tag_attr.id)
 
     # Add second attribute
@@ -169,7 +269,7 @@ def test_page_create_mutation_with_published_at_date(
             "slug": page_slug,
             "pageType": page_type_id,
             "attributes": [
-                {"id": tag_attr_id, "values": [tag_value_name]},
+                {"id": tag_attr_id, "values": [tag_value.name]},
                 {"id": size_attr_id, "values": [non_existent_attr_value]},
             ],
         }
@@ -192,7 +292,25 @@ def test_page_create_mutation_with_published_at_date(
         data["page"]["attributes"][1]["values"][0]["slug"],
     )
     assert slugify(non_existent_attr_value) in values
-    assert tag_value_slug in values
+    assert tag_value.slug in values
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_size_assigned_attribute = {
+        "attribute": {"slug": size_attr.slug},
+        "choice": {
+            "name": non_existent_attr_value,
+            "slug": slugify(non_existent_attr_value),
+        },
+    }
+    expected_tag_assigned_attribute = {
+        "attribute": {"slug": tag_attr.slug},
+        "choice": {
+            "name": tag_value.name,
+            "slug": tag_value.slug,
+        },
+    }
+    assert expected_size_assigned_attribute in assigned_attributes
+    assert expected_tag_assigned_attribute in assigned_attributes
 
 
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
@@ -455,6 +573,16 @@ def test_create_page_with_file_attribute(
     }
     assert data["page"]["attributes"][0] == expected_attr_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_file_attribute.refresh_from_db()
     assert page_file_attribute.values.count() == values_count + 1
 
@@ -537,6 +665,16 @@ def test_create_page_with_file_attribute_new_attribute_value(
     }
     assert data["page"]["attributes"][0] == expected_attr_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": new_value_content_type,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_file_attribute.refresh_from_db()
     assert page_file_attribute.values.count() == values_count + 1
 
@@ -587,6 +725,13 @@ def test_create_page_with_file_attribute_not_required_no_file_url_given(
     assert data["page"]["pageType"]["id"] == page_type_id
     assert len(data["page"]["attributes"]) == 1
     assert len(data["page"]["attributes"][0]["values"]) == 0
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_file_attribute.slug},
+        "file": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_page_with_file_attribute_required_no_file_url_given(
@@ -707,6 +852,13 @@ def test_create_page_with_page_reference_attribute(
     }
     assert data["page"]["attributes"][0] == expected_attr_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_page_reference_attribute.slug},
+        "pages": [{"slug": page.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_page_reference_attribute.refresh_from_db()
     assert page_type_page_reference_attribute.values.count() == values_count + 1
 
@@ -767,8 +919,14 @@ def test_create_page_with_date_attribute(
             }
         ],
     }
-
     assert expected_attributes_data in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_attribute.slug},
+        "date": str(date_value),
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 @freeze_time(datetime.datetime(2020, 5, 5, 5, 5, 5, tzinfo=datetime.UTC))
@@ -830,6 +988,13 @@ def test_create_page_with_date_time_attribute(
 
     assert expected_attributes_data in data["page"]["attributes"]
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_time_attribute.slug},
+        "datetime": date_time_value.isoformat(),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_page_with_plain_text_attribute(
     staff_api_client,
@@ -887,8 +1052,14 @@ def test_create_page_with_plain_text_attribute(
             }
         ],
     }
-
     assert expected_attributes_data in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute_page_type.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_page_with_page_reference_attribute_not_required_no_references_given(
@@ -907,7 +1078,7 @@ def test_create_page_with_page_reference_attribute_not_required_no_references_gi
     )
     page_type_id = graphene.Node.to_global_id("PageType", page_type.pk)
 
-    file_attribute_id = graphene.Node.to_global_id(
+    reference_attribute_id = graphene.Node.to_global_id(
         "Attribute", page_type_page_reference_attribute.pk
     )
     page_type.page_attributes.add(page_type_page_reference_attribute)
@@ -923,7 +1094,7 @@ def test_create_page_with_page_reference_attribute_not_required_no_references_gi
             "isPublished": page_is_published,
             "slug": page_slug,
             "pageType": page_type_id,
-            "attributes": [{"id": file_attribute_id, "file": ""}],
+            "attributes": [{"id": reference_attribute_id}],
         }
     }
 
@@ -943,6 +1114,13 @@ def test_create_page_with_page_reference_attribute_not_required_no_references_gi
     assert len(data["page"]["attributes"]) == 1
     assert len(data["page"]["attributes"][0]["values"]) == 0
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_page_reference_attribute.slug},
+        "pages": [],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_page_with_page_reference_attribute_required_no_references_given(
     staff_api_client,
@@ -960,7 +1138,7 @@ def test_create_page_with_page_reference_attribute_required_no_references_given(
     )
     page_type_id = graphene.Node.to_global_id("PageType", page_type.pk)
 
-    file_attribute_id = graphene.Node.to_global_id(
+    reference_attribute_id = graphene.Node.to_global_id(
         "Attribute", page_type_page_reference_attribute.pk
     )
     page_type.page_attributes.add(page_type_page_reference_attribute)
@@ -976,7 +1154,11 @@ def test_create_page_with_page_reference_attribute_required_no_references_given(
             "isPublished": page_is_published,
             "slug": page_slug,
             "pageType": page_type_id,
-            "attributes": [{"id": file_attribute_id, "file": ""}],
+            "attributes": [
+                {
+                    "id": reference_attribute_id,
+                }
+            ],
         }
     }
 
@@ -992,7 +1174,7 @@ def test_create_page_with_page_reference_attribute_required_no_references_given(
     assert len(errors) == 1
     assert errors[0]["code"] == PageErrorCode.REQUIRED.name
     assert errors[0]["field"] == "attributes"
-    assert errors[0]["attributes"] == [file_attribute_id]
+    assert errors[0]["attributes"] == [reference_attribute_id]
 
 
 def test_create_page_with_product_reference_attribute(
@@ -1067,6 +1249,13 @@ def test_create_page_with_product_reference_attribute(
     }
     assert data["page"]["attributes"][0] == expected_attr_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_product_reference_attribute.slug},
+        "products": [{"slug": product.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_product_reference_attribute.refresh_from_db()
     assert page_type_product_reference_attribute.values.count() == values_count + 1
 
@@ -1087,7 +1276,7 @@ def test_create_page_with_product_reference_attribute_not_required_no_references
     )
     page_type_id = graphene.Node.to_global_id("PageType", page_type.pk)
 
-    file_attribute_id = graphene.Node.to_global_id(
+    reference_attribute_id = graphene.Node.to_global_id(
         "Attribute", page_type_product_reference_attribute.pk
     )
     page_type.page_attributes.add(page_type_product_reference_attribute)
@@ -1103,7 +1292,7 @@ def test_create_page_with_product_reference_attribute_not_required_no_references
             "isPublished": page_is_published,
             "slug": page_slug,
             "pageType": page_type_id,
-            "attributes": [{"id": file_attribute_id, "file": ""}],
+            "attributes": [{"id": reference_attribute_id}],
         }
     }
 
@@ -1122,6 +1311,13 @@ def test_create_page_with_product_reference_attribute_not_required_no_references
     assert data["page"]["pageType"]["id"] == page_type_id
     assert len(data["page"]["attributes"]) == 1
     assert len(data["page"]["attributes"][0]["values"]) == 0
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_product_reference_attribute.slug},
+        "products": [],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_page_with_product_reference_attribute_required_no_references_given(
@@ -1247,6 +1443,13 @@ def test_create_page_with_variant_reference_attribute(
     }
     assert data["page"]["attributes"][0] == expected_attr_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_variant_reference_attribute.slug},
+        "variants": [{"sku": variant.sku}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_variant_reference_attribute.refresh_from_db()
     assert page_type_variant_reference_attribute.values.count() == values_count + 1
 
@@ -1322,6 +1525,13 @@ def test_create_page_with_category_reference_attribute(
     }
     assert data["page"]["attributes"][0] == expected_attr_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_category_reference_attribute.slug},
+        "categories": [{"slug": category.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_category_reference_attribute.refresh_from_db()
     assert page_type_category_reference_attribute.values.count() == values_count + 1
 
@@ -1396,6 +1606,12 @@ def test_create_page_with_collection_reference_attribute(
         ],
     }
     assert data["page"]["attributes"][0] == expected_attr_data
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_collection_reference_attribute.slug},
+        "collections": [{"slug": collection.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     page_type_collection_reference_attribute.refresh_from_db()
     assert page_type_collection_reference_attribute.values.count() == values_count + 1
@@ -1513,6 +1729,34 @@ def test_create_page_with_single_reference_attributes(
     for attr_data in attributes_data:
         assert attr_data in expected_attributes_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+
+    expected_assigned_page_attribute = {
+        "attribute": {"slug": page_type_page_single_reference_attribute.slug},
+        "page": {"slug": page.slug},
+    }
+    expected_assigned_product_attribute = {
+        "attribute": {"slug": page_type_product_single_reference_attribute.slug},
+        "product": {"slug": product.slug},
+    }
+    expected_assigned_variant_attribute = {
+        "attribute": {"slug": page_type_variant_single_reference_attribute.slug},
+        "variant": {"sku": product_variant_list[0].sku},
+    }
+    expected_assigned_category_attribute = {
+        "attribute": {"slug": page_type_category_single_reference_attribute.slug},
+        "category": {"slug": categories[0].slug},
+    }
+    expected_assigned_collection_attribute = {
+        "attribute": {"slug": page_type_collection_single_reference_attribute.slug},
+        "collection": {"slug": collection.slug},
+    }
+    assert expected_assigned_page_attribute in assigned_attributes
+    assert expected_assigned_product_attribute in assigned_attributes
+    assert expected_assigned_variant_attribute in assigned_attributes
+    assert expected_assigned_category_attribute in assigned_attributes
+    assert expected_assigned_collection_attribute in assigned_attributes
+
 
 @freeze_time("2020-03-18 12:00:00")
 def test_page_create_mutation_with_numeric_attribue(
@@ -1566,6 +1810,13 @@ def test_page_create_mutation_with_numeric_attribue(
         == f"{Page.objects.get().id}_{numeric_attribute.id}"
     )
     assert attribute["values"][0]["name"] == numeric_name
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     assert numeric_attribute.values.filter(
         name=numeric_name, numeric=numeric_value

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -25,41 +25,121 @@ from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
 
 UPDATE_PAGE_MUTATION = """
-    mutation updatePage(
-        $id: ID!, $input: PageInput!
-    ) {
-        pageUpdate(
-            id: $id, input: $input
-        ) {
-            page {
-                id
-                title
-                slug
-                isPublished
-                publishedAt
-                attributes {
-                    attribute {
-                        slug
-                    }
-                    values {
-                        slug
-                        name
-                        reference
-                        file {
-                            url
-                            contentType
-                        }
-                        plainText
-                    }
-                }
-            }
-            errors {
-                field
-                code
-                message
-            }
+mutation updatePage($id: ID!, $input: PageInput!) {
+  pageUpdate(id: $id, input: $input) {
+    page {
+      id
+      title
+      slug
+      isPublished
+      publishedAt
+      assignedAttributes {
+        ... on AssignedAttributeInterface {
+          attribute {
+            slug
+          }
         }
+        ... on AssignedSingleChoiceAttribute {
+          choice: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedNumericAttribute {
+          value
+        }
+        ... on AssignedFileAttribute {
+          file: value {
+            contentType
+            url
+          }
+        }
+        ... on AssignedMultiPageReferenceAttribute {
+          pages: value {
+            slug
+          }
+        }
+        ... on AssignedDateAttribute {
+          date: value
+        }
+        ... on AssignedDateTimeAttribute {
+          datetime: value
+        }
+        ... on AssignedTextAttribute {
+          text: value
+        }
+        ... on AssignedPlainTextAttribute {
+          plain_text: value
+        }
+        ... on AssignedMultiProductReferenceAttribute {
+          products: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductVariantReferenceAttribute {
+          variants: value {
+            sku
+          }
+        }
+        ... on AssignedMultiCategoryReferenceAttribute {
+          categories: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCollectionReferenceAttribute {
+          collections: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCategoryReferenceAttribute {
+          category: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCollectionReferenceAttribute {
+          collection: value {
+            slug
+          }
+        }
+        ... on AssignedSinglePageReferenceAttribute {
+          page: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductReferenceAttribute {
+          product: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductVariantReferenceAttribute {
+          variant: value {
+            sku
+          }
+        }
+      }
+      attributes {
+        attribute {
+          slug
+        }
+        values {
+          slug
+          name
+          reference
+          file {
+            url
+            contentType
+          }
+          plainText
+        }
+      }
     }
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
 """
 
 
@@ -100,23 +180,24 @@ def test_update_page(staff_api_client, permission_manage_pages, page):
     assert data["page"]["title"] == page_title
     assert data["page"]["slug"] == new_slug
 
-    expected_attributes = []
-    for attr in page_type.page_attributes.all():
-        if attr.slug != tag_attr.slug:
-            values = [
+    size_attr, tag_attr = page_type.page_attributes.all()
+    size_attr_value = get_page_attribute_values(page, size_attr).get()
+    expected_attributes = [
+        {
+            "attribute": {"slug": size_attr.slug},
+            "values": [
                 {
-                    "slug": slug,
+                    "slug": size_attr_value.slug,
                     "file": None,
-                    "name": name,
+                    "name": size_attr_value.name,
                     "reference": None,
                     "plainText": None,
                 }
-                for slug, name in get_page_attribute_values(page, attr).values_list(
-                    "slug", "name"
-                )
-            ]
-        else:
-            values = [
+            ],
+        },
+        {
+            "attribute": {"slug": tag_attr.slug},
+            "values": [
                 {
                     "slug": slugify(new_value),
                     "file": None,
@@ -124,17 +205,32 @@ def test_update_page(staff_api_client, permission_manage_pages, page):
                     "plainText": None,
                     "reference": None,
                 }
-            ]
-        attr_data = {
-            "attribute": {"slug": attr.slug},
-            "values": values,
-        }
-        expected_attributes.append(attr_data)
+            ],
+        },
+    ]
 
     attributes = data["page"]["attributes"]
     assert len(attributes) == len(expected_attributes)
     for attr_data in attributes:
         assert attr_data in expected_attributes
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_size_assigned_attribute = {
+        "attribute": {"slug": size_attr.slug},
+        "choice": {
+            "name": size_attr_value.name,
+            "slug": size_attr_value.slug,
+        },
+    }
+    expected_tag_assigned_attribute = {
+        "attribute": {"slug": tag_attr.slug},
+        "choice": {
+            "name": new_value,
+            "slug": slugify(new_value),
+        },
+    }
+    assert expected_size_assigned_attribute in assigned_attributes
+    assert expected_tag_assigned_attribute in assigned_attributes
 
 
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
@@ -228,30 +324,46 @@ def test_update_page_only_title(staff_api_client, permission_manage_pages, page)
     assert data["page"]["title"] == page_title
     assert data["page"]["slug"] == new_slug
 
-    expected_attributes = []
-    for attr in page_type.page_attributes.all():
-        values = [
-            {
-                "slug": slug,
-                "file": None,
-                "name": name,
-                "reference": None,
-                "plainText": None,
-            }
-            for slug, name in get_page_attribute_values(page, attr).values_list(
-                "slug", "name"
-            )
-        ]
-        attr_data = {
-            "attribute": {"slug": attr.slug},
-            "values": values,
-        }
-        expected_attributes.append(attr_data)
+    size_attr, tag_attr = page_type.page_attributes.all()
+    size_attr_value = get_page_attribute_values(page, size_attr).get()
+    expected_attributes = [
+        {
+            "attribute": {"slug": size_attr.slug},
+            "values": [
+                {
+                    "slug": size_attr_value.slug,
+                    "file": None,
+                    "name": size_attr_value.name,
+                    "reference": None,
+                    "plainText": None,
+                }
+            ],
+        },
+        {
+            "attribute": {"slug": tag_attr.slug},
+            "values": [],
+        },
+    ]
 
     attributes = data["page"]["attributes"]
     assert len(attributes) == len(expected_attributes)
     for attr_data in attributes:
         assert attr_data in expected_attributes
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_size_assigned_attribute = {
+        "attribute": {"slug": size_attr.slug},
+        "choice": {
+            "name": size_attr_value.name,
+            "slug": size_attr_value.slug,
+        },
+    }
+    expected_tag_assigned_attribute = {
+        "attribute": {"slug": tag_attr.slug},
+        "choice": None,
+    }
+    assert expected_size_assigned_attribute in assigned_attributes
+    assert expected_tag_assigned_attribute in assigned_attributes
 
 
 def test_update_page_with_file_attribute_value(
@@ -302,6 +414,16 @@ def test_update_page_with_file_attribute_value(
         ],
     }
     assert updated_attribute in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_update_page_with_file_attribute_new_value_is_not_created(
@@ -356,6 +478,16 @@ def test_update_page_with_file_attribute_new_value_is_not_created(
     }
     assert updated_attribute in data["page"]["attributes"]
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": existing_value.content_type,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_update_page_clear_file_attribute_values(
     staff_api_client, permission_manage_pages, page, page_file_attribute
@@ -402,6 +534,13 @@ def test_update_page_clear_file_attribute_values(
         if attr["attribute"]["slug"] == attribute.slug
     ][0]
     assert not attr_data["values"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_file_attribute.slug},
+        "file": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
     assert not get_page_attribute_values(page, page_file_attribute).exists()
 
 
@@ -456,6 +595,13 @@ def test_update_page_with_page_reference_attribute_new_value(
         ],
     }
     assert updated_attribute in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_page_reference_attribute.slug},
+        "pages": [{"slug": ref_page.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     page_type_page_reference_attribute.refresh_from_db()
     assert page_type_page_reference_attribute.values.count() == values_count + 1
@@ -523,6 +669,13 @@ def test_update_page_with_page_reference_attribute_existing_value(
     }
     assert updated_attribute in data["page"]["attributes"]
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_page_reference_attribute.slug},
+        "pages": [{"slug": ref_page.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_page_reference_attribute.refresh_from_db()
     assert page_type_page_reference_attribute.values.count() == values_count
 
@@ -577,6 +730,13 @@ def test_update_page_with_plain_text_attribute_new_value(
         ],
     }
     assert updated_attribute in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute_page_type.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     plain_text_attribute_page_type.refresh_from_db()
     assert plain_text_attribute_page_type.values.count() == values_count + 1
@@ -636,6 +796,13 @@ def test_update_page_with_plain_text_attribute_existing_value(
         ],
     }
     assert updated_attribute in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute_page_type.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     plain_text_attribute_page_type.refresh_from_db()
     assert plain_text_attribute_page_type.values.count() == values_count
@@ -740,6 +907,13 @@ def test_update_page_with_product_reference_attribute_new_value(
     }
     assert updated_attribute in data["page"]["attributes"]
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_product_reference_attribute.slug},
+        "products": [{"slug": product.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_product_reference_attribute.refresh_from_db()
     assert page_type_product_reference_attribute.values.count() == values_count + 1
 
@@ -806,6 +980,13 @@ def test_update_page_with_product_reference_attribute_existing_value(
     }
     assert updated_attribute in data["page"]["attributes"]
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_product_reference_attribute.slug},
+        "products": [{"slug": product.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_product_reference_attribute.refresh_from_db()
     assert page_type_product_reference_attribute.values.count() == values_count
 
@@ -860,6 +1041,13 @@ def test_update_page_with_variant_reference_attribute_new_value(
         ],
     }
     assert updated_attribute in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_variant_reference_attribute.slug},
+        "variants": [{"sku": variant.sku}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     page_type_variant_reference_attribute.refresh_from_db()
     assert page_type_variant_reference_attribute.values.count() == values_count + 1
@@ -927,6 +1115,13 @@ def test_update_page_with_variant_reference_attribute_existing_value(
     }
     assert updated_attribute in data["page"]["attributes"]
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_variant_reference_attribute.slug},
+        "variants": [{"sku": variant.sku}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_variant_reference_attribute.refresh_from_db()
     assert page_type_variant_reference_attribute.values.count() == values_count
 
@@ -980,6 +1175,13 @@ def test_update_page_with_category_reference_attribute_new_value(
     }
     assert updated_attribute in data["page"]["attributes"]
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_category_reference_attribute.slug},
+        "categories": [{"slug": category.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     page_type_category_reference_attribute.refresh_from_db()
     assert page_type_category_reference_attribute.values.count() == values_count + 1
 
@@ -1032,6 +1234,13 @@ def test_update_page_with_collection_reference_attribute_new_value(
         ],
     }
     assert updated_attribute in data["page"]["attributes"]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": page_type_collection_reference_attribute.slug},
+        "collections": [{"slug": collection.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     page_type_collection_reference_attribute.refresh_from_db()
     assert page_type_collection_reference_attribute.values.count() == values_count + 1
@@ -1157,6 +1366,43 @@ UPDATE_PAGE_ATTRIBUTES_MUTATION = """
                 id
                 title
                 slug
+                assignedAttributes {
+                    ... on AssignedAttributeInterface {
+                        attribute {
+                            slug
+                        }
+                    }
+                    ... on AssignedMultiProductReferenceAttribute {
+                        products: value {
+                            slug
+                        }
+                    }
+                    ... on AssignedSingleCategoryReferenceAttribute {
+                        category: value {
+                            slug
+                        }
+                    }
+                    ... on AssignedSingleCollectionReferenceAttribute {
+                        collection: value {
+                            slug
+                        }
+                    }
+                    ... on AssignedSinglePageReferenceAttribute {
+                        page: value {
+                            slug
+                        }
+                    }
+                    ... on AssignedSingleProductReferenceAttribute {
+                        product: value {
+                            slug
+                        }
+                    }
+                    ... on AssignedSingleProductVariantReferenceAttribute {
+                        variant: value {
+                            sku
+                        }
+                    }
+                }
                 attributes {
                     attribute {
                         slug
@@ -1239,7 +1485,15 @@ def test_update_page_change_attribute_values_ordering(
         get_page_attribute_values(page, attribute).values_list("id", flat=True)
     ) == [attr_value_3.pk, attr_value_2.pk, attr_value_1.pk]
 
-    new_ref_order = [product_list[1], product_list[0], product_list[2]]
+    expected_first_product = product_list[1]
+    expected_second_product = product_list[0]
+    expected_third_product = product_list[2]
+
+    new_ref_order = [
+        expected_first_product,
+        expected_second_product,
+        expected_third_product,
+    ]
     variables = {
         "id": page_id,
         "input": {
@@ -1276,6 +1530,14 @@ def test_update_page_change_attribute_values_ordering(
         graphene.Node.to_global_id("AttributeValue", val.pk)
         for val in [attr_value_2, attr_value_1, attr_value_3]
     ]
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assigned_values = assigned_attributes[0]["products"]
+    assert len(assigned_values) == 3
+    assert assigned_values[0]["slug"] == expected_first_product.slug
+    assert assigned_values[1]["slug"] == expected_second_product.slug
+    assert assigned_values[2]["slug"] == expected_third_product.slug
 
     assert list(
         get_page_attribute_values(page, attribute).values_list("id", flat=True)
@@ -1416,6 +1678,34 @@ def test_update_page_with_single_reference_attributes(
     for attr_data in attributes_data:
         assert attr_data in expected_attributes_data
 
+    assigned_attributes = data["page"]["assignedAttributes"]
+
+    expected_assigned_page_attribute = {
+        "attribute": {"slug": page_type_page_single_reference_attribute.slug},
+        "page": {"slug": page_ref.slug},
+    }
+    expected_assigned_product_attribute = {
+        "attribute": {"slug": page_type_product_single_reference_attribute.slug},
+        "product": {"slug": product.slug},
+    }
+    expected_assigned_variant_attribute = {
+        "attribute": {"slug": page_type_variant_single_reference_attribute.slug},
+        "variant": {"sku": product_variant_list[0].sku},
+    }
+    expected_assigned_category_attribute = {
+        "attribute": {"slug": page_type_category_single_reference_attribute.slug},
+        "category": {"slug": categories[0].slug},
+    }
+    expected_assigned_collection_attribute = {
+        "attribute": {"slug": page_type_collection_single_reference_attribute.slug},
+        "collection": {"slug": collection.slug},
+    }
+    assert expected_assigned_page_attribute in assigned_attributes
+    assert expected_assigned_product_attribute in assigned_attributes
+    assert expected_assigned_variant_attribute in assigned_attributes
+    assert expected_assigned_category_attribute in assigned_attributes
+    assert expected_assigned_collection_attribute in assigned_attributes
+
 
 def test_update_page_with_numeric_attribute(
     staff_api_client, permission_manage_pages, page, numeric_attribute
@@ -1458,6 +1748,13 @@ def test_update_page_with_numeric_attribute(
     assert len(attributes[0]["values"]) == 1
     assert attributes[0]["values"][0]["slug"] == f"{page.pk}_{numeric_attribute.pk}"
     assert attributes[0]["values"][0]["name"] == numeric_name
+
+    assigned_attributes = data["page"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     assert numeric_attribute.values.filter(
         name=numeric_name,

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -22,64 +22,165 @@ from ....tests.utils import (
 )
 
 PRODUCT_BULK_CREATE_MUTATION = """
-    mutation ProductBulkCreate(
-        $products: [ProductBulkCreateInput!]!
-        $errorPolicy: ErrorPolicyEnum
-    ) {
-        productBulkCreate(products: $products, errorPolicy: $errorPolicy) {
-            results {
-                errors {
-                    path
-                    code
-                    message
-                    warehouses
-                    channels
-                }
-                product{
-                    id
-                    name
-                    slug
-                    media{
-                        url
-                        alt
-                        type
-                        oembedData
-                    }
-                    category{
-                        name
-                    }
-                    collections{
-                        id
-                    }
-                    description
-                    attributes{
-                        attribute{
-                          slug
-                        }
-                        values{
-                           value
-                        }
-                    }
-                    channelListings{
-                        id
-                        channel{
-                            name
-                        }
-                    }
-                    variants{
-                        name
-                        stocks{
-                            warehouse{
-                                slug
-                            }
-                            quantity
-                        }
-                    }
-                }
-            }
-            count
+mutation ProductBulkCreate($products: [ProductBulkCreateInput!]!, $errorPolicy: ErrorPolicyEnum) {
+  productBulkCreate(products: $products, errorPolicy: $errorPolicy) {
+    results {
+      errors {
+        path
+        code
+        message
+        warehouses
+        channels
+      }
+      product {
+        id
+        name
+        slug
+        media {
+          url
+          alt
+          type
+          oembedData
         }
+        category {
+          name
+        }
+        collections {
+          id
+        }
+        description
+        attributes {
+          attribute {
+            slug
+          }
+          values {
+            value
+          }
+        }
+        assignedAttributes {
+          ... on AssignedAttributeInterface {
+            attribute {
+              slug
+            }
+          }
+          ... on AssignedNumericAttribute {
+            value
+          }
+          ... on AssignedTextAttribute {
+            text: value
+          }
+          ... on AssignedPlainTextAttribute {
+            plain_text: value
+          }
+          ... on AssignedFileAttribute {
+            file: value {
+              contentType
+              url
+            }
+          }
+          ... on AssignedMultiPageReferenceAttribute {
+            pages: value {
+              slug
+            }
+          }
+          ... on AssignedMultiProductReferenceAttribute {
+            products: value {
+              slug
+            }
+          }
+          ... on AssignedMultiCategoryReferenceAttribute {
+            categories: value {
+              slug
+            }
+          }
+          ... on AssignedMultiCollectionReferenceAttribute {
+            collections: value {
+              slug
+            }
+          }
+          ... on AssignedSinglePageReferenceAttribute {
+            page: value {
+              slug
+            }
+          }
+          ... on AssignedSingleProductReferenceAttribute {
+            product: value {
+              slug
+            }
+          }
+          ... on AssignedSingleProductVariantReferenceAttribute {
+            variant: value {
+              sku
+            }
+          }
+          ... on AssignedSingleCategoryReferenceAttribute {
+            category: value {
+              slug
+            }
+          }
+          ... on AssignedSingleCollectionReferenceAttribute {
+            collection: value {
+              slug
+            }
+          }
+          ... on AssignedMultiProductVariantReferenceAttribute {
+            variants: value {
+              sku
+            }
+          }
+          ... on AssignedSingleChoiceAttribute {
+            choice: value {
+              name
+              slug
+            }
+          }
+          ... on AssignedMultiChoiceAttribute {
+            multi: value {
+              name
+              slug
+            }
+          }
+          ... on AssignedSwatchAttribute {
+            swatch: value {
+              name
+              slug
+              hexColor
+              file {
+                url
+                contentType
+              }
+            }
+          }
+          ... on AssignedBooleanAttribute {
+            bool: value
+          }
+          ... on AssignedDateAttribute {
+            date: value
+          }
+          ... on AssignedDateTimeAttribute {
+            datetime: value
+          }
+        }
+        channelListings {
+          id
+          channel {
+            name
+          }
+        }
+        variants {
+          name
+          stocks {
+            warehouse {
+              slug
+            }
+            quantity
+          }
+        }
+      }
     }
+    count
+  }
+}
 """
 
 
@@ -790,6 +891,16 @@ def test_product_bulk_create_with_attributes(
         == color_attr.slug
     )
 
+    first_p_assigned_attributes = data["results"][0]["product"]["assignedAttributes"]
+    assert len(first_p_assigned_attributes) == 2
+    assert first_p_assigned_attributes[0]["choice"]["name"] == color_value_name
+    assert first_p_assigned_attributes[1]["choice"]["name"] == non_existent_attr_value
+
+    second_p_assigned_attributes = data["results"][1]["product"]["assignedAttributes"]
+    assert len(second_p_assigned_attributes) == 2
+    assert second_p_assigned_attributes[0]["choice"]["name"] == color_value_name
+    assert second_p_assigned_attributes[1]["choice"]["name"] == non_existent_attr_value
+
     for product in products:
         product_attributes = get_product_attributes(product)
         assert len(product_attributes) == 2
@@ -874,6 +985,16 @@ def test_product_bulk_create_with_single_reference_attributes(
         == attribute.slug
     )
 
+    first_p_assigned_attributes = data["results"][0]["product"]["assignedAttributes"]
+    second_p_assigned_attributes = data["results"][1]["product"]["assignedAttributes"]
+
+    expected_assigned_page_attribute = {
+        "attribute": {"slug": product_type_page_single_reference_attribute.slug},
+        "page": {"slug": page.slug},
+    }
+    assert expected_assigned_page_attribute in first_p_assigned_attributes
+    assert expected_assigned_page_attribute in second_p_assigned_attributes
+
 
 def test_product_bulk_create_with_attributes_using_external_refs(
     staff_api_client,
@@ -897,7 +1018,8 @@ def test_product_bulk_create_with_attributes_using_external_refs(
 
     # Default attribute defined in product_type fixture
     color_attr = product_type.product_attributes.get(name="Color")
-    color_value_external_reference = color_attr.values.first().external_reference
+    color_value = color_attr.values.first()
+    color_value_external_reference = color_value.external_reference
 
     # Add second attribute
     product_type.product_attributes.add(size_attribute)
@@ -941,6 +1063,11 @@ def test_product_bulk_create_with_attributes_using_external_refs(
         data["results"][0]["product"]["attributes"][0]["attribute"]["slug"]
         == color_attr.slug
     )
+
+    first_p_assigned_attributes = data["results"][0]["product"]["assignedAttributes"]
+    assert len(first_p_assigned_attributes) == 2
+    assert first_p_assigned_attributes[0]["choice"]["name"] == color_value.name
+    assert first_p_assigned_attributes[1]["choice"]["name"] == non_existent_attr_value
 
     for product in products:
         attributes = get_product_attributes(product)
@@ -1016,6 +1143,11 @@ def test_product_bulk_create_with_attributes_and_create_new_value_with_external_
         data["results"][0]["product"]["attributes"][0]["attribute"]["slug"]
         == color_attr.slug
     )
+
+    first_p_assigned_attributes = data["results"][0]["product"]["assignedAttributes"]
+    assert len(first_p_assigned_attributes) == 1
+    assert first_p_assigned_attributes[0]["choice"]["name"] == new_value
+
     assert color_attr.values.count() == color_attr_values_count + 1
     attributes = get_product_attributes(product)
     first_attribute_assignment = attributes[0]

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -21,68 +21,169 @@ from .....product.models import Product
 from .....tests.utils import dummy_editorjs
 
 CREATE_PRODUCT_MUTATION = """
-       mutation createProduct(
-           $input: ProductCreateInput!
-       ) {
-                productCreate(
-                    input: $input) {
-                        product {
-                            id
-                            category {
-                                name
-                            }
-                            description
-                            chargeTaxes
-                            taxClass {
-                                id
-                            }
-                            taxType {
-                                taxCode
-                                description
-                            }
-                            name
-                            slug
-                            rating
-                            productType {
-                                name
-                            }
-                            metadata {
-                                key
-                                value
-                            }
-                            privateMetadata {
-                                key
-                                value
-                            }
-                            attributes {
-                                attribute {
-                                    slug
-                                }
-                                values {
-                                    slug
-                                    name
-                                    reference
-                                    richText
-                                    plainText
-                                    boolean
-                                    dateTime
-                                    date
-                                    file {
-                                        url
-                                        contentType
-                                    }
-                                }
-                            }
-                            externalReference
-                          }
-                          errors {
-                            field
-                            code
-                            message
-                            attributes
-                          }
-                        }
-                      }
+mutation createProduct($input: ProductCreateInput!) {
+  productCreate(input: $input) {
+    product {
+      id
+      category {
+        name
+      }
+      description
+      chargeTaxes
+      taxClass {
+        id
+      }
+      taxType {
+        taxCode
+        description
+      }
+      name
+      slug
+      rating
+      productType {
+        name
+      }
+      metadata {
+        key
+        value
+      }
+      privateMetadata {
+        key
+        value
+      }
+      assignedAttributes {
+        ... on AssignedAttributeInterface {
+          attribute {
+            slug
+          }
+        }
+        ... on AssignedNumericAttribute {
+          value
+        }
+        ... on AssignedTextAttribute {
+          text: value
+        }
+        ... on AssignedPlainTextAttribute {
+          plain_text: value
+        }
+        ... on AssignedFileAttribute {
+          file: value {
+            contentType
+            url
+          }
+        }
+        ... on AssignedMultiPageReferenceAttribute {
+          pages: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductReferenceAttribute {
+          products: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCategoryReferenceAttribute {
+          categories: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCollectionReferenceAttribute {
+          collections: value {
+            slug
+          }
+        }
+        ... on AssignedSinglePageReferenceAttribute {
+          page: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductReferenceAttribute {
+          product: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductVariantReferenceAttribute {
+          variant: value {
+            sku
+          }
+        }
+        ... on AssignedSingleCategoryReferenceAttribute {
+          category: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCollectionReferenceAttribute {
+          collection: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductVariantReferenceAttribute {
+          variants: value {
+            sku
+          }
+        }
+        ... on AssignedSingleChoiceAttribute {
+          choice: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedMultiChoiceAttribute {
+          multi: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedSwatchAttribute {
+          swatch: value {
+            name
+            slug
+            hexColor
+            file {
+              url
+              contentType
+            }
+          }
+        }
+        ... on AssignedBooleanAttribute {
+          bool: value
+        }
+        ... on AssignedDateAttribute {
+          date: value
+        }
+        ... on AssignedDateTimeAttribute {
+          datetime: value
+        }
+      }
+      attributes {
+        attribute {
+          slug
+        }
+        values {
+          slug
+          name
+          reference
+          richText
+          plainText
+          boolean
+          dateTime
+          date
+          file {
+            url
+            contentType
+          }
+        }
+      }
+      externalReference
+    }
+    errors {
+      field
+      code
+      message
+      attributes
+    }
+  }
+}
 """
 
 
@@ -171,12 +272,18 @@ def test_create_product(
     assert data["product"]["category"]["name"] == category.name
     assert data["product"]["taxClass"]["id"] == tax_class_id
     assert data["product"]["externalReference"] == external_reference
+
     values = (
         data["product"]["attributes"][0]["values"][0]["slug"],
         data["product"]["attributes"][1]["values"][0]["slug"],
     )
     assert slugify(non_existent_attr_value) in values
     assert color_value_slug in values
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    assert len(assigned_attributes) == 2
+    assert assigned_attributes[0]["choice"]["name"] == color_value_name
+    assert assigned_attributes[1]["choice"]["name"] == non_existent_attr_value
 
     product = Product.objects.first()
     assert product.search_index_dirty is True
@@ -334,6 +441,7 @@ def test_create_product_with_using_attribute_external_ref(
     product_name = "test name"
     product_slug = "product-test-slug"
 
+    expected_attr_value_name = "newColor"
     # test creating root product
     variables = {
         "input": {
@@ -344,7 +452,7 @@ def test_create_product_with_using_attribute_external_ref(
             "attributes": [
                 {
                     "externalReference": color_attribute.external_reference,
-                    "dropdown": {"value": "newColor"},
+                    "dropdown": {"value": expected_attr_value_name},
                 }
             ],
         }
@@ -367,8 +475,8 @@ def test_create_product_with_using_attribute_external_ref(
             "attribute": {"slug": "color"},
             "values": [
                 {
-                    "slug": "newcolor",
-                    "name": "newColor",
+                    "slug": expected_attr_value_name.lower(),
+                    "name": expected_attr_value_name,
                     "reference": None,
                     "richText": None,
                     "plainText": None,
@@ -383,6 +491,16 @@ def test_create_product_with_using_attribute_external_ref(
 
     for attr_data in data["product"]["attributes"]:
         assert attr_data in expected_attributes_data
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": {
+            "name": expected_attr_value_name,
+            "slug": expected_attr_value_name.lower(),
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
 
 
 def test_create_product_with_using_attribute_id_and_external_ref(
@@ -495,6 +613,16 @@ def test_create_product_with_using_attribute_and_value_external_ref(
     for attr_data in data["product"]["attributes"]:
         assert attr_data in expected_attributes_data
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": {
+            "name": attr_value.name,
+            "slug": attr_value.slug,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_with_rich_text_attribute(
     staff_api_client,
@@ -572,6 +700,13 @@ def test_create_product_with_rich_text_attribute(
     for attr_data in data["product"]["attributes"]:
         assert attr_data in expected_attributes_data
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": rich_text_attribute.slug},
+        "text": rich_text_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_no_value_for_rich_text_attribute(
     staff_api_client,
@@ -611,6 +746,14 @@ def test_create_product_no_value_for_rich_text_attribute(
     assert data["errors"] == []
     assert data["product"]["name"] == product_name
     assert data["product"]["productType"]["name"] == product_type.name
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": rich_text_attribute.slug},
+        "text": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     expected_attributes_data = {
         "attribute": {"slug": rich_text_attribute.slug},
         "values": [],
@@ -692,6 +835,13 @@ def test_create_product_with_plain_text_attribute(
         },
     ]
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": text_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     for attr_data in data["product"]["attributes"]:
         assert attr_data in expected_attributes_data
 
@@ -738,6 +888,14 @@ def test_create_product_no_value_for_plain_text_attribute(
     assert data["errors"] == []
     assert data["product"]["name"] == product_name
     assert data["product"]["productType"]["name"] == product_type.name
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     expected_attributes_data = {
         "attribute": {"slug": plain_text_attribute.slug},
         "values": [],
@@ -808,6 +966,13 @@ def test_create_product_with_date_time_attribute(
 
     assert expected_attributes_data in data["product"]["attributes"]
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_time_attribute.slug},
+        "datetime": str(value.isoformat()),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 @freeze_time(datetime.datetime(2020, 5, 5, 5, 5, 5, tzinfo=datetime.UTC))
 def test_create_product_with_date_attribute(
@@ -870,6 +1035,13 @@ def test_create_product_with_date_attribute(
 
     assert expected_attributes_data in data["product"]["attributes"]
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_attribute.slug},
+        "date": str(value),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_no_value_for_date_attribute(
     staff_api_client,
@@ -912,6 +1084,13 @@ def test_create_product_no_value_for_date_attribute(
         "values": [],
     }
     assert expected_attributes_data in data["product"]["attributes"]
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_attribute.slug},
+        "date": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_boolean_attribute(
@@ -973,6 +1152,13 @@ def test_create_product_with_boolean_attribute(
     }
     assert expected_attributes_data in data["product"]["attributes"]
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": boolean_attribute.slug},
+        "bool": False,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_no_value_for_boolean_attribute(
     staff_api_client,
@@ -1015,6 +1201,13 @@ def test_create_product_no_value_for_boolean_attribute(
         "values": [],
     }
     assert expected_attributes_data in data["product"]["attributes"]
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": boolean_attribute.slug},
+        "bool": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 @pytest.mark.parametrize("input_slug", ["", None])
@@ -1467,6 +1660,7 @@ def test_create_product_with_file_attribute(
     query = CREATE_PRODUCT_MUTATION
 
     product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+
     category_id = graphene.Node.to_global_id("Category", category.pk)
     product_name = "test name"
     product_slug = "product-test-slug"
@@ -1529,6 +1723,16 @@ def test_create_product_with_file_attribute(
 
     file_attribute.refresh_from_db()
     assert file_attribute.values.count() == values_count + 1
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_page_reference_attribute(
@@ -1603,6 +1807,13 @@ def test_create_product_with_page_reference_attribute(
     product_type_page_reference_attribute.refresh_from_db()
     assert product_type_page_reference_attribute.values.count() == values_count + 1
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_page_reference_attribute.slug},
+        "pages": [{"slug": page.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_with_product_reference_attribute(
     staff_api_client,
@@ -1675,6 +1886,13 @@ def test_create_product_with_product_reference_attribute(
 
     product_type_product_reference_attribute.refresh_from_db()
     assert product_type_product_reference_attribute.values.count() == values_count + 1
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_product_reference_attribute.slug},
+        "products": [{"slug": product.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_variant_reference_attribute(
@@ -1753,6 +1971,13 @@ def test_create_product_with_variant_reference_attribute(
     product_type_variant_reference_attribute.refresh_from_db()
     assert product_type_variant_reference_attribute.values.count() == values_count + 1
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_variant_reference_attribute.slug},
+        "variants": [{"sku": variant.sku}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_with_category_reference_attribute(
     staff_api_client,
@@ -1826,6 +2051,13 @@ def test_create_product_with_category_reference_attribute(
 
     product_type_category_reference_attribute.refresh_from_db()
     assert product_type_category_reference_attribute.values.count() == values_count + 1
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_category_reference_attribute.slug},
+        "categories": [{"slug": category.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_collection_reference_attribute(
@@ -1903,6 +2135,13 @@ def test_create_product_with_collection_reference_attribute(
     assert (
         product_type_collection_reference_attribute.values.count() == values_count + 1
     )
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_collection_reference_attribute.slug},
+        "collections": [{"slug": collection.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_single_reference_attributes(
@@ -2017,6 +2256,34 @@ def test_create_product_with_single_reference_attributes(
     for attr_data in data["product"]["attributes"]:
         assert attr_data in expected_attributes_data
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+
+    expected_assigned_page_attribute = {
+        "attribute": {"slug": product_type_page_single_reference_attribute.slug},
+        "page": {"slug": page.slug},
+    }
+    expected_assigned_product_attribute = {
+        "attribute": {"slug": product_type_product_single_reference_attribute.slug},
+        "product": {"slug": product.slug},
+    }
+    expected_assigned_variant_attribute = {
+        "attribute": {"slug": product_type_variant_single_reference_attribute.slug},
+        "variant": {"sku": product_variant_list[0].sku},
+    }
+    expected_assigned_category_attribute = {
+        "attribute": {"slug": product_type_category_single_reference_attribute.slug},
+        "category": {"slug": categories[0].slug},
+    }
+    expected_assigned_collection_attribute = {
+        "attribute": {"slug": product_type_collection_single_reference_attribute.slug},
+        "collection": {"slug": collection.slug},
+    }
+    assert expected_assigned_page_attribute in assigned_attributes
+    assert expected_assigned_product_attribute in assigned_attributes
+    assert expected_assigned_variant_attribute in assigned_attributes
+    assert expected_assigned_category_attribute in assigned_attributes
+    assert expected_assigned_collection_attribute in assigned_attributes
+
 
 def test_create_product_with_product_reference_attribute_values_saved_in_order(
     staff_api_client,
@@ -2083,6 +2350,12 @@ def test_create_product_with_product_reference_attribute_values_saved_in_order(
         }
         for product, reference in zip(reference_instances, reference_ids, strict=False)
     ]
+    expected_assigned_attribute = [
+        {
+            "attribute": {"slug": product_type_product_reference_attribute.slug},
+            "products": [{"slug": product.slug} for product in reference_instances],
+        }
+    ]
 
     assert len(data["product"]["attributes"]) == 1
     attribute_data = data["product"]["attributes"][0]
@@ -2095,6 +2368,13 @@ def test_create_product_with_product_reference_attribute_values_saved_in_order(
 
     product_type_product_reference_attribute.refresh_from_db()
     assert product_type_product_reference_attribute.values.count() == values_count + 3
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_product_reference_attribute.slug},
+        "products": [{"slug": product.slug} for product in reference_instances],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_page_reference_attribute_and_invalid_product_one(
@@ -2221,6 +2501,21 @@ def test_create_product_with_file_attribute_new_attribute_value(
     file_attribute.refresh_from_db()
     assert file_attribute.values.count() == values_count + 1
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": None,
+    }
+    expected_assigned_file_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+    assert expected_assigned_file_attribute in assigned_attributes
+
 
 def test_create_product_with_file_attribute_not_required_no_file_url_given(
     staff_api_client,
@@ -2274,6 +2569,18 @@ def test_create_product_with_file_attribute_not_required_no_file_url_given(
         assert attr_data in expected_attributes_data
 
     file_attribute.refresh_from_db()
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": None,
+    }
+    expected_assigned_file_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": None,
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+    assert expected_assigned_file_attribute in assigned_attributes
 
 
 def test_create_product_with_file_attribute_required_no_file_url_given(
@@ -2468,11 +2775,13 @@ def test_create_product_no_values_given(
     assert data["product"]["category"]["name"] == category.name
     assert len(data["product"]["attributes"]) == 1
     assert data["product"]["attributes"][0]["values"] == []
+    assert len(data["product"]["assignedAttributes"]) == 1
+    assert data["product"]["assignedAttributes"][0]["choice"] is None
 
 
 @pytest.mark.parametrize(
     ("value", "expected_name", "expected_slug"),
-    [(20.1, "20.1", "20_1"), (20, "20", "20"), ("1", "1", "1")],
+    [(20.1, "20.1", "20_1"), (20, "20", "20"), (1, "1", "1")],
 )
 def test_create_product_with_numeric_attribute_new_attribute_value(
     value,
@@ -2529,6 +2838,13 @@ def test_create_product_with_numeric_attribute_new_attribute_value(
     assert len(values) == 1
     assert values[0]["name"] == expected_name
     assert values[0]["slug"] == f"{product_pk}_{numeric_attribute.id}"
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     numeric_attribute.refresh_from_db()
     assert numeric_attribute.values.filter(name=expected_name, numeric=value).exists()
@@ -2589,6 +2905,13 @@ def test_create_product_with_numeric_attribute_existing_value(
     numeric_attribute.refresh_from_db()
     assert numeric_attribute.values.count() == values_count + 1
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": existing_value.numeric,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_with_swatch_attribute_new_attribute_value(
     staff_api_client,
@@ -2643,6 +2966,18 @@ def test_create_product_with_swatch_attribute_new_attribute_value(
 
     swatch_attribute.refresh_from_db()
     assert swatch_attribute.values.count() == values_count + 1
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": {
+            "name": new_value,
+            "slug": slugify(new_value),
+            "hexColor": None,
+            "file": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_swatch_attribute_new_value_using_values_field(
@@ -2701,6 +3036,18 @@ def test_create_product_with_swatch_attribute_new_value_using_values_field(
     swatch_attribute.refresh_from_db()
     assert swatch_attribute.values.count() == values_count + 1
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": {
+            "name": new_value,
+            "slug": slugify(new_value),
+            "hexColor": None,
+            "file": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_with_swatch_attribute_existing_value(
     staff_api_client,
@@ -2757,6 +3104,18 @@ def test_create_product_with_swatch_attribute_existing_value(
     swatch_attribute.refresh_from_db()
     assert swatch_attribute.values.count() == values_count
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": {
+            "name": existing_value.name,
+            "slug": existing_value.slug,
+            "hexColor": existing_value.value,
+            "file": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_create_product_with_swatch_attribute_existing_value_using_values_field(
     staff_api_client,
@@ -2811,6 +3170,18 @@ def test_create_product_with_swatch_attribute_existing_value_using_values_field(
 
     swatch_attribute.refresh_from_db()
     assert swatch_attribute.values.count() == values_count
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": {
+            "name": existing_value.name,
+            "slug": existing_value.slug,
+            "hexColor": existing_value.value,
+            "file": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_create_product_with_numeric_attribute_not_numeric_value_given(

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -29,73 +29,177 @@ from .....product.models import Product
 from ....attribute.utils.type_handlers import AttributeInputErrors
 
 MUTATION_UPDATE_PRODUCT = """
-    mutation updateProduct($productId: ID!, $input: ProductInput!) {
-        productUpdate(id: $productId, input: $input) {
-                product {
-                    category {
-                        name
-                    }
-                    collections {
-                        name
-                    }
-                    rating
-                    description
-                    chargeTaxes
-                    variants {
-                        name
-                    }
-                    productVariants(first: 10) {
-                        edges {
-                            node {
-                                id
-                                name
-                            }
-                        }
-                    }
-                    taxType {
-                        taxCode
-                        description
-                    }
-                    name
-                    slug
-                    productType {
-                        name
-                    }
-                    metadata {
-                        key
-                        value
-                    }
-                    privateMetadata {
-                        key
-                        value
-                    }
-                    attributes {
-                        attribute {
-                            id
-                            name
-                        }
-                        values {
-                            id
-                            name
-                            slug
-                            boolean
-                            reference
-                            plainText
-                            file {
-                                url
-                                contentType
-                            }
-                        }
-                    }
-                    externalReference
-                }
-                errors {
-                    message
-                    field
-                    code
-                }
-            }
+mutation updateProduct($productId: ID!, $input: ProductInput!) {
+  productUpdate(id: $productId, input: $input) {
+    product {
+      category {
+        name
+      }
+      collections {
+        name
+      }
+      rating
+      description
+      chargeTaxes
+      variants {
+        name
+      }
+      productVariants(first: 10) {
+        edges {
+          node {
+            id
+            name
+          }
         }
+      }
+      taxType {
+        taxCode
+        description
+      }
+      name
+      slug
+      productType {
+        name
+      }
+      metadata {
+        key
+        value
+      }
+      privateMetadata {
+        key
+        value
+      }
+      assignedAttributes {
+        ... on AssignedAttributeInterface {
+          attribute {
+            slug
+          }
+        }
+        ... on AssignedNumericAttribute {
+          value
+        }
+        ... on AssignedTextAttribute {
+          text: value
+        }
+        ... on AssignedPlainTextAttribute {
+          plain_text: value
+        }
+        ... on AssignedFileAttribute {
+          file: value {
+            contentType
+            url
+          }
+        }
+        ... on AssignedMultiPageReferenceAttribute {
+          pages: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductReferenceAttribute {
+          products: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCategoryReferenceAttribute {
+          categories: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCollectionReferenceAttribute {
+          collections: value {
+            slug
+          }
+        }
+        ... on AssignedSinglePageReferenceAttribute {
+          page: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductReferenceAttribute {
+          product: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductVariantReferenceAttribute {
+          variant: value {
+            sku
+          }
+        }
+        ... on AssignedSingleCategoryReferenceAttribute {
+          category: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCollectionReferenceAttribute {
+          collection: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductVariantReferenceAttribute {
+          variants: value {
+            sku
+          }
+        }
+        ... on AssignedSingleChoiceAttribute {
+          choice: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedMultiChoiceAttribute {
+          multi: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedSwatchAttribute {
+          swatch: value {
+            name
+            slug
+            hexColor
+            file {
+              url
+              contentType
+            }
+          }
+        }
+        ... on AssignedBooleanAttribute {
+          bool: value
+        }
+        ... on AssignedDateAttribute {
+          date: value
+        }
+        ... on AssignedDateTimeAttribute {
+          datetime: value
+        }
+      }
+      attributes {
+        attribute {
+          id
+          name
+        }
+        values {
+          id
+          name
+          slug
+          boolean
+          reference
+          plainText
+          file {
+            url
+            contentType
+          }
+        }
+      }
+      externalReference
+    }
+    errors {
+      message
+      field
+      code
+    }
+  }
+}
 """
 
 
@@ -194,6 +298,10 @@ def test_update_product(
     assert attributes[0]["attribute"]["id"] == attribute_id
     assert attributes[0]["values"][0]["name"] == "Rainbow"
     assert attributes[0]["values"][0]["slug"] == "rainbow"
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assert assigned_attributes[0]["choice"]["name"] == attr_value
 
     updated_webhook_mock.assert_called_once_with(product)
     created_webhook_mock.assert_not_called()
@@ -489,6 +597,13 @@ def test_update_product_with_boolean_attribute_value(
     }
     assert expected_att_data in attributes
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": boolean_attribute.slug},
+        "bool": new_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     updated_webhook_mock.assert_called_once_with(product)
 
 
@@ -548,6 +663,16 @@ def test_update_product_with_file_attribute_value(
         ],
     }
     assert expected_file_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     updated_webhook_mock.assert_called_once_with(product)
 
@@ -615,6 +740,16 @@ def test_update_product_with_file_attribute_value_new_value_is_not_created(
     }
     assert expected_file_att_data in attributes
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": existing_value.content_type,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     file_attribute.refresh_from_db()
     assert file_attribute.values.count() == values_count
 
@@ -674,6 +809,14 @@ def test_update_product_with_numeric_attribute_value(
         ],
     }
     assert expected_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert numeric_attribute.values.filter(
         name=new_value,
         numeric=numeric_value,
@@ -743,6 +886,13 @@ def test_update_product_with_numeric_attribute_value_new_value_is_not_created(
     }
     assert expected_att_data in attributes
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert AttributeValue.objects.count() == value_count
     value.refresh_from_db()
     assert value.name == new_value
@@ -766,6 +916,8 @@ def test_update_product_clear_attribute_values(
     attribute.value_required = False
     attribute.save(update_fields=["value_required"])
 
+    assert attribute.input_type == AttributeInputType.DROPDOWN
+
     attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
 
     variables = {
@@ -787,6 +939,14 @@ def test_update_product_clear_attribute_values(
 
     assert len(attributes) == 1
     assert not attributes[0]["values"]
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "choice": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert not get_product_attribute_values(product, attribute).exists()
 
     updated_webhook_mock.assert_called_once_with(product)
@@ -835,6 +995,14 @@ def test_update_product_clean_boolean_attribute_value(
         "values": [],
     }
     assert expected_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": boolean_attribute.slug},
+        "bool": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert get_product_attribute_values(product, product_attr).count() == 0
 
 
@@ -880,7 +1048,16 @@ def test_update_product_clean_file_attribute_value(
         "attribute": {"id": attribute_id, "name": file_attribute.name},
         "values": [],
     }
+    file_attribute.refresh_from_db()
     assert expected_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert get_product_attribute_values(product, file_attribute).count() == 0
 
 
@@ -900,6 +1077,8 @@ def test_update_product_none_as_attribute_values(
     attribute = get_product_attributes(product).first()
     attribute.value_required = False
     attribute.save(update_fields=["value_required"])
+
+    assert attribute.input_type == AttributeInputType.DROPDOWN
 
     attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
 
@@ -922,6 +1101,14 @@ def test_update_product_none_as_attribute_values(
 
     assert len(attributes) == 1
     assert not attributes[0]["values"]
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "choice": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert not get_product_attribute_values(product, attribute).exists()
 
     updated_webhook_mock.assert_called_once_with(product)
@@ -978,6 +1165,13 @@ def test_update_product_with_plain_text_attribute_value(
         ],
     }
     assert expected_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     updated_webhook_mock.assert_called_once_with(product)
 
@@ -1036,6 +1230,13 @@ def test_update_product_with_plain_text_attribute_value_required(
         ],
     }
     assert expected_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     updated_webhook_mock.assert_called_once_with(product)
 
@@ -1168,6 +1369,13 @@ def test_update_product_with_page_reference_attribute_value(
     }
     assert expected_file_att_data in attributes
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_page_reference_attribute.slug},
+        "pages": [{"slug": page.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     updated_webhook_mock.assert_called_once_with(product)
 
     product_type_page_reference_attribute.refresh_from_db()
@@ -1272,6 +1480,34 @@ def test_update_product_with_single_reference_attribute_value(
     for attr_data in expected_attributes_data:
         assert attr_data in attributes_data
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+
+    expected_assigned_page_attribute = {
+        "attribute": {"slug": product_type_page_single_reference_attribute.slug},
+        "page": {"slug": page.slug},
+    }
+    expected_assigned_product_attribute = {
+        "attribute": {"slug": product_type_product_single_reference_attribute.slug},
+        "product": {"slug": product.slug},
+    }
+    expected_assigned_variant_attribute = {
+        "attribute": {"slug": product_type_variant_single_reference_attribute.slug},
+        "variant": {"sku": product_variant_list[0].sku},
+    }
+    expected_assigned_category_attribute = {
+        "attribute": {"slug": product_type_category_single_reference_attribute.slug},
+        "category": {"slug": categories[0].slug},
+    }
+    expected_assigned_collection_attribute = {
+        "attribute": {"slug": product_type_collection_single_reference_attribute.slug},
+        "collection": {"slug": collection.slug},
+    }
+    assert expected_assigned_page_attribute in assigned_attributes
+    assert expected_assigned_product_attribute in assigned_attributes
+    assert expected_assigned_variant_attribute in assigned_attributes
+    assert expected_assigned_category_attribute in assigned_attributes
+    assert expected_assigned_collection_attribute in assigned_attributes
+
 
 def test_update_product_without_supplying_required_product_attribute(
     staff_api_client, product, permission_manage_products, color_attribute
@@ -1282,10 +1518,16 @@ def test_update_product_without_supplying_required_product_attribute(
     product_type = product.product_type
     color_attribute_id = graphene.Node.to_global_id("Attribute", color_attribute.id)
 
+    assert color_attribute.input_type == AttributeInputType.DROPDOWN
+
     # Create and assign a new attribute requiring a value to be always supplied
     required_attribute = Attribute.objects.create(
-        name="Required One", slug="required-one", value_required=True
+        name="Required One",
+        slug="required-one",
+        value_required=True,
+        input_type=AttributeInputType.DROPDOWN,
     )
+
     product_type.product_attributes.add(required_attribute)
     required_attribute_id = graphene.Node.to_global_id(
         "Attribute", required_attribute.id
@@ -1324,6 +1566,18 @@ def test_update_product_without_supplying_required_product_attribute(
             }
         ],
     } in attributes_data
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_color_assigned_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": {"name": value, "slug": value.lower()},
+    }
+    assert expected_color_assigned_attribute in assigned_attributes
+    expected_required_assigned_attribute = {
+        "attribute": {"slug": required_attribute.slug},
+        "choice": None,
+    }
+    assert expected_required_assigned_attribute in assigned_attributes
 
 
 def test_update_product_with_empty_input_collections(
@@ -1428,6 +1682,13 @@ def test_update_product_with_page_reference_attribute_existing_value(
         ],
     }
     assert expected_file_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_page_reference_attribute.slug},
+        "pages": [{"slug": page.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     updated_webhook_mock.assert_called_once_with(product)
 
@@ -1537,6 +1798,13 @@ def test_update_product_with_product_reference_attribute_value(
     }
     assert expected_file_att_data in attributes
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_product_reference_attribute.slug},
+        "products": [{"slug": product_ref.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     updated_webhook_mock.assert_called_once_with(product)
 
     product_type_product_reference_attribute.refresh_from_db()
@@ -1601,6 +1869,14 @@ def test_update_product_with_variant_reference_attribute_value(
         ],
     }
     assert expected_file_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_variant_reference_attribute.slug},
+        "variants": [{"sku": variant_ref.sku}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     product_type_variant_reference_attribute.refresh_from_db()
     assert product_type_variant_reference_attribute.values.count() == values_count + 1
 
@@ -1664,6 +1940,14 @@ def test_update_product_with_category_reference_attribute_value(
         ],
     }
     assert expected_file_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_category_reference_attribute.slug},
+        "categories": [{"slug": category.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     product_type_category_reference_attribute.refresh_from_db()
     assert product_type_category_reference_attribute.values.count() == values_count + 1
 
@@ -1730,6 +2014,13 @@ def test_update_product_with_collection_reference_attribute_value(
     assert (
         product_type_collection_reference_attribute.values.count() == values_count + 1
     )
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_collection_reference_attribute.slug},
+        "collections": [{"slug": collection.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     updated_webhook_mock.assert_called_once_with(product)
 
@@ -1834,6 +2125,13 @@ def test_update_product_with_product_reference_attribute_existing_value(
     }
     assert expected_file_att_data in attributes
 
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_product_reference_attribute.slug},
+        "products": [{"slug": product_ref.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     updated_webhook_mock.assert_called_once_with(product)
 
     product_type_product_reference_attribute.refresh_from_db()
@@ -1930,6 +2228,8 @@ def test_update_product_change_values_ordering(
         ).values_list("value_id", flat=True)
     ) == [attr_value_2.pk, attr_value_1.pk]
 
+    expected_first_page = page_list[0]
+    expected_second_page = page_list[1]
     variables = {
         "productId": product_id,
         "input": {
@@ -1937,8 +2237,8 @@ def test_update_product_change_values_ordering(
                 {
                     "id": attribute_id,
                     "references": [
-                        graphene.Node.to_global_id("Page", page_list[0].pk),
-                        graphene.Node.to_global_id("Page", page_list[1].pk),
+                        graphene.Node.to_global_id("Page", expected_first_page.pk),
+                        graphene.Node.to_global_id("Page", expected_second_page.pk),
                     ],
                 }
             ]
@@ -1964,6 +2264,14 @@ def test_update_product_change_values_ordering(
         graphene.Node.to_global_id("AttributeValue", val.pk)
         for val in [attr_value_1, attr_value_2]
     ]
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assigned_values = assigned_attributes[0]["pages"]
+    assert len(assigned_values) == 2
+    assert assigned_values[0]["slug"] == expected_first_page.slug
+    assert assigned_values[1]["slug"] == expected_second_page.slug
+
     product.refresh_from_db()
 
     attribute = get_product_attributes(product).first()
@@ -2397,6 +2705,14 @@ def test_update_product_with_numeric_attribute_value_by_numeric_field(
         ],
     }
     assert expected_att_data in attributes
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert numeric_attribute.values.filter(
         name=new_value, numeric=numeric_value
     ).first()
@@ -2439,6 +2755,13 @@ def test_update_product_with_numeric_attribute_by_numeric_field_null_value(
     data = content["data"]["productUpdate"]
     assert data["errors"] == []
     assert not data["product"]["attributes"][1]["values"]
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_update_product_with_numeric_attribute_by_numeric_field_new_value_not_created(
@@ -2499,6 +2822,12 @@ def test_update_product_with_numeric_attribute_by_numeric_field_new_value_not_cr
         ],
     }
     assert expected_att_data in attributes
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     assert AttributeValue.objects.count() == value_count
     value.refresh_from_db()
@@ -2523,6 +2852,9 @@ def test_update_product_with_dropdown_attribute_non_existing_value(
     attribute_id = graphene.Node.to_global_id("Attribute", color_attribute.pk)
     product_type.product_attributes.add(color_attribute)
 
+    assert color_attribute.input_type == AttributeInputType.DROPDOWN
+
+    new_color_name = "new-color"
     variables = {
         "productId": product_id,
         "input": {
@@ -2530,7 +2862,7 @@ def test_update_product_with_dropdown_attribute_non_existing_value(
                 {
                     "id": attribute_id,
                     "dropdown": {
-                        "value": "new color",
+                        "value": new_color_name,
                     },
                 }
             ]
@@ -2548,7 +2880,18 @@ def test_update_product_with_dropdown_attribute_non_existing_value(
     errors = data["errors"]
 
     assert not errors
-    assert data["product"]["attributes"][0]["values"][0]["name"] == "new color"
+    assert data["product"]["attributes"][0]["values"][0]["name"] == new_color_name
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": {
+            "name": new_color_name,
+            "slug": new_color_name.lower(),
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+
     updated_webhook_mock.assert_called_once_with(product)
 
 
@@ -2566,12 +2909,13 @@ def test_update_product_with_dropdown_attribute_existing_value(
     product_id = graphene.Node.to_global_id("Product", product.pk)
     attribute = product_type.product_attributes.first()
 
+    assert attribute.input_type == AttributeInputType.DROPDOWN
+
     attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
     attribute_value = attribute.values.model.objects.first()
     attribute_value_id = graphene.Node.to_global_id(
         "AttributeValue", attribute_value.pk
     )
-    attribute_value_name = attribute.values.model.objects.first().name
     product_type.product_attributes.add(attribute)
 
     variables = {
@@ -2599,7 +2943,18 @@ def test_update_product_with_dropdown_attribute_existing_value(
     errors = data["errors"]
 
     assert not errors
-    assert data["product"]["attributes"][0]["values"][0]["name"] == attribute_value_name
+    assert data["product"]["attributes"][0]["values"][0]["name"] == attribute_value.name
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "choice": {
+            "name": attribute_value.name,
+            "slug": attribute_value.slug,
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+
     updated_webhook_mock.assert_called_once_with(product)
 
 
@@ -2616,12 +2971,14 @@ def test_update_product_with_dropdown_attribute_existing_value_passed_as_new_val
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
     attribute = product_type.product_attributes.first()
+
+    assert attribute.input_type == AttributeInputType.DROPDOWN
+
     attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
     attribute_value = attribute.values.model.objects.first()
     attribute_value_id = graphene.Node.to_global_id(
         "AttributeValue", attribute_value.pk
     )
-    attribute_value_name = attribute.values.model.objects.first().name
     product_type.product_attributes.add(attribute)
 
     value_count = AttributeValue.objects.count()
@@ -2633,7 +2990,7 @@ def test_update_product_with_dropdown_attribute_existing_value_passed_as_new_val
                 {
                     "id": attribute_id,
                     "dropdown": {
-                        "value": attribute_value_name,
+                        "value": attribute_value.name,
                     },
                 }
             ]
@@ -2652,6 +3009,17 @@ def test_update_product_with_dropdown_attribute_existing_value_passed_as_new_val
 
     assert not errors
     assert data["product"]["attributes"][0]["values"][0]["id"] == attribute_value_id
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "choice": {
+            "name": attribute_value.name,
+            "slug": attribute_value.slug,
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+
     assert AttributeValue.objects.count() == value_count
     updated_webhook_mock.assert_called_once_with(product)
 
@@ -2698,6 +3066,13 @@ def test_update_product_with_dropdown_attribute_null_value(
 
     assert not errors
     assert not data["product"]["attributes"][0]["values"]
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": None,
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
     updated_webhook_mock.assert_called_once_with(product)
 
 
@@ -2718,13 +3093,18 @@ def test_update_product_with_multiselect_attribute_non_existing_values(
 
     value_count = AttributeValue.objects.count()
 
+    first_value_name = "new-mode-1"
+    second_value_name = "new-mode-2"
     variables = {
         "productId": product_id,
         "input": {
             "attributes": [
                 {
                     "id": attribute_id,
-                    "multiselect": [{"value": "new mode 1"}, {"value": "new mode 2"}],
+                    "multiselect": [
+                        {"value": first_value_name},
+                        {"value": second_value_name},
+                    ],
                 }
             ]
         },
@@ -2743,8 +3123,22 @@ def test_update_product_with_multiselect_attribute_non_existing_values(
     assert not errors
     values = data["product"]["attributes"][0]["values"]
     assert len(values) == 2
-    assert values[0]["name"] == "new mode 1"
-    assert values[1]["name"] == "new mode 2"
+    assert values[0]["name"] == first_value_name
+    assert values[1]["name"] == second_value_name
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "multi": [
+            {"name": first_value_name, "slug": first_value_name.lower()},
+            {
+                "name": second_value_name,
+                "slug": second_value_name.lower(),
+            },
+        ],
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+
     updated_webhook_mock.assert_called_once_with(product)
 
     assert AttributeValue.objects.count() == value_count + 2
@@ -2768,10 +3162,8 @@ def test_update_product_with_multiselect_attribute_existing_values(
     attribute_values = get_product_attribute_values(product, attribute)
     attr_value_1 = attribute_values[0]
     attr_value_id_1 = graphene.Node.to_global_id("AttributeValue", attr_value_1.pk)
-    attr_value_name_1 = attr_value_1.name
     attr_value_2 = attribute_values[1]
     attr_value_id_2 = graphene.Node.to_global_id("AttributeValue", attr_value_2.pk)
-    attr_value_name_2 = attr_value_2.name
 
     associate_attribute_values_to_instance(product, {attribute.pk: [attr_value_1]})
 
@@ -2803,8 +3195,18 @@ def test_update_product_with_multiselect_attribute_existing_values(
     assert not errors
     values = data["product"]["attributes"][0]["values"]
     assert len(values) == 2
-    assert values[0]["name"] == attr_value_name_1
-    assert values[1]["name"] == attr_value_name_2
+    assert values[0]["name"] == attr_value_1.name
+    assert values[1]["name"] == attr_value_2.name
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "multi": [
+            {"name": attr_value_1.name, "slug": attr_value_1.slug},
+            {"name": attr_value_2.name, "slug": attr_value_2.slug},
+        ],
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
     updated_webhook_mock.assert_called_once_with(product)
 
 
@@ -2827,11 +3229,9 @@ def test_update_product_with_multiselect_attribute_new_values_not_created(
 
     attr_value_1 = attr_values[0]
     attr_value_id_1 = graphene.Node.to_global_id("AttributeValue", attr_value_1.pk)
-    attr_value_name_1 = attr_value_1.name
 
     attr_value_2 = attr_values[1]
     attr_value_id_2 = graphene.Node.to_global_id("AttributeValue", attr_value_2.pk)
-    attr_value_name_2 = attr_value_2.name
 
     value_count = AttributeValue.objects.count()
 
@@ -2844,8 +3244,8 @@ def test_update_product_with_multiselect_attribute_new_values_not_created(
                 {
                     "id": attribute_id,
                     "multiselect": [
-                        {"value": attr_value_name_1},
-                        {"value": attr_value_name_2},
+                        {"value": attr_value_1.name},
+                        {"value": attr_value_2.name},
                     ],
                 }
             ]
@@ -2867,6 +3267,17 @@ def test_update_product_with_multiselect_attribute_new_values_not_created(
     assert len(values) == 2
     assert values[0]["id"] == attr_value_id_1
     assert values[1]["id"] == attr_value_id_2
+
+    assigned_attributes = data["product"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "multi": [
+            {"name": attr_value_1.name, "slug": attr_value_1.slug},
+            {"name": attr_value_2.name, "slug": attr_value_2.slug},
+        ],
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+
     assert AttributeValue.objects.count() == value_count
     updated_webhook_mock.assert_called_once_with(product)
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -20,82 +20,184 @@ from ....core.enums import ErrorPolicyEnum
 from ....tests.utils import get_graphql_content
 
 PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
-    mutation ProductVariantBulkCreate(
-        $variants: [ProductVariantBulkCreateInput!]!,
-        $productId: ID!,
-        $errorPolicy: ErrorPolicyEnum
-    ) {
-        productVariantBulkCreate(
-            variants: $variants, product: $productId, errorPolicy: $errorPolicy
-            ) {
-                results{
-                    productVariant{
-                        metadata {
-                            key
-                            value
-                        }
-                        id
-                        name
-                        sku
-                        trackInventory
-                        attributes{
-                            attribute {
-                                slug
-                            }
-                            values {
-                                name
-                                slug
-                                reference
-                                richText
-                                plainText
-                                boolean
-                                date
-                                dateTime
-                                file {
-                                    url
-                                    contentType
-                                }
-                            }
-                        }
-                        stocks {
-                            warehouse {
-                                slug
-                            }
-                            quantity
-                        }
-                        channelListings {
-                            channel {
-                                slug
-                            }
-                            price {
-                                currency
-                                amount
-                            }
-                            costPrice {
-                                currency
-                                amount
-                            }
-                            preorderThreshold {
-                                quantity
-                            }
-                        }
-                        preorder {
-                            globalThreshold
-                            endDate
-                        }
-                    }
-                    errors {
-                        field
-                        path
-                        message
-                        code
-                        warehouses
-                        channels
-                    }
-                }
-            count
+mutation ProductVariantBulkCreate($variants: [ProductVariantBulkCreateInput!]!, $productId: ID!, $errorPolicy: ErrorPolicyEnum) {
+  productVariantBulkCreate(
+    variants: $variants
+    product: $productId
+    errorPolicy: $errorPolicy
+  ) {
+    results {
+      productVariant {
+        metadata {
+          key
+          value
         }
+        id
+        name
+        sku
+        trackInventory
+        assignedAttributes {
+          ... on AssignedAttributeInterface {
+            attribute {
+              slug
+            }
+          }
+          ... on AssignedNumericAttribute {
+            value
+          }
+          ... on AssignedTextAttribute {
+            text: value
+          }
+          ... on AssignedPlainTextAttribute {
+            plain_text: value
+          }
+          ... on AssignedFileAttribute {
+            file: value {
+              contentType
+              url
+            }
+          }
+          ... on AssignedMultiPageReferenceAttribute {
+            pages: value {
+              slug
+            }
+          }
+          ... on AssignedMultiProductReferenceAttribute {
+            products: value {
+              slug
+            }
+          }
+          ... on AssignedMultiCategoryReferenceAttribute {
+            categories: value {
+              slug
+            }
+          }
+          ... on AssignedMultiCollectionReferenceAttribute {
+            collections: value {
+              slug
+            }
+          }
+          ... on AssignedSinglePageReferenceAttribute {
+            page: value {
+              slug
+            }
+          }
+          ... on AssignedSingleProductReferenceAttribute {
+            product: value {
+              slug
+            }
+          }
+          ... on AssignedSingleProductVariantReferenceAttribute {
+            variant: value {
+              sku
+            }
+          }
+          ... on AssignedSingleCategoryReferenceAttribute {
+            category: value {
+              slug
+            }
+          }
+          ... on AssignedSingleCollectionReferenceAttribute {
+            collection: value {
+              slug
+            }
+          }
+          ... on AssignedMultiProductVariantReferenceAttribute {
+            variants: value {
+              sku
+            }
+          }
+          ... on AssignedSingleChoiceAttribute {
+            choice: value {
+              name
+              slug
+            }
+          }
+          ... on AssignedMultiChoiceAttribute {
+            multi: value {
+              name
+              slug
+            }
+          }
+          ... on AssignedSwatchAttribute {
+            swatch: value {
+              name
+              slug
+              hexColor
+              file {
+                url
+                contentType
+              }
+            }
+          }
+          ... on AssignedBooleanAttribute {
+            bool: value
+          }
+          ... on AssignedDateAttribute {
+            date: value
+          }
+          ... on AssignedDateTimeAttribute {
+            datetime: value
+          }
+        }
+        attributes {
+          attribute {
+            slug
+          }
+          values {
+            name
+            slug
+            reference
+            richText
+            plainText
+            boolean
+            date
+            dateTime
+            file {
+              url
+              contentType
+            }
+          }
+        }
+        stocks {
+          warehouse {
+            slug
+          }
+          quantity
+        }
+        channelListings {
+          channel {
+            slug
+          }
+          price {
+            currency
+            amount
+          }
+          costPrice {
+            currency
+            amount
+          }
+          preorderThreshold {
+            quantity
+          }
+        }
+        preorder {
+          globalThreshold
+          endDate
+        }
+      }
+      errors {
+        field
+        path
+        message
+        code
+        warehouses
+        channels
+      }
     }
+    count
+  }
+}
 """
 
 
@@ -284,6 +386,15 @@ def test_product_variant_bulk_create_by_attribute_external_ref(
         data["results"][0]["productVariant"]["attributes"][1]["values"][0]["slug"]
         == attribute_value.slug
     )
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": {
+            "name": attribute_value.name,
+            "slug": attribute_value.slug,
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
 
 
 def test_product_variant_bulk_create_return_error_when_attribute_external_ref_and_id(
@@ -389,6 +500,15 @@ def test_product_variant_bulk_create_will_create_new_attr_value_and_external_ref
         data["results"][0]["productVariant"]["attributes"][1]["values"][0]["name"]
         == new_value
     )
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": color_attribute.slug},
+        "choice": {
+            "name": new_value,
+            "slug": new_value.lower(),
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
 
 
 def test_product_variant_bulk_create_with_swatch_attribute(
@@ -480,6 +600,14 @@ def test_product_variant_bulk_create_with_plain_text_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["plainText"] == plain_text
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": plain_text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -521,6 +649,14 @@ def test_product_variant_bulk_create_with_date_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["date"] == str(date_value)
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_attribute.slug},
+        "date": str(date_value),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -561,6 +697,17 @@ def test_product_variant_bulk_create_with_file_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["file"]["url"] == file_url
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -604,6 +751,14 @@ def test_product_variant_bulk_create_with_datetime_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["dateTime"] == date_time_value.isoformat()
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_time_attribute.slug},
+        "datetime": date_time_value.isoformat(),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -619,7 +774,7 @@ def test_product_variant_bulk_create_with_rich_text_attribute(
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
     attribute_id = graphene.Node.to_global_id("Attribute", rich_text_attribute.pk)
-    rich_text = json.dumps(dummy_editorjs("Sample text"))
+    rich_text = dummy_editorjs("Sample text")
 
     sku = str(uuid4())[:12]
     variants = [
@@ -627,7 +782,7 @@ def test_product_variant_bulk_create_with_rich_text_attribute(
             "sku": sku,
             "weight": 2.5,
             "trackInventory": True,
-            "attributes": [{"id": attribute_id, "richText": rich_text}],
+            "attributes": [{"id": attribute_id, "richText": json.dumps(rich_text)}],
         }
     ]
 
@@ -645,7 +800,15 @@ def test_product_variant_bulk_create_with_rich_text_attribute(
     assert not data["results"][0]["errors"]
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
-    assert attributes[-1]["values"][0]["richText"] == rich_text
+    assert attributes[-1]["values"][0]["richText"] == json.dumps(rich_text)
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": rich_text_attribute.slug},
+        "text": rich_text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -688,6 +851,14 @@ def test_product_variant_bulk_create_with_numeric_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["name"] == existing_value.name
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": existing_value.numeric,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -733,6 +904,14 @@ def test_product_variant_bulk_create_with_page_reference_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["reference"] == reference
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_page_reference_attribute.slug},
+        "pages": [{"slug": page.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -776,6 +955,14 @@ def test_product_variant_bulk_create_with_single_reference_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["reference"] == reference
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_category_single_reference_attribute.slug},
+        "category": {"slug": category.slug},
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -827,6 +1014,14 @@ def test_product_variant_bulk_create_with_dropdown_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["name"] == attribute_value.name
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": size_attribute.slug},
+        "choice": {"slug": attribute_value.slug, "name": attribute_value.name},
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
@@ -874,6 +1069,14 @@ def test_product_variant_bulk_create_with_multiselect_attribute(
     assert data["count"] == 1
     attributes = data["results"][0]["productVariant"]["attributes"]
     assert attributes[-1]["values"][0]["name"] == attribute_value.name
+
+    assigned_attributes = data["results"][0]["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": size_attribute.slug},
+        "multi": [{"slug": attribute_value.slug, "name": attribute_value.name}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert product_variant_count + 1 == ProductVariant.objects.count()
 
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -15,64 +15,167 @@ from ....core.enums import WeightUnitsEnum
 from ....tests.utils import get_graphql_content
 
 CREATE_VARIANT_MUTATION = """
-      mutation createVariant ($input: ProductVariantCreateInput!) {
-                productVariantCreate(input: $input) {
-                    errors {
-                      field
-                      message
-                      attributes
-                      code
-                    }
-                    productVariant {
-                        id
-                        name
-                        sku
-                        attributes {
-                            attribute {
-                                slug
-                            }
-                            values {
-                                name
-                                slug
-                                reference
-                                richText
-                                plainText
-                                boolean
-                                date
-                                dateTime
-                                file {
-                                    url
-                                    contentType
-                                }
-                            }
-                        }
-                        weight {
-                            value
-                            unit
-                        }
-                        stocks {
-                            quantity
-                            warehouse {
-                                slug
-                            }
-                        }
-                        preorder {
-                            globalThreshold
-                            endDate
-                        }
-                        metadata {
-                            key
-                            value
-                        }
-                        privateMetadata {
-                            key
-                            value
-                        }
-                        externalReference
-                    }
-                }
+mutation createVariant($input: ProductVariantCreateInput!) {
+  productVariantCreate(input: $input) {
+    errors {
+      field
+      message
+      attributes
+      code
+    }
+    productVariant {
+      id
+      name
+      sku
+      assignedAttributes {
+        ... on AssignedAttributeInterface {
+          attribute {
+            slug
+          }
+        }
+        ... on AssignedNumericAttribute {
+          value
+        }
+        ... on AssignedTextAttribute {
+          text: value
+        }
+        ... on AssignedPlainTextAttribute {
+          plain_text: value
+        }
+        ... on AssignedFileAttribute {
+          file: value {
+            contentType
+            url
+          }
+        }
+        ... on AssignedMultiPageReferenceAttribute {
+          pages: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductReferenceAttribute {
+          products: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCategoryReferenceAttribute {
+          categories: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCollectionReferenceAttribute {
+          collections: value {
+            slug
+          }
+        }
+        ... on AssignedSinglePageReferenceAttribute {
+          page: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductReferenceAttribute {
+          product: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductVariantReferenceAttribute {
+          variant: value {
+            sku
+          }
+        }
+        ... on AssignedSingleCategoryReferenceAttribute {
+          category: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCollectionReferenceAttribute {
+          collection: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductVariantReferenceAttribute {
+          variants: value {
+            sku
+          }
+        }
+        ... on AssignedSingleChoiceAttribute {
+          choice: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedMultiChoiceAttribute {
+          multi: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedSwatchAttribute {
+          swatch: value {
+            name
+            slug
+            hexColor
+            file {
+              url
+              contentType
             }
-
+          }
+        }
+        ... on AssignedBooleanAttribute {
+          bool: value
+        }
+        ... on AssignedDateAttribute {
+          date: value
+        }
+        ... on AssignedDateTimeAttribute {
+          datetime: value
+        }
+      }
+      attributes {
+        attribute {
+          slug
+        }
+        values {
+          name
+          slug
+          reference
+          richText
+          plainText
+          boolean
+          date
+          dateTime
+          file {
+            url
+            contentType
+          }
+        }
+      }
+      weight {
+        value
+        unit
+      }
+      stocks {
+        quantity
+        warehouse {
+          slug
+        }
+      }
+      preorder {
+        globalThreshold
+        endDate
+      }
+      metadata {
+        key
+        value
+      }
+      privateMetadata {
+        key
+        value
+      }
+      externalReference
+    }
+  }
+}
 """
 
 
@@ -94,11 +197,9 @@ def test_create_variant_with_name(
     weight = 10.22
     metadata_key = "md key"
     metadata_value = "md value"
-    variant_slug = product_type.variant_attributes.first().slug
-    attribute_id = graphene.Node.to_global_id(
-        "Attribute", product_type.variant_attributes.first().pk
-    )
-    variant_value = "test-value"
+    attribute = product_type.variant_attributes.first()
+    attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
+    attr_value = "test-value"
     stocks = [
         {
             "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
@@ -114,7 +215,7 @@ def test_create_variant_with_name(
             "stocks": stocks,
             "name": name,
             "weight": weight,
-            "attributes": [{"id": attribute_id, "values": [variant_value]}],
+            "attributes": [{"id": attribute_id, "values": [attr_value]}],
             "trackInventory": True,
             "metadata": [{"key": metadata_key, "value": metadata_value}],
             "privateMetadata": [{"key": metadata_key, "value": metadata_value}],
@@ -133,8 +234,8 @@ def test_create_variant_with_name(
     data = content["productVariant"]
     assert data["name"] == name
     assert data["sku"] == sku
-    assert data["attributes"][0]["attribute"]["slug"] == variant_slug
-    assert data["attributes"][0]["values"][0]["slug"] == variant_value
+    assert data["attributes"][0]["attribute"]["slug"] == attribute.slug
+    assert data["attributes"][0]["values"][0]["slug"] == attr_value
     assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
     assert data["weight"]["value"] == weight
     assert len(data["stocks"]) == 1
@@ -145,6 +246,16 @@ def test_create_variant_with_name(
     assert data["privateMetadata"][0]["key"] == metadata_key
     assert data["privateMetadata"][0]["value"] == metadata_value
     assert data["externalReference"] == external_reference
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "choice": {
+            "name": attr_value,
+            "slug": attr_value.lower(),
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
 
     created_webhook_mock.assert_called_once_with(product.variants.last())
     updated_webhook_mock.assert_not_called()
@@ -168,11 +279,11 @@ def test_create_variant_without_name(
     product_id = graphene.Node.to_global_id("Product", product.pk)
     sku = "1"
     weight = 10.22
-    variant_slug = product_type.variant_attributes.first().slug
-    attribute_id = graphene.Node.to_global_id(
-        "Attribute", product_type.variant_attributes.first().pk
-    )
-    variant_value = "test-value"
+
+    attribute = product_type.variant_attributes.first()
+    attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
+    attr_value = "test-value"
+
     stocks = [
         {
             "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
@@ -186,7 +297,7 @@ def test_create_variant_without_name(
             "sku": sku,
             "stocks": stocks,
             "weight": weight,
-            "attributes": [{"id": attribute_id, "values": [variant_value]}],
+            "attributes": [{"id": attribute_id, "values": [attr_value]}],
             "trackInventory": True,
         }
     }
@@ -200,15 +311,26 @@ def test_create_variant_without_name(
     # then
     assert not content["errors"]
     data = content["productVariant"]
-    assert data["name"] == variant_value
+    assert data["name"] == attr_value
     assert data["sku"] == sku
-    assert data["attributes"][0]["attribute"]["slug"] == variant_slug
-    assert data["attributes"][0]["values"][0]["slug"] == variant_value
+    assert data["attributes"][0]["attribute"]["slug"] == attribute.slug
+    assert data["attributes"][0]["values"][0]["slug"] == attr_value.lower()
     assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
     assert data["weight"]["value"] == weight
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "choice": {
+            "name": attr_value,
+            "slug": attr_value.lower(),
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+
     created_webhook_mock.assert_called_once_with(product.variants.last())
     updated_webhook_mock.assert_not_called()
 
@@ -425,6 +547,16 @@ def test_create_variant_with_file_attribute(
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
 
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     file_attribute.refresh_from_db()
     assert file_attribute.values.count() == values_count + 1
 
@@ -495,6 +627,13 @@ def test_create_variant_with_boolean_attribute(
     }
 
     assert expected_attribute_data in data["attributes"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": boolean_attribute.slug},
+        "bool": True,
+    }
+    assert expected_assigned_attribute in assigned_attributes
     created_webhook_mock.assert_called_once_with(product.variants.last())
 
 
@@ -554,6 +693,16 @@ def test_create_variant_with_file_attribute_new_value(
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     file_attribute.refresh_from_db()
     assert file_attribute.values.count() == values_count + 1
@@ -616,6 +765,13 @@ def test_create_variant_with_file_attribute_no_file_url_given(
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     file_attribute.refresh_from_db()
     assert file_attribute.values.count() == values_count
@@ -705,6 +861,14 @@ def test_create_variant_with_page_reference_attribute(
     ]
     for value in expected_values:
         assert value in data["attributes"][0]["values"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_page_reference_attribute.slug},
+        "pages": [{"slug": page_list[0].slug}, {"slug": page_list[1].slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
@@ -867,6 +1031,14 @@ def test_create_variant_with_product_reference_attribute(
     ]
     for value in expected_values:
         assert value in data["attributes"][0]["values"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_product_reference_attribute.slug},
+        "products": [{"slug": product_list[0].slug}, {"slug": product_list[1].slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
@@ -1036,6 +1208,14 @@ def test_create_variant_with_variant_reference_attribute(
     ]
     for value in expected_values:
         assert value in data["attributes"][0]["values"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_variant_reference_attribute.slug},
+        "variants": [{"sku": variant_1.sku}, {"sku": variant_2.sku}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
@@ -1207,6 +1387,17 @@ def test_create_variant_with_category_reference_attribute(
     ]
     for value in expected_values:
         assert value in data["attributes"][0]["values"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_category_reference_attribute.slug},
+        "categories": [
+            {"slug": category_list[0].slug},
+            {"slug": category_list[1].slug},
+        ],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
@@ -1308,6 +1499,17 @@ def test_create_variant_with_collection_reference_attribute(
     ]
     for value in expected_values:
         assert value in data["attributes"][0]["values"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_collection_reference_attribute.slug},
+        "collections": [
+            {"slug": collection_list[0].slug},
+            {"slug": collection_list[1].slug},
+        ],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
@@ -1431,6 +1633,34 @@ def test_create_variant_with_single_reference_attributes(
     for attr_data in data["attributes"]:
         assert attr_data in expected_attributes_data
 
+    assigned_attributes = data["assignedAttributes"]
+
+    expected_assigned_page_attribute = {
+        "attribute": {"slug": product_type_page_single_reference_attribute.slug},
+        "page": {"slug": page.slug},
+    }
+    expected_assigned_product_attribute = {
+        "attribute": {"slug": product_type_product_single_reference_attribute.slug},
+        "product": {"slug": product.slug},
+    }
+    expected_assigned_variant_attribute = {
+        "attribute": {"slug": product_type_variant_single_reference_attribute.slug},
+        "variant": {"sku": product_variant_list[0].sku},
+    }
+    expected_assigned_category_attribute = {
+        "attribute": {"slug": product_type_category_single_reference_attribute.slug},
+        "category": {"slug": categories[0].slug},
+    }
+    expected_assigned_collection_attribute = {
+        "attribute": {"slug": product_type_collection_single_reference_attribute.slug},
+        "collection": {"slug": collection.slug},
+    }
+    assert expected_assigned_page_attribute in assigned_attributes
+    assert expected_assigned_product_attribute in assigned_attributes
+    assert expected_assigned_variant_attribute in assigned_attributes
+    assert expected_assigned_category_attribute in assigned_attributes
+    assert expected_assigned_collection_attribute in assigned_attributes
+
     created_webhook_mock.assert_called_once_with(product.variants.get(pk=variant_pk))
 
 
@@ -1489,6 +1719,14 @@ def test_create_variant_with_numeric_attribute(
         data["attributes"][0]["values"][0]["slug"]
         == f"{variant_pk}_{numeric_attribute.pk}"
     )
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
     assert data["weight"]["value"] == weight
     assert len(data["stocks"]) == 1
@@ -1797,7 +2035,7 @@ def test_create_variant_with_rich_text_attribute(
     sku = "1"
     weight = 10.22
     attr_id = graphene.Node.to_global_id("Attribute", rich_text_attribute.id)
-    rich_text = json.dumps(dummy_editorjs("Sample text"))
+    rich_text = dummy_editorjs("Sample text")
     stocks = [
         {
             "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
@@ -1811,7 +2049,7 @@ def test_create_variant_with_rich_text_attribute(
             "stocks": stocks,
             "weight": weight,
             "attributes": [
-                {"id": attr_id, "richText": rich_text},
+                {"id": attr_id, "richText": json.dumps(rich_text)},
             ],
             "trackInventory": True,
         }
@@ -1826,7 +2064,15 @@ def test_create_variant_with_rich_text_attribute(
     assert not content["errors"]
     assert data["name"] == sku
     assert data["sku"] == sku
-    assert data["attributes"][-1]["values"][0]["richText"] == rich_text
+    assert data["attributes"][-1]["values"][0]["richText"] == json.dumps(rich_text)
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": rich_text_attribute.slug},
+        "text": rich_text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     created_webhook_mock.assert_called_once_with(product.variants.last())
 
 
@@ -1880,6 +2126,14 @@ def test_create_variant_with_plain_text_attribute(
     assert data["name"] == sku
     assert data["sku"] == sku
     assert data["attributes"][-1]["values"][0]["plainText"] == text
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     created_webhook_mock.assert_called_once_with(product.variants.last())
 
 
@@ -1941,6 +2195,13 @@ def test_create_variant_with_date_attribute(
     assert not content["errors"]
     assert data["sku"] == sku
     assert expected_attributes_data in data["attributes"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_attribute.slug},
+        "date": str(date_value),
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     created_webhook_mock.assert_called_once_with(variant)
 
@@ -2005,6 +2266,13 @@ def test_create_variant_with_date_time_attribute(
     assert data["sku"] == sku
     assert expected_attributes_data in data["attributes"]
 
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_time_attribute.slug},
+        "datetime": date_time_value.isoformat(),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     created_webhook_mock.assert_called_once_with(variant)
 
 
@@ -2023,11 +2291,11 @@ def test_create_variant_with_empty_string_for_sku(
     product_id = graphene.Node.to_global_id("Product", product.pk)
     sku = ""
     weight = 10.22
-    variant_slug = product_type.variant_attributes.first().slug
-    attribute_id = graphene.Node.to_global_id(
-        "Attribute", product_type.variant_attributes.first().pk
-    )
-    variant_value = "test-value"
+
+    attribute = product_type.variant_attributes.first()
+    attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
+    attr_value = "test-value"
+
     stocks = [
         {
             "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
@@ -2041,7 +2309,7 @@ def test_create_variant_with_empty_string_for_sku(
             "sku": sku,
             "stocks": stocks,
             "weight": weight,
-            "attributes": [{"id": attribute_id, "values": [variant_value]}],
+            "attributes": [{"id": attribute_id, "values": [attr_value]}],
             "trackInventory": True,
         }
     }
@@ -2052,15 +2320,26 @@ def test_create_variant_with_empty_string_for_sku(
 
     assert not content["errors"]
     data = content["productVariant"]
-    assert data["name"] == variant_value
+    assert data["name"] == attr_value
     assert data["sku"] is None
-    assert data["attributes"][0]["attribute"]["slug"] == variant_slug
-    assert data["attributes"][0]["values"][0]["slug"] == variant_value
+    assert data["attributes"][0]["attribute"]["slug"] == attribute.slug
+    assert data["attributes"][0]["values"][0]["slug"] == attr_value
     assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
     assert data["weight"]["value"] == weight
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "choice": {
+            "name": attr_value,
+            "slug": attr_value.lower(),
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
+
     created_webhook_mock.assert_called_once_with(product.variants.last())
     updated_webhook_mock.assert_not_called()
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -42,6 +42,17 @@ def test_product_variant_update_with_new_attributes(
             }
             productVariant {
               id
+              assignedAttributes {
+                  ... on AssignedSingleChoiceAttribute {
+                        attribute {
+                            slug
+                        }
+                        choice: value {
+                            name
+                            slug
+                        }
+                  }
+              }
               attributes {
                 attribute {
                   id
@@ -90,6 +101,16 @@ def test_product_variant_update_with_new_attributes(
     attributes = data["productVariant"]["attributes"]
     assert len(attributes) == 1
     assert attributes[0]["attribute"]["id"] == size_attribute_id
+
+    assigned_attributes = data["productVariant"]["assignedAttributes"]
+    expected_assigned_choice_attribute = {
+        "attribute": {"slug": size_attribute.slug},
+        "choice": {
+            "name": attr_value,
+            "slug": attr_value.lower(),
+        },
+    }
+    assert expected_assigned_choice_attribute in assigned_attributes
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")
@@ -640,46 +661,142 @@ def test_update_product_variant_change_sku_to_empty_string(
 
 
 QUERY_UPDATE_VARIANT_ATTRIBUTES = """
-    mutation updateVariant (
-        $id: ID!,
-        $sku: String,
-        $attributes: [AttributeValueInput!]) {
-            productVariantUpdate(
-                id: $id,
-                input: {
-                    sku: $sku,
-                    attributes: $attributes
-                }) {
-                productVariant {
-                    sku
-                    attributes {
-                        attribute {
-                            slug
-                        }
-                        values {
-                            id
-                            slug
-                            name
-                            file {
-                                url
-                                contentType
-                            }
-                            reference
-                            richText
-                            plainText
-                            boolean
-                            date
-                            dateTime
-                        }
-                    }
-                }
-                errors {
-                    field
-                    code
-                    message
-                }
-            }
+mutation updateVariant($id: ID!, $sku: String, $attributes: [AttributeValueInput!]) {
+  productVariantUpdate(id: $id, input: {sku: $sku, attributes: $attributes}) {
+    productVariant {
+      sku
+      assignedAttributes {
+        ... on AssignedAttributeInterface {
+          attribute {
+            slug
+          }
         }
+        ... on AssignedNumericAttribute {
+          value
+        }
+        ... on AssignedTextAttribute {
+          text: value
+        }
+        ... on AssignedPlainTextAttribute {
+          plain_text: value
+        }
+        ... on AssignedFileAttribute {
+          file: value {
+            contentType
+            url
+          }
+        }
+        ... on AssignedMultiPageReferenceAttribute {
+          pages: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductReferenceAttribute {
+          products: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCategoryReferenceAttribute {
+          categories: value {
+            slug
+          }
+        }
+        ... on AssignedMultiCollectionReferenceAttribute {
+          collections: value {
+            slug
+          }
+        }
+        ... on AssignedSinglePageReferenceAttribute {
+          page: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductReferenceAttribute {
+          product: value {
+            slug
+          }
+        }
+        ... on AssignedSingleProductVariantReferenceAttribute {
+          variant: value {
+            sku
+          }
+        }
+        ... on AssignedSingleCategoryReferenceAttribute {
+          category: value {
+            slug
+          }
+        }
+        ... on AssignedSingleCollectionReferenceAttribute {
+          collection: value {
+            slug
+          }
+        }
+        ... on AssignedMultiProductVariantReferenceAttribute {
+          variants: value {
+            sku
+          }
+        }
+        ... on AssignedSingleChoiceAttribute {
+          choice: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedMultiChoiceAttribute {
+          multi: value {
+            name
+            slug
+          }
+        }
+        ... on AssignedSwatchAttribute {
+          swatch: value {
+            name
+            slug
+            hexColor
+            file {
+              url
+              contentType
+            }
+          }
+        }
+        ... on AssignedBooleanAttribute {
+          bool: value
+        }
+        ... on AssignedDateAttribute {
+          date: value
+        }
+        ... on AssignedDateTimeAttribute {
+          datetime: value
+        }
+      }
+      attributes {
+        attribute {
+          slug
+        }
+        values {
+          id
+          slug
+          name
+          file {
+            url
+            contentType
+          }
+          reference
+          richText
+          plainText
+          boolean
+          date
+          dateTime
+        }
+      }
+    }
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
 """
 
 
@@ -711,6 +828,7 @@ def test_update_product_variant_do_not_require_required_attributes(
     assert data["productVariant"]["sku"] == sku
     assert len(data["productVariant"]["attributes"]) == 1
     assert data["productVariant"]["attributes"][0]["values"]
+    assert len(data["productVariant"]["assignedAttributes"]) == 1
 
 
 def test_update_product_variant_with_current_attribute(
@@ -808,6 +926,8 @@ def test_update_product_variant_with_value_that_matching_existing_slug(
     assert not variant.sku == sku
 
     attribute_1, attribute_2 = product.product_type.variant_attributes.all()
+    assert attribute_1.input_type == AttributeInputType.DROPDOWN
+    assert attribute_2.input_type == AttributeInputType.DROPDOWN
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     attribute_1_id = graphene.Node.to_global_id("Attribute", attribute_1.pk)
@@ -816,12 +936,14 @@ def test_update_product_variant_with_value_that_matching_existing_slug(
     attr_1_values_count = attribute_1.values.count()
     attr_2_values_count = attribute_2.values.count()
 
+    value_for_attr_1 = attribute_1.values.first()
+    value_for_attr_2 = attribute_2.values.first()
     variables = {
         "id": variant_id,
         "sku": sku,
         "attributes": [
-            {"id": attribute_1_id, "values": [attribute_1.values.first().slug]},
-            {"id": attribute_2_id, "values": [attribute_2.values.first().slug]},
+            {"id": attribute_1_id, "values": [value_for_attr_1.slug]},
+            {"id": attribute_2_id, "values": [value_for_attr_2.slug]},
         ],
     }
 
@@ -841,6 +963,24 @@ def test_update_product_variant_with_value_that_matching_existing_slug(
     for attr_data in data["productVariant"]["attributes"]:
         assert len(attr_data["values"]) == 1
 
+    assigned_attributes = data["productVariant"]["assignedAttributes"]
+    expected_first_assigned_choice_attribute = {
+        "attribute": {"slug": attribute_1.slug},
+        "choice": {
+            "name": value_for_attr_1.name,
+            "slug": value_for_attr_1.slug,
+        },
+    }
+    expected_second_assigned_choice_attribute = {
+        "attribute": {"slug": attribute_2.slug},
+        "choice": {
+            "name": value_for_attr_2.name,
+            "slug": value_for_attr_2.slug,
+        },
+    }
+    assert expected_first_assigned_choice_attribute in assigned_attributes
+    assert expected_second_assigned_choice_attribute in assigned_attributes
+
 
 def test_update_product_variant_with_value_that_matching_existing_name(
     staff_api_client,
@@ -853,6 +993,8 @@ def test_update_product_variant_with_value_that_matching_existing_name(
     assert not variant.sku == sku
 
     attribute_1, attribute_2 = product.product_type.variant_attributes.all()
+    assert attribute_1.input_type == AttributeInputType.DROPDOWN
+    assert attribute_2.input_type == AttributeInputType.DROPDOWN
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     attribute_1_id = graphene.Node.to_global_id("Attribute", attribute_1.pk)
@@ -861,12 +1003,15 @@ def test_update_product_variant_with_value_that_matching_existing_name(
     attr_1_values_count = attribute_1.values.count()
     attr_2_values_count = attribute_2.values.count()
 
+    value_for_attr_1 = attribute_1.values.first()
+    value_for_attr_2 = attribute_2.values.first()
+
     variables = {
         "id": variant_id,
         "sku": sku,
         "attributes": [
-            {"id": attribute_1_id, "values": [attribute_1.values.first().name]},
-            {"id": attribute_2_id, "values": [attribute_2.values.first().name]},
+            {"id": attribute_1_id, "values": [value_for_attr_1.name]},
+            {"id": attribute_2_id, "values": [value_for_attr_2.name]},
         ],
     }
 
@@ -888,6 +1033,24 @@ def test_update_product_variant_with_value_that_matching_existing_name(
     for attr_data in data["productVariant"]["attributes"]:
         assert len(attr_data["values"]) == 1
 
+    assigned_attributes = data["productVariant"]["assignedAttributes"]
+    expected_first_assigned_choice_attribute = {
+        "attribute": {"slug": attribute_1.slug},
+        "choice": {
+            "name": value_for_attr_1.name,
+            "slug": value_for_attr_1.slug,
+        },
+    }
+    expected_second_assigned_choice_attribute = {
+        "attribute": {"slug": attribute_2.slug},
+        "choice": {
+            "name": value_for_attr_2.name,
+            "slug": value_for_attr_2.slug,
+        },
+    }
+    assert expected_first_assigned_choice_attribute in assigned_attributes
+    assert expected_second_assigned_choice_attribute in assigned_attributes
+
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
 def test_update_variant_with_boolean_attribute(
@@ -908,13 +1071,14 @@ def test_update_variant_with_boolean_attribute(
     attr_id = graphene.Node.to_global_id("Attribute", boolean_attribute.id)
     size_attr_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
 
+    size_value_name = "XXXL"
     new_value = False
     values_count = boolean_attribute.values.count()
     variables = {
         "id": variant_id,
         "sku": sku,
         "attributes": [
-            {"id": size_attr_id, "values": ["XXXL"]},
+            {"id": size_attr_id, "values": [size_value_name]},
             {"id": attr_id, "boolean": new_value},
         ],
     }
@@ -936,6 +1100,22 @@ def test_update_variant_with_boolean_attribute(
     assert data["attributes"][-1]["attribute"]["slug"] == boolean_attribute.slug
     assert data["attributes"][-1]["values"][0]["name"] == "Boolean: No"
     assert data["attributes"][-1]["values"][0]["boolean"] is new_value
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_boolean_assigned_choice_attribute = {
+        "attribute": {"slug": boolean_attribute.slug},
+        "bool": new_value,
+    }
+    expected_size_assigned_choice_attribute = {
+        "attribute": {"slug": size_attribute.slug},
+        "choice": {
+            "name": size_value_name,
+            "slug": size_value_name.lower(),
+        },
+    }
+    assert expected_boolean_assigned_choice_attribute in assigned_attributes
+    assert expected_size_assigned_choice_attribute in assigned_attributes
+
     assert boolean_attribute.values.count() == values_count
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -985,6 +1165,19 @@ def test_update_variant_with_swatch_attribute_new_value_created(
     assert data["sku"] == sku
     assert data["attributes"][-1]["attribute"]["slug"] == swatch_attribute.slug
     assert data["attributes"][-1]["values"][0]["name"] == value
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": {
+            "name": value,
+            "slug": slugify(value),
+            "hexColor": None,
+            "file": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert swatch_attribute.values.count() == values_count + 1
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -1035,6 +1228,19 @@ def test_update_variant_with_swatch_attribute_existing_value(
     assert data["sku"] == sku
     assert data["attributes"][-1]["attribute"]["slug"] == swatch_attribute.slug
     assert data["attributes"][-1]["values"][0]["name"] == value.name
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": {
+            "name": value.name,
+            "slug": value.slug,
+            "hexColor": value.value,
+            "file": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert swatch_attribute.values.count() == values_count
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -1081,6 +1287,19 @@ def test_update_variant_with_swatch_attribute_use_values(
     assert data["sku"] == sku
     assert data["attributes"][-1]["attribute"]["slug"] == swatch_attribute.slug
     assert data["attributes"][-1]["values"][0]["name"] == value
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": {
+            "name": value,
+            "slug": slugify(value),
+            "hexColor": None,
+            "file": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert swatch_attribute.values.count() == values_count + 1
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -1126,6 +1345,13 @@ def test_update_variant_with_swatch_attribute_no_values_given(
     assert data["attributes"][-1]["attribute"]["slug"] == swatch_attribute.slug
     assert not data["attributes"][-1]["values"]
 
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": swatch_attribute.slug},
+        "swatch": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
 def test_update_variant_with_rich_text_attribute(
@@ -1144,12 +1370,12 @@ def test_update_variant_with_rich_text_attribute(
     sku = "123"
     attr_id = graphene.Node.to_global_id("Attribute", rich_text_attribute.id)
     rich_text_attribute_value = rich_text_attribute.values.first()
-    rich_text = json.dumps(rich_text_attribute_value.rich_text)
+    rich_text = rich_text_attribute_value.rich_text
     variables = {
         "id": variant_id,
         "sku": sku,
         "attributes": [
-            {"id": attr_id, "richText": rich_text},
+            {"id": attr_id, "richText": json.dumps(rich_text)},
         ],
     }
     rich_text_attribute_value.slug = f"{variant.id}_{rich_text_attribute.id}"
@@ -1169,7 +1395,15 @@ def test_update_variant_with_rich_text_attribute(
     assert not content["errors"]
     assert data["sku"] == sku
     assert data["attributes"][-1]["attribute"]["slug"] == rich_text_attribute.slug
-    assert data["attributes"][-1]["values"][0]["richText"] == rich_text
+    assert data["attributes"][-1]["values"][0]["richText"] == json.dumps(rich_text)
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": rich_text_attribute.slug},
+        "text": rich_text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert rich_text_attribute.values.count() == values_count
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -1221,6 +1455,14 @@ def test_update_variant_with_plain_text_attribute(
     assert data["sku"] == sku
     assert data["attributes"][-1]["attribute"]["slug"] == plain_text_attribute.slug
     assert data["attributes"][-1]["values"][0]["plainText"] == text
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert plain_text_attribute.values.count() == values_count
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -1276,6 +1518,14 @@ def test_update_variant_with_plain_text_attribute_value_required(
     assert data["sku"] == sku
     assert data["attributes"][-1]["attribute"]["slug"] == plain_text_attribute.slug
     assert data["attributes"][-1]["values"][0]["plainText"] == text
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": plain_text_attribute.slug},
+        "plain_text": text,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert plain_text_attribute.values.count() == values_count
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -1390,6 +1640,14 @@ def test_update_variant_with_date_attribute(
     assert data["sku"] == sku
     assert date_values_count + 1 == date_attribute.values.count()
     assert expected_attributes_data in data["attributes"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_attribute.slug},
+        "date": str(date_value),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     product_variant_updated.assert_called_once_with(product.variants.last())
 
 
@@ -1452,6 +1710,14 @@ def test_update_variant_with_date_time_attribute(
     assert data["sku"] == sku
     assert date_time_values_count + 1 == date_time_attribute.values.count()
     assert expected_attributes_data in data["attributes"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": date_time_attribute.slug},
+        "datetime": date_time_value.isoformat(),
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     product_variant_updated.assert_called_once_with(product.variants.last())
 
 
@@ -1497,6 +1763,14 @@ def test_update_variant_removes_numeric_attribute_value(
     assert data["sku"] == sku
     assert data["attributes"][-1]["attribute"]["slug"] == numeric_attribute.slug
     assert not data["attributes"][-1]["values"]
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": None,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     assert numeric_attribute.values.count() == values_count
     product_variant_updated.assert_called_once_with(product.variants.last())
 
@@ -1547,6 +1821,13 @@ def test_update_variant_adds_numeric_attribute(
     ][0]
     assert attribute_data["attribute"]["slug"] == numeric_attribute.slug
     assert attribute_data["values"][0]["name"] == numeric_name
+
+    assigned_attributes = data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
     assert numeric_attribute.values.filter(
         name=numeric_name, numeric=numeric_value
@@ -1636,6 +1917,13 @@ def test_update_product_variant_clear_attributes(
     assert not data["errors"]
     variant.refresh_from_db()
     assert not data["productVariant"]["attributes"][0]["values"]
+    assigned_attributes = data["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": attribute.slug},
+        "multi": [],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
     with pytest.raises(variant_attr._meta.model.DoesNotExist):
         variant_attr.refresh_from_db()
 
@@ -1740,6 +2028,16 @@ def test_update_product_variant_with_current_file_attribute(
         == f"{slugify(second_value)}-2"
     )
 
+    assigned_attributes = variant_data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": None,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_update_product_variant_with_duplicated_file_attribute(
     staff_api_client,
@@ -1843,6 +2141,16 @@ def test_update_product_variant_with_file_attribute_new_value_is_not_created(
     assert value_data["file"]["url"] == file_url
     assert value_data["file"]["contentType"] == existing_value.content_type
 
+    assigned_attributes = variant_data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": file_attribute.slug},
+        "file": {
+            "url": file_url,
+            "contentType": existing_value.content_type,
+        },
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_update_product_variant_with_page_reference_attribute(
     staff_api_client,
@@ -1893,6 +2201,15 @@ def test_update_product_variant_with_page_reference_attribute(
         variant_data["attributes"][0]["values"][0]["slug"] == f"{variant.pk}_{page.pk}"
     )
     assert variant_data["attributes"][0]["values"][0]["reference"] == reference
+
+    assigned_attributes = variant_data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_page_reference_attribute.slug},
+        "pages": [
+            {"slug": page.slug},
+        ],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_update_product_variant_with_product_reference_attribute(
@@ -1947,6 +2264,13 @@ def test_update_product_variant_with_product_reference_attribute(
         == f"{variant.pk}_{product_ref.pk}"
     )
     assert variant_data["attributes"][0]["values"][0]["reference"] == reference
+
+    assigned_attributes = variant_data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_product_reference_attribute.slug},
+        "products": [{"slug": product_ref.slug}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_update_product_variant_with_variant_reference_attribute(
@@ -2006,6 +2330,13 @@ def test_update_product_variant_with_variant_reference_attribute(
     )
     assert variant_data["attributes"][0]["values"][0]["reference"] == reference
 
+    assigned_attributes = variant_data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_variant_reference_attribute.slug},
+        "variants": [{"sku": variant_ref.sku}],
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
 
 def test_update_product_variant_with_category_reference_attribute(
     staff_api_client,
@@ -2060,6 +2391,15 @@ def test_update_product_variant_with_category_reference_attribute(
         == f"{variant.pk}_{category.pk}"
     )
     assert variant_data["attributes"][0]["values"][0]["reference"] == reference
+
+    assigned_attributes = variant_data["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": product_type_category_reference_attribute.slug},
+        "categories": [
+            {"slug": category.slug},
+        ],
+    }
+    assert expected_assigned_attribute in assigned_attributes
 
 
 def test_update_product_variant_with_single_reference_attributes(
@@ -2164,6 +2504,34 @@ def test_update_product_variant_with_single_reference_attributes(
     for attr_data in attributes_data:
         assert attr_data in expected_attributes_data
 
+    assigned_attributes = variant_data["assignedAttributes"]
+
+    expected_assigned_page_attribute = {
+        "attribute": {"slug": product_type_page_single_reference_attribute.slug},
+        "page": {"slug": page.slug},
+    }
+    expected_assigned_product_attribute = {
+        "attribute": {"slug": product_type_product_single_reference_attribute.slug},
+        "product": {"slug": product.slug},
+    }
+    expected_assigned_variant_attribute = {
+        "attribute": {"slug": product_type_variant_single_reference_attribute.slug},
+        "variant": {"sku": product_variant_list[0].sku},
+    }
+    expected_assigned_category_attribute = {
+        "attribute": {"slug": product_type_category_single_reference_attribute.slug},
+        "category": {"slug": categories[0].slug},
+    }
+    expected_assigned_collection_attribute = {
+        "attribute": {"slug": product_type_collection_single_reference_attribute.slug},
+        "collection": {"slug": collection.slug},
+    }
+    assert expected_assigned_page_attribute in assigned_attributes
+    assert expected_assigned_product_attribute in assigned_attributes
+    assert expected_assigned_variant_attribute in assigned_attributes
+    assert expected_assigned_category_attribute in assigned_attributes
+    assert expected_assigned_collection_attribute in assigned_attributes
+
 
 def test_update_product_variant_change_attribute_values_ordering(
     staff_api_client,
@@ -2219,7 +2587,16 @@ def test_update_product_variant_change_attribute_values_ordering(
         )
     ) == [attr_value_3.pk, attr_value_2.pk, attr_value_1.pk]
 
-    new_ref_order = [product_list[1], product_list[0], product_list[2]]
+    expected_first_product = product_list[1]
+    expected_second_product = product_list[0]
+    expected_third_product = product_list[2]
+
+    new_ref_order = [
+        expected_first_product,
+        expected_second_product,
+        expected_third_product,
+    ]
+
     variables = {
         "id": variant_id,
         "sku": sku,
@@ -2255,6 +2632,14 @@ def test_update_product_variant_change_attribute_values_ordering(
         graphene.Node.to_global_id("AttributeValue", val.pk)
         for val in [attr_value_2, attr_value_1, attr_value_3]
     ]
+    assigned_attributes = data["productVariant"]["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assigned_values = assigned_attributes[0]["products"]
+    assert len(assigned_values) == 3
+    assert assigned_values[0]["slug"] == expected_first_product.slug
+    assert assigned_values[1]["slug"] == expected_second_product.slug
+    assert assigned_values[2]["slug"] == expected_third_product.slug
+
     variant.refresh_from_db()
     assert list(
         variant.attributes.first().variantvalueassignment.values_list(

--- a/saleor/graphql/product/tests/queries/test_categories_query_with_filter.py
+++ b/saleor/graphql/product/tests/queries/test_categories_query_with_filter.py
@@ -169,13 +169,30 @@ query (
     id
     name
     products(
-        first: 5, channel: $channel, filter: $filters, where: $where, search: $search
+      first: 5
+      channel: $channel
+      filter: $filters
+      where: $where
+      search: $search
     ) {
       edges {
         node {
           id
           name
           channel
+          assignedAttributes {
+            ... on AssignedAttributeInterface {
+              attribute {
+                choices(first: 10) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
           attributes {
             attribute {
               choices(first: 10) {
@@ -329,6 +346,18 @@ def test_category_filter_products_by_multiple_attributes(
     assert len(products) == 1
     assert products[0]["node"]["id"] == product_with_multiple_values_attributes_id
     assert products[0]["node"]["attributes"] == [
+        {
+            "attribute": {
+                "choices": {
+                    "edges": [
+                        {"node": {"slug": "eco"}},
+                        {"node": {"slug": "power"}},
+                    ]
+                }
+            }
+        }
+    ]
+    assert products[0]["node"]["assignedAttributes"] == [
         {
             "attribute": {
                 "choices": {

--- a/saleor/graphql/product/tests/queries/test_collection_query.py
+++ b/saleor/graphql/product/tests/queries/test_collection_query.py
@@ -7,10 +7,7 @@ from django.core.files import File
 from .....product.tests.utils import create_image
 from .....thumbnail.models import Thumbnail
 from ....core.enums import LanguageCodeEnum, ThumbnailFormatEnum
-from ....tests.utils import (
-    get_graphql_content,
-    get_graphql_content_from_response,
-)
+from ....tests.utils import get_graphql_content, get_graphql_content_from_response
 
 QUERY_COLLECTION = """
     query ($id: ID, $slug: String, $channel: String, $slugLanguageCode: LanguageCodeEnum){
@@ -183,6 +180,19 @@ query CollectionProducts(
       edges {
         node {
           id
+          assignedAttributes {
+            ... on AssignedAttributeInterface {
+              attribute {
+                choices(first: 10) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
           attributes {
             attribute {
               choices(first: 10) {
@@ -301,6 +311,18 @@ def test_filter_collection_products_by_multiple_attributes(
         "Product", product_with_multiple_values_attributes.pk
     )
     assert product["attributes"] == [
+        {
+            "attribute": {
+                "choices": {
+                    "edges": [
+                        {"node": {"slug": "eco"}},
+                        {"node": {"slug": "power"}},
+                    ]
+                }
+            }
+        }
+    ]
+    assert product["assignedAttributes"] == [
         {
             "attribute": {
                 "choices": {

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -1672,7 +1672,7 @@ def test_product_variant_without_price_as_staff_with_permission(
     assert variants_data[1]["node"]["pricing"] is None
 
 
-def test_get_product_with_sorted_attribute_values(
+def test_get_product_with_sorted_attribute_values_for_attributes_field(
     staff_api_client,
     product,
     permission_manage_products,
@@ -1732,6 +1732,71 @@ def test_get_product_with_sorted_attribute_values(
         graphene.Node.to_global_id("AttributeValue", val.pk)
         for val in [attr_value_2, attr_value_1]
     ]
+
+
+def test_get_product_with_sorted_attribute_values_for_assigned_attributes_field(
+    staff_api_client,
+    product,
+    permission_manage_products,
+    product_type_page_reference_attribute,
+    page_list,
+):
+    # given
+    query = """
+    query getProduct($productID: ID!) {
+      product(id: $productID) {
+        assignedAttributes {
+          ... on AssignedMultiPageReferenceAttribute {
+            value {
+              id
+            }
+          }
+        }
+      }
+    }
+    """
+    product_type = product.product_type
+    product_type.product_attributes.set([product_type_page_reference_attribute])
+
+    attr_value_1 = AttributeValue.objects.create(
+        attribute=product_type_page_reference_attribute,
+        name=page_list[0].title,
+        slug=f"{product.pk}_{page_list[0].pk}",
+        reference_page=page_list[0],
+    )
+    attr_value_2 = AttributeValue.objects.create(
+        attribute=product_type_page_reference_attribute,
+        name=page_list[1].title,
+        slug=f"{product.pk}_{page_list[1].pk}",
+        reference_page=page_list[1],
+    )
+
+    associate_attribute_values_to_instance(
+        product,
+        {product_type_page_reference_attribute.pk: [attr_value_2, attr_value_1]},
+    )
+
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    variables = {"productID": product_id}
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["product"]
+
+    assigned_attributes = data["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assigned_values = assigned_attributes[0]["value"]
+    assert len(assigned_values) == 2
+    assert assigned_values[0]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[1].pk
+    )
+    assert assigned_values[1]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
 
 
 QUERY_PRODUCT_IMAGE_BY_ID = """
@@ -2651,10 +2716,26 @@ query Product($id: ID!, $channel: String, $slug: String!) {
                 slug
             }
         }
+        assignedAttribute(slug: $slug) {
+            ... on AssignedAttributeInterface {
+                attribute {
+                    id
+                    slug
+                }
+            }
+        }
         attributes {
             attribute {
                 id
                 slug
+            }
+        }
+        assignedAttributes {
+            ... on AssignedAttributeInterface {
+                attribute {
+                    id
+                    slug
+                }
             }
         }
     }
@@ -2681,8 +2762,11 @@ def test_product_attribute_field_filtering(staff_api_client, product, channel_US
     # then
     expected_slug = "color"
     content = get_graphql_content(response)
-    queried_slug = content["data"]["product"]["attribute"]["attribute"]["slug"]
-    assert queried_slug == expected_slug
+    product_data = content["data"]["product"]
+    attribute_queried_slug = product_data["attribute"]["attribute"]["slug"]
+    assigned_queried_slug = product_data["assignedAttribute"]["attribute"]["slug"]
+    assert assigned_queried_slug == expected_slug
+    assert attribute_queried_slug == expected_slug
 
 
 def test_product_attribute_field_filtering_not_found(
@@ -2706,6 +2790,7 @@ def test_product_attribute_field_filtering_not_found(
     # then
     content = get_graphql_content(response)
     assert content["data"]["product"]["attribute"] is None
+    assert content["data"]["product"]["assignedAttribute"] is None
 
 
 def test_product_attribute_not_visible_in_storefront_for_customer_is_not_returned(
@@ -2741,6 +2826,7 @@ def test_product_attribute_not_visible_in_storefront_for_customer_is_not_returne
         }
     }
     assert attr_data not in content["data"]["product"]["attributes"]
+    assert attr_data not in content["data"]["product"]["assignedAttributes"]
 
 
 def test_product_attribute_visible_in_storefront_for_customer_is_returned(
@@ -2764,9 +2850,9 @@ def test_product_attribute_visible_in_storefront_for_customer_is_returned(
 
     # then
     content = get_graphql_content(response)
-    assert (
-        content["data"]["product"]["attribute"]["attribute"]["slug"] == attribute.slug
-    )
+    product_data = content["data"]["product"]
+    assert product_data["attribute"]["attribute"]["slug"] == attribute.slug
+    assert product_data["assignedAttribute"]["attribute"]["slug"] == attribute.slug
 
 
 @pytest.mark.parametrize("visible_in_storefront", [False, True])

--- a/saleor/graphql/product/tests/queries/test_products_query.py
+++ b/saleor/graphql/product/tests/queries/test_products_query.py
@@ -1181,6 +1181,13 @@ def test_products_with_variants_query_as_app(
               node{
                 id
                 name
+                assignedAttributes {
+                    ... on AssignedAttributeInterface {
+                        attribute {
+                            slug
+                        }
+                    }
+                }
                 attributes {
                     attribute {
                         id
@@ -1211,6 +1218,9 @@ def test_products_with_variants_query_as_app(
         attrs = response_product["node"]["attributes"]
         assert len(attrs) == 1
         assert attrs[0]["attribute"]["id"] == attribute_id
+        assigned_attribtues = response_product["node"]["assignedAttributes"]
+        assert len(assigned_attribtues) == 1
+        assert assigned_attribtues[0]["attribute"]["slug"] == attribute.slug
 
 
 PRODUCT_SEARCH_QUERY = """

--- a/saleor/graphql/product/tests/queries/test_variant_query.py
+++ b/saleor/graphql/product/tests/queries/test_variant_query.py
@@ -28,6 +28,30 @@ query variant(
         id
         sku
         externalReference
+        assignedAttributes(variantSelection: $variantSelection) {
+            ... on AssignedAttributeInterface {
+                attribute {
+                    slug
+                }
+            }
+            ... on AssignedFileAttribute {
+                file: value {
+                    contentType
+                    url
+                }
+            }
+            ... on AssignedSingleChoiceAttribute {
+                choice: value {
+                    name
+                    slug
+                }
+            }
+            ... on AssignedMultiProductReferenceAttribute {
+                products: value {
+                    slug
+                }
+            }
+        }
         attributes(variantSelection: $variantSelection) {
             attribute {
                 slug
@@ -559,11 +583,20 @@ def test_get_variant_by_id_with_variant_selection_filter(
             data["attributes"][0]["attribute"]["slug"]
             == file_attribute_with_file_input_type_without_values.slug
         )
+        assert len(data["assignedAttributes"]) == 1
+        assert (
+            data["assignedAttributes"][0]["attribute"]["slug"]
+            == file_attribute_with_file_input_type_without_values.slug
+        )
     elif variant_selection == VariantAttributeScope.VARIANT_SELECTION.name:
         assert len(data["attributes"]) == 1
         assert data["attributes"][0]["attribute"]["slug"] == size_attribute.slug
+
+        assert len(data["assignedAttributes"]) == 1
+        assert data["assignedAttributes"][0]["attribute"]["slug"] == size_attribute.slug
     else:
         assert len(data["attributes"]) == 2
+        assert len(data["assignedAttributes"]) == 2
 
 
 def test_get_variant_with_sorted_attribute_values(
@@ -581,17 +614,24 @@ def test_get_variant_with_sorted_attribute_values(
         attribute=product_type_product_reference_attribute,
         name=product_list[0].name,
         slug=f"{variant.pk}_{product_list[0].pk}",
+        reference_product=product_list[0],
     )
     attr_value_2 = AttributeValue.objects.create(
         attribute=product_type_product_reference_attribute,
         name=product_list[1].name,
         slug=f"{variant.pk}_{product_list[1].pk}",
+        reference_product=product_list[1],
     )
     attr_value_3 = AttributeValue.objects.create(
         attribute=product_type_product_reference_attribute,
         name=product_list[2].name,
         slug=f"{variant.pk}_{product_list[2].pk}",
+        reference_product=product_list[2],
     )
+
+    expected_first_product = product_list[1]
+    expected_second_product = product_list[0]
+    expected_third_product = product_list[2]
 
     attr_values = [attr_value_2, attr_value_1, attr_value_3]
     associate_attribute_values_to_instance(
@@ -614,6 +654,14 @@ def test_get_variant_with_sorted_attribute_values(
     assert [value["id"] for value in values] == [
         graphene.Node.to_global_id("AttributeValue", val.pk) for val in attr_values
     ]
+
+    assigned_attributes = data["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assigned_values = assigned_attributes[0]["products"]
+    assert len(assigned_values) == 3
+    assert assigned_values[0]["slug"] == expected_first_product.slug
+    assert assigned_values[1]["slug"] == expected_second_product.slug
+    assert assigned_values[2]["slug"] == expected_third_product.slug
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I want to merge this change because it extends all tests where we have a validation for `SelectedAttribute`.
The PR also adds missing `if`:
```python
        if not root.value:
            return None
```
Rest of the code is related to extending the current tests

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
