### PR TITLE
Fix race condition during price recalculation

### DIFF
--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -2,14 +2,15 @@ from decimal import Decimal
 from typing import Literal, Union
 from unittest.mock import Mock, patch
 
+import before_after
 import pytest
+from django.db.models import F
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 from graphene import Node
 from prices import Money, TaxedMoney
 
-from ...checkout.utils import add_promo_code_to_checkout, set_external_shipping
 from ...core.prices import quantize_price
 from ...core.taxes import TaxData, TaxDataErrorMessage, TaxLineData, zero_taxed_money
 from ...graphql.core.utils import to_global_id_or_none
@@ -32,6 +33,11 @@ from ..calculations import (
     fetch_checkout_data,
 )
 from ..fetch import CheckoutLineInfo, fetch_checkout_info, fetch_checkout_lines
+from ..models import Checkout
+from ..utils import (
+    add_promo_code_to_checkout,
+    set_external_shipping,
+)
 
 
 @pytest.fixture
@@ -1034,3 +1040,105 @@ def test_fetch_order_data_plugin_tax_data_price_overflow(
     assert checkout.tax_error == TaxDataErrorMessage.OVERFLOW
     assert TaxDataErrorMessage.OVERFLOW in caplog.text
     assert caplog.records[0].checkout_id == to_global_id_or_none(checkout)
+
+
+def test_fetch_checkout_data_checkout_removed_before_save(
+    checkout_with_prices,
+):
+    # given
+    checkout = checkout_with_prices
+    currency = checkout.currency
+    checkout.price_expiration = timezone.now()
+    checkout.save(update_fields=["price_expiration"])
+    start_total_price = checkout.total
+    lines = list(checkout.lines.all())
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines_info, _ = fetch_checkout_lines(checkout)
+    fetch_kwargs = {
+        "checkout_info": fetch_checkout_info(checkout, lines_info, manager),
+        "manager": manager,
+        "lines": lines_info,
+        "address": checkout.shipping_address,
+    }
+
+    # when
+    def delete_checkout(*args, **kwargs):
+        # Simulate checkout deletion. We can't run `delete()` on `checkout_with_prices`, because
+        # it's would pass `checkout` without `pk` to `checkout_info`.
+        Checkout.objects.filter(pk=checkout.pk).delete()
+
+    with before_after.after(
+        "saleor.checkout.calculations._calculate_and_add_tax", delete_checkout
+    ):
+        result_checkout_info, result_lines_info = fetch_checkout_data(**fetch_kwargs)
+
+    # then
+    # Check if checkout was deleted.
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    # Check if prices are recalculated and returned in info objects.
+    assert start_total_price != result_checkout_info.checkout.total
+    assert result_checkout_info.checkout.total is not None
+    assert result_checkout_info.checkout.total > zero_taxed_money(currency)
+
+    for line, result_line in zip(lines, result_lines_info, strict=True):
+        assert line.total_price != result_line.line.total_price
+        assert result_line.line.total_price is not None
+        assert result_line.line.total_price > zero_taxed_money(currency)
+
+
+def test_fetch_checkout_data_checkout_updated_during_price_recalculation(
+    checkout_with_prices,
+):
+    # given
+    checkout = checkout_with_prices
+    currency = checkout.currency
+    checkout.price_expiration = timezone.now()
+    checkout.save(update_fields=["price_expiration", "last_change"])
+    checkout.refresh_from_db()
+    total_price_before_recalculation = checkout.total
+    last_change_before_recalculation = checkout.last_change
+    lines = list(checkout.lines.all())
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines_info, _ = fetch_checkout_lines(checkout)
+    fetch_kwargs = {
+        "checkout_info": fetch_checkout_info(checkout, lines_info, manager),
+        "manager": manager,
+        "lines": lines_info,
+        "address": checkout.shipping_address,
+    }
+    expected_email = "new_email@example.com"
+
+    # when
+    def modify_checkout(*args, **kwargs):
+        checkout_to_modify = Checkout.objects.get(pk=checkout.pk)
+        checkout_to_modify.lines.update(quantity=F("quantity") + 1)
+        checkout_to_modify.email = expected_email
+        checkout_to_modify.save(update_fields=["email", "last_change"])
+
+    with before_after.after(
+        "saleor.checkout.calculations._calculate_and_add_tax", modify_checkout
+    ):
+        result_checkout_info, result_lines_info = fetch_checkout_data(**fetch_kwargs)
+
+    # then
+    # Check if prices are recalculated and returned in info objects.
+    assert result_checkout_info.checkout.total != total_price_before_recalculation
+    assert result_checkout_info.checkout.total is not None
+    assert result_checkout_info.checkout.total > zero_taxed_money(currency)
+
+    for line, result_line in zip(lines, result_lines_info, strict=True):
+        assert line.total_price != result_line.line.total_price
+        assert result_line.line.total_price is not None
+        assert result_line.line.total_price > zero_taxed_money(currency)
+        assert result_line.line.quantity == line.quantity
+
+    # Check if database contains updated checkout by other requests.
+    checkout.refresh_from_db()
+    assert checkout.last_change > last_change_before_recalculation
+    assert checkout.email == expected_email
+    for old_line, new_line in zip(lines, checkout.lines.all(), strict=True):
+        assert old_line.quantity + 1 == new_line.quantity

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -419,7 +419,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(82):
+    with django_assert_num_queries(83):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -437,7 +437,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(82):
+    with django_assert_num_queries(83):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -568,7 +568,7 @@ def test_create_checkout_with_order_promotion(
     }
 
     # when
-    with django_assert_num_queries(87):
+    with django_assert_num_queries(88):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then
@@ -823,7 +823,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(105):
+    with django_assert_num_queries(106):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -837,7 +837,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(105):
+    with django_assert_num_queries(106):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -1095,7 +1095,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(102):
+    with django_assert_num_queries(103):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -1108,7 +1108,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(102):
+    with django_assert_num_queries(103):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,
@@ -1158,7 +1158,7 @@ def test_add_checkout_lines_catalogue_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(94):
+    with django_assert_num_queries(95):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1243,7 +1243,7 @@ def test_add_checkout_lines_multiple_catalogue_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(94):
+    with django_assert_num_queries(95):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1278,7 +1278,7 @@ def test_add_checkout_lines_order_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(97):
+    with django_assert_num_queries(98):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1312,7 +1312,7 @@ def test_add_checkout_lines_gift_discount_applies(
     }
 
     # when
-    with django_assert_num_queries(123):
+    with django_assert_num_queries(124):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -8505,7 +8505,9 @@ def checkout_with_prices(
 ):
     # Need to save shipping_method before fetching checkout info.
     checkout_with_items.shipping_method = shipping_method
-    checkout_with_items.save(update_fields=["shipping_method"])
+    country_code = address_other_country.country.code
+    checkout_with_items.set_country(country_code, commit=False)
+    checkout_with_items.save(update_fields=["shipping_method", "country"])
 
     manager = get_plugins_manager(allow_replica=False)
     lines = checkout_with_items.lines.all()


### PR DESCRIPTION
I want to merge this change because it fixes a race condition during price recalculation.
Port https://github.com/saleor/saleor/pull/18115

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
