### PR TITLE
Improve celery logger

### DIFF
--- a/saleor/core/logging.py
+++ b/saleor/core/logging.py
@@ -22,15 +22,17 @@ class JsonFormatter(BaseFormatter):
 
 class JsonCeleryFormatter(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
-        message_dict.update(
-            {
-                "celeryTaskId": record.data.get("id"),
-                "celeryTaskName": record.data.get("name"),
-                "celeryTaskRuntime": record.data.get("runtime"),
-            }
-        )
+        if record and hasattr(record, "data"):
+            if task_id := record.data.get("id"):
+                message_dict["celeryTaskId"] = task_id
+            if task_name := record.data.get("name"):
+                message_dict["celeryTaskName"] = task_name
+            if task_runtime := record.data.get("runtime"):
+                message_dict["celeryTaskRuntime"] = task_runtime
+
         super().add_fields(log_record, record, message_dict)
-        log_record.pop("data")
+        if "data" in log_record:
+            log_record.pop("data")
 
 
 class JsonCeleryTaskFormatter(JsonFormatter):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -349,6 +349,7 @@ LOGGING = {
             "datefmt": "%Y-%m-%dT%H:%M:%SZ",
             "format": (
                 "%(asctime)s %(levelname)s %(celeryTaskId)s %(celeryTaskName)s "
+                "%(message)s "
             ),
         },
         "celery_task_json": {
@@ -413,6 +414,11 @@ LOGGING = {
             "propagate": False,
         },
         "celery.app.trace": {
+            "handlers": ["celery_app"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "celery.worker": {
             "handlers": ["celery_app"],
             "level": "INFO",
             "propagate": False,


### PR DESCRIPTION
I want to merge this change because it fixes the celery logger.
The success event missed the message field.
Additionally wrap celery.worker with our json logger.

This unify the logs produced by Celery.



Port of changes from: https://github.com/saleor/saleor/pull/18204

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
