### PR TITLE
Fix `null` explicitly passed as the metadata input to `checkoutLinesAdd` mutation.

### DIFF
--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -378,6 +378,9 @@ def group_lines_input_on_add(
         variant_id = cast(str, line.get("variant_id"))
         force_new_line = line.get("force_new_line")
         metadata_list_from_input = line.get("metadata", [])
+        # if metadata is None in input, it should be treated as empty list
+        if not metadata_list_from_input:
+            metadata_list_from_input = []
 
         _, variant_db_id = graphene.Node.from_global_id(variant_id)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -690,6 +690,87 @@ def test_checkout_lines_add_with_existing_variant_and_metadata(
     assert line.metadata == {**old_meta, metadata_key: metadata_value}
 
 
+def test_checkout_lines_add_with_existing_metadata_and_null_in_metadata_input(
+    user_api_client,
+    checkout_with_item,
+    stock,
+):
+    # given
+    checkout = checkout_with_item
+
+    old_meta = {"old_key": "old_value"}
+
+    line = checkout.lines.first()
+    line.store_value_in_metadata(old_meta)
+    line.save(update_fields=["metadata"])
+
+    lines, _ = fetch_checkout_lines(checkout)
+    assert calculate_checkout_quantity(lines) == 3
+    variant_id = graphene.Node.to_global_id("ProductVariant", line.variant_id)
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [
+            {
+                "variantId": variant_id,
+                "quantity": 1,
+                "metadata": None,
+            }
+        ],
+        "channelSlug": checkout.channel.slug,
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesAdd"]
+    checkout.refresh_from_db()
+    line.refresh_from_db()
+
+    # then
+    assert not data["errors"]
+    assert line.quantity == 4
+    assert line.metadata == old_meta
+
+
+def test_checkout_lines_add_with_null_as_metadata_input(
+    user_api_client,
+    checkout_with_item,
+    stock,
+):
+    # given
+    checkout = checkout_with_item
+    line = checkout.lines.first()
+
+    lines, _ = fetch_checkout_lines(checkout)
+    assert calculate_checkout_quantity(lines) == 3
+    variant_id = graphene.Node.to_global_id("ProductVariant", line.variant_id)
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [
+            {
+                "variantId": variant_id,
+                "quantity": 1,
+                "metadata": None,
+            }
+        ],
+        "channelSlug": checkout.channel.slug,
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesAdd"]
+    checkout.refresh_from_db()
+    line.refresh_from_db()
+
+    # then
+    assert not data["errors"]
+    assert line.quantity == 4
+    assert line.metadata == {}
+
+
 def test_checkout_lines_add_with_new_variant_and_metadata(
     user_api_client,
     checkout_with_item,


### PR DESCRIPTION
I want to merge this change because it fixes the situation where null is explicitly passed as the metadata input to the checkoutLinesAdd mutation.

⚠️ ⚠️ ⚠️
Once these changes have been released, https://github.com/saleor/saleor-multitenant/pull/2027 should be merged.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
