### PR TITLE
Add test for django-mptt 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,6 @@ package-mode = false
   django-countries = "^7.2"
   django-filter = "^24.3"
   django-measurement = "^3.0"
-  # Version 0.18 introduces changes in index definitions.
-  # Upgrading to this version requires new migrations, which are already included in later versions.
-  # Block upgrading to prevent potential migration conflicts.
   django-mptt = ">=0,<0.18"
   django-phonenumber-field = ">=4,<9"
   django-stubs-ext = "^5.1.1"

--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 from urllib.parse import urljoin
 
+import mptt
 import pytest
 from django.core.management import CommandError, call_command
 from django.db.utils import DataError
@@ -462,3 +463,13 @@ def test_prepare_unique_attribute_value_slug_non_existing_slug(color_attribute):
     result = prepare_unique_attribute_value_slug(color_attribute, non_existing_slug)
 
     assert result == non_existing_slug
+
+
+def test_mptt_version():
+    # Ensure the django-mptt library version is below 0.18
+    # Version 0.18 introduces changes in index definitions.
+    # Upgrading to this version requires new migrations, which are already included in later versions.
+    version = tuple(map(int, mptt.__version__.split(".")))
+    assert version <= (0, 18), (
+        f"mptt version is {mptt.__version__}, must be 0.18 or lower"
+    )


### PR DESCRIPTION
Add test to ensure `django-mptt` won't be upgraded

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
