### PR TITLE
Fix fulfilment cancel

### DIFF
--- a/saleor/graphql/order/mutations/fulfillment_cancel.py
+++ b/saleor/graphql/order/mutations/fulfillment_cancel.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from ....account.models import User
 from ....giftcard.utils import order_has_gift_card_lines
 from ....order import FulfillmentStatus
-from ....order.actions import cancel_fulfillment, cancel_waiting_fulfillment
+from ....order.actions import cancel_fulfillment
 from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ...app.dataloaders import get_app_promise
@@ -112,12 +112,8 @@ class FulfillmentCancel(BaseMutation):
 
         app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
-        if fulfillment.status == FulfillmentStatus.WAITING_FOR_APPROVAL:
-            cancel_waiting_fulfillment(fulfillment, user, app, manager)
-            fulfillment_response = None
-        else:
-            fulfillment = cancel_fulfillment(fulfillment, user, app, warehouse, manager)
-            fulfillment_response = SyncWebhookControlContext(node=fulfillment)
+        fulfillment = cancel_fulfillment(fulfillment, user, app, warehouse, manager)
+        fulfillment_response = SyncWebhookControlContext(node=fulfillment)
         order.refresh_from_db(fields=["status"])
         return FulfillmentCancel(
             fulfillment=fulfillment_response, order=SyncWebhookControlContext(order)


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/18137

Fix canceling fulfillments in waiting for approval status. Previously, such fulfilment was deleted, which influence the order history. After change, fulfilment is marked as cancel and will be visible on order details.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
