### PR TITLE
Fix failing `checkout` field on User

### DIFF
--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -38,6 +38,10 @@ mutation RegisterAccount($input: AccountRegisterInput!) {
       }
       metafield(key: "test")
       metafields(keys: ["test1"])
+      checkout{
+        id
+      }
+      checkoutTokens
       checkoutIds
       checkouts(first: 10) {
         edges {

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -512,7 +512,7 @@ class User(ModelObjectType[models.User]):
     @staticmethod
     def resolve_checkout(root: models.User, info: ResolveInfo):
         if is_newly_created_user(root):
-            return []
+            return None
         database_connection_name = get_database_connection_name(info.context)
         checkout = get_user_checkout(
             root, database_connection_name=database_connection_name


### PR DESCRIPTION
I want to merge this change because fetching `checkout` field in response to `accountRegister` will always raise an exception.

Port of changes: https://github.com/saleor/saleor/pull/18163

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
