### PR TITLE
Attempt to build images on separate builders, so we can use native ones

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -46,13 +46,15 @@ jobs:
 
       - name: Build Image Name
         id: image
+        env:
+          GH_REPO: ${{ github.repository }}
         run: |
           # The name of the owner and of the repository: owner/repository
-          IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME=$(echo "$GH_REPO" | tr '[:upper:]' '[:lower:]')
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
 
@@ -121,9 +123,11 @@ jobs:
     steps:
       - name: Build Image Name
         id: image
+        env:
+          GH_REPO: ${{ github.repository }}
         run: |
           # The name of the owner and of the repository: owner/repository
-          IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME=$(echo "$GH_REPO" | tr '[:upper:]' '[:lower:]')
           echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
 
       - name: Download digests
@@ -135,7 +139,7 @@ jobs:
 
       # Needed by `docker/metadata-action` (to fetch tags and other git information)
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
 
@@ -161,16 +165,39 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        env:
+          DOCKER_META_JSON: ${{ steps.meta.outputs.json }}
+          IMAGE_NAME: ${{ steps.image.outputs.image_name }}
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "${{steps.meta.outputs.json}}") \
-            $(printf 'ghcr.io/${{ steps.image.outputs.image_name }}@sha256:%s ' *)
+          set -x
+          tag_list=$(echo "$DOCKER_META_JSON" | jq -cr '.tags | map("-t " + .) | join(" ")')
+          image_digest_list=$(printf "ghcr.io/$IMAGE_NAME@sha256:%s " *)
+          docker buildx imagetools create $tag_list $image_digest_list
 
       - name: Inspect image
+        env:
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+          IMAGE_NAME: ${{ steps.image.outputs.image_name }}
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ steps.image.outputs.image_name }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/"$IMAGE_NAME":"$IMAGE_VERSION"
+
+  notify:
+    if: ${{ failure() }}
+    needs: build-and-push
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          sparse-checkout: |
+            ./.github/workflows/notify
 
       - name: Notify Slack
-        if: ${{ failure() }}
         env:
           JOB_STATUS: ${{ job.status }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
The way we build all images in QEMU is super slow, so this is a first step to build each image using a separate job (not yet running natively ARM64, still uses QEMU for now, QEMU will be dropped later on)

> [!NOTE]
> Changes were tested at e2b7dcf40df91551706e651e44c45b10d3639d3f (separate branch)
>
> **Test Results:**
>
> ARM64:
> ```
> $ docker run --rm \
>   --platform linux/arm64 \
>   -ti ghcr.io/saleor/saleor:testing-uv-supportbuild-multi-arch-publish-containers \
>   uname -m
> aarch64
>
> $ docker run --rm \
>   --platform linux/arm64 \
>   -ti ghcr.io/saleor/saleor:testing-uv-supportbuild-multi-arch-publish-containers
> […]
> INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
> INFO:     Started parent process [1]
> ```
> 
> x64:
> ```
> $ docker run --rm \
>   --platform linux/amd64 \
>   -ti ghcr.io/saleor/saleor:testing-uv-supportbuild-multi-arch-publish-containers \
>   uname -m
> x86_64
> 
> $ docker run --rm \
>   --platform linux/amd64 \
>   -ti ghcr.io/saleor/saleor:testing-uv-supportbuild-multi-arch-publish-containers
> […]
> Status: Downloaded newer image for ghcr.io/saleor/saleor:testing-uv-supportbuild-multi-arch-publish-containers
> INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
> INFO:     Started parent process [1]
> ```

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
