### PR TITLE
Use `PositiveInt` to limit assignedAttribtues

### DIFF
--- a/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
+++ b/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
@@ -763,7 +763,7 @@ def test_assigned_multi_page_reference_attribute(
 
 
 ASSIGNED_MULTIPLE_PRODUCT_REFERENCE_ATTRIBUTE_QUERY = """
-query PageQuery($id: ID, $valueLimit: Int) {
+query PageQuery($id: ID, $valueLimit: PositiveInt) {
   page(id: $id) {
     assignedAttributes(limit:10) {
       ...on AssignedMultiProductReferenceAttribute{
@@ -881,7 +881,7 @@ def test_applies_limit_to_multi_product_references(
 
 
 ASSIGNED_MULTIPLE_PRODUCT_VARIANT_REFERENCE_ATTRIBUTE_QUERY = """
-query PageQuery($id: ID, $valueLimit: Int) {
+query PageQuery($id: ID, $valueLimit: PositiveInt) {
   page(id: $id) {
     assignedAttributes(limit:10) {
       ...on AssignedMultiProductVariantReferenceAttribute{
@@ -999,7 +999,7 @@ def test_applies_limit_to_multi_variant_references(
 
 
 ASSIGNED_MULTIPLE_CATEGORY_REFERENCE_ATTRIBUTE_QUERY = """
-query PageQuery($id: ID, $valueLimit: Int) {
+query PageQuery($id: ID, $valueLimit: PositiveInt) {
   page(id: $id) {
     assignedAttributes(limit:10) {
       ...on AssignedMultiCategoryReferenceAttribute{
@@ -1122,7 +1122,7 @@ def test_applies_limit_to_multi_category_references(
 
 
 ASSIGNED_MULTIPLE_COLLECTION_REFERENCE_ATTRIBUTE_QUERY = """
-query PageQuery($id: ID, $valueLimit: Int) {
+query PageQuery($id: ID, $valueLimit: PositiveInt) {
   page(id: $id) {
     assignedAttributes(limit:10) {
       ...on AssignedMultiCollectionReferenceAttribute{
@@ -1329,7 +1329,7 @@ def test_assigned_single_choice_attribute(
 
 
 ASSIGNED_MULTI_CHOICE_ATTRIBUTE_QUERY = """
-query PageQuery($id: ID, $valueLimit: Int) {
+query PageQuery($id: ID, $valueLimit: PositiveInt) {
   page(id: $id) {
     assignedAttributes(limit:10) {
       ... on AssignedMultiChoiceAttribute {

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -33,7 +33,7 @@ from ..core.descriptions import (
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.enums import LanguageCodeEnum, MeasurementUnitsEnum
 from ..core.fields import ConnectionField, FilterConnectionField, JSONString
-from ..core.scalars import JSON, Date, DateTime
+from ..core.scalars import JSON, Date, DateTime, PositiveInt
 from ..core.types import (
     BaseInputObjectType,
     BaseInterface,
@@ -45,7 +45,6 @@ from ..core.types import (
     NonNullList,
 )
 from ..core.types.context import ChannelContextType, ChannelContextTypeForObjectType
-from ..core.validators import validate_limit_input_value
 from ..decorators import check_attribute_required_permissions
 from ..meta.types import ObjectWithMetadata
 from ..page.dataloaders import PageByIdLoader
@@ -988,10 +987,10 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
         "saleor.graphql.page.types.Page",
         description="List of assigned page references.",
         required=True,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of referenced pages to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -1008,8 +1007,6 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[page_models.Page]]]:
-        validate_limit_input_value(limit)
-
         if not root.values:
             return Promise.resolve([])
 
@@ -1038,10 +1035,10 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.Product",
         description="List of assigned product references.",
         required=True,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of referenced products to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -1058,8 +1055,6 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[product_models.Product]]]:
-        validate_limit_input_value(limit)
-
         if not root.values:
             return Promise.resolve([])
 
@@ -1089,10 +1084,10 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.ProductVariant",
         description="List of assigned product variant references.",
         required=True,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of referenced product variants to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -1111,8 +1106,6 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[product_models.ProductVariant]]]:
-        validate_limit_input_value(limit)
-
         if not root.values:
             return Promise.resolve([])
 
@@ -1142,10 +1135,10 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.Category",
         description="List of assigned category references.",
         required=True,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of referenced categories to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -1162,7 +1155,6 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[product_models.Category]]:
-        validate_limit_input_value(limit)
         if not root.values:
             return Promise.resolve([])
         attr_values = [value.node for value in root.values]
@@ -1178,7 +1170,7 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
         "saleor.graphql.product.types.Collection",
         description="List of assigned collection references.",
         required=True,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of referenced collections to return. "
                 f"Default is {DEFAULT_NESTED_LIST_LIMIT}"
@@ -1198,7 +1190,6 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> Promise[list[ChannelContext[product_models.Collection]]]:
-        validate_limit_input_value(limit)
         if not root.values:
             return Promise.resolve([])
 
@@ -1278,10 +1269,10 @@ class AssignedMultiChoiceAttribute(BaseObjectType):
         AssignedChoiceAttributeValue,
         required=True,
         description="List of assigned choice values.",
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of choices to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -1298,7 +1289,6 @@ class AssignedMultiChoiceAttribute(BaseObjectType):
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ) -> list[models.AttributeValue]:
-        validate_limit_input_value(limit)
         values = root.values[:limit]
         return [value.node for value in values]
 

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -215,10 +215,3 @@ def validate_if_int_or_uuid(id):
             UUID(id)
         except (AttributeError, ValueError) as e:
             raise ValidationError("Must receive an int or UUID.") from e
-
-
-def validate_limit_input_value(limit_value: int | None):
-    if not limit_value or limit_value < 1:
-        raise GraphQLError(
-            f"`limit` must be greater than 1. Provided value is {limit_value}."
-        )

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -28,10 +28,9 @@ from ..core.descriptions import ADDED_IN_322, DEPRECATED_IN_3X_INPUT, RICH_CONTE
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import FilterConnectionField, JSONString, PermissionsField
-from ..core.scalars import Date, DateTime
+from ..core.scalars import Date, DateTime, PositiveInt
 from ..core.types import ModelObjectType, NonNullList
 from ..core.types.context import ChannelContextType
-from ..core.validators import validate_limit_input_value
 from ..meta.types import ObjectWithMetadata
 from ..translations.fields import TranslationField
 from ..translations.types import PageTranslation
@@ -206,10 +205,10 @@ class Page(ChannelContextType[models.Page]):
         "saleor.graphql.attribute.types.AssignedAttribute",
         required=True,
         description="List of attributes assigned to this page." + ADDED_IN_322,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of attributes to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -254,7 +253,6 @@ class Page(ChannelContextType[models.Page]):
         info: ResolveInfo,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ):
-        validate_limit_input_value(limit)
         return cls._resolve_assigned_attributes(root, info, limit)
 
     @classmethod

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -80,7 +80,7 @@ from ...core.fields import (
     JSONString,
     PermissionsField,
 )
-from ...core.scalars import Date, DateTime
+from ...core.scalars import Date, DateTime, PositiveInt
 from ...core.tracing import traced_resolver
 from ...core.types import (
     BaseObjectType,
@@ -96,7 +96,6 @@ from ...core.types import (
 from ...core.types.context import ChannelContextType
 from ...core.utils import from_global_id_or_error
 from ...core.validators import (
-    validate_limit_input_value,
     validate_one_of_args_is_in_query,
 )
 from ...meta.types import ObjectWithMetadata
@@ -359,10 +358,10 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
             VariantAttributeScope,
             description="Define scope of returned attributes.",
         ),
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of attributes to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -676,7 +675,6 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
         variant_selection: str | None = None,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ):
-        validate_limit_input_value(limit)
         return cls._resolve_attributes(root, info, variant_selection, limit)
 
     @classmethod
@@ -1065,10 +1063,10 @@ class Product(ChannelContextType[models.Product]):
         AssignedAttribute,
         required=True,
         description="List of attributes assigned to this product." + ADDED_IN_322,
-        limit=graphene.Int(
+        limit=PositiveInt(
             description=(
                 "Maximum number of attributes to return. "
-                f"Value must be greater than 0. Default is {DEFAULT_NESTED_LIST_LIMIT}."
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
             ),
             default_value=DEFAULT_NESTED_LIST_LIMIT,
         ),
@@ -1525,7 +1523,6 @@ class Product(ChannelContextType[models.Product]):
         info,
         limit: int = DEFAULT_NESTED_LIST_LIMIT,
     ):
-        validate_limit_input_value(limit)
         return cls._resolve_attributes(root, info, limit)
 
     @classmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5715,10 +5715,8 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
   Added in Saleor 3.22.
   """
   assignedAttributes(
-    """
-    Maximum number of attributes to return. Value must be greater than 0. Default is 100.
-    """
-    limit: Int = 100
+    """Maximum number of attributes to return. Default is 100."""
+    limit: PositiveInt = 100
   ): [AssignedAttribute!]!
 
   """Get a single attribute attached to product by attribute slug."""
@@ -7426,10 +7424,8 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
     """Define scope of returned attributes."""
     variantSelection: VariantAttributeScope
 
-    """
-    Maximum number of attributes to return. Value must be greater than 0. Default is 100.
-    """
-    limit: Int = 100
+    """Maximum number of attributes to return. Default is 100."""
+    limit: PositiveInt = 100
   ): [AssignedAttribute!]!
 
   """List of attributes assigned to this variant."""
@@ -7682,6 +7678,13 @@ interface AssignedAttribute @doc(category: "Attributes") {
   """Attribute assigned to an object."""
   attribute: Attribute!
 }
+
+"""
+Positive Integer scalar implementation.
+
+Should be used in places where value must be positive (greater than 0).
+"""
+scalar PositiveInt
 
 """Represents an assigned attribute to an object."""
 type SelectedAttribute @doc(category: "Attributes") {
@@ -8769,10 +8772,8 @@ type Page implements Node & ObjectWithMetadata @doc(category: "Pages") {
   Added in Saleor 3.22.
   """
   assignedAttributes(
-    """
-    Maximum number of attributes to return. Value must be greater than 0. Default is 100.
-    """
-    limit: Int = 100
+    """Maximum number of attributes to return. Default is 100."""
+    limit: PositiveInt = 100
   ): [AssignedAttribute!]!
 
   """List of attributes assigned to this page."""
@@ -34643,10 +34644,8 @@ type AssignedMultiChoiceAttribute implements AssignedAttribute @doc(category: "A
 
   """List of assigned choice values."""
   value(
-    """
-    Maximum number of choices to return. Value must be greater than 0. Default is 100.
-    """
-    limit: Int = 100
+    """Maximum number of choices to return. Default is 100."""
+    limit: PositiveInt = 100
   ): [AssignedChoiceAttributeValue!]!
 }
 
@@ -34797,10 +34796,8 @@ type AssignedMultiPageReferenceAttribute implements AssignedAttribute @doc(categ
 
   """List of assigned page references."""
   value(
-    """
-    Maximum number of referenced pages to return. Value must be greater than 0. Default is 100.
-    """
-    limit: Int = 100
+    """Maximum number of referenced pages to return. Default is 100."""
+    limit: PositiveInt = 100
   ): [Page!]!
 }
 
@@ -34815,10 +34812,8 @@ type AssignedMultiProductReferenceAttribute implements AssignedAttribute @doc(ca
 
   """List of assigned product references."""
   value(
-    """
-    Maximum number of referenced products to return. Value must be greater than 0. Default is 100.
-    """
-    limit: Int = 100
+    """Maximum number of referenced products to return. Default is 100."""
+    limit: PositiveInt = 100
   ): [Product!]!
 }
 
@@ -34834,9 +34829,9 @@ type AssignedMultiProductVariantReferenceAttribute implements AssignedAttribute 
   """List of assigned product variant references."""
   value(
     """
-    Maximum number of referenced product variants to return. Value must be greater than 0. Default is 100.
+    Maximum number of referenced product variants to return. Default is 100.
     """
-    limit: Int = 100
+    limit: PositiveInt = 100
   ): [ProductVariant!]!
 }
 
@@ -34851,10 +34846,8 @@ type AssignedMultiCategoryReferenceAttribute implements AssignedAttribute @doc(c
 
   """List of assigned category references."""
   value(
-    """
-    Maximum number of referenced categories to return. Value must be greater than 0. Default is 100.
-    """
-    limit: Int = 100
+    """Maximum number of referenced categories to return. Default is 100."""
+    limit: PositiveInt = 100
   ): [Category!]!
 }
 
@@ -34870,7 +34863,7 @@ type AssignedMultiCollectionReferenceAttribute implements AssignedAttribute @doc
   """List of assigned collection references."""
   value(
     """Maximum number of referenced collections to return. Default is 100"""
-    limit: Int = 100
+    limit: PositiveInt = 100
   ): [Collection!]!
 }
 


### PR DESCRIPTION
I want to merge this change because it adds usage of PositiveInt introduced: https://github.com/saleor/saleor/pull/18118

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
