### PR TITLE
Deprecate attribute(s) fields for `Product` and `ProductVariant` type

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -371,6 +371,7 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
             VariantAttributeScope,
             description="Define scope of returned attributes.",
         ),
+        deprecation_reason="Use the `assignedAttributes` field instead.",
     )
     margin = graphene.Int(description="Gross margin percentage value.")
     quantity_ordered = PermissionsField(
@@ -1077,11 +1078,13 @@ class Product(ChannelContextType[models.Product]):
             required=True,
         ),
         description="Get a single attribute attached to product by attribute slug.",
+        deprecation_reason="Use the `assignedAttribute` field instead.",
     )
     attributes = NonNullList(
         SelectedAttribute,
         required=True,
         description="List of attributes assigned to this product.",
+        deprecation_reason="Use the `assignedAttributes` field instead.",
     )
     channel_listings = PermissionsField(
         NonNullList(ProductChannelListing),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5750,10 +5750,10 @@ type Product implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(ca
   attribute(
     """Slug of the attribute"""
     slug: String!
-  ): SelectedAttribute
+  ): SelectedAttribute @deprecated(reason: "Use the `assignedAttribute` field instead.")
 
   """List of attributes assigned to this product."""
-  attributes: [SelectedAttribute!]!
+  attributes: [SelectedAttribute!]! @deprecated(reason: "Use the `assignedAttributes` field instead.")
 
   """
   List of availability in channels for the product.
@@ -7500,7 +7500,7 @@ type ProductVariant implements Node & ObjectWithMetadata & ObjectWithAttributes 
   attributes(
     """Define scope of returned attributes."""
     variantSelection: VariantAttributeScope
-  ): [SelectedAttribute!]!
+  ): [SelectedAttribute!]! @deprecated(reason: "Use the `assignedAttributes` field instead.")
 
   """Gross margin percentage value."""
   margin: Int


### PR DESCRIPTION
I want to merge this change because we introduced a new field for  attributes (`assignedAttribute`), but I forgot to add deprecation reason in `Product`, `Page`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
