### PR TITLE
Add filter over referenced category

### DIFF
--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -13,6 +13,8 @@ from ..attribute.shared_filters import (
     get_attribute_values_by_date_time_value,
     get_attribute_values_by_date_value,
     get_attribute_values_by_numeric_value,
+    get_attribute_values_by_referenced_category_ids,
+    get_attribute_values_by_referenced_category_slugs,
     get_attribute_values_by_referenced_page_ids,
     get_attribute_values_by_referenced_page_slugs,
     get_attribute_values_by_referenced_product_ids,
@@ -266,6 +268,46 @@ def filter_by_contains_referenced_product_slugs(
     return Q()
 
 
+def filter_by_contains_referenced_category_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter pages based on their references to categories.
+
+    - If `contains_all` is provided, only pages that reference all of the
+    specified categories will match.
+    - If `contains_any` is provided, pages that reference at least one of
+    the specified categories will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for category_slug in contains_all:
+            referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+                slugs=[category_slug], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
 def filter_by_contains_referenced_variant_skus(
     attr_id: int | None,
     attr_value: CONTAINS_TYPING,
@@ -310,6 +352,7 @@ def _filter_by_contains_all_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -344,6 +387,17 @@ def _filter_by_contains_all_referenced_object_ids(
                 db_connection_name=db_connection_name,
                 referenced_attr_values=referenced_attr_values,
             )
+    if category_ids:
+        for category_id in category_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+                ids=[category_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+
     return expression
 
 
@@ -351,6 +405,7 @@ def _filter_by_contains_any_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -382,6 +437,15 @@ def _filter_by_contains_any_referenced_object_ids(
             db_connection_name=db_connection_name,
             referenced_attr_values=referenced_attr_values,
         )
+    if category_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+            ids=list(category_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
     return expression
 
 
@@ -396,6 +460,7 @@ def filter_by_contains_referenced_object_ids(
     variant_ids = set()
     product_ids = set()
     page_ids = set()
+    category_ids = set()
 
     for obj_id in contains_any or contains_all or []:
         type_, id_ = graphene.Node.from_global_id(obj_id)
@@ -405,12 +470,15 @@ def filter_by_contains_referenced_object_ids(
             product_ids.add(id_)
         elif type_ == "ProductVariant":
             variant_ids.add(id_)
+        elif type_ == "Category":
+            category_ids.add(id_)
 
     if contains_all:
         return _filter_by_contains_all_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -419,6 +487,7 @@ def filter_by_contains_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -429,7 +498,12 @@ def filter_objects_by_reference_attributes(
     attr_id: int | None,
     attr_value: dict[
         Literal[
-            "referenced_ids", "page_slugs", "product_slugs", "product_variant_skus"
+            "referenced_ids",
+            "page_slugs",
+            "product_slugs",
+            "product_variant_skus",
+            "category_slugs",
+            "collection_slugs",
         ],
         CONTAINS_TYPING,
     ],
@@ -459,6 +533,12 @@ def filter_objects_by_reference_attributes(
         filter_expression &= filter_by_contains_referenced_variant_skus(
             attr_id,
             attr_value["product_variant_skus"],
+            db_connection_name,
+        )
+    if "category_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_category_slugs(
+            attr_id,
+            attr_value["category_slugs"],
             db_connection_name,
         )
     return filter_expression

--- a/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_categories.py
+++ b/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_categories.py
@@ -1,0 +1,302 @@
+import graphene
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import QUERY_PAGES_WITH_WHERE
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attr_slug_and_attribute_value_reference_to_categories(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_category_reference_attribute,
+    category_list,
+):
+    # given
+    page_type.page_attributes.add(page_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=page_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=page_type_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            page_type_category_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {page_type_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "category-reference",
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"),
+    [("containsAny", 2), ("containsAll", 1)],
+)
+def test_pages_query_with_attribute_value_reference_to_category(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_category_reference_attribute,
+    category_list,
+):
+    # given
+    second_category_reference_attribute = Attribute.objects.create(
+        slug="second-category-reference",
+        name="category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.CATEGORY,
+    )
+
+    page_type.page_attributes.add(page_type_category_reference_attribute)
+    page_type.page_attributes.add(second_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=page_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=second_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+
+    page_with_both_references = page_list[0]
+    associate_attribute_values_to_instance(
+        page_with_both_references,
+        {
+            page_type_category_reference_attribute.pk: [
+                attribute_value_1,
+            ],
+            second_category_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    page_with_single_reference = page_list[1]
+    associate_attribute_values_to_instance(
+        page_with_single_reference,
+        {second_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == expected_count
+    assert pages_nodes[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Page", page_list[0].pk
+    )
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_pages_query_with_attr_slug_and_attribute_value_referenced_category_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    page_list,
+    page_type,
+    page_type_category_reference_attribute,
+    category_list,
+):
+    # given
+    page_type.page_attributes.add(
+        page_type_category_reference_attribute,
+    )
+    first_category = category_list[0]
+    second_category = category_list[1]
+    third_category = category_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=page_type_category_reference_attribute,
+                    name=f"Category {first_category.pk}",
+                    slug=f"category-{first_category.pk}",
+                    reference_category=first_category,
+                ),
+                AttributeValue(
+                    attribute=page_type_category_reference_attribute,
+                    name=f"Category {second_category.pk}",
+                    slug=f"category-{second_category.pk}",
+                    reference_category=second_category,
+                ),
+                AttributeValue(
+                    attribute=page_type_category_reference_attribute,
+                    name=f"Category {third_category.pk}",
+                    slug=f"category-{third_category.pk}",
+                    reference_category=third_category,
+                ),
+            ]
+        )
+    )
+    fist_page_with_all_ids = page_list[0]
+    second_page_with_all_ids = page_list[1]
+    page_with_single_id = page_list[2]
+    associate_attribute_values_to_instance(
+        fist_page_with_all_ids,
+        {
+            page_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_page_with_all_ids,
+        {
+            page_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        page_with_single_id,
+        {
+            page_type_category_reference_attribute.pk: [
+                first_attr_value,
+            ],
+        },
+    )
+    referenced_first_global_id = to_global_id_or_none(first_category)
+    referenced_second_global_id = to_global_id_or_none(second_category)
+    referenced_third_global_id = to_global_id_or_none(third_category)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": page_type_category_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                },
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(page_list) > len(pages_nodes)
+    assert len(pages_nodes) == expected_count

--- a/saleor/graphql/product/filters/product_attributes.py
+++ b/saleor/graphql/product/filters/product_attributes.py
@@ -22,6 +22,8 @@ from ...attribute.shared_filters import (
     get_attribute_values_by_date_time_value,
     get_attribute_values_by_date_value,
     get_attribute_values_by_numeric_value,
+    get_attribute_values_by_referenced_category_ids,
+    get_attribute_values_by_referenced_category_slugs,
     get_attribute_values_by_referenced_page_ids,
     get_attribute_values_by_referenced_page_slugs,
     get_attribute_values_by_referenced_product_ids,
@@ -547,10 +549,51 @@ def filter_by_contains_referenced_variant_skus(
     return Q()
 
 
+def filter_by_contains_referenced_category_slugs(
+    attr_id: int | None,
+    attr_value: CONTAINS_TYPING,
+    db_connection_name: str,
+):
+    """Build an expression to filter products based on their references to categories.
+
+    - If `contains_all` is provided, only products that reference all of the
+    specified categories will match.
+    - If `contains_any` is provided, products that reference at least one of
+    the specified categories will match.
+    """
+    contains_all = attr_value.get("contains_all")
+    contains_any = attr_value.get("contains_any")
+
+    if contains_all:
+        expression = Q()
+        for category_slug in contains_all:
+            referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+                slugs=[category_slug], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
+        return expression
+
+    if contains_any:
+        referenced_attr_values = get_attribute_values_by_referenced_category_slugs(
+            slugs=contains_any, db_connection_name=db_connection_name
+        )
+        return _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
+    return Q()
+
+
 def _filter_by_contains_all_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -585,6 +628,16 @@ def _filter_by_contains_all_referenced_object_ids(
                 db_connection_name=db_connection_name,
                 referenced_attr_values=referenced_attr_values,
             )
+    if category_ids:
+        for category_id in category_ids:
+            referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+                ids=[category_id], db_connection_name=db_connection_name
+            )
+            expression &= _filter_contains_single_expression(
+                attr_id=attr_id,
+                db_connection_name=db_connection_name,
+                referenced_attr_values=referenced_attr_values,
+            )
     return expression
 
 
@@ -592,6 +645,7 @@ def _filter_by_contains_any_referenced_object_ids(
     variant_ids: set[int],
     product_ids: set[int],
     page_ids: set[int],
+    category_ids: set[int],
     attr_id: int | None,
     db_connection_name: str,
 ) -> Q:
@@ -623,6 +677,15 @@ def _filter_by_contains_any_referenced_object_ids(
             db_connection_name=db_connection_name,
             referenced_attr_values=referenced_attr_values,
         )
+    if category_ids:
+        referenced_attr_values = get_attribute_values_by_referenced_category_ids(
+            ids=list(category_ids), db_connection_name=db_connection_name
+        )
+        expression |= _filter_contains_single_expression(
+            attr_id=attr_id,
+            db_connection_name=db_connection_name,
+            referenced_attr_values=referenced_attr_values,
+        )
     return expression
 
 
@@ -637,6 +700,7 @@ def filter_by_contains_referenced_object_ids(
     variant_ids = set()
     product_ids = set()
     page_ids = set()
+    category_ids = set()
 
     for obj_id in contains_any or contains_all or []:
         type_, id_ = graphene.Node.from_global_id(obj_id)
@@ -646,12 +710,15 @@ def filter_by_contains_referenced_object_ids(
             product_ids.add(id_)
         elif type_ == "ProductVariant":
             variant_ids.add(id_)
+        elif type_ == "Category":
+            category_ids.add(id_)
 
     if contains_all:
         return _filter_by_contains_all_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -660,6 +727,7 @@ def filter_by_contains_referenced_object_ids(
             variant_ids=variant_ids,
             product_ids=product_ids,
             page_ids=page_ids,
+            category_ids=category_ids,
             attr_id=attr_id,
             db_connection_name=db_connection_name,
         )
@@ -670,7 +738,11 @@ def filter_objects_by_reference_attributes(
     attr_id: int | None,
     attr_value: dict[
         Literal[
-            "referenced_ids", "page_slugs", "product_slugs", "product_variant_skus"
+            "referenced_ids",
+            "page_slugs",
+            "product_slugs",
+            "product_variant_skus",
+            "category_slugs",
         ],
         CONTAINS_TYPING,
     ],
@@ -700,6 +772,12 @@ def filter_objects_by_reference_attributes(
         filter_expression &= filter_by_contains_referenced_variant_skus(
             attr_id,
             attr_value["product_variant_skus"],
+            db_connection_name,
+        )
+    if "category_slugs" in attr_value:
+        filter_expression &= filter_by_contains_referenced_category_slugs(
+            attr_id,
+            attr_value["category_slugs"],
             db_connection_name,
         )
     return filter_expression

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_categories.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_categories.py
@@ -1,0 +1,297 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCTS_FILTER_QUERY, PRODUCTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_reference_to_categories(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_type,
+    product_list,
+    category_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {product_type_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "category-reference",
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_products_query_with_attribute_value_reference_to_categories(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    category_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+):
+    # given
+    second_category_reference_attribute = Attribute.objects.create(
+        slug="second-category-reference",
+        name="Category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.CATEGORY,
+    )
+    product_type.product_attributes.add(
+        product_type_category_reference_attribute,
+        second_category_reference_attribute,
+    )
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=second_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+    product_with_both_references = product_list[0]
+    associate_attribute_values_to_instance(
+        product_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [attribute_value_1],
+            second_category_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_with_single_reference = product_list[1]
+    associate_attribute_values_to_instance(
+        product_with_single_reference,
+        {second_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count
+
+
+@pytest.mark.parametrize("query", [PRODUCTS_WHERE_QUERY, PRODUCTS_FILTER_QUERY])
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_products_query_with_attr_slug_and_attribute_value_referenced_category_ids(
+    query,
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_list,
+    product_type,
+    category_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+):
+    # given
+    product_type.product_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+    third_category = category_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {first_category.pk}",
+                    slug=f"category-{first_category.pk}",
+                    reference_category=first_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {second_category.pk}",
+                    slug=f"category-{second_category.pk}",
+                    reference_category=second_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {third_category.pk}",
+                    slug=f"category-{third_category.pk}",
+                    reference_category=third_category,
+                ),
+            ]
+        )
+    )
+
+    first_product_with_all_ids = product_list[0]
+    second_product_with_all_ids = product_list[1]
+    product_with_single_id = product_list[2]
+    associate_attribute_values_to_instance(
+        first_product_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_with_single_id,
+        {product_type_category_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(first_category)
+    referenced_second_global_id = to_global_id_or_none(second_category)
+    referenced_third_global_id = to_global_id_or_none(third_category)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_category_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == expected_count

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_references_categories.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_references_categories.py
@@ -1,0 +1,292 @@
+import pytest
+
+from ......attribute import AttributeEntityType, AttributeInputType, AttributeType
+from ......attribute.models import Attribute, AttributeValue
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....core.utils import to_global_id_or_none
+from .....tests.utils import get_graphql_content
+from .shared import PRODUCT_VARIANTS_WHERE_QUERY
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_reference_to_categories(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type_category_reference_attribute,
+    channel_USD,
+    category_list,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [
+                attribute_value_1,
+                attribute_value_2,
+            ]
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {product_type_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": "category-reference",
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 2), ("containsAll", 1)]
+)
+def test_product_variants_query_with_attribute_value_reference_to_categories(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    product_type_category_reference_attribute,
+    channel_USD,
+    category_list,
+):
+    # given
+    second_category_reference_attribute = Attribute.objects.create(
+        slug="second-category-reference",
+        name="Category reference",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.REFERENCE,
+        entity_type=AttributeEntityType.CATEGORY,
+    )
+    product_type.variant_attributes.add(
+        product_type_category_reference_attribute,
+        second_category_reference_attribute,
+    )
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+
+    attribute_value_1, attribute_value_2 = AttributeValue.objects.bulk_create(
+        [
+            AttributeValue(
+                attribute=product_type_category_reference_attribute,
+                name=f"Category {first_category.pk}",
+                slug=f"category-{first_category.pk}",
+                reference_category=first_category,
+            ),
+            AttributeValue(
+                attribute=second_category_reference_attribute,
+                name=f"Category {second_category.pk}",
+                slug=f"category-{second_category.pk}",
+                reference_category=second_category,
+            ),
+        ]
+    )
+
+    product_variant_with_both_references = product_variant_list[0]
+    associate_attribute_values_to_instance(
+        product_variant_with_both_references,
+        {
+            product_type_category_reference_attribute.pk: [attribute_value_1],
+            second_category_reference_attribute.pk: [attribute_value_2],
+        },
+    )
+
+    product_variant_with_single_reference = product_variant_list[1]
+    associate_attribute_values_to_instance(
+        product_variant_with_single_reference,
+        {second_category_reference_attribute.pk: [attribute_value_2]},
+    )
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "value": {
+                        "reference": {
+                            "categorySlugs": {
+                                filter_type: [first_category.slug, second_category.slug]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "expected_count"), [("containsAny", 3), ("containsAll", 2)]
+)
+def test_product_variants_query_with_attr_slug_and_attribute_value_referenced_category_ids(
+    filter_type,
+    expected_count,
+    staff_api_client,
+    product_variant_list,
+    product_type,
+    product_type_category_reference_attribute,
+    channel_USD,
+    category_list,
+):
+    # given
+    product_type.variant_attributes.add(product_type_category_reference_attribute)
+
+    first_category = category_list[0]
+    second_category = category_list[1]
+    third_category = category_list[2]
+
+    first_attr_value, second_attr_value, third_attr_value = (
+        AttributeValue.objects.bulk_create(
+            [
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {first_category.pk}",
+                    slug=f"category-{first_category.pk}",
+                    reference_category=first_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {second_category.pk}",
+                    slug=f"category-{second_category.pk}",
+                    reference_category=second_category,
+                ),
+                AttributeValue(
+                    attribute=product_type_category_reference_attribute,
+                    name=f"Category {third_category.pk}",
+                    slug=f"category-{third_category.pk}",
+                    reference_category=third_category,
+                ),
+            ]
+        )
+    )
+    first_product_variant_with_all_ids = product_variant_list[0]
+    second_product_variant_with_all_ids = product_variant_list[1]
+    product_variant_with_single_id = product_variant_list[3]
+    associate_attribute_values_to_instance(
+        first_product_variant_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        second_product_variant_with_all_ids,
+        {
+            product_type_category_reference_attribute.pk: [
+                first_attr_value,
+                second_attr_value,
+                third_attr_value,
+            ],
+        },
+    )
+
+    associate_attribute_values_to_instance(
+        product_variant_with_single_id,
+        {product_type_category_reference_attribute.pk: [first_attr_value]},
+    )
+
+    referenced_first_global_id = to_global_id_or_none(first_category)
+    referenced_second_global_id = to_global_id_or_none(second_category)
+    referenced_third_global_id = to_global_id_or_none(third_category)
+
+    variables = {
+        "where": {
+            "attributes": [
+                {
+                    "slug": product_type_category_reference_attribute.slug,
+                    "value": {
+                        "reference": {
+                            "referencedIds": {
+                                filter_type: [
+                                    referenced_first_global_id,
+                                    referenced_second_global_id,
+                                    referenced_third_global_id,
+                                ]
+                            }
+                        }
+                    },
+                }
+            ]
+        },
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(product_variants_nodes) == expected_count

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7187,6 +7187,11 @@ input AssignedAttributeReferenceInput {
   Returns objects with a reference pointing to a product variant identified by the given sku.
   """
   productVariantSkus: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a category identified by the given slug.
+  """
+  categorySlugs: ContainsFilterInput
 }
 
 """


### PR DESCRIPTION
I want to merge this change because it extends the filter to allow filtering objects by their referenced category.

I’m skipping the changelog since the entire filter will be introduced in 3.22.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
