### PR TITLE
Re-enable `uv` bytecode compilation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
 
 WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
-ENV UV_SYSTEM_PYTHON=1 UV_PROJECT_ENVIRONMENT=/usr/local
+ENV UV_COMPILE_BYTECODE=1 UV_SYSTEM_PYTHON=1 UV_PROJECT_ENVIRONMENT=/usr/local
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \

--- a/.github/workflows/bump-dependencies.yml
+++ b/.github/workflows/bump-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
           enable-cache: true
 
       - run: python -m pip install pre-commit
-      - run: uv lock
+      - run: uv lock --upgrade
       - run: pre-commit autoupdate
       - run: git status
 

--- a/.github/workflows/bump-dependencies.yml
+++ b/.github/workflows/bump-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
           enable-cache: true
 
       - run: python -m pip install pre-commit
-      - run: uv lock --upgrade
+      - run: uv lock
       - run: pre-commit autoupdate
       - run: git status
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -y update \
 # Install Python dependencies
 WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
-ENV UV_SYSTEM_PYTHON=1 UV_PROJECT_ENVIRONMENT=/usr/local
+ENV UV_COMPILE_BYTECODE=1 UV_SYSTEM_PYTHON=1 UV_PROJECT_ENVIRONMENT=/usr/local
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \


### PR DESCRIPTION
This reverts commit 1b52167ddebd5a7afbf9d0c7d12e73346755f024 as we implemented native ARM64 builds to fix timeout errors from `uv` compilations (due to taking more 60s to compile).

**Very basic** tests performed (Macbook Pro "M1 Pro" chip, sample size is 1):
- `$ time ./manage.py migrate`: -7s
- `$ time ./manage.py populatedb`: -0.400s (script doesn't import many libraries, likely is within margin of error)
- `$ time ./manage.py runserver`: -6s

Negative impacts (accepted):
- This increases the container image size by around 100 MB, however, based on our tests this should greatly improve cold starts in production environments thus negating the size increase.
- This increases build time by around 1 minute (thus takes around 2 minutes now)

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
