### PR TITLE
Add prefetch for pages

### DIFF
--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -7,9 +7,10 @@ from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F, Q, Value, prefetch_related_objects
 
 from ..attribute import AttributeInputType
-from ..attribute.models import Attribute, AttributeValue
+from ..attribute.models import AssignedProductAttributeValue, Attribute, AttributeValue
 from ..core.postgres import FlatConcatSearchVector, NoValidationSearchVector
 from ..core.utils.editorjs import clean_editor_js
+from ..page.models import Page
 from ..product.models import Product
 
 if TYPE_CHECKING:
@@ -20,7 +21,6 @@ PRODUCT_FIELDS_TO_PREFETCH = [
     "variants__attributes__values",
     "variants__attributes__assignment__attribute",
     "attributevalues__value",
-    "attributevalues__value__reference_page",
     "product_type__attributeproduct__attribute",
 ]
 
@@ -30,12 +30,18 @@ PRODUCTS_BATCH_SIZE = 100
 # and product variants.
 
 
-def _prep_product_search_vector_index(products):
+def _prep_product_search_vector_index(
+    products, page_id_to_title_map: dict[int, str] | None = None
+):
     prefetch_related_objects(products, *PRODUCT_FIELDS_TO_PREFETCH)
 
     for product in products:
         product.search_vector = FlatConcatSearchVector(
-            *prepare_product_search_vector_value(product, already_prefetched=True)
+            *prepare_product_search_vector_value(
+                product,
+                already_prefetched=True,
+                page_id_to_title_map=page_id_to_title_map,
+            )
         )
         product.search_index_dirty = False
 
@@ -64,23 +70,35 @@ def queryset_in_batches(queryset):
 
 
 def update_products_search_vector(product_ids: Iterable[int]):
+    db_conn = settings.DATABASE_CONNECTION_REPLICA_NAME
     product_ids = list(product_ids)
-    products = (
-        Product.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
-        .filter(pk__in=product_ids)
-        .order_by("pk")
-    )
+    products = Product.objects.using(db_conn).filter(pk__in=product_ids).order_by("pk")
     for product_pks in queryset_in_batches(products):
-        products_batch = list(
-            Product.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME).filter(
-                id__in=product_pks
-            )
+        value_ids = (
+            AssignedProductAttributeValue.objects.using(db_conn)
+            .filter(product_id__in=product_pks)
+            .values_list("value_id", flat=True)
         )
-        _prep_product_search_vector_index(products_batch)
+        value_to_page_id = (
+            AttributeValue.objects.using(db_conn)
+            .filter(id__in=value_ids, reference_page_id__isnull=False)
+            .values_list("id", "reference_page_id")
+        )
+        page_id_to_title_map = dict(
+            Page.objects.using(db_conn)
+            .filter(id__in=[page_id for _, page_id in value_to_page_id])
+            .values_list("id", "title")
+        )
+
+        products_batch = list(Product.objects.using(db_conn).filter(id__in=product_pks))
+        _prep_product_search_vector_index(products_batch, page_id_to_title_map)
 
 
 def prepare_product_search_vector_value(
-    product: "Product", *, already_prefetched=False
+    product: "Product",
+    *,
+    already_prefetched=False,
+    page_id_to_title_map: dict[int, str] | None = None,
 ) -> list[NoValidationSearchVector]:
     if not already_prefetched:
         prefetch_related_objects([product], *PRODUCT_FIELDS_TO_PREFETCH)
@@ -91,7 +109,7 @@ def prepare_product_search_vector_value(
             Value(product.description_plaintext), config="simple", weight="C"
         ),
         *generate_attributes_search_vector_value(
-            product,
+            product, page_id_to_title_map=page_id_to_title_map
         ),
         *generate_variants_search_vector_value(product),
     ]
@@ -122,6 +140,8 @@ def generate_variants_search_vector_value(
 
 def generate_attributes_search_vector_value(
     product: "Product",
+    *,
+    page_id_to_title_map: dict[int, str] | None = None,
 ) -> list[NoValidationSearchVector]:
     """Prepare `search_vector` value for assigned attributes.
 
@@ -146,7 +166,9 @@ def generate_attributes_search_vector_value(
             : settings.PRODUCT_MAX_INDEXED_ATTRIBUTE_VALUES
         ]
 
-        search_vectors += get_search_vectors_for_values(attribute, values)
+        search_vectors += get_search_vectors_for_values(
+            attribute, values, page_id_to_title_map=page_id_to_title_map
+        )
     return search_vectors
 
 
@@ -169,7 +191,9 @@ def generate_attributes_search_vector_value_with_assignment(
 
 
 def get_search_vectors_for_values(
-    attribute: Attribute, values: Union[list, "QuerySet"]
+    attribute: Attribute,
+    values: Union[list, "QuerySet"],
+    page_id_to_title_map: dict[int, str] | None = None,
 ) -> list[NoValidationSearchVector]:
     search_vectors = []
 
@@ -221,7 +245,11 @@ def get_search_vectors_for_values(
         # for now only AttributeEntityType.PAGE is supported
         search_vectors += [
             NoValidationSearchVector(
-                Value(get_reference_attribute_search_value(value)),
+                Value(
+                    get_reference_attribute_search_value(
+                        value, page_id_to_title_map=page_id_to_title_map
+                    )
+                ),
                 config="simple",
                 weight="B",
             )
@@ -231,10 +259,18 @@ def get_search_vectors_for_values(
     return search_vectors
 
 
-def get_reference_attribute_search_value(attribute_value: AttributeValue) -> str:
+def get_reference_attribute_search_value(
+    attribute_value: AttributeValue, page_id_to_title_map: dict[int, str] | None = None
+) -> str:
     """Get search value for reference attribute."""
-    if attribute_value.reference_page:
-        return attribute_value.reference_page.title
+    if attribute_value.reference_page_id:
+        if page_id_to_title_map:
+            return page_id_to_title_map.get(attribute_value.reference_page_id, "")
+        return (
+            attribute_value.reference_page.title
+            if attribute_value.reference_page
+            else ""
+        )
     return ""
 
 

--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -20,6 +20,7 @@ PRODUCT_FIELDS_TO_PREFETCH = [
     "variants__attributes__values",
     "variants__attributes__assignment__attribute",
     "attributevalues__value",
+    "attributevalues__value__reference_page",
     "product_type__attributeproduct__attribute",
 ]
 

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -308,7 +308,7 @@ def test_update_products_search_vector_task_with_static_number_of_queries(
         product_list[i].save(update_fields=["search_index_dirty"])
 
     # when & # then
-    with django_assert_num_queries(15):
+    with django_assert_num_queries(16):
         update_products_search_vector_task()
 
 


### PR DESCRIPTION
Add prefetch to load pages for the search vector in one DB query.

Part of https://github.com/saleor/saleor/pull/18041

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
