### PR TITLE
Fix race condition durign price recalculation

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -356,6 +356,7 @@ def _is_checkout_modified(
     try:
         refreshed_checkout_last_change = (
             Checkout.objects.using(database_connection_name)
+            .only("last_change")
             .get(token=checkout.token)
             .last_change
         )

--- a/saleor/checkout/tests/fixtures/checkout_with_prices.py
+++ b/saleor/checkout/tests/fixtures/checkout_with_prices.py
@@ -22,7 +22,9 @@ def checkout_with_prices(
 ):
     # Need to save shipping_method before fetching checkout info.
     checkout_with_items.shipping_method = shipping_method
-    checkout_with_items.save(update_fields=["shipping_method"])
+    country_code = address_other_country.country.code
+    checkout_with_items.set_country(country_code, commit=False)
+    checkout_with_items.save(update_fields=["shipping_method", "country"])
 
     manager = get_plugins_manager(allow_replica=False)
     lines = checkout_with_items.lines.all()

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -1296,8 +1296,8 @@ def test_fetch_checkout_data_checkout_removed_before_save(
         # it's would pass `checkout` without `pk` to `checkout_info`.
         Checkout.objects.filter(pk=checkout.pk).delete()
 
-    with race_condition.RunBefore(
-        "saleor.checkout.calculations._is_checkout_modified", delete_checkout
+    with race_condition.RunAfter(
+        "saleor.checkout.calculations._calculate_and_add_tax", delete_checkout
     ):
         result_checkout_info, result_lines_info = fetch_checkout_data(**fetch_kwargs)
 
@@ -1347,8 +1347,8 @@ def test_fetch_checkout_data_checkout_updated_during_price_recalculation(
         checkout_to_modify.email = expected_email
         checkout_to_modify.save(update_fields=["email", "last_change"])
 
-    with race_condition.RunBefore(
-        "saleor.checkout.calculations._is_checkout_modified", modify_checkout
+    with race_condition.RunAfter(
+        "saleor.checkout.calculations._calculate_and_add_tax", modify_checkout
     ):
         result_checkout_info, result_lines_info = fetch_checkout_data(**fetch_kwargs)
 

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -3,16 +3,13 @@ from typing import Literal
 from unittest.mock import Mock, patch
 
 import pytest
+from django.db.models import F
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 from graphene import Node
 from prices import Money, TaxedMoney
 
-from ...checkout.utils import (
-    add_promo_code_to_checkout,
-    assign_external_shipping_to_checkout,
-)
 from ...core.prices import quantize_price
 from ...core.taxes import (
     TaxData,
@@ -31,6 +28,7 @@ from ...product.models import ProductVariantChannelListing
 from ...shipping.interface import ShippingMethodData
 from ...tax import TaxCalculationStrategy
 from ...tax.calculations.checkout import update_checkout_prices_with_flat_rates
+from ...tests import race_condition
 from ..base_calculations import (
     base_checkout_delivery_price,
     calculate_base_line_total_price,
@@ -43,6 +41,11 @@ from ..calculations import (
     logger,
 )
 from ..fetch import CheckoutLineInfo, fetch_checkout_info, fetch_checkout_lines
+from ..models import Checkout
+from ..utils import (
+    add_promo_code_to_checkout,
+    assign_external_shipping_to_checkout,
+)
 
 
 @pytest.fixture
@@ -1265,3 +1268,105 @@ def test_fetch_checkout_with_prior_price_none(
     line.refresh_from_db()
     assert line.prior_unit_price_amount is None
     assert line.currency is not None
+
+
+def test_fetch_checkout_data_checkout_removed_before_save(
+    checkout_with_prices,
+):
+    # given
+    checkout = checkout_with_prices
+    currency = checkout.currency
+    checkout.price_expiration = timezone.now()
+    checkout.save(update_fields=["price_expiration"])
+    start_total_price = checkout.total
+    lines = list(checkout.lines.all())
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines_info, _ = fetch_checkout_lines(checkout)
+    fetch_kwargs = {
+        "checkout_info": fetch_checkout_info(checkout, lines_info, manager),
+        "manager": manager,
+        "lines": lines_info,
+        "address": checkout.shipping_address,
+    }
+
+    # when
+    def delete_checkout(*args, **kwargs):
+        # Simulate checkout deletion. We can't run `delete()` on `checkout_with_prices`, because
+        # it's would pass `checkout` without `pk` to `checkout_info`.
+        Checkout.objects.filter(pk=checkout.pk).delete()
+
+    with race_condition.RunBefore(
+        "saleor.checkout.calculations._is_checkout_modified", delete_checkout
+    ):
+        result_checkout_info, result_lines_info = fetch_checkout_data(**fetch_kwargs)
+
+    # then
+    # Check if checkout was deleted.
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    # Check if prices are recalculated and returned in info objects.
+    assert start_total_price != result_checkout_info.checkout.total
+    assert result_checkout_info.checkout.total is not None
+    assert result_checkout_info.checkout.total > zero_taxed_money(currency)
+
+    for line, result_line in zip(lines, result_lines_info, strict=True):
+        assert line.total_price != result_line.line.total_price
+        assert result_line.line.total_price is not None
+        assert result_line.line.total_price > zero_taxed_money(currency)
+
+
+def test_fetch_checkout_data_checkout_updated_during_price_recalculation(
+    checkout_with_prices,
+):
+    # given
+    checkout = checkout_with_prices
+    currency = checkout.currency
+    checkout.price_expiration = timezone.now()
+    checkout.save(update_fields=["price_expiration", "last_change"])
+    checkout.refresh_from_db()
+    total_price_before_recalculation = checkout.total
+    last_change_before_recalculation = checkout.last_change
+    lines = list(checkout.lines.all())
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines_info, _ = fetch_checkout_lines(checkout)
+    fetch_kwargs = {
+        "checkout_info": fetch_checkout_info(checkout, lines_info, manager),
+        "manager": manager,
+        "lines": lines_info,
+        "address": checkout.shipping_address,
+    }
+    expected_email = "new_email@example.com"
+
+    # when
+    def modify_checkout(*args, **kwargs):
+        checkout_to_modify = Checkout.objects.get(pk=checkout.pk)
+        checkout_to_modify.lines.update(quantity=F("quantity") + 1)
+        checkout_to_modify.email = expected_email
+        checkout_to_modify.save(update_fields=["email", "last_change"])
+
+    with race_condition.RunBefore(
+        "saleor.checkout.calculations._is_checkout_modified", modify_checkout
+    ):
+        result_checkout_info, result_lines_info = fetch_checkout_data(**fetch_kwargs)
+
+    # then
+    # Check if prices are recalculated and returned in info objects.
+    assert result_checkout_info.checkout.total != total_price_before_recalculation
+    assert result_checkout_info.checkout.total is not None
+    assert result_checkout_info.checkout.total > zero_taxed_money(currency)
+
+    for line, result_line in zip(lines, result_lines_info, strict=True):
+        assert line.total_price != result_line.line.total_price
+        assert result_line.line.total_price is not None
+        assert result_line.line.total_price > zero_taxed_money(currency)
+        assert result_line.line.quantity == line.quantity
+
+    # Check if database contains updated checkout by other requests.
+    checkout.refresh_from_db()
+    assert checkout.last_change > last_change_before_recalculation
+    assert checkout.email == expected_email
+    for old_line, new_line in zip(lines, checkout.lines.all(), strict=True):
+        assert old_line.quantity + 1 == new_line.quantity

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -422,7 +422,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(83):
+    with django_assert_num_queries(84):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -440,7 +440,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(83):
+    with django_assert_num_queries(84):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -572,7 +572,7 @@ def test_create_checkout_with_order_promotion(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(88):
+    with django_assert_num_queries(89):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then
@@ -828,7 +828,7 @@ def test_update_checkout_lines_with_reservations(
     )
 
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(105):
+    with django_assert_num_queries(106):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -842,7 +842,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(105):
+    with django_assert_num_queries(106):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -1103,7 +1103,7 @@ def test_add_checkout_lines_with_reservations(
 
     user_api_client.ensure_access_token()
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(102):
+    with django_assert_num_queries(103):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -1116,7 +1116,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(102):
+    with django_assert_num_queries(103):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,
@@ -1167,7 +1167,7 @@ def test_add_checkout_lines_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(93):
+    with django_assert_num_queries(94):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1253,7 +1253,7 @@ def test_add_checkout_lines_multiple_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(93):
+    with django_assert_num_queries(94):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1289,7 +1289,7 @@ def test_add_checkout_lines_order_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(97):
+    with django_assert_num_queries(98):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1324,7 +1324,7 @@ def test_add_checkout_lines_gift_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(124):
+    with django_assert_num_queries(125):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -9,6 +9,10 @@ from django.test import override_settings
 from django.utils import timezone
 
 from .....checkout.actions import call_checkout_info_event
+from .....checkout.calculations import (
+    _calculate_and_add_tax,
+    fetch_checkout_data,
+)
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout, CheckoutLine
@@ -22,6 +26,7 @@ from .....core.models import EventDelivery
 from .....discount import RewardValueType
 from .....plugins.manager import get_plugins_manager
 from .....product.models import ProductChannelListing, ProductVariantChannelListing
+from .....tests import race_condition
 from .....warehouse.models import Reservation, Stock
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.transport.asynchronous.transport import send_webhook_request_async
@@ -1914,3 +1919,57 @@ def test_checkout_lines_update_with_new_metadata_merge_old(
     assert line.metadata["new_key"] == "new_value"
 
     assert line.variant == variant
+
+
+@mock.patch(
+    "saleor.checkout.calculations._calculate_and_add_tax",
+    wraps=_calculate_and_add_tax,
+)
+@mock.patch(
+    "saleor.checkout.calculations.fetch_checkout_data",
+    wraps=fetch_checkout_data,
+)
+def test_checkout_lines_update_checkout_updated_during_price_recalculation(
+    mock_fetch_checkout_data,
+    mock_calculate_and_add_tax,
+    user_api_client,
+    checkout_with_prices,
+):
+    # given
+    expected_email = "new_email@example.com"
+    checkout = checkout_with_prices
+    line = checkout.lines.first()
+    variant = line.variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "quantity": 1}],
+    }
+
+    # when
+    def modify_checkout(*args, **kwargs):
+        checkout_to_modify = Checkout.objects.get(pk=checkout.pk)
+        checkout_to_modify.email = expected_email
+        checkout_to_modify.save(update_fields=["email", "last_change"])
+
+    with race_condition.RunBefore(
+        "saleor.checkout.calculations._is_checkout_modified", modify_checkout
+    ):
+        response = user_api_client.post_graphql(
+            MUTATION_CHECKOUT_LINES_UPDATE, variables
+        )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesUpdate"]
+    assert not data["errors"]
+
+    # Ensure that the checkout prices recalculation was triggered more than one time.
+    assert mock_fetch_checkout_data.call_count > 1
+
+    # Ensure that the checkout price are recalculated only one time
+    assert mock_calculate_and_add_tax.call_count == 1
+
+    checkout.refresh_from_db()
+    assert checkout.email == expected_email

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1953,8 +1953,8 @@ def test_checkout_lines_update_checkout_updated_during_price_recalculation(
         checkout_to_modify.email = expected_email
         checkout_to_modify.save(update_fields=["email", "last_change"])
 
-    with race_condition.RunBefore(
-        "saleor.checkout.calculations._is_checkout_modified", modify_checkout
+    with race_condition.RunAfter(
+        "saleor.checkout.calculations._calculate_and_add_tax", modify_checkout
     ):
         response = user_api_client.post_graphql(
             MUTATION_CHECKOUT_LINES_UPDATE, variables

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2895,7 +2895,7 @@ def test_checkout_prices_with_checkout_updated_during_price_recalculation(
             checkout_to_modify.save(update_fields=["email", "last_change"])
 
     with race_condition.RunBefore(
-        "saleor.checkout.calculations._is_checkout_modified", modify_checkout
+        "saleor.checkout.calculations._calculate_and_add_tax", modify_checkout
     ):
         response = user_api_client.post_graphql(QUERY_CHECKOUT_PRICES, variables)
     content = get_graphql_content(response)


### PR DESCRIPTION
I want to merge this change because it fixes a race condition during price recalculation. 
Fix #18087 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
