### PR TITLE
gha: build images natively on ARM64

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -25,25 +25,20 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - ubuntu-24.04 # AMD64
+          - ubuntu-24.04-arm # ARM64
+
+    runs-on: ${{ matrix.platform }}
 
     permissions:
       contents: read
       packages: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
       - name: Build Image Name
         id: image
         env:
@@ -64,9 +59,6 @@ jobs:
         with:
           images: |
             ghcr.io/${{ steps.image.outputs.image_name }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -91,7 +83,6 @@ jobs:
           # the container repository name instead (ghcr.io/saleor/saleor)
           # (we cannot push both by tags and by digest, only one or the other)
           tags: ghcr.io/${{ steps.image.outputs.image_name }}
-          platforms: ${{ matrix.platform }}
           push: true
 
       - name: Export digest
@@ -103,7 +94,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.platform }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
This removes QEMU emulation for ARM64 container image builds in favor of native compilation (using ARM64 runners).

Test results (w/ cache disabled, `uv` compilation still disabled, sample size is 1):
* AMD64: 69s
* ARM64: 92s (vs 25 minutes before the changes)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs


<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
