### PR TITLE
Update schema with doc-category for assigned-attribtues

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -124,6 +124,7 @@ GraphQLDocDirective = graphql.GraphQLDirective(
         graphql.DirectiveLocation.FIELD_DEFINITION,
         graphql.DirectiveLocation.INPUT_OBJECT,
         graphql.DirectiveLocation.OBJECT,
+        graphql.DirectiveLocation.INTERFACE,
     ],
 )
 

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -36,6 +36,7 @@ from ..core.fields import ConnectionField, FilterConnectionField, JSONString
 from ..core.scalars import JSON, Date, DateTime
 from ..core.types import (
     BaseInputObjectType,
+    BaseInterface,
     BaseObjectType,
     DateRangeInput,
     DateTimeRangeInput,
@@ -673,7 +674,7 @@ class SelectedAttribute(ChannelContextTypeForObjectType):
         description = "Represents an assigned attribute to an object."
 
 
-class AssignedAttribute(graphene.Interface):
+class AssignedAttribute(BaseInterface):
     attribute = graphene.Field(
         Attribute,
         default_value=None,
@@ -706,6 +707,7 @@ class AssignedNumericAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents a numeric value of an attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> float | None:
@@ -736,6 +738,7 @@ class AssignedTextAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents text attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> JSON | None:
@@ -784,6 +787,7 @@ class AssignedPlainTextAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents plain text attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> str | None:
@@ -819,6 +823,7 @@ class AssignedFileAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents file attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> File | None:
@@ -838,6 +843,7 @@ class AssignedSinglePageReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents single page reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -866,6 +872,7 @@ class AssignedSingleProductReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents single product reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -898,6 +905,7 @@ class AssignedSingleProductVariantReferenceAttribute(BaseObjectType):
         description = (
             "Represents single product variant reference attribute." + ADDED_IN_322
         )
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -930,6 +938,7 @@ class AssignedSingleCategoryReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents single category reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -951,6 +960,7 @@ class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents single collection reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -990,6 +1000,7 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents multi page reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -1039,6 +1050,7 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents multi product reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -1091,6 +1103,7 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
         description = (
             "Represents multi product variant reference attribute." + ADDED_IN_322
         )
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -1141,6 +1154,7 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents multi category reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -1176,6 +1190,7 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents multi collection reference attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -1224,6 +1239,7 @@ class AssignedChoiceAttributeValue(BaseObjectType):
         description = (
             "Represents a single choice value of the attribute." + ADDED_IN_322
         )
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_translation(
@@ -1246,6 +1262,7 @@ class AssignedSingleChoiceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents a single choice attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     def resolve_value(
         root: AssignedAttributeData, info: ResolveInfo
@@ -1273,6 +1290,7 @@ class AssignedMultiChoiceAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents a multi choice attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -1316,6 +1334,10 @@ class AssignedSwatchAttributeValue(BaseObjectType):
             return None
         return File(url=root.file_url, content_type=root.content_type)
 
+    class Meta:
+        description = "Represents a single swatch value." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
+
 
 class AssignedSwatchAttribute(BaseObjectType):
     value = graphene.Field(
@@ -1327,6 +1349,7 @@ class AssignedSwatchAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents a swatch attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(
@@ -1347,6 +1370,7 @@ class AssignedBooleanAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents a boolean attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> bool | None:
@@ -1366,6 +1390,7 @@ class AssignedDateAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents a date attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(root: AssignedAttributeData, _info: ResolveInfo) -> date | None:
@@ -1385,6 +1410,7 @@ class AssignedDateTimeAttribute(BaseObjectType):
     class Meta:
         interfaces = [AssignedAttribute]
         description = "Represents a date time attribute." + ADDED_IN_322
+        doc_category = DOC_CATEGORY_ATTRIBUTES
 
     @staticmethod
     def resolve_value(

--- a/saleor/graphql/core/types/__init__.py
+++ b/saleor/graphql/core/types/__init__.py
@@ -1,4 +1,10 @@
-from .base import BaseConnection, BaseEnum, BaseInputObjectType, BaseObjectType
+from .base import (
+    BaseConnection,
+    BaseEnum,
+    BaseInputObjectType,
+    BaseInterface,
+    BaseObjectType,
+)
 from .common import (
     TYPES_WITH_DOUBLE_ID_AVAILABLE,
     AccountError,
@@ -91,6 +97,7 @@ __all__ = [
     "BaseConnection",
     "BaseEnum",
     "BaseInputObjectType",
+    "BaseInterface",
     "BaseObjectType",
     "BulkProductError",
     "BulkStockError",

--- a/saleor/graphql/core/types/base.py
+++ b/saleor/graphql/core/types/base.py
@@ -1,6 +1,7 @@
 from graphene.relay.connection import Connection
 from graphene.types.enum import Enum
 from graphene.types.inputobjecttype import InputObjectType
+from graphene.types.interface import Interface
 from graphene.types.objecttype import ObjectType
 
 
@@ -55,3 +56,16 @@ class BaseConnection(Connection):
     ):
         cls.doc_category = doc_category
         super().__init_subclass_with_meta__(node=node, name=name, **options)
+
+
+class BaseInterface(Interface):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def __init_subclass_with_meta__(cls, _meta=None, doc_category=None, **options):
+        cls.doc_category = doc_category
+        super().__init_subclass_with_meta__(
+            _meta=_meta,
+            **options,
+        )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -8,7 +8,7 @@ schema {
 directive @doc(
   """Name of the grouping category"""
   category: String!
-) on ENUM | FIELD | FIELD_DEFINITION | INPUT_OBJECT | OBJECT
+) on ENUM | FIELD | FIELD_DEFINITION | INPUT_OBJECT | OBJECT | INTERFACE
 
 """Webhook events triggered by a specific location."""
 directive @webhookEventsInfo(
@@ -7678,7 +7678,7 @@ Represents an attribute assigned to an object.
 
 Added in Saleor 3.22.
 """
-interface AssignedAttribute {
+interface AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 }
@@ -34550,7 +34550,7 @@ Represents a numeric value of an attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedNumericAttribute implements AssignedAttribute {
+type AssignedNumericAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34563,7 +34563,7 @@ Represents text attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedTextAttribute implements AssignedAttribute {
+type AssignedTextAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34579,7 +34579,7 @@ Represents plain text attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedPlainTextAttribute implements AssignedAttribute {
+type AssignedPlainTextAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34595,7 +34595,7 @@ Represents file attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedFileAttribute implements AssignedAttribute {
+type AssignedFileAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34608,7 +34608,7 @@ Represents a single choice attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedSingleChoiceAttribute implements AssignedAttribute {
+type AssignedSingleChoiceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34621,7 +34621,7 @@ Represents a single choice value of the attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedChoiceAttributeValue {
+type AssignedChoiceAttributeValue @doc(category: "Attributes") {
   """Name of a value displayed in the interface."""
   name: String
 
@@ -34637,7 +34637,7 @@ Represents a multi choice attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedMultiChoiceAttribute implements AssignedAttribute {
+type AssignedMultiChoiceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34655,7 +34655,7 @@ Represents a swatch attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedSwatchAttribute implements AssignedAttribute {
+type AssignedSwatchAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34663,7 +34663,12 @@ type AssignedSwatchAttribute implements AssignedAttribute {
   value: AssignedSwatchAttributeValue
 }
 
-type AssignedSwatchAttributeValue {
+"""
+Represents a single swatch value.
+
+Added in Saleor 3.22.
+"""
+type AssignedSwatchAttributeValue @doc(category: "Attributes") {
   """Name of the selected swatch value."""
   name: String
 
@@ -34682,7 +34687,7 @@ Represents a boolean attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedBooleanAttribute implements AssignedAttribute {
+type AssignedBooleanAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34695,7 +34700,7 @@ Represents a date attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedDateAttribute implements AssignedAttribute {
+type AssignedDateAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34708,7 +34713,7 @@ Represents a date time attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedDateTimeAttribute implements AssignedAttribute {
+type AssignedDateTimeAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34721,7 +34726,7 @@ Represents single page reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedSinglePageReferenceAttribute implements AssignedAttribute {
+type AssignedSinglePageReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34734,7 +34739,7 @@ Represents single product reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedSingleProductReferenceAttribute implements AssignedAttribute {
+type AssignedSingleProductReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34747,7 +34752,7 @@ Represents single product variant reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedSingleProductVariantReferenceAttribute implements AssignedAttribute {
+type AssignedSingleProductVariantReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34760,7 +34765,7 @@ Represents single category reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedSingleCategoryReferenceAttribute implements AssignedAttribute {
+type AssignedSingleCategoryReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34773,7 +34778,7 @@ Represents single collection reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedSingleCollectionReferenceAttribute implements AssignedAttribute {
+type AssignedSingleCollectionReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34786,7 +34791,7 @@ Represents multi page reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedMultiPageReferenceAttribute implements AssignedAttribute {
+type AssignedMultiPageReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34804,7 +34809,7 @@ Represents multi product reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedMultiProductReferenceAttribute implements AssignedAttribute {
+type AssignedMultiProductReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34822,7 +34827,7 @@ Represents multi product variant reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedMultiProductVariantReferenceAttribute implements AssignedAttribute {
+type AssignedMultiProductVariantReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34840,7 +34845,7 @@ Represents multi category reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedMultiCategoryReferenceAttribute implements AssignedAttribute {
+type AssignedMultiCategoryReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 
@@ -34858,7 +34863,7 @@ Represents multi collection reference attribute.
 
 Added in Saleor 3.22.
 """
-type AssignedMultiCollectionReferenceAttribute implements AssignedAttribute {
+type AssignedMultiCollectionReferenceAttribute implements AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 

--- a/saleor/graphql/schema_printer.py
+++ b/saleor/graphql/schema_printer.py
@@ -252,7 +252,12 @@ def print_object(type_: GrapheneObjectType) -> str:
 
 
 def print_interface(type_: GraphQLInterfaceType) -> str:
-    return print_description(type_) + f"interface {type_.name}" + print_fields(type_)
+    return (
+        print_description(type_)
+        + f"interface {type_.name}"
+        + print_object_directives(type_)
+        + print_fields(type_)
+    )
 
 
 def print_union(type_: GraphQLUnionType) -> str:


### PR DESCRIPTION
I want to merge this change because it adds missing doc_category to all new types introduced for Assigned*Attribute types

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
