### PR TITLE
Use `PositiveInt` for limit in `referenceTypes` field on `Attribute` type

### DIFF
--- a/saleor/graphql/attribute/tests/queries/test_attribute_query.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_query.py
@@ -726,7 +726,7 @@ def test_get_reference_category_attribute(
 
 
 QUERY_ATTRIBUTE_REFERENCE_TYPES = """
-    query ($id: ID!, $limit: Int) {
+    query ($id: ID!, $limit: PositiveInt) {
         attribute(id: $id) {
             id
             name
@@ -816,8 +816,9 @@ def test_get_attribute_reference_product_types_limit_exceeded(
 
     # then
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == (
-        f"`limit` must be greater than 1. Provided value is {limit}."
+    assert (
+        f'Variable "$limit" got invalid value {limit}'
+        in content["errors"][0]["message"]
     )
 
 
@@ -875,8 +876,9 @@ def test_get_attribute_reference_page_types_invalid_limit(
 
     # then
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == (
-        f"`limit` must be greater than 1. Provided value is {limit}."
+    assert (
+        f'Variable "$limit" got invalid value {limit}'
+        in content["errors"][0]["message"]
     )
 
 

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -29,7 +29,7 @@ from ..core.descriptions import (
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.enums import MeasurementUnitsEnum
 from ..core.fields import ConnectionField, FilterConnectionField, JSONString
-from ..core.scalars import Date, DateTime
+from ..core.scalars import Date, DateTime, PositiveInt
 from ..core.types import (
     BaseInputObjectType,
     BaseObjectType,
@@ -266,7 +266,7 @@ class Attribute(ChannelContextType[models.Attribute]):
             "the choices of reference objects." + ADDED_IN_322
         ),
         required=False,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=NESTED_QUERY_LIMIT_DESCRIPTION,
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),

--- a/saleor/graphql/core/dataloaders.py
+++ b/saleor/graphql/core/dataloaders.py
@@ -12,7 +12,6 @@ from ...thumbnail.utils import get_thumbnail_format
 from . import SaleorContext
 from .const import DEFAULT_NESTED_LIST_LIMIT
 from .context import get_database_connection_name
-from .validators import validate_limit_input_value
 
 K = TypeVar("K")
 R = TypeVar("R")
@@ -83,7 +82,6 @@ class DataLoaderWithLimit(DataLoader[K, R]):
 
     def __new__(cls, context: SaleorContext, limit: int = DEFAULT_NESTED_LIST_LIMIT):
         loader = super().__new__(cls, context)
-        validate_limit_input_value(limit)
         loader.limit = limit
         return loader
 
@@ -91,7 +89,6 @@ class DataLoaderWithLimit(DataLoader[K, R]):
         self, context: SaleorContext, limit: int = DEFAULT_NESTED_LIST_LIMIT
     ) -> None:
         if getattr(self, "limit", None) != limit:
-            validate_limit_input_value(limit)
             self.limit = limit
         super().__init__(context=context)
 

--- a/saleor/graphql/core/tests/test_query_cost_validation.py
+++ b/saleor/graphql/core/tests/test_query_cost_validation.py
@@ -240,7 +240,7 @@ def test_query_with_fragments_have_same_multiplied_complexity_cost(
 
 
 ATTRIBUTE_QUERY_WITH_LIMIT = """
-query($limit: Int) {
+query($limit: PositiveInt) {
   attributes(first:100) {
     edges {
       node {

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -217,13 +217,6 @@ def validate_if_int_or_uuid(id):
             raise ValidationError("Must receive an int or UUID.") from e
 
 
-def validate_limit_input_value(limit_value: int | None):
-    if not limit_value or limit_value < 1:
-        raise GraphQLError(
-            f"`limit` must be greater than 1. Provided value is {limit_value}."
-        )
-
-
 def validate_limit_of_list_input(
     input_list: list,
     limit: int,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6079,7 +6079,7 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
     """
     Maximum number of objects to return. Value must be greater than 0. Default is 100.
     """
-    limit: Int = 100
+    limit: PositiveInt = 100
   ): [ReferenceType!]
 
   """Name of an attribute displayed in the interface."""
@@ -6486,6 +6486,13 @@ enum MeasurementUnitsEnum {
   KG
   TONNE
 }
+
+"""
+Positive Integer scalar implementation.
+
+Should be used in places where value must be positive (greater than 0).
+"""
+scalar PositiveInt
 
 type AttributeValueCountableConnection @doc(category: "Attributes") {
   """Pagination data for this connection."""


### PR DESCRIPTION
- Adjust `limit` on `Attribute.referenceTypes`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
