### PR TITLE
Change `PaymentMethodDetails` from union to interface

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -33,7 +33,7 @@ from .menu.schema import MenuMutations, MenuQueries
 from .meta.schema import MetaMutations
 from .order.schema import OrderMutations, OrderQueries
 from .page.schema import PageMutations, PageQueries
-from .payment.schema import PaymentMutations, PaymentQueries
+from .payment.schema import PAYMENT_ADDITIONAL_TYPES, PaymentMutations, PaymentQueries
 from .plugins.schema import PluginsMutations, PluginsQueries
 from .product.schema import ProductMutations, ProductQueries
 from .shipping.schema import ShippingMutations, ShippingQueries
@@ -176,7 +176,7 @@ GraphQLWebhookEventsInfoDirective = graphql.GraphQLDirective(
 schema = build_federated_schema(
     Query,
     mutation=Mutation,
-    types=unit_enums + list(WEBHOOK_TYPES_MAP.values()),
+    types=unit_enums + list(WEBHOOK_TYPES_MAP.values()) + PAYMENT_ADDITIONAL_TYPES,
     subscription=Subscription,
     directives=graphql.specified_directives
     + [GraphQLDocDirective, GraphQLWebhookEventsInfoDirective],

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -28,7 +28,18 @@ from .mutations import (
     TransactionUpdate,
 )
 from .resolvers import resolve_payment_by_id, resolve_payments, resolve_transaction
-from .types import Payment, PaymentCountableConnection, TransactionItem
+from .types import (
+    CardPaymentMethodDetails,
+    OtherPaymentMethodDetails,
+    Payment,
+    PaymentCountableConnection,
+    TransactionItem,
+)
+
+PAYMENT_ADDITIONAL_TYPES = [
+    CardPaymentMethodDetails,
+    OtherPaymentMethodDetails,
+]
 
 
 class PaymentQueries(graphene.ObjectType):

--- a/saleor/graphql/payment/tests/queries/test_transaction.py
+++ b/saleor/graphql/payment/tests/queries/test_transaction.py
@@ -94,9 +94,7 @@ TRANSACTION_QUERY = """
             }
             paymentMethodDetails{
                 __typename
-                ...on GenericPaymentMethodDetails{
-                    name
-                }
+                name
                 ...on CardPaymentMethodDetails{
                     name
                     brand

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -430,7 +430,7 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
         return None
 
 
-class GenericPaymentMethodDetails(graphene.Interface):
+class PaymentMethodDetails(graphene.Interface):
     name = graphene.String(required=True, description="Name of the payment method.")
 
     class Meta:
@@ -438,6 +438,13 @@ class GenericPaymentMethodDetails(graphene.Interface):
             "Represents a payment method used for a transaction." + ADDED_IN_322
         )
 
+    @classmethod
+    def resolve_type(cls, instance, info: graphene.ResolveInfo):
+        if instance.payment_method_type == PaymentMethodType.CARD:
+            return CardPaymentMethodDetails
+        return OtherPaymentMethodDetails
+
+    @staticmethod
     def resolve_name(root: models.TransactionItem, _info):
         return root.payment_method_name or ""
 
@@ -464,7 +471,7 @@ class CardPaymentMethodDetails(BaseObjectType):
         description = (
             "Represents a card payment method used for a transaction." + ADDED_IN_322
         )
-        interfaces = [GenericPaymentMethodDetails]
+        interfaces = [PaymentMethodDetails]
 
     @staticmethod
     def resolve_brand(root: models.TransactionItem, _info):
@@ -494,18 +501,7 @@ class OtherPaymentMethodDetails(BaseObjectType):
         description = (
             "Represents a payment method used for a transaction." + ADDED_IN_322
         )
-        interfaces = [GenericPaymentMethodDetails]
-
-
-class PaymentMethodDetails(graphene.Union):
-    class Meta:
-        types = (CardPaymentMethodDetails, OtherPaymentMethodDetails)
-
-    @classmethod
-    def resolve_type(cls, instance, info: graphene.ResolveInfo):
-        if instance.payment_method_type == PaymentMethodType.CARD:
-            return CardPaymentMethodDetails
-        return OtherPaymentMethodDetails
+        interfaces = [PaymentMethodDetails]
 
 
 class TransactionItem(ModelObjectType[models.TransactionItem]):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12409,49 +12409,12 @@ enum TransactionEventTypeEnum @doc(category: "Payments") {
 
 union UserOrApp = User | App
 
-union PaymentMethodDetails = CardPaymentMethodDetails | OtherPaymentMethodDetails
-
-"""
-Represents a card payment method used for a transaction.
-
-Added in Saleor 3.22.
-"""
-type CardPaymentMethodDetails implements GenericPaymentMethodDetails {
-  """Name of the payment method."""
-  name: String!
-
-  """Card brand."""
-  brand: String
-
-  """First 4 digits of the card number."""
-  firstDigits: String
-
-  """Last 4 digits of the card number."""
-  lastDigits: String
-
-  """Two-digit number representing the card’s expiration month."""
-  expMonth: Int
-
-  """Four-digit number representing the card’s expiration year."""
-  expYear: Int
-}
-
 """
 Represents a payment method used for a transaction.
 
 Added in Saleor 3.22.
 """
-interface GenericPaymentMethodDetails {
-  """Name of the payment method."""
-  name: String!
-}
-
-"""
-Represents a payment method used for a transaction.
-
-Added in Saleor 3.22.
-"""
-type OtherPaymentMethodDetails implements GenericPaymentMethodDetails {
+interface PaymentMethodDetails {
   """Name of the payment method."""
   name: String!
 }
@@ -34466,6 +34429,41 @@ type PaymentMethodProcessTokenizationSession implements Event @doc(category: "Pa
   The ID returned by app from `PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION` webhook.
   """
   id: String!
+}
+
+"""
+Represents a card payment method used for a transaction.
+
+Added in Saleor 3.22.
+"""
+type CardPaymentMethodDetails implements PaymentMethodDetails {
+  """Name of the payment method."""
+  name: String!
+
+  """Card brand."""
+  brand: String
+
+  """First 4 digits of the card number."""
+  firstDigits: String
+
+  """Last 4 digits of the card number."""
+  lastDigits: String
+
+  """Two-digit number representing the card’s expiration month."""
+  expMonth: Int
+
+  """Four-digit number representing the card’s expiration year."""
+  expYear: Int
+}
+
+"""
+Represents a payment method used for a transaction.
+
+Added in Saleor 3.22.
+"""
+type OtherPaymentMethodDetails implements PaymentMethodDetails {
+  """Name of the payment method."""
+  name: String!
 }
 
 """_Any value scalar as defined by Federation spec."""


### PR DESCRIPTION
I want to merge this change because while adding the payment-method-details, I've added separate interface for payment methods, and additioanlly wrap them inside the union type. 
This PR makes it simpler, it removes the union, and keep only the interface. This API is not yet released, this is why I am changing it directly. 
Previously to get generic name, we would need to make:
```
                ...on GenericPaymentMethodDetails{
                    name
                }
```
now, we can just call `name` 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
