### PR TITLE
Switch Dependabot to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
-- package-ecosystem: pip
+- package-ecosystem: "uv"
   directory: "/"
   schedule:
-    interval: weekly
+    interval: "weekly"
   open-pull-requests-limit: 10


### PR DESCRIPTION
This way it should be able to bump the lock file.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
