### PR TITLE
Fix `patch` when the `alt` field raises an error inside ProductBulkCreate.

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -61,12 +61,14 @@ def get_results(instances_data_with_errors_list, reject_everything=False):
             for data in instances_data_with_errors_list
         ]
     return [
-        ProductBulkResult(
-            product=ChannelContext(node=data.get("instance"), channel_slug=None),
-            errors=data.get("errors"),
+        (
+            ProductBulkResult(
+                product=ChannelContext(node=data.get("instance"), channel_slug=None),
+                errors=data.get("errors"),
+            )
+            if data.get("instance")
+            else ProductBulkResult(product=None, errors=data.get("errors"))
         )
-        if data.get("instance")
-        else ProductBulkResult(product=None, errors=data.get("errors"))
         for data in instances_data_with_errors_list
     ]
 
@@ -457,7 +459,7 @@ class ProductBulkCreate(BaseMutation):
             if alt and len(alt) > ALT_CHAR_LIMIT:
                 index_error_map[product_index].append(
                     ProductBulkCreateError(
-                        path=f"media.{index}",
+                        path=f"media.{index}.alt",
                         message=f"Alt field exceeds the character "
                         f"limit of {ALT_CHAR_LIMIT}.",
                         code=ProductBulkCreateErrorCode.INVALID.value,
@@ -518,9 +520,11 @@ class ProductBulkCreate(BaseMutation):
             for error in errors:
                 index_error_map[product_index].append(
                     ProductBulkCreateError(
-                        path=f"variants.{index}.{error.path}"
-                        if error.path
-                        else f"variants.{index}",
+                        path=(
+                            f"variants.{index}.{error.path}"
+                            if error.path
+                            else f"variants.{index}"
+                        ),
                         message=error.message,
                         code=error.code,
                         attributes=error.attributes,

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -2054,9 +2054,11 @@ def test_product_bulk_create_with_media_incorrect_alt(
     error_1 = data["results"][0]["errors"]
     assert error_1
     assert len(error_1) == 2
-    for error in error_1:
+    for index, error in enumerate(error_1):
         assert error["code"] == ProductBulkCreateErrorCode.INVALID.name
+        assert error["path"] == f"media.{index}.alt"
     error_2 = data["results"][1]["errors"]
     assert error_2[0]["code"] == ProductBulkCreateErrorCode.INVALID.name
+    assert error_2[0]["path"] == "media.0.alt"
     assert len(error_2) == 1
     assert data["count"] == 0


### PR DESCRIPTION
I want to merge this change because fixing `patch` when the `alt` field raises an error inside ProductBulkCreate.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
