### PR TITLE
Add checkoutFullyAuthorized webhook

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -1199,7 +1199,9 @@ def test_transaction_create_for_checkout_by_staff(
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_create_for_checkout_fully_paid(
+    mocked_checkout_fully_authorized,
     mocked_checkout_fully_paid,
     mocked_automatic_checkout_completion_task,
     checkout_with_prices,
@@ -1249,12 +1251,15 @@ def test_transaction_create_for_checkout_fully_paid(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_create_for_checkout_fully_paid_automatic_completion(
     mocked_checkout_fully_paid,
+    mocked_checkout_fully_authorized,
     checkout_with_prices,
     permission_manage_payments,
     staff_api_client,
@@ -1302,6 +1307,7 @@ def test_transaction_create_for_checkout_fully_paid_automatic_completion(
 
     # then
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     with pytest.raises(Checkout.DoesNotExist):
         checkout.refresh_from_db()
 
@@ -1314,9 +1320,11 @@ def test_transaction_create_for_checkout_fully_paid_automatic_completion(
 
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_create_for_checkout_fully_authorized(
     mocked_checkout_fully_paid,
+    mocked_checkout_fully_authorized,
     mocked_automatic_checkout_completion_task,
     checkout_with_prices,
     permission_manage_payments,
@@ -1364,13 +1372,16 @@ def test_transaction_create_for_checkout_fully_authorized(
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_checkout_fully_paid.assert_not_called()
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_create_for_checkout_fully_authorized_automatic_completion(
     mocked_checkout_fully_paid,
+    mocked_checkout_fully_authorized,
     checkout_with_prices,
     permission_manage_payments,
     staff_api_client,
@@ -1417,6 +1428,7 @@ def test_transaction_create_for_checkout_fully_authorized_automatic_completion(
     )
 
     # then
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_checkout_fully_paid.assert_not_called()
 
     with pytest.raises(Checkout.DoesNotExist):

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -1390,7 +1390,9 @@ def test_transaction_event_updates_checkout_last_transaction_modified_at(
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
+    mocked_fully_authorized,
     mocked_fully_paid,
     mocked_automatic_checkout_completion_task,
     transaction_item_generator,
@@ -1455,13 +1457,16 @@ def test_transaction_event_updates_checkout_full_paid_with_charged_amount(
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_event_updates_checkout_full_paid_with_pending_charge_amount(
     mocked_fully_paid,
+    mocked_fully_authorized,
     mocked_automatic_checkout_completion_task,
     transaction_item_generator,
     app_api_client,
@@ -1522,12 +1527,15 @@ def test_transaction_event_updates_checkout_full_paid_with_pending_charge_amount
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_full_paid_automatic_completion(
     mocked_fully_paid,
+    checkout_fully_authorized,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1599,12 +1607,15 @@ def test_transaction_event_updates_checkout_full_paid_automatic_completion(
         type=OrderEvents.PLACED_AUTOMATICALLY_FROM_PAID_CHECKOUT
     ).exists()
 
+    checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_full_paid_pending_charge_automatic_complete(
     mocked_fully_paid,
+    checkout_fully_authorized,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1673,11 +1684,14 @@ def test_transaction_event_updates_checkout_full_paid_pending_charge_automatic_c
     assert order.authorize_status == CheckoutAuthorizeStatus.NONE
 
     mocked_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
 
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_event_updates_checkout_fully_authorized(
+    mocked_fully_authorized,
     mocked_fully_paid,
     mocked_automatic_checkout_completion_task,
     transaction_item_generator,
@@ -1741,13 +1755,17 @@ def test_transaction_event_updates_checkout_fully_authorized(
 
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+
     mocked_fully_paid.assert_not_called()
+    mocked_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_fully_authorized_automatic_complete(
     mocked_fully_paid,
+    mocked_fully_authorized,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1819,11 +1837,14 @@ def test_transaction_event_updates_checkout_fully_authorized_automatic_complete(
         type=OrderEvents.PLACED_AUTOMATICALLY_FROM_PAID_CHECKOUT
     ).exists()
     mocked_fully_paid.assert_not_called()
+    mocked_fully_authorized.assert_called_once_with(checkout, webhooks=set())
 
 
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
 def test_transaction_event_updates_checkout_fully_authorized_pending_automatic_complete(
     mocked_fully_paid,
+    mocked_fully_authorized,
     transaction_item_generator,
     app_api_client,
     permission_manage_payments,
@@ -1892,6 +1913,7 @@ def test_transaction_event_updates_checkout_fully_authorized_pending_automatic_c
     assert order.charge_status == CheckoutChargeStatus.NONE
     assert order.authorize_status == CheckoutAuthorizeStatus.NONE
     mocked_fully_paid.assert_not_called()
+    mocked_fully_authorized.assert_called_once_with(checkout, webhooks=set())
 
 
 def test_transaction_event_report_with_info_event(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -2693,7 +2693,9 @@ def test_transaction_update_for_checkout_updates_payment_statuses(
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_update_for_checkout_fully_paid(
+    mocked_checkout_fully_authorized,
     mocked_checkout_fully_paid,
     mocked_automatic_checkout_completion_task,
     checkout_with_prices,
@@ -2741,11 +2743,14 @@ def test_transaction_update_for_checkout_fully_paid(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_update_for_checkout_fully_paid_automatic_completion(
+    mocked_checkout_fully_authorized,
     mocked_checkout_fully_paid,
     checkout_with_prices,
     permission_manage_payments,
@@ -2801,11 +2806,14 @@ def test_transaction_update_for_checkout_fully_paid_automatic_completion(
     ).exists()
 
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
 
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_update_for_checkout_fully_authorized(
+    mocked_checkout_fully_authorized,
     mocked_checkout_fully_paid,
     mocked_automatic_checkout_completion_task,
     checkout_with_prices,
@@ -2853,11 +2861,14 @@ def test_transaction_update_for_checkout_fully_authorized(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
 
     mocked_checkout_fully_paid.assert_not_called()
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_transaction_update_for_checkout_fully_authorized_automatic_completion(
+    mocked_checkout_fully_authorized,
     mocked_checkout_fully_paid,
     checkout_with_prices,
     permission_manage_payments,
@@ -2911,6 +2922,7 @@ def test_transaction_update_for_checkout_fully_authorized_automatic_completion(
     ).exists()
 
     mocked_checkout_fully_paid.assert_not_called()
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
 
 
 def test_transaction_update_accepts_old_id_for_old_transaction(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2052,7 +2052,17 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A checkout is updated. It also triggers all updates related to the checkout.
   """
   CHECKOUT_UPDATED
+
+  """
+  A checkout is fully authorized (`checkout.authorizeStatus` = `FULL`).
+  This event is emitted only for checkouts whose payments are processed through the Transaction API.
+  """
   CHECKOUT_FULLY_AUTHORIZED
+
+  """
+  A checkout is fully paid (`checkout.chargeStatus` = `FULL` or `OVERCHARGED`). This event is not sent if payments are only authorized but not fully charged.
+  This event is emitted only for checkouts whose payments are processed through the Transaction API.
+  """
   CHECKOUT_FULLY_PAID
 
   """A checkout metadata is updated."""
@@ -2615,7 +2625,17 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A checkout is updated. It also triggers all updates related to the checkout.
   """
   CHECKOUT_UPDATED
+
+  """
+  A checkout is fully authorized (`checkout.authorizeStatus` = `FULL`).
+  This event is emitted only for checkouts whose payments are processed through the Transaction API.
+  """
   CHECKOUT_FULLY_AUTHORIZED
+
+  """
+  A checkout is fully paid (`checkout.chargeStatus` = `FULL` or `OVERCHARGED`). This event is not sent if payments are only authorized but not fully charged.
+  This event is emitted only for checkouts whose payments are processed through the Transaction API.
+  """
   CHECKOUT_FULLY_PAID
 
   """A checkout metadata is updated."""
@@ -31373,7 +31393,8 @@ type CheckoutUpdated implements Event @doc(category: "Checkout") {
 }
 
 """
-Event sent when checkout is fully paid with transactions.The checkout is considered as fully paid when the `checkout.chargeStatus` is `FULL` or `OVERCHARGED`. The event is not sent when the checkout is fully authorized.
+Event sent when a checkout is fully paid. A checkout is considered fully paid when `checkout.chargeStatus` is `FULL` or `OVERCHARGED`. This event is not sent if payments are only authorized but not fully charged.
+It is triggered only for checkouts whose payments are processed through the Transaction API.
 """
 type CheckoutFullyPaid implements Event @doc(category: "Checkout") {
   """Time of the event."""
@@ -31393,7 +31414,8 @@ type CheckoutFullyPaid implements Event @doc(category: "Checkout") {
 }
 
 """
-Event sent when checkout is fully authorized with transactions. The checkout is considered as fully authorized when the `checkout.authorizeStatus` is `FULL`.
+Event sent when a checkout is fully authorized. A checkout is considered fully authorized when `checkout.authorizeStatus` is `FULL`.
+It is triggered only for checkouts whose payments are processed through the Transaction API.
 """
 type CheckoutFullyAuthorized implements Event @doc(category: "Checkout") {
   """Time of the event."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2052,6 +2052,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A checkout is updated. It also triggers all updates related to the checkout.
   """
   CHECKOUT_UPDATED
+  CHECKOUT_FULLY_AUTHORIZED
   CHECKOUT_FULLY_PAID
 
   """A checkout metadata is updated."""
@@ -2614,6 +2615,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A checkout is updated. It also triggers all updates related to the checkout.
   """
   CHECKOUT_UPDATED
+  CHECKOUT_FULLY_AUTHORIZED
   CHECKOUT_FULLY_PAID
 
   """A checkout metadata is updated."""
@@ -3425,6 +3427,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   PRODUCT_VARIANT_STOCK_UPDATED
   CHECKOUT_CREATED
   CHECKOUT_UPDATED
+  CHECKOUT_FULLY_AUTHORIZED
   CHECKOUT_FULLY_PAID
   CHECKOUT_METADATA_UPDATED
   NOTIFY_USER
@@ -31017,6 +31020,20 @@ type Subscription @doc(category: "Miscellaneous") {
   ): CheckoutFullyPaid @doc(category: "Checkout")
 
   """
+  Event sent when checkout is fully authorized.
+  
+  Added in Saleor 3.21.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  checkoutFullyAuthorized(
+    """
+    List of channel slugs. The event will be sent only if the object belongs to one of the provided channels. If the channel slug list is empty, objects that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): CheckoutFullyAuthorized @doc(category: "Checkout")
+
+  """
   Event sent when checkout metadata is updated.
   
   Added in Saleor 3.21.
@@ -31356,9 +31373,29 @@ type CheckoutUpdated implements Event @doc(category: "Checkout") {
 }
 
 """
-Event sent when checkout is fully paid with transactions. The checkout is considered as fully paid when the checkout `charge_status` is `FULL` or `OVERCHARGED`. The event is not sent when the checkout authorization flow strategy is used.
+Event sent when checkout is fully paid with transactions.The checkout is considered as fully paid when the `checkout.chargeStatus` is `FULL` or `OVERCHARGED`. The event is not sent when the checkout is fully authorized.
 """
 type CheckoutFullyPaid implements Event @doc(category: "Checkout") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The checkout the event relates to."""
+  checkout: Checkout
+}
+
+"""
+Event sent when checkout is fully authorized with transactions. The checkout is considered as fully authorized when the `checkout.authorizeStatus` is `FULL`.
+"""
+type CheckoutFullyAuthorized implements Event @doc(category: "Checkout") {
   """Time of the event."""
   issuedAt: DateTime
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2054,13 +2054,15 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   CHECKOUT_UPDATED
 
   """
-  A checkout is fully authorized (`checkout.authorizeStatus` = `FULL`).
+  A checkout was fully authorized (its `authorizeStatus` is `FULL`).
+  
   This event is emitted only for checkouts whose payments are processed through the Transaction API.
   """
   CHECKOUT_FULLY_AUTHORIZED
 
   """
-  A checkout is fully paid (`checkout.chargeStatus` = `FULL` or `OVERCHARGED`). This event is not sent if payments are only authorized but not fully charged.
+  A checkout was fully paid (its `chargeStatus` is `FULL` or `OVERCHARGED`). This event is not sent if payments are only authorized but not fully charged.
+  
   This event is emitted only for checkouts whose payments are processed through the Transaction API.
   """
   CHECKOUT_FULLY_PAID
@@ -2627,13 +2629,15 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   CHECKOUT_UPDATED
 
   """
-  A checkout is fully authorized (`checkout.authorizeStatus` = `FULL`).
+  A checkout was fully authorized (its `authorizeStatus` is `FULL`).
+  
   This event is emitted only for checkouts whose payments are processed through the Transaction API.
   """
   CHECKOUT_FULLY_AUTHORIZED
 
   """
-  A checkout is fully paid (`checkout.chargeStatus` = `FULL` or `OVERCHARGED`). This event is not sent if payments are only authorized but not fully charged.
+  A checkout was fully paid (its `chargeStatus` is `FULL` or `OVERCHARGED`). This event is not sent if payments are only authorized but not fully charged.
+  
   This event is emitted only for checkouts whose payments are processed through the Transaction API.
   """
   CHECKOUT_FULLY_PAID
@@ -31393,7 +31397,8 @@ type CheckoutUpdated implements Event @doc(category: "Checkout") {
 }
 
 """
-Event sent when a checkout is fully paid. A checkout is considered fully paid when `checkout.chargeStatus` is `FULL` or `OVERCHARGED`. This event is not sent if payments are only authorized but not fully charged.
+Event sent when a checkout was fully paid. A checkout is considered fully paid when its `chargeStatus` is `FULL` or `OVERCHARGED`. This event is not sent if payments are only authorized but not fully charged.
+
 It is triggered only for checkouts whose payments are processed through the Transaction API.
 """
 type CheckoutFullyPaid implements Event @doc(category: "Checkout") {
@@ -31414,7 +31419,8 @@ type CheckoutFullyPaid implements Event @doc(category: "Checkout") {
 }
 
 """
-Event sent when a checkout is fully authorized. A checkout is considered fully authorized when `checkout.authorizeStatus` is `FULL`.
+Event sent when a checkout was fully authorized. A checkout is considered fully authorized when its `authorizeStatus` is `FULL`.
+
 It is triggered only for checkouts whose payments are processed through the Transaction API.
 """
 type CheckoutFullyAuthorized implements Event @doc(category: "Checkout") {

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -27,15 +27,16 @@ order_updated_event_enum_description = (
     "covers all other order webhooks, except for ORDER_CREATED."
 )
 checkout_fully_authorized_event_enum_description = (
-    "A checkout is fully authorized "
-    "(`checkout.authorizeStatus` = `FULL`).\nThis event is emitted only for "
-    "checkouts whose payments are processed through the Transaction API."
+    "A checkout was fully authorized (its `authorizeStatus` is `FULL`)."
+    "\n\nThis event is emitted only for checkouts whose payments are "
+    "processed through the Transaction API."
 )
 checkout_fully_paid_event_enum_description = (
-    "A checkout is fully paid (`checkout.chargeStatus` = `FULL` "
+    "A checkout was fully paid (its `chargeStatus` is `FULL` "
     "or `OVERCHARGED`). This event is not sent if payments are only authorized "
-    "but not fully charged.\nThis event is emitted only for checkouts whose payments "
-    "are processed through the Transaction API."
+    "but not fully charged."
+    "\n\nThis event is emitted only for checkouts whose payments are processed"
+    " through the Transaction API."
 )
 
 WEBHOOK_EVENT_DESCRIPTION = {

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -26,7 +26,17 @@ order_updated_event_enum_description = (
     "An order is updated; triggered for all changes related to an order; "
     "covers all other order webhooks, except for ORDER_CREATED."
 )
-
+checkout_fully_authorized_event_enum_description = (
+    "A checkout is fully authorized "
+    "(`checkout.authorizeStatus` = `FULL`).\nThis event is emitted only for "
+    "checkouts whose payments are processed through the Transaction API."
+)
+checkout_fully_paid_event_enum_description = (
+    "A checkout is fully paid (`checkout.chargeStatus` = `FULL` "
+    "or `OVERCHARGED`). This event is not sent if payments are only authorized "
+    "but not fully charged.\nThis event is emitted only for checkouts whose payments "
+    "are processed through the Transaction API."
+)
 
 WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED: (
@@ -65,6 +75,8 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.CHANNEL_METADATA_UPDATED: "A channel metadata is updated.",
     WebhookEventAsyncType.CHECKOUT_CREATED: "A new checkout is created.",
     WebhookEventAsyncType.CHECKOUT_UPDATED: checkout_updated_event_enum_description,
+    WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED: checkout_fully_authorized_event_enum_description,
+    WebhookEventAsyncType.CHECKOUT_FULLY_PAID: checkout_fully_paid_event_enum_description,
     WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED: "A checkout metadata is updated.",
     WebhookEventAsyncType.COLLECTION_CREATED: "A new collection is created.",
     WebhookEventAsyncType.COLLECTION_UPDATED: "A collection is updated.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1506,11 +1506,12 @@ class CheckoutFullyPaid(SubscriptionObjectType, CheckoutBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when a checkout is fully paid. A checkout is "
-            "considered fully paid when `checkout.chargeStatus` is `FULL` "
+            "Event sent when a checkout was fully paid. A checkout is "
+            "considered fully paid when its `chargeStatus` is `FULL` "
             "or `OVERCHARGED`. This event is not sent if payments are only "
-            "authorized but not fully charged.\nIt is triggered only for "
-            "checkouts whose payments are processed through the Transaction API."
+            "authorized but not fully charged."
+            "\n\nIt is triggered only for checkouts whose payments are "
+            "processed through the Transaction API."
         )
 
 
@@ -1520,9 +1521,9 @@ class CheckoutFullyAuthorized(SubscriptionObjectType, CheckoutBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when a checkout is fully authorized. A checkout is "
-            "considered fully authorized when `checkout.authorizeStatus` is `FULL`.\n"
-            "It is triggered only for checkouts whose payments are processed through "
+            "Event sent when a checkout was fully authorized. A checkout is "
+            "considered fully authorized when its `authorizeStatus` is `FULL`."
+            "\n\nIt is triggered only for checkouts whose payments are processed through "
             "the Transaction API."
         )
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1506,10 +1506,11 @@ class CheckoutFullyPaid(SubscriptionObjectType, CheckoutBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when checkout is fully paid with transactions."
-            "The checkout is considered as fully paid when the "
-            "`checkout.chargeStatus` is `FULL` or `OVERCHARGED`. "
-            "The event is not sent when the checkout is fully authorized."
+            "Event sent when a checkout is fully paid. A checkout is "
+            "considered fully paid when `checkout.chargeStatus` is `FULL` "
+            "or `OVERCHARGED`. This event is not sent if payments are only "
+            "authorized but not fully charged.\nIt is triggered only for "
+            "checkouts whose payments are processed through the Transaction API."
         )
 
 
@@ -1519,9 +1520,10 @@ class CheckoutFullyAuthorized(SubscriptionObjectType, CheckoutBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when checkout is fully authorized with transactions. "
-            "The checkout is considered as fully authorized when the "
-            "`checkout.authorizeStatus` is `FULL`. "
+            "Event sent when a checkout is fully authorized. A checkout is "
+            "considered fully authorized when `checkout.authorizeStatus` is `FULL`.\n"
+            "It is triggered only for checkouts whose payments are processed through "
+            "the Transaction API."
         )
 
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1507,10 +1507,21 @@ class CheckoutFullyPaid(SubscriptionObjectType, CheckoutBase):
         interfaces = (Event,)
         description = (
             "Event sent when checkout is fully paid with transactions."
-            " The checkout is considered as fully paid when the checkout "
-            "`charge_status` is `FULL` or `OVERCHARGED`. "
-            "The event is not sent when the checkout authorization flow strategy "
-            "is used."
+            "The checkout is considered as fully paid when the "
+            "`checkout.chargeStatus` is `FULL` or `OVERCHARGED`. "
+            "The event is not sent when the checkout is fully authorized."
+        )
+
+
+class CheckoutFullyAuthorized(SubscriptionObjectType, CheckoutBase):
+    class Meta:
+        root_type = "Checkout"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = (
+            "Event sent when checkout is fully authorized with transactions. "
+            "The checkout is considered as fully authorized when the "
+            "`checkout.authorizeStatus` is `FULL`. "
         )
 
 
@@ -2783,6 +2794,17 @@ class Subscription(SubscriptionObjectType):
         channels=channels_argument,
         doc_category=DOC_CATEGORY_CHECKOUT,
     )
+    checkout_fully_authorized = BaseField(
+        CheckoutFullyAuthorized,
+        description=(
+            "Event sent when checkout is fully authorized."
+            + ADDED_IN_321
+            + PREVIEW_FEATURE
+        ),
+        resolver=default_channel_filterable_resolver,
+        channels=channels_argument,
+        doc_category=DOC_CATEGORY_CHECKOUT,
+    )
     checkout_metadata_updated = BaseField(
         CheckoutMetadataUpdated,
         description=(
@@ -3007,6 +3029,7 @@ ASYNC_WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.COLLECTION_METADATA_UPDATED: CollectionMetadataUpdated,
     WebhookEventAsyncType.CHECKOUT_CREATED: CheckoutCreated,
     WebhookEventAsyncType.CHECKOUT_UPDATED: CheckoutUpdated,
+    WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED: CheckoutFullyAuthorized,
     WebhookEventAsyncType.CHECKOUT_FULLY_PAID: CheckoutFullyPaid,
     WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED: CheckoutMetadataUpdated,
     WebhookEventAsyncType.PAGE_CREATED: PageCreated,

--- a/saleor/payment/tests/test_utils/test_create_transaction_event_for_transaction_session.py
+++ b/saleor/payment/tests/test_utils/test_create_transaction_event_for_transaction_session.py
@@ -916,7 +916,9 @@ def test_create_transaction_event_with_invalid_message(
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_create_transaction_event_from_session_when_authorized_triggers_checkout_completion(
+    mocked_checkout_fully_authorized,
     mocked_checkout_fully_paid,
     mocked_automatic_checkout_completion_task,
     transaction_item_generator,
@@ -963,6 +965,7 @@ def test_create_transaction_event_from_session_when_authorized_triggers_checkout
     checkout.refresh_from_db()
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_checkout_fully_paid.assert_not_called()
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_called_once_with(
         checkout.pk, None, app.id
     )

--- a/saleor/payment/tests/test_utils/test_utils.py
+++ b/saleor/payment/tests/test_utils/test_utils.py
@@ -820,8 +820,10 @@ def test_create_transaction_event_from_request_and_webhook_response_full_event(
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_create_transaction_event_from_request_when_paid(
     mocked_checkout_fully_paid,
+    mocked_checkout_fully_authorized,
     mocked_automatic_checkout_completion_task,
     transaction_item_generator,
     app,
@@ -860,14 +862,17 @@ def test_create_transaction_event_from_request_when_paid(
     checkout.refresh_from_db()
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_not_called()
 
 
 @patch.object(logger, "error")
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_create_transaction_event_from_request_when_authorized_logs_warnning(
     mocked_checkout_fully_paid,
+    mocked_checkout_fully_authorized,
     mocked_automatic_checkout_completion_task,
     mocked_logger,
     transaction_item_generator,
@@ -913,6 +918,7 @@ def test_create_transaction_event_from_request_when_authorized_logs_warnning(
     assert checkout.authorize_status == CheckoutAuthorizeStatus.NONE
     checkout.refresh_from_db()
     mocked_checkout_fully_paid.assert_not_called()
+    mocked_checkout_fully_authorized.assert_not_called()
     mocked_automatic_checkout_completion_task.assert_not_called()
     assert mocked_logger.call_count == 1
     assert len(mocked_logger.call_args) == 2
@@ -920,8 +926,10 @@ def test_create_transaction_event_from_request_when_authorized_logs_warnning(
 
 @patch("saleor.checkout.tasks.automatic_checkout_completion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.checkout_fully_paid")
+@patch("saleor.plugins.manager.PluginsManager.checkout_fully_authorized")
 def test_create_transaction_event_from_request_when_paid_triggers_checkout_completion(
     mocked_checkout_fully_paid,
+    mocked_checkout_fully_authorized,
     mocked_automatic_checkout_completion_task,
     transaction_item_generator,
     app,
@@ -967,6 +975,7 @@ def test_create_transaction_event_from_request_when_paid_triggers_checkout_compl
     checkout.refresh_from_db()
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
     mocked_checkout_fully_paid.assert_called_once_with(checkout, webhooks=set())
+    mocked_checkout_fully_authorized.assert_called_once_with(checkout, webhooks=set())
     mocked_automatic_checkout_completion_task.assert_called_once_with(
         checkout.pk, None, app.id
     )

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -545,6 +545,15 @@ class BasePlugin:
     # Webhook-related functionality will be moved from the plugin to core modules.
     checkout_fully_paid: Callable[["Checkout", Any, None], Any]
 
+    # Trigger when checkout is fully authorized with transactions.
+    #
+    # Overwrite this method if you need to trigger specific logic when a checkout is
+    # updated.
+    #
+    # Note: This method is deprecated and will be removed in a future release.
+    # Webhook-related functionality will be moved from the plugin to core modules.
+    checkout_fully_authorized: Callable[["Checkout", Any, None], Any]
+
     # Trigger when checkout metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a checkout

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1366,6 +1366,18 @@ class PluginsManager(PaymentInterface):
 
     # Note: this method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from plugin to core modules.
+    def checkout_fully_authorized(self, checkout: "Checkout", webhooks=None):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "checkout_fully_authorized",
+            default_value,
+            checkout,
+            channel_slug=checkout.channel.slug,
+            webhooks=webhooks,
+        )
+
+    # Note: this method is deprecated and will be removed in a future release.
+    # Webhook-related functionality will be moved from plugin to core modules.
     def checkout_fully_paid(self, checkout: "Checkout", webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -339,6 +339,9 @@ class PluginSample(BasePlugin):
     def checkout_fully_paid(self, checkout, previous_value, webhooks):
         return None
 
+    def checkout_fully_authorized(self, checkout, previous_value, webhooks):
+        return None
+
     def order_fully_refunded(self, order, previous_value, webhooks):
         return None
 

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1276,6 +1276,26 @@ def test_checkout_fully_paid(mocked_sample_method, checkout, webhook):
     )
 
 
+@patch("saleor.plugins.tests.sample_plugins.PluginSample.checkout_fully_authorized")
+def test_checkout_fully_authorized(mocked_sample_method, checkout, webhook):
+    # given
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.tests.sample_plugins.PluginInactive",
+    ]
+
+    manager = PluginsManager(plugins=plugins)
+    webhooks = {webhook}
+
+    # when
+    manager.checkout_fully_authorized(checkout, webhooks=webhooks)
+
+    # then
+    mocked_sample_method.assert_called_once_with(
+        checkout, previous_value=None, webhooks=webhooks
+    )
+
+
 @patch("saleor.plugins.tests.sample_plugins.PluginSample.order_fully_refunded")
 def test_order_fully_refunded(mocked_sample_method, order, webhook):
     # given

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2123,6 +2123,31 @@ class WebhookPlugin(BasePlugin):
             )
         return previous_value
 
+    def checkout_fully_authorized(
+        self, checkout: "Checkout", previous_value: None, webhooks=None
+    ) -> None:
+        if not self.active:
+            return previous_value
+        event_type = WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED
+        if webhooks := self._get_webhooks_for_channel_events(
+            event_type, checkout.channel.slug, webhooks
+        ):
+            checkout_data_generator = partial(
+                generate_checkout_payload,
+                checkout,
+                self.requestor,
+            )
+            self.trigger_webhooks_async(
+                None,
+                event_type,
+                webhooks,
+                checkout,
+                self.requestor,
+                legacy_data_generator=checkout_data_generator,
+                queue=settings.CHECKOUT_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
+            )
+        return previous_value
+
     def checkout_fully_paid(
         self, checkout: "Checkout", previous_value: None, webhooks=None
     ) -> None:

--- a/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_checkout_fully_authorized.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/filterable_webhooks/test_checkout_fully_authorized.py
@@ -1,0 +1,247 @@
+import json
+from unittest.mock import patch
+
+import graphene
+from django.test import override_settings
+
+from ......core.models import EventDelivery
+from ......graphql.webhook.subscription_query import SubscriptionQuery
+from ......webhook.event_types import WebhookEventAsyncType
+from .....manager import get_plugins_manager
+
+CHECKOUT_FULLY_AUTHORIZED_SUBSCRIPTION = """
+subscription {
+  checkoutFullyAuthorized(channels: ["%s"]) {
+    checkout {
+      id
+      token
+      lines {
+        id
+        variant {
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(
+    PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"],
+    CELERY_TASK_ALWAYS_EAGER=True,
+)
+def test_checkout_fully_authorized(
+    mocked_async, checkout_with_item, subscription_webhook, settings
+):
+    # given
+    manager = get_plugins_manager(False)
+    checkout = checkout_with_item
+    checkout_line = checkout.lines.first()
+
+    channel = checkout.channel
+    assert channel.slug == settings.DEFAULT_CHANNEL_SLUG
+
+    event_type = WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED
+
+    query = CHECKOUT_FULLY_AUTHORIZED_SUBSCRIPTION % settings.DEFAULT_CHANNEL_SLUG
+    webhook = subscription_webhook(query, event_type)
+    subscription_query = SubscriptionQuery(query)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    manager.checkout_fully_authorized(checkout)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "checkoutFullyAuthorized": {
+                    "checkout": {
+                        "id": checkout_id,
+                        "token": str(checkout.token),
+                        "lines": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "CheckoutLine", checkout_line.id
+                                ),
+                                "variant": {
+                                    "id": graphene.Node.to_global_id(
+                                        "ProductVariant", checkout_line.variant_id
+                                    )
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    )
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(
+    PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"],
+    CELERY_TASK_ALWAYS_EAGER=True,
+)
+def test_checkout_fully_authorized_without_channels_input(
+    mocked_async, checkout_with_item, subscription_webhook
+):
+    # given
+    manager = get_plugins_manager(False)
+    checkout = checkout_with_item
+    checkout_line = checkout.lines.first()
+
+    event_type = WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED
+
+    query = """subscription {
+      checkoutFullyAuthorized {
+        checkout {
+          id
+          token
+          lines {
+            id
+            variant {
+              id
+            }
+          }
+        }
+      }
+    }"""
+    webhook = subscription_webhook(query, event_type)
+    subscription_query = SubscriptionQuery(query)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    manager.checkout_fully_authorized(checkout)
+
+    # then
+    expected_payload = json.dumps(
+        {
+            "data": {
+                "checkoutFullyAuthorized": {
+                    "checkout": {
+                        "id": checkout_id,
+                        "token": str(checkout.token),
+                        "lines": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "CheckoutLine", checkout_line.id
+                                ),
+                                "variant": {
+                                    "id": graphene.Node.to_global_id(
+                                        "ProductVariant", checkout_line.variant_id
+                                    )
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    )
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 1
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert deliveries[0].webhook == webhook
+    assert mocked_async.called
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(
+    PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"],
+    CELERY_TASK_ALWAYS_EAGER=True,
+)
+def test_checkout_fully_authorized_with_different_channel(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    checkout_JPY_with_item,
+    subscription_webhook,
+    settings,
+):
+    # given
+    manager = get_plugins_manager(False)
+    checkout = checkout_JPY_with_item
+    channel = checkout.channel
+    assert channel.slug != settings.DEFAULT_CHANNEL_SLUG
+
+    event_type = WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED
+
+    query = CHECKOUT_FULLY_AUTHORIZED_SUBSCRIPTION % settings.DEFAULT_CHANNEL_SLUG
+    webhook = subscription_webhook(query, event_type)
+    subscription_query = SubscriptionQuery(query)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.checkout_fully_authorized(checkout)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0
+
+
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.create_event_delivery_list_for_webhooks"
+)
+@patch(
+    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+)
+@override_settings(
+    PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"],
+    CELERY_TASK_ALWAYS_EAGER=True,
+)
+def test_different_event_doesnt_trigger_webhook(
+    mocked_async,
+    mocked_create_event_delivery_list_for_webhooks,
+    checkout_with_item,
+    subscription_webhook,
+    settings,
+):
+    # given
+    manager = get_plugins_manager(False)
+
+    checkout = checkout_with_item
+
+    channel = checkout.channel
+    assert channel.slug == settings.DEFAULT_CHANNEL_SLUG
+
+    event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
+
+    query = CHECKOUT_FULLY_AUTHORIZED_SUBSCRIPTION % settings.DEFAULT_CHANNEL_SLUG
+    webhook = subscription_webhook(query, event_type)
+    subscription_query = SubscriptionQuery(query)
+    webhook.filterable_channel_slugs = subscription_query.get_filterable_channel_slugs()
+    webhook.save()
+
+    # when
+    manager.checkout_fully_authorized(checkout)
+
+    # then
+    assert not mocked_async.called
+    assert not mocked_create_event_delivery_list_for_webhooks.called
+    deliveries = EventDelivery.objects.all()
+    assert len(deliveries) == 0

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1239,6 +1239,7 @@ def async_subscription_webhooks_with_root_objects(
     subscription_collection_metadata_updated_webhook,
     subscription_checkout_created_webhook,
     subscription_checkout_updated_webhook,
+    subscription_checkout_fully_authorized_webhook,
     subscription_checkout_fully_paid_webhook,
     subscription_checkout_metadata_updated_webhook,
     subscription_page_created_webhook,
@@ -1525,6 +1526,10 @@ def async_subscription_webhooks_with_root_objects(
         events.CHECKOUT_UPDATED: [subscription_checkout_updated_webhook, checkout],
         events.CHECKOUT_FULLY_PAID: [
             subscription_checkout_fully_paid_webhook,
+            checkout,
+        ],
+        events.CHECKOUT_FULLY_AUTHORIZED: [
+            subscription_checkout_fully_authorized_webhook,
             checkout,
         ],
         events.CHECKOUT_METADATA_UPDATED: [

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -145,6 +145,7 @@ class WebhookEventAsyncType:
 
     CHECKOUT_CREATED = "checkout_created"
     CHECKOUT_UPDATED = "checkout_updated"
+    CHECKOUT_FULLY_AUTHORIZED = "checkout_fully_authorized"
     CHECKOUT_FULLY_PAID = "checkout_fully_paid"
     CHECKOUT_METADATA_UPDATED = "checkout_metadata_updated"
 
@@ -606,6 +607,10 @@ class WebhookEventAsyncType:
             "name": "Checkout updated",
             "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
             "is_deferred_payload": True,
+        },
+        CHECKOUT_FULLY_AUTHORIZED: {
+            "name": "Checkout fully authorized",
+            "permission": CheckoutPermissions.MANAGE_CHECKOUTS,
         },
         CHECKOUT_FULLY_PAID: {
             "name": "Checkout fully paid",

--- a/saleor/webhook/tests/fixtures/subscription_webhooks.py
+++ b/saleor/webhook/tests/fixtures/subscription_webhooks.py
@@ -812,6 +812,14 @@ def subscription_checkout_fully_paid_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_checkout_fully_authorized_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.CHECKOUT_FULLY_AUTHORIZED,
+        WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED,
+    )
+
+
+@pytest.fixture
 def subscription_checkout_metadata_updated_webhook(subscription_webhook):
     return subscription_webhook(
         queries.CHECKOUT_METADATA_UPDATED,

--- a/saleor/webhook/tests/fixtures/webhook.py
+++ b/saleor/webhook/tests/fixtures/webhook.py
@@ -136,6 +136,14 @@ def setup_checkout_webhooks(
             ...CheckoutFragment
           }
         }
+        ... on CheckoutFullyAuthorized {
+          issuingPrincipal {
+            ...IssuingPrincipal
+          }
+          checkout {
+            ...CheckoutFragment
+          }
+        }
         ... on CheckoutMetadataUpdated {
           issuingPrincipal {
             ...IssuingPrincipal

--- a/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1804,6 +1804,18 @@ CHECKOUT_FULLY_PAID = """
     }
 """
 
+CHECKOUT_FULLY_AUTHORIZED = """
+    subscription{
+      event{
+        ...on CheckoutFullyAuthorized{
+          checkout{
+            id
+          }
+        }
+      }
+    }
+"""
+
 CHECKOUT_METADATA_UPDATED = """
     subscription{
       event{

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -2178,6 +2178,25 @@ def test_checkout_fully_paid(checkout, subscription_checkout_fully_paid_webhook)
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_checkout_fully_authorized(
+    checkout, subscription_checkout_fully_authorized_webhook
+):
+    # given
+    webhooks = [subscription_checkout_fully_authorized_webhook]
+    event_type = WebhookEventAsyncType.CHECKOUT_FULLY_AUTHORIZED
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, checkout, webhooks)
+
+    # then
+    expected_payload = json.dumps({"checkout": {"id": checkout_id}})
+
+    assert deliveries[0].payload.get_payload() == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_checkout_metadata_updated(
     checkout, subscription_checkout_metadata_updated_webhook
 ):


### PR DESCRIPTION
I want to merge this change because it adds a new webhook `CHECKOUT_FULLY_AUTHORIZED`. The webhook is triggered when `checkout.authorizeStatus` is changed to `FULL`. 

It supports subscription query:
```graphql
subscription {
  event{
    ...on CheckoutFullyAuthorized{
      checkout{
        id
      }
    }
  }
}
```
There is also a possibility to filter out by channel slugs:
```graphql
subscription {
  checkoutFullyAuthorized(channels: ["default-channel"]){
    __typename
    checkout{
      id
    }
  }
}
```


Note: Skipping the changelog as this will be ported to 3.21


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/1670

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
