### PR TITLE
Add 'limit' field to `Assigned*Attribute` types

### DIFF
--- a/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
+++ b/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
@@ -151,7 +151,7 @@ def test_attribute_value_name_when_referenced_page_was_changed(
 ASSIGNED_NUMERIC_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ... on AssignedNumericAttribute {
         attribute {
           id
@@ -191,7 +191,7 @@ def test_assigned_numeric_attribute(staff_api_client, page, numeric_attribute):
 ASSIGNED_TEXT_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedTextAttribute{
         value
         translation(languageCode:FR)
@@ -267,7 +267,7 @@ def test_assigned_text_attribute(staff_api_client, page, rich_text_attribute):
 ASSIGNED_PLAIN_TEXT_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedPlainTextAttribute{
         value
         translation(languageCode:FR)
@@ -351,7 +351,7 @@ def test_assigned_plain_text_attribute(staff_api_client, page, plain_text_attrib
 ASSIGNED_FILE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedFileAttribute{
         value {
           url
@@ -400,7 +400,7 @@ def test_assigned_file_attribute(staff_api_client, page, file_attribute):
 ASSIGNED_SINGLE_PAGE_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       __typename
       ...on AssignedSinglePageReferenceAttribute{
         value{
@@ -460,7 +460,7 @@ def test_assigned_single_page_reference_attribute(
 ASSIGNED_SINGLE_PRODUCT_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       __typename
       ...on AssignedSingleProductReferenceAttribute{
         value{
@@ -521,7 +521,7 @@ def test_assigned_single_product_reference_attribute(
 ASSIGNED_SINGLE_PRODUCT_VARIANT_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       __typename
       ...on AssignedSingleProductVariantReferenceAttribute{
         value{
@@ -582,7 +582,7 @@ def test_assigned_single_product_variant_reference_attribute(
 ASSIGNED_SINGLE_CATEGORY_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       __typename
       ...on AssignedSingleCategoryReferenceAttribute{
         value{
@@ -643,7 +643,7 @@ def test_assigned_single_category_reference_attribute(
 ASSIGNED_SINGLE_COLLECTION_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       __typename
       ...on AssignedSingleCollectionReferenceAttribute{
         value{
@@ -704,7 +704,7 @@ def test_assigned_single_collection_reference_attribute(
 ASSIGNED_MULTIPLE_PAGE_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedMultiPageReferenceAttribute{
         __typename
         value{
@@ -765,7 +765,7 @@ def test_assigned_multi_page_reference_attribute(
 ASSIGNED_MULTIPLE_PRODUCT_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedMultiProductReferenceAttribute{
         __typename
         value{
@@ -826,7 +826,7 @@ def test_assigned_multi_product_reference_attribute(
 ASSIGNED_MULTIPLE_PRODUCT_VARIANT_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedMultiProductVariantReferenceAttribute{
         __typename
         value{
@@ -887,7 +887,7 @@ def test_assigned_multi_product_variant_reference_attribute(
 ASSIGNED_MULTIPLE_CATEGORY_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedMultiCategoryReferenceAttribute{
         __typename
         value{
@@ -948,7 +948,7 @@ def test_assigned_multi_category_reference_attribute(
 ASSIGNED_MULTIPLE_COLLECTION_REFERENCE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedMultiCollectionReferenceAttribute{
         __typename
         value{
@@ -1009,7 +1009,7 @@ def test_assigned_multi_collection_reference_attribute(
 ASSIGNED_SINGLE_CHOICE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ...on AssignedSingleChoiceAttribute{
         __typename
         value{
@@ -1094,7 +1094,7 @@ def test_assigned_single_choice_attribute(
 ASSIGNED_MULTI_CHOICE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ... on AssignedMultiChoiceAttribute {
         __typename
         value {
@@ -1185,7 +1185,7 @@ def test_assigned_multi_choice_attribute(
 ASSIGNED_SWATCH_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ... on AssignedSwatchAttribute {
         value {
           name
@@ -1280,7 +1280,7 @@ def test_assigned_swatch_file_attribute(staff_api_client, page, swatch_attribute
 ASSIGNED_BOOLEAN_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ... on AssignedBooleanAttribute {
         value
       }
@@ -1326,7 +1326,7 @@ def test_assigned_boolean_attribute(
 ASSIGNED_DATE_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ... on AssignedDateAttribute {
         value
       }
@@ -1372,7 +1372,7 @@ def test_assigned_date_attribute(
 ASSIGNED_DATETIME_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {
-    assignedAttributes {
+    assignedAttributes(limit:10) {
       ... on AssignedDateTimeAttribute {
         value
       }

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -19,6 +19,7 @@ from ..core.connection import (
     create_connection_slice,
     filter_connection_queryset,
 )
+from ..core.const import DEFAULT_NESTED_LIST_LIMIT
 from ..core.context import (
     ChannelContext,
     ChannelQsContext,
@@ -43,6 +44,7 @@ from ..core.types import (
     NonNullList,
 )
 from ..core.types.context import ChannelContextType, ChannelContextTypeForObjectType
+from ..core.validators import validate_limit_input_value
 from ..decorators import check_attribute_required_permissions
 from ..meta.types import ObjectWithMetadata
 from ..page.dataloaders import PageByIdLoader
@@ -976,6 +978,13 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
         "saleor.graphql.page.types.Page",
         description="List of assigned page references.",
         required=True,
+        limit=graphene.Int(
+            description=(
+                "Maximum number of referenced pages to return. "
+                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+            ),
+            default_value=DEFAULT_NESTED_LIST_LIMIT,
+        ),
     )
 
     class Meta:
@@ -984,13 +993,18 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, info: ResolveInfo
+        root: AssignedAttributeData,
+        info: ResolveInfo,
+        limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[page_models.Page]]]:
+        validate_limit_input_value(limit)
+
         if not root.values:
             return Promise.resolve([])
 
         channel_slug = root.attribute.channel_slug
         attr_values = [value.node for value in root.values]
+        attr_values = attr_values[:limit]
 
         def _wrap_with_channel_context(
             pages: list[page_models.Page],
@@ -1013,6 +1027,13 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.Product",
         description="List of assigned product references.",
         required=True,
+        limit=graphene.Int(
+            description=(
+                "Maximum number of referenced products to return. "
+                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+            ),
+            default_value=DEFAULT_NESTED_LIST_LIMIT,
+        ),
     )
 
     class Meta:
@@ -1021,13 +1042,18 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, info: ResolveInfo
+        root: AssignedAttributeData,
+        info: ResolveInfo,
+        limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[product_models.Product]]]:
+        validate_limit_input_value(limit)
+
         if not root.values:
             return Promise.resolve([])
 
         channel_slug = root.attribute.channel_slug
         attr_values = [value.node for value in root.values]
+        attr_values = attr_values[:limit]
 
         def _wrap_with_channel_context(
             products: list[product_models.Product],
@@ -1051,6 +1077,13 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.ProductVariant",
         description="List of assigned product variant references.",
         required=True,
+        limit=graphene.Int(
+            description=(
+                "Maximum number of referenced product variants to return. "
+                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+            ),
+            default_value=DEFAULT_NESTED_LIST_LIMIT,
+        ),
     )
 
     class Meta:
@@ -1061,13 +1094,18 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, info: ResolveInfo
+        root: AssignedAttributeData,
+        info: ResolveInfo,
+        limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[product_models.ProductVariant]]]:
+        validate_limit_input_value(limit)
+
         if not root.values:
             return Promise.resolve([])
 
         channel_slug = root.attribute.channel_slug
         attr_values = [value.node for value in root.values]
+        attr_values = attr_values[:limit]
 
         def _wrap_with_channel_context(
             variants: list[product_models.ProductVariant],
@@ -1091,6 +1129,13 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.Category",
         description="List of assigned category references.",
         required=True,
+        limit=graphene.Int(
+            description=(
+                "Maximum number of referenced categories to return. "
+                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+            ),
+            default_value=DEFAULT_NESTED_LIST_LIMIT,
+        ),
     )
 
     class Meta:
@@ -1099,11 +1144,15 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, info: ResolveInfo
+        root: AssignedAttributeData,
+        info: ResolveInfo,
+        limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[product_models.Category]]:
+        validate_limit_input_value(limit)
         if not root.values:
             return Promise.resolve([])
         attr_values = [value.node for value in root.values]
+        attr_values = attr_values[:limit]
 
         return CategoryByIdLoader(info.context).load_many(
             [value.reference_category_id for value in attr_values]
@@ -1115,6 +1164,13 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.Collection",
         description="List of assigned collection references.",
         required=True,
+        limit=graphene.Int(
+            description=(
+                "Maximum number of referenced collections to return. "
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}"
+            ),
+            default_value=DEFAULT_NESTED_LIST_LIMIT,
+        ),
     )
 
     class Meta:
@@ -1123,13 +1179,17 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, info: ResolveInfo
+        root: AssignedAttributeData,
+        info: ResolveInfo,
+        limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[product_models.Collection]]]:
+        validate_limit_input_value(limit)
         if not root.values:
             return Promise.resolve([])
 
         channel_slug = root.attribute.channel_slug
         attr_values = [value.node for value in root.values]
+        attr_values = attr_values[:limit]
 
         def _wrap_with_channel_context(
             collections: list[product_models.Collection],
@@ -1201,6 +1261,13 @@ class AssignedMultiChoiceAttribute(BaseObjectType):
         AssignedChoiceAttributeValue,
         required=True,
         description="List of assigned choice values.",
+        limit=graphene.Int(
+            description=(
+                "Maximum number of choices to return. "
+                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+            ),
+            default_value=DEFAULT_NESTED_LIST_LIMIT,
+        ),
     )
 
     class Meta:
@@ -1209,9 +1276,13 @@ class AssignedMultiChoiceAttribute(BaseObjectType):
 
     @staticmethod
     def resolve_value(
-        root: AssignedAttributeData, info: ResolveInfo
+        root: AssignedAttributeData,
+        info: ResolveInfo,
+        limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> list[models.AttributeValue]:
-        return [value.node for value in root.values]
+        validate_limit_input_value(limit)
+        values = root.values[:limit]
+        return [value.node for value in values]
 
 
 class AssignedSwatchAttributeValue(BaseObjectType):

--- a/saleor/graphql/core/const.py
+++ b/saleor/graphql/core/const.py
@@ -1,0 +1,2 @@
+# Default value for list with limit argument
+DEFAULT_NESTED_LIST_LIMIT = 100

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -215,3 +215,10 @@ def validate_if_int_or_uuid(id):
             UUID(id)
         except (AttributeError, ValueError) as e:
             raise ValidationError("Must receive an int or UUID.") from e
+
+
+def validate_limit_input_value(limit_value: int | None):
+    if not limit_value or limit_value < 1:
+        raise GraphQLError(
+            f"`limit` must be greater than 1. Provided value is {limit_value}."
+        )

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -29,7 +29,7 @@ mutation CreatePage($input: PageCreateInput!) {
       pageType {
         id
       }
-      assignedAttributes {
+      assignedAttributes(limit:10) {
         attribute {
           slug
         }

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -33,7 +33,7 @@ mutation updatePage($id: ID!, $input: PageInput!) {
       slug
       isPublished
       publishedAt
-      assignedAttributes {
+      assignedAttributes(limit:10) {
         attribute {
           slug
         }
@@ -1364,7 +1364,7 @@ UPDATE_PAGE_ATTRIBUTES_MUTATION = """
                 id
                 title
                 slug
-                assignedAttributes {
+                assignedAttributes(limit:10) {
                     attribute {
                         slug
                     }

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -24,7 +24,7 @@ PAGE_QUERY = """
             }
             content
             contentJson
-            assignedAttributes {
+            assignedAttributes(limit:10) {
                 attribute {
                     slug
                 }
@@ -496,7 +496,7 @@ def test_page_query_by_translated_slug(user_api_client, page, page_translation_f
 QUERY_PAGE_WITH_ATTRIBUTE = """
 query Page($id: ID!, $slug: String!) {
     page(id: $id) {
-        assignedAttributes {
+        assignedAttributes(limit:10) {
             attribute {
                 slug
             }

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -710,3 +710,50 @@ def test_page_channel_not_found(staff_api_client, page, permission_manage_pages)
     # then
     content = get_graphql_content(response)
     assert content["data"]["page"] is None
+
+
+def test_applies_limit_on_page_assigned_attributes(
+    page, channel_USD, user_api_client, size_page_attribute, tag_page_attribute
+):
+    # given
+    query = """
+    query Page($id: ID!, $channel: String) {
+        page(id: $id, channel: $channel) {
+            assignedAttributes(limit:1) {
+                attribute {
+                    slug
+                }
+            }
+        }
+    }
+    """
+
+    associate_attribute_values_to_instance(
+        page,
+        {
+            size_page_attribute.pk: [size_page_attribute.values.first()],
+            tag_page_attribute.pk: [tag_page_attribute.values.first()],
+        },
+    )
+
+    assert page.attributevalues.count() == 2
+    first_attribute = page.attributevalues.first().value.attribute
+
+    page_id = graphene.Node.to_global_id("Page", page.id)
+    variables = {
+        "id": page_id,
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+
+    expected_limit = 1
+    assert len(content["data"]["page"]["assignedAttributes"]) == expected_limit
+    assert (
+        content["data"]["page"]["assignedAttributes"][0]["attribute"]["slug"]
+        == first_attribute.slug
+    )

--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -271,7 +271,7 @@ PAGES_QUERY = """
             slug
           }
         }
-        assignedAttributes {
+        assignedAttributes(limit:5) {
           attr: attribute {
             slug
           }

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -57,7 +57,7 @@ mutation ProductBulkCreate($products: [ProductBulkCreateInput!]!, $errorPolicy: 
             value
           }
         }
-        assignedAttributes {
+        assignedAttributes(limit:10) {
           attribute {
             slug
           }

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -51,7 +51,7 @@ mutation createProduct($input: ProductCreateInput!) {
         key
         value
       }
-      assignedAttributes {
+      assignedAttributes(limit:10) {
         attribute {
           slug
         }

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -69,7 +69,7 @@ mutation updateProduct($productId: ID!, $input: ProductInput!) {
         key
         value
       }
-      assignedAttributes {
+      assignedAttributes(limit:10) {
         attribute {
           slug
         }

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -36,7 +36,7 @@ mutation ProductVariantBulkCreate($variants: [ProductVariantBulkCreateInput!]!, 
         name
         sku
         trackInventory
-        assignedAttributes {
+        assignedAttributes(limit:10) {
           attribute {
             slug
           }

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -27,7 +27,7 @@ mutation createVariant($input: ProductVariantCreateInput!) {
       id
       name
       sku
-      assignedAttributes {
+      assignedAttributes(limit:10) {
         attribute {
           slug
         }

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -42,7 +42,7 @@ def test_product_variant_update_with_new_attributes(
             }
             productVariant {
               id
-              assignedAttributes {
+              assignedAttributes(limit:10) {
                   ... on AssignedSingleChoiceAttribute {
                         attribute {
                             slug
@@ -665,7 +665,7 @@ mutation updateVariant($id: ID!, $sku: String, $attributes: [AttributeValueInput
   productVariantUpdate(id: $id, input: {sku: $sku, attributes: $attributes}) {
     productVariant {
       sku
-      assignedAttributes {
+      assignedAttributes(limit:10) {
         attribute {
           slug
         }

--- a/saleor/graphql/product/tests/queries/test_categories_query_with_filter.py
+++ b/saleor/graphql/product/tests/queries/test_categories_query_with_filter.py
@@ -180,7 +180,7 @@ query (
           id
           name
           channel
-          assignedAttributes {
+          assignedAttributes(limit:10) {
             attribute {
               choices(first: 10) {
                 edges {

--- a/saleor/graphql/product/tests/queries/test_collection_query.py
+++ b/saleor/graphql/product/tests/queries/test_collection_query.py
@@ -180,7 +180,7 @@ query CollectionProducts(
       edges {
         node {
           id
-          assignedAttributes {
+          assignedAttributes(limit:10) {
             attribute {
               choices(first: 10) {
                 edges {

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -3116,3 +3116,49 @@ def test_query_product_variants_with_where(
 
     assert len(variants) == 1
     assert variants[0]["node"]["sku"] == sku_value
+
+
+def test_applies_limit_on_product_assigned_attributes(
+    product, channel_USD, user_api_client, size_attribute
+):
+    # given
+    query = """
+    query Product($id: ID!, $channel: String) {
+        product(id: $id, channel: $channel) {
+            assignedAttributes(limit:1) {
+                attribute {
+                    slug
+                }
+            }
+        }
+    }
+    """
+
+    associate_attribute_values_to_instance(
+        product,
+        {
+            size_attribute.pk: [size_attribute.values.first()],
+        },
+    )
+
+    assert product.attributevalues.count() == 2
+    first_attribute = product.attributevalues.first().value.attribute
+
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    variables = {
+        "id": product_id,
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+
+    expected_limit = 1
+    assert len(content["data"]["product"]["assignedAttributes"]) == expected_limit
+    assert (
+        content["data"]["product"]["assignedAttributes"][0]["attribute"]["slug"]
+        == first_attribute.slug
+    )

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -1745,7 +1745,7 @@ def test_get_product_with_sorted_attribute_values_for_assigned_attributes_field(
     query = """
     query getProduct($productID: ID!) {
       product(id: $productID) {
-        assignedAttributes {
+        assignedAttributes(limit:10) {
           ... on AssignedMultiPageReferenceAttribute {
             value {
               id
@@ -2728,7 +2728,7 @@ query Product($id: ID!, $channel: String, $slug: String!) {
                 slug
             }
         }
-        assignedAttributes {
+        assignedAttributes(limit:10) {
             attribute {
                 id
                 slug

--- a/saleor/graphql/product/tests/queries/test_product_variant_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_variant_query.py
@@ -1,11 +1,14 @@
 import graphene
+import pytest
 from django.contrib.sites.models import Site
 from measurement.measures import Weight
 
+from .....attribute.utils import associate_attribute_values_to_instance
 from .....core.units import WeightUnits
 from .....warehouse import WarehouseClickAndCollectOption
 from ....core.enums import WeightUnitsEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import VariantAttributeScope
 
 QUERY_VARIANT = """query ProductVariantDetails(
         $id: ID!, $address: AddressInput, $countryCode: CountryCode, $channel: String
@@ -858,3 +861,70 @@ def test_query_product_variant_for_federation_as_staff_user_without_chanel(
             "name": variant.name,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "variant_selection",
+    [
+        VariantAttributeScope.ALL.name,
+        VariantAttributeScope.VARIANT_SELECTION.name,
+    ],
+)
+def test_applies_limit_on_product_assigned_attributes(
+    variant,
+    channel_USD,
+    user_api_client,
+    size_attribute,
+    weight_attribute,
+    variant_selection,
+):
+    # given
+    query = """
+    query productVariant($id: ID!, $channel: String, $variantSelection: VariantAttributeScope) {
+      productVariant(id: $id, channel: $channel) {
+        assignedAttributes(limit: 1, variantSelection: $variantSelection) {
+          attribute {
+            slug
+          }
+        }
+      }
+    }
+    """
+
+    product_type = variant.product.product_type
+    product_type.variant_attributes.set([size_attribute, weight_attribute])
+
+    weight_attribute.storefront_search_position = (
+        size_attribute.storefront_search_position + 1
+    )
+    weight_attribute.save(update_fields=["storefront_search_position"])
+
+    associate_attribute_values_to_instance(
+        variant,
+        {
+            size_attribute.pk: [size_attribute.values.first()],
+            weight_attribute.pk: [weight_attribute.values.first()],
+        },
+    )
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variables = {
+        "id": variant_id,
+        "channel": channel_USD.slug,
+        "variantSelection": variant_selection,
+    }
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+
+    expected_limit = 1
+    assert (
+        len(content["data"]["productVariant"]["assignedAttributes"]) == expected_limit
+    )
+    assert (
+        content["data"]["productVariant"]["assignedAttributes"][0]["attribute"]["slug"]
+        == size_attribute.slug
+    )

--- a/saleor/graphql/product/tests/queries/test_products_query.py
+++ b/saleor/graphql/product/tests/queries/test_products_query.py
@@ -1181,7 +1181,7 @@ def test_products_with_variants_query_as_app(
               node{
                 id
                 name
-                assignedAttributes {
+                assignedAttributes(limit:10) {
                     attribute {
                         slug
                     }

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -38,7 +38,7 @@ query ($channel: String) {
             slug
           }
         }
-        assignedAttributes {
+        assignedAttributes(limit:10) {
           attr: attribute {
               slug
               type
@@ -174,7 +174,7 @@ query ($channel: String) {
               slug
             }
           }
-          assignedAttributes {
+          assignedAttributes(limit:10) {
             ... on AssignedNumericAttribute {
               attribute {
                 id

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -641,6 +641,9 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
             selected_attributes,
         ) -> list[AssignedAttributeData]:
             if not variant_selection or variant_selection == VariantAttributeScope.ALL:
+                selected_attributes = (
+                    selected_attributes[:limit] if limit else selected_attributes
+                )
                 return [
                     AssignedAttributeData(
                         attribute=ChannelContext(

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -160,15 +160,14 @@ COST_MAP = {
         "value": {"complexity": 1},
     },
     "AssignedChoiceAttributeValue": {
-        "name": {"complexity": 1},
-        "slug": {"complexity": 1},
         "translation": {"complexity": 1},
     },
     "AssignedSingleChoiceAttribute": {
         "value": {"complexity": 1},
     },
     "AssignedMultiChoiceAttribute": {
-        "value": {"complexity": 1},
+        "attribute": {"complexity": 1},
+        "value": {"complexity": 1, "multipliers": ["limit"]},
     },
     "AssignedSwatchAttribute": {
         "attribute": {"complexity": 1},
@@ -188,23 +187,23 @@ COST_MAP = {
     },
     "AssignedMultiPageReferenceAttribute": {
         "attribute": {"complexity": 1},
-        "value": {"complexity": 1},
+        "value": {"complexity": 1, "multipliers": ["limit"]},
     },
     "AssignedMultiProductReferenceAttribute": {
         "attribute": {"complexity": 1},
-        "value": {"complexity": 1},
+        "value": {"complexity": 1, "multipliers": ["limit"]},
     },
     "AssignedMultiProductVariantReferenceAttribute": {
         "attribute": {"complexity": 1},
-        "value": {"complexity": 1},
+        "value": {"complexity": 1, "multipliers": ["limit"]},
     },
     "AssignedMultiCategoryReferenceAttribute": {
         "attribute": {"complexity": 1},
-        "value": {"complexity": 1},
+        "value": {"complexity": 1, "multipliers": ["limit"]},
     },
     "AssignedMultiCollectionReferenceAttribute": {
         "attribute": {"complexity": 1},
-        "value": {"complexity": 1},
+        "value": {"complexity": 1, "multipliers": ["limit"]},
     },
     "AssignedSinglePageReferenceAttribute": {
         "attribute": {"complexity": 1},
@@ -318,6 +317,7 @@ COST_MAP = {
         "variant": {"complexity": 1},
     },
     "Page": {
+        "assignedAttributes": {"complexity": 1, "multipliers": ["limit"]},
         "attributes": {"complexity": 1},
         "pageType": {"complexity": 1},
     },
@@ -330,6 +330,7 @@ COST_MAP = {
         "transactions": {"complexity": 1},
     },
     "Product": {
+        "assignedAttributes": {"complexity": 1, "multipliers": ["limit"]},
         "attributes": {"complexity": 1},
         "category": {"complexity": 1},
         "channelListings": {"complexity": 1},
@@ -362,6 +363,7 @@ COST_MAP = {
         "products": {"complexity": 1, "multipliers": ["first", "last"]},
     },
     "ProductVariant": {
+        "assignedAttributes": {"complexity": 1, "multipliers": ["limit"]},
         "attributes": {"complexity": 1},
         "channelListings": {"complexity": 1},
         "images": {"complexity": 1},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5714,7 +5714,12 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
   
   Added in Saleor 3.22.
   """
-  assignedAttributes: [AssignedAttribute!]!
+  assignedAttributes(
+    """
+    Maximum number of attributes to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
+  ): [AssignedAttribute!]!
 
   """Get a single attribute attached to product by attribute slug."""
   attribute(
@@ -7410,6 +7415,11 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
   assignedAttributes(
     """Define scope of returned attributes."""
     variantSelection: VariantAttributeScope
+
+    """
+    Maximum number of attributes to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
   ): [AssignedAttribute!]!
 
   """List of attributes assigned to this variant."""
@@ -8748,7 +8758,12 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
   
   Added in Saleor 3.22.
   """
-  assignedAttributes: [AssignedAttribute!]!
+  assignedAttributes(
+    """
+    Maximum number of attributes to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
+  ): [AssignedAttribute!]!
 
   """List of attributes assigned to this page."""
   attributes: [SelectedAttribute!]! @deprecated(reason: "Use `assignedAttributes` field instead.")
@@ -34618,7 +34633,12 @@ type AssignedMultiChoiceAttribute implements AssignedAttribute {
   attribute: Attribute!
 
   """List of assigned choice values."""
-  value: [AssignedChoiceAttributeValue!]!
+  value(
+    """
+    Maximum number of choices to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
+  ): [AssignedChoiceAttributeValue!]!
 }
 
 """
@@ -34762,7 +34782,12 @@ type AssignedMultiPageReferenceAttribute implements AssignedAttribute {
   attribute: Attribute!
 
   """List of assigned page references."""
-  value: [Page!]!
+  value(
+    """
+    Maximum number of referenced pages to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
+  ): [Page!]!
 }
 
 """
@@ -34775,7 +34800,12 @@ type AssignedMultiProductReferenceAttribute implements AssignedAttribute {
   attribute: Attribute!
 
   """List of assigned product references."""
-  value: [Product!]!
+  value(
+    """
+    Maximum number of referenced products to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
+  ): [Product!]!
 }
 
 """
@@ -34788,7 +34818,12 @@ type AssignedMultiProductVariantReferenceAttribute implements AssignedAttribute 
   attribute: Attribute!
 
   """List of assigned product variant references."""
-  value: [ProductVariant!]!
+  value(
+    """
+    Maximum number of referenced product variants to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
+  ): [ProductVariant!]!
 }
 
 """
@@ -34801,7 +34836,12 @@ type AssignedMultiCategoryReferenceAttribute implements AssignedAttribute {
   attribute: Attribute!
 
   """List of assigned category references."""
-  value: [Category!]!
+  value(
+    """
+    Maximum number of referenced categories to return. Value must be greater than 0. Default is 100.
+    """
+    limit: Int = 100
+  ): [Category!]!
 }
 
 """
@@ -34814,7 +34854,10 @@ type AssignedMultiCollectionReferenceAttribute implements AssignedAttribute {
   attribute: Attribute!
 
   """List of assigned collection references."""
-  value: [Collection!]!
+  value(
+    """Maximum number of referenced collections to return. Default is 100"""
+    limit: Int = 100
+  ): [Collection!]!
 }
 
 """_Any value scalar as defined by Federation spec."""

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -926,8 +926,6 @@ TRANSACTION_BATCH_FOR_RELEASING_FUNDS = os.environ.get(
     "TRANSACTION_BATCH_FOR_RELEASING_FUNDS", 60
 )
 
-NESTED_QUERY_LIMIT = int(os.environ.get("NESTED_QUERY_LIMIT", 100))
-
 
 # The maximum SearchVector expression count allowed per index SQL statement
 # If the count is exceeded, the expression list will be truncated


### PR DESCRIPTION
I want to merge this change because it adds a `limit` field to all list resolvers related to the `Assigned*Attribute` types.
The PR also extends the query_cost_map to take into account `limit` field. 

Note: The dataloaders which are responsible for fetching assigned-attributes data are not optimized to work with `limit` field right now. This will be handled in separate PR.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
