### PR TITLE
Mark page search index as dirty

### DIFF
--- a/saleor/graphql/attribute/bulk_mutations.py
+++ b/saleor/graphql/attribute/bulk_mutations.py
@@ -6,6 +6,9 @@ from ...attribute import models
 from ...attribute.lock_objects import attribute_value_qs_select_for_update
 from ...permission.enums import PageTypePermissions
 from ...product import models as product_models
+from ...product.utils.search_helpers import (
+    mark_products_search_vector_as_dirty_in_batches,
+)
 from ...webhook.event_types import WebhookEventAsyncType
 from ...webhook.utils import get_webhooks_for_event
 from ..core import ResolveInfo
@@ -46,9 +49,7 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
         _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "Attribute")
         product_ids = cls.get_product_ids_to_update(attribute_pks)
         response = super().perform_mutation(root, info, ids=ids)
-        product_models.Product.objects.filter(id__in=product_ids).update(
-            search_index_dirty=True
-        )
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
         return response
 
     @classmethod
@@ -120,9 +121,7 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "AttributeValue")
         product_ids = cls.get_product_ids_to_update(attribute_pks)
         response = super().perform_mutation(root, info, ids=ids)
-        product_models.Product.objects.filter(id__in=product_ids).update(
-            search_index_dirty=True
-        )
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
         return response
 
     @classmethod

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -18,7 +18,9 @@ from ....attribute.lock_objects import (
     attribute_value_qs_select_for_update,
 )
 from ....core.tracing import traced_atomic_transaction
+from ....page.tasks import mark_pages_search_vector_as_dirty
 from ....permission.enums import PageTypePermissions, ProductTypePermissions
+from ....product.tasks import mark_products_search_vector_as_dirty
 from ....webhook.utils import get_webhooks_for_event
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
@@ -47,7 +49,6 @@ from .mixins import AttributeMixin
 from .utils import (
     get_page_ids_to_search_index_update_for_attribute_values,
     get_product_ids_to_search_index_update_for_attribute_values,
-    mark_search_index_dirty,
 )
 
 
@@ -883,6 +884,7 @@ class AttributeBulkUpdate(BaseMutation):
         # prepare and return data
         results = get_results(instances_data_with_errors_list)
         cls.post_save_actions(info, attributes, values_to_remove, values_to_create)
-        mark_search_index_dirty(product_ids_to_search_update, page_ids_to_search_update)
+        mark_products_search_vector_as_dirty.delay(product_ids_to_search_update)
+        mark_pages_search_vector_as_dirty.delay(page_ids_to_search_update)
 
         return AttributeBulkUpdate(count=len(attributes), results=results)

--- a/saleor/graphql/attribute/mutations/attribute_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_update.py
@@ -1,12 +1,9 @@
 import graphene
 from django.core.exceptions import ValidationError
-from django.db.models import Exists, OuterRef
 
 from ....attribute import models as models
 from ....attribute.error_codes import AttributeErrorCode
-from ....page import models as page_models
 from ....permission.enums import ProductTypePermissions
-from ....product import models as product_models
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
@@ -21,6 +18,11 @@ from ..descriptions import AttributeDescriptions, AttributeValueDescriptions
 from ..types import Attribute
 from .attribute_create import AttributeValueInput
 from .mixins import REFERENCE_TYPES_LIMIT, AttributeMixin
+from .utils import (
+    get_page_ids_to_search_index_update_for_attribute_values,
+    get_product_ids_to_search_index_update_for_attribute_values,
+    mark_search_index_dirty,
+)
 
 
 class AttributeValueUpdateInput(AttributeValueInput):
@@ -161,8 +163,12 @@ class AttributeUpdate(AttributeMixin, ModelWithExtRefMutation):
         cls.clean_attribute(instance, cleaned_input)
         cls.clean_values(cleaned_input, instance)
         remove_values = cls.clean_remove_values(cleaned_input, instance)
-        product_ids = cls.get_product_ids_to_search_index_update(remove_values)
-        page_ids = cls.get_page_ids_to_search_index_update(remove_values)
+        product_ids = get_product_ids_to_search_index_update_for_attribute_values(
+            remove_values
+        )
+        page_ids = get_page_ids_to_search_index_update_for_attribute_values(
+            remove_values
+        )
 
         # Construct the attribute
         instance = cls.construct_instance(instance, cleaned_input)
@@ -173,7 +179,7 @@ class AttributeUpdate(AttributeMixin, ModelWithExtRefMutation):
         cls._save_m2m(info, instance, cleaned_input)
         cls.post_save_action(info, instance, cleaned_input)
         if remove_values:
-            cls.mark_search_index_dirty(product_ids, page_ids)
+            mark_search_index_dirty(product_ids, page_ids)
 
         # Return the attribute that was created
         return AttributeUpdate(attribute=ChannelContext(instance, None))
@@ -182,48 +188,3 @@ class AttributeUpdate(AttributeMixin, ModelWithExtRefMutation):
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.attribute_updated, instance)
-
-    @classmethod
-    def get_product_ids_to_search_index_update(
-        cls, remove_values: list[models.AttributeValue]
-    ) -> list[int]:
-        if not remove_values:
-            return []
-        assigned_variant_values = models.AssignedVariantAttributeValue.objects.filter(
-            value_id__in=[v.id for v in remove_values]
-        )
-        assigned_attributes = models.AssignedVariantAttribute.objects.filter(
-            Exists(assigned_variant_values.filter(assignment_id=OuterRef("id")))
-        )
-        variants = product_models.ProductVariant.objects.filter(
-            Exists(assigned_attributes.filter(variant_id=OuterRef("id")))
-        )
-        assigned_product_values = models.AssignedProductAttributeValue.objects.filter(
-            value_id__in=[v.id for v in remove_values]
-        )
-        product_ids = product_models.Product.objects.filter(
-            Exists(assigned_product_values.filter(product_id=OuterRef("id")))
-            | Exists(variants.filter(product_id=OuterRef("id")))
-        ).values_list("id", flat=True)
-        return list(product_ids)
-
-    @classmethod
-    def get_page_ids_to_search_index_update(
-        cls, remove_values: list[models.AttributeValue]
-    ) -> list[int]:
-        if not remove_values:
-            return []
-        assigned_values = models.AssignedPageAttributeValue.objects.filter(
-            value_id__in=[v.id for v in remove_values]
-        )
-        page_ids = page_models.Page.objects.filter(
-            Exists(assigned_values.filter(page_id=OuterRef("id")))
-        ).values_list("id", flat=True)
-        return list(page_ids)
-
-    @classmethod
-    def mark_search_index_dirty(cls, product_ids: list[int], page_ids: list[int]):
-        product_models.Product.objects.filter(id__in=product_ids).update(
-            search_index_dirty=True
-        )
-        page_models.Page.objects.filter(id__in=page_ids).update(search_index_dirty=True)

--- a/saleor/graphql/attribute/mutations/attribute_value_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_delete.py
@@ -60,7 +60,9 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
         return response
 
     @classmethod
-    def get_product_ids_to_search_index_update(cls, instance):
+    def get_product_ids_to_search_index_update(
+        cls, instance: models.AttributeValue
+    ) -> list[int]:
         variants = product_models.ProductVariant.objects.filter(
             Exists(instance.variantassignments.filter(variant_id=OuterRef("id")))
         )
@@ -71,21 +73,23 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
         return list(product_ids)
 
     @classmethod
-    def get_page_ids_to_search_index_update(cls, instance):
+    def get_page_ids_to_search_index_update(
+        cls, instance: models.AttributeValue
+    ) -> list[int]:
         page_ids = page_models.Page.objects.filter(
             Exists(instance.pagevalueassignment.filter(page_id=OuterRef("id")))
         ).values_list("id", flat=True)
         return list(page_ids)
 
     @classmethod
-    def mark_search_index_dirty(cls, product_ids, page_ids):
+    def mark_search_index_dirty(cls, product_ids: list[int], page_ids: list[int]):
         product_models.Product.objects.filter(id__in=product_ids).update(
             search_index_dirty=True
         )
         page_models.Page.objects.filter(id__in=page_ids).update(search_index_dirty=True)
 
     @classmethod
-    def success_response(cls, instance):
+    def success_response(cls, instance: models.AttributeValue):
         response = super().success_response(instance)
         response.attribute = ChannelContext(instance.attribute, None)
         response.attributeValue = ChannelContext(instance, None)

--- a/saleor/graphql/attribute/mutations/attribute_value_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_delete.py
@@ -3,9 +3,11 @@ from typing import cast
 import graphene
 
 from ....attribute import models as models
-from ....page.tasks import mark_pages_search_vector_as_dirty
+from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
 from ....permission.enums import ProductTypePermissions
-from ....product.tasks import mark_products_search_vector_as_dirty
+from ....product.utils.search_helpers import (
+    mark_products_search_vector_as_dirty_in_batches,
+)
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
@@ -61,8 +63,8 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
         response = super().perform_mutation(
             _root, info, external_reference=external_reference, id=id
         )
-        mark_products_search_vector_as_dirty.delay(product_ids)
-        mark_pages_search_vector_as_dirty.delay(page_ids)
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
+        mark_pages_search_vector_as_dirty_in_batches(page_ids)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.attribute_value_deleted, instance)
         cls.call_event(manager.attribute_updated, instance.attribute)

--- a/saleor/graphql/attribute/mutations/attribute_value_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_update.py
@@ -5,6 +5,7 @@ from django.db.models import Exists, OuterRef, Q
 from ....attribute import models as models
 from ....core.utils.batches import queryset_in_batches
 from ....page import models as page_models
+from ....page.lock_objects import page_qs_select_for_update
 from ....permission.enums import ProductTypePermissions
 from ....product import models as product_models
 from ....product.lock_objects import product_qs_select_for_update
@@ -124,11 +125,7 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
         ).order_by("pk")
         for batch_pks in queryset_in_batches(pages, BATCH_SIZE):
             with transaction.atomic():
-                _pages = list(
-                    page_models.Page.objects.select_for_update().filter(
-                        pk__in=batch_pks
-                    )
-                )
+                _pages = list(page_qs_select_for_update().filter(pk__in=batch_pks))
                 page_models.Page.objects.filter(pk__in=batch_pks).update(
                     search_index_dirty=True
                 )

--- a/saleor/graphql/attribute/mutations/utils.py
+++ b/saleor/graphql/attribute/mutations/utils.py
@@ -1,0 +1,61 @@
+from django.db.models import Exists, OuterRef
+
+from ....attribute import models
+from ....page import models as page_models
+from ....product import models as product_models
+
+
+def get_product_ids_to_search_index_update_for_attribute_values(
+    values: list[models.AttributeValue],
+) -> list[int]:
+    """Get product IDs that need search index updates when attribute values are changed.
+
+    Finds all products that has the given attribute values assigned or their variants
+    have the given attribute values assigned.
+    """
+    if not values:
+        return []
+    assigned_variant_values = models.AssignedVariantAttributeValue.objects.filter(
+        value_id__in=[v.id for v in values]
+    )
+    assigned_attributes = models.AssignedVariantAttribute.objects.filter(
+        Exists(assigned_variant_values.filter(assignment_id=OuterRef("id")))
+    )
+    variants = product_models.ProductVariant.objects.filter(
+        Exists(assigned_attributes.filter(variant_id=OuterRef("id")))
+    )
+    assigned_product_values = models.AssignedProductAttributeValue.objects.filter(
+        value_id__in=[v.id for v in values]
+    )
+    product_ids = product_models.Product.objects.filter(
+        Exists(assigned_product_values.filter(product_id=OuterRef("id")))
+        | Exists(variants.filter(product_id=OuterRef("id")))
+    ).values_list("id", flat=True)
+    return list(product_ids)
+
+
+def get_page_ids_to_search_index_update_for_attribute_values(
+    values: list[models.AttributeValue],
+) -> list[int]:
+    """Get page IDs that need search index updates when attribute values are changed.
+
+    Finds all pages that has the given attribute values assigned.
+    """
+    if not values:
+        return []
+    assigned_values = models.AssignedPageAttributeValue.objects.filter(
+        value_id__in=[v.id for v in values]
+    )
+    page_ids = page_models.Page.objects.filter(
+        Exists(assigned_values.filter(page_id=OuterRef("id")))
+    ).values_list("id", flat=True)
+    return list(page_ids)
+
+
+def mark_search_index_dirty(product_ids: list[int], page_ids: list[int]):
+    """Mark products and pages as needing search index updates."""
+    # TODO: consider moving batches and lock here
+    product_models.Product.objects.filter(id__in=product_ids).update(
+        search_index_dirty=True
+    )
+    page_models.Page.objects.filter(id__in=page_ids).update(search_index_dirty=True)

--- a/saleor/graphql/attribute/mutations/utils.py
+++ b/saleor/graphql/attribute/mutations/utils.py
@@ -1,11 +1,8 @@
-from django.db import transaction
 from django.db.models import Exists, OuterRef
 
 from ....attribute import models
 from ....page import models as page_models
-from ....page.lock_objects import page_qs_select_for_update
 from ....product import models as product_models
-from ....product.lock_objects import product_qs_select_for_update
 
 
 def get_product_ids_to_search_index_update_for_attribute_values(
@@ -53,15 +50,3 @@ def get_page_ids_to_search_index_update_for_attribute_values(
         Exists(assigned_values.filter(page_id=OuterRef("id")))
     ).values_list("id", flat=True)
     return list(page_ids)
-
-
-def mark_search_index_dirty(product_ids: list[int], page_ids: list[int]):
-    """Mark products and pages as needing search index updates."""
-    with transaction.atomic():
-        _products = list(product_qs_select_for_update().filter(pk__in=product_ids))
-        product_models.Product.objects.filter(id__in=product_ids).update(
-            search_index_dirty=True
-        )
-    with transaction.atomic():
-        _pages = list(page_qs_select_for_update().filter(pk__in=page_ids))
-        page_models.Page.objects.filter(id__in=page_ids).update(search_index_dirty=True)

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -1187,7 +1187,6 @@ def test_update_attribute_add_value_does_not_mark_product_search_index_dirty(
 ):
     # given
     attribute = get_product_attributes(product).first()
-
     assert product.search_index_dirty is False
 
     node_id = graphene.Node.to_global_id("Attribute", attribute.id)

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -9,6 +9,10 @@ from freezegun import freeze_time
 from .....attribute import AttributeEntityType, AttributeInputType
 from .....attribute.error_codes import AttributeErrorCode
 from .....attribute.models import Attribute, AttributeValue
+from .....attribute.tests.model_helpers import (
+    get_product_attribute_values,
+    get_product_attributes,
+)
 from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
@@ -1142,3 +1146,136 @@ def test_update_attribute_with_reference_types_product_types_provided_for_page_r
     assert len(errors) == 1
     assert errors[0]["field"] == "referenceTypes"
     assert errors[0]["code"] == AttributeErrorCode.INVALID.name
+
+
+def test_update_attribute_remove_value_marks_product_search_index_dirty(
+    staff_api_client, product, permission_manage_product_types_and_attributes
+):
+    # given
+    query = UPDATE_ATTRIBUTE_MUTATION
+    attribute = get_product_attributes(product).first()
+    value = get_product_attribute_values(product, attribute).first()
+
+    assert product.search_index_dirty is False
+
+    node_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    value_id = graphene.Node.to_global_id("AttributeValue", value.id)
+    variables = {
+        "id": node_id,
+        "input": {
+            "removeValues": [value_id],
+            "addValues": [],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeUpdate"]
+    assert not data["errors"]
+
+    product.refresh_from_db()
+    assert product.search_index_dirty is True
+
+
+def test_update_attribute_add_value_does_not_mark_product_search_index_dirty(
+    staff_api_client, product, permission_manage_product_types_and_attributes
+):
+    # given
+    attribute = get_product_attributes(product).first()
+
+    assert product.search_index_dirty is False
+
+    node_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    variables = {
+        "id": node_id,
+        "input": {
+            "addValues": [{"name": "New value"}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_ATTRIBUTE_MUTATION,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeUpdate"]
+    assert not data["errors"]
+
+    product.refresh_from_db()
+    assert product.search_index_dirty is False
+
+
+def test_update_attribute_remove_value_marks_page_search_index_dirty(
+    staff_api_client, page, permission_manage_product_types_and_attributes
+):
+    # given
+    value = page.attributevalues.first().value
+    attribute = value.attribute
+
+    assert page.search_index_dirty is False
+
+    node_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    value_id = graphene.Node.to_global_id("AttributeValue", value.id)
+    variables = {
+        "id": node_id,
+        "input": {
+            "removeValues": [value_id],
+            "addValues": [],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_ATTRIBUTE_MUTATION,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeUpdate"]
+    assert not data["errors"]
+
+    page.refresh_from_db()
+    assert page.search_index_dirty is True
+
+
+def test_update_attribute_add_value_does_not_mark_page_search_index_dirty(
+    staff_api_client, page, permission_manage_product_types_and_attributes
+):
+    # given
+    attribute = page.attributevalues.first().value.attribute
+
+    assert page.search_index_dirty is False
+
+    node_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    variables = {
+        "id": node_id,
+        "input": {
+            "addValues": [{"name": "New value"}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_ATTRIBUTE_MUTATION,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeUpdate"]
+    assert not data["errors"]
+
+    page.refresh_from_db()
+    assert page.search_index_dirty is False

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -72,6 +72,28 @@ def test_delete_attribute_value_update_search_index_dirty_in_product(
     assert product.search_index_dirty is True
 
 
+def test_delete_attribute_value_update_search_index_dirty_in_page(
+    staff_api_client,
+    page,
+    permission_manage_product_types_and_attributes,
+):
+    # given
+    attribute_value = page.attributevalues.first()
+    query = ATTRIBUTE_VALUE_DELETE_MUTATION
+    node_id = graphene.Node.to_global_id("AttributeValue", attribute_value.value.id)
+    variables = {"id": node_id}
+    assert page.search_index_dirty is False
+
+    # when
+    staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    page.refresh_from_db(fields=["search_index_dirty"])
+    assert page.search_index_dirty is True
+
+
 @freeze_time("2022-05-12 12:00:00")
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -80,7 +80,7 @@ def test_delete_attribute_value_update_search_index_dirty_in_page(
     # given
     attribute_value = page.attributevalues.first()
     query = ATTRIBUTE_VALUE_DELETE_MUTATION
-    node_id = graphene.Node.to_global_id("AttributeValue", attribute_value.value.id)
+    node_id = graphene.Node.to_global_id("AttributeValue", attribute_value.value_id)
     variables = {"id": node_id}
     assert page.search_index_dirty is False
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -115,6 +115,30 @@ def test_update_attribute_value_update_search_index_dirty_in_product(
     assert product.search_index_dirty is True
 
 
+def test_update_attribute_value_update_search_index_dirty_in_page(
+    staff_api_client,
+    page,
+    permission_manage_product_types_and_attributes,
+):
+    # given
+    query = UPDATE_ATTRIBUTE_VALUE_MUTATION
+
+    attribute_value = page.attributevalues.first()
+
+    node_id = graphene.Node.to_global_id("AttributeValue", attribute_value.value_id)
+    name = "Crimson name"
+    variables = {"input": {"name": name}, "id": node_id}
+
+    # when
+    staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    page.refresh_from_db(fields=["search_index_dirty"])
+    assert page.search_index_dirty is True
+
+
 @freeze_time("2022-05-12 12:00:00")
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -9,8 +9,10 @@ from ...attribute.lock_objects import attribute_value_qs_select_for_update
 from ...core.tracing import traced_atomic_transaction
 from ...page import models
 from ...permission.enums import PagePermissions, PageTypePermissions
-from ...product.lock_objects import product_qs_select_for_update
 from ...product.models import Product
+from ...product.utils.search_helpers import (
+    mark_products_search_vector_as_dirty_in_batches,
+)
 from ...webhook.event_types import WebhookEventAsyncType
 from ...webhook.utils import get_webhooks_for_event
 from ..core import ResolveInfo
@@ -50,22 +52,19 @@ class PageBulkDelete(ModelBulkDeleteMutation):
     @classmethod
     def update_products_search_index(cls, instance_pks):
         # Mark products that use these page instances as references as dirty
-        with transaction.atomic():
-            locked_ids = (
-                product_qs_select_for_update()
-                .filter(
-                    Exists(
-                        attribute_models.AssignedProductAttributeValue.objects.filter(
-                            product_id=OuterRef("id"),
-                            value__in=attribute_models.AttributeValue.objects.filter(
-                                reference_page__in=instance_pks
-                            ),
-                        )
+        products_ids = list(
+            Product.objects.filter(
+                Exists(
+                    attribute_models.AssignedProductAttributeValue.objects.filter(
+                        product_id=OuterRef("id"),
+                        value__in=attribute_models.AttributeValue.objects.filter(
+                            reference_page__in=instance_pks
+                        ),
                     )
                 )
-                .values_list("id", flat=True)
-            )
-            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)
+            ).values_list("id", flat=True)
+        )
+        mark_products_search_vector_as_dirty_in_batches(products_ids)
 
     @classmethod
     def delete_assigned_attribute_values(cls, instance_pks):
@@ -150,22 +149,19 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
         page_ids = models.Page.objects.filter(page_type__in=instance_pks).values_list(
             "id", flat=True
         )
-        with transaction.atomic():
-            locked_ids = (
-                product_qs_select_for_update()
-                .filter(
-                    Exists(
-                        attribute_models.AssignedProductAttributeValue.objects.filter(
-                            product_id=OuterRef("id"),
-                            value__in=attribute_models.AttributeValue.objects.filter(
-                                reference_page_id__in=page_ids
-                            ),
-                        )
+        product_ids = list(
+            Product.objects.filter(
+                Exists(
+                    attribute_models.AssignedProductAttributeValue.objects.filter(
+                        product_id=OuterRef("id"),
+                        value__in=attribute_models.AttributeValue.objects.filter(
+                            reference_page_id__in=page_ids
+                        ),
                     )
                 )
-                .values_list("id", flat=True)
-            )
-            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)
+            ).values_list("id", flat=True)
+        )
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/page/mutations/page_attribute_assign.py
+++ b/saleor/graphql/page/mutations/page_attribute_assign.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from ....attribute import AttributeType, models
 from ....page import models as page_models
 from ....page.error_codes import PageErrorCode
-from ....page.tasks import mark_pages_search_vector_as_dirty
+from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
 from ....permission.enums import PageTypePermissions
 from ...attribute.types import Attribute
 from ...core import ResolveInfo
@@ -113,5 +113,5 @@ class PageAttributeAssign(BaseMutation):
                 "pk", flat=True
             )
         )
-        mark_pages_search_vector_as_dirty.delay(page_ids)
+        mark_pages_search_vector_as_dirty_in_batches(page_ids)
         return cls(page_type=page_type)

--- a/saleor/graphql/page/mutations/page_attribute_assign.py
+++ b/saleor/graphql/page/mutations/page_attribute_assign.py
@@ -103,4 +103,12 @@ class PageAttributeAssign(BaseMutation):
 
         page_type.page_attributes.add(*attr_pks)
 
+        # Mark related page search indexes as dirty. Currently, unassigning attributes
+        # from a page type does not remove their values from existing pages.
+        # As a result, if the attribute is reassigned, its value should be included
+        # in the page search vector.
+        page_models.Page.objects.filter(page_type_id=page_type.pk).update(
+            search_index_dirty=True
+        )
+
         return cls(page_type=page_type)

--- a/saleor/graphql/page/mutations/page_attribute_assign.py
+++ b/saleor/graphql/page/mutations/page_attribute_assign.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from ....attribute import AttributeType, models
 from ....page import models as page_models
 from ....page.error_codes import PageErrorCode
+from ....page.tasks import mark_pages_search_vector_as_dirty
 from ....permission.enums import PageTypePermissions
 from ...attribute.types import Attribute
 from ...core import ResolveInfo
@@ -107,8 +108,10 @@ class PageAttributeAssign(BaseMutation):
         # from a page type does not remove their values from existing pages.
         # As a result, if the attribute is reassigned, its value should be included
         # in the page search vector.
-        page_models.Page.objects.filter(page_type_id=page_type.pk).update(
-            search_index_dirty=True
+        page_ids = list(
+            page_models.Page.objects.filter(page_type=page_type).values_list(
+                "pk", flat=True
+            )
         )
-
+        mark_pages_search_vector_as_dirty.delay(page_ids)
         return cls(page_type=page_type)

--- a/saleor/graphql/page/mutations/page_attribute_unassign.py
+++ b/saleor/graphql/page/mutations/page_attribute_unassign.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ....page import models
-from ....page.tasks import mark_pages_search_vector_as_dirty
+from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
 from ....permission.enums import PageTypePermissions
 from ...attribute.types import Attribute
 from ...core import ResolveInfo
@@ -51,6 +51,6 @@ class PageAttributeUnassign(BaseMutation):
         page_ids = list(
             models.Page.objects.filter(page_type=page_type).values_list("pk", flat=True)
         )
-        mark_pages_search_vector_as_dirty.delay(page_ids)
+        mark_pages_search_vector_as_dirty_in_batches(page_ids)
 
         return cls(page_type=page_type)

--- a/saleor/graphql/page/mutations/page_attribute_unassign.py
+++ b/saleor/graphql/page/mutations/page_attribute_unassign.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ....page import models
 from ....permission.enums import PageTypePermissions
 from ...attribute.types import Attribute
 from ...core import ResolveInfo
@@ -45,5 +46,9 @@ class PageAttributeUnassign(BaseMutation):
         _, attr_pks = resolve_global_ids_to_primary_keys(attribute_ids, Attribute)
 
         page_type.page_attributes.remove(*attr_pks)
+
+        models.Page.objects.filter(page_type_id=page_type.pk).update(
+            search_index_dirty=True
+        )
 
         return cls(page_type=page_type)

--- a/saleor/graphql/page/mutations/page_delete.py
+++ b/saleor/graphql/page/mutations/page_delete.py
@@ -7,7 +7,9 @@ from ....core.tracing import traced_atomic_transaction
 from ....page import models
 from ....permission.enums import PagePermissions
 from ....product.models import Product
-from ....product.tasks import mark_products_search_vector_as_dirty
+from ....product.utils.search_helpers import (
+    mark_products_search_vector_as_dirty_in_batches,
+)
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
 from ...core.mutations import ModelDeleteMutation
@@ -57,7 +59,7 @@ class PageDelete(ModelDeleteMutation):
                 )
             ).values_list("id", flat=True)
         )
-        mark_products_search_vector_as_dirty.delay(product_ids)
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
 
     @staticmethod
     def delete_assigned_attribute_values(instance):

--- a/saleor/graphql/page/mutations/page_delete.py
+++ b/saleor/graphql/page/mutations/page_delete.py
@@ -1,5 +1,4 @@
 import graphene
-from django.db import transaction
 from django.db.models.expressions import Exists, OuterRef
 
 from ....attribute import AttributeInputType
@@ -7,8 +6,8 @@ from ....attribute import models as attribute_models
 from ....core.tracing import traced_atomic_transaction
 from ....page import models
 from ....permission.enums import PagePermissions
-from ....product.lock_objects import product_qs_select_for_update
 from ....product.models import Product
+from ....product.tasks import mark_products_search_vector_as_dirty
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
 from ...core.mutations import ModelDeleteMutation
@@ -46,22 +45,19 @@ class PageDelete(ModelDeleteMutation):
     @classmethod
     def update_products_search_index(cls, instance):
         # Mark products that use this instance as reference as dirty
-        with transaction.atomic():
-            locked_ids = (
-                product_qs_select_for_update()
-                .filter(
-                    Exists(
-                        attribute_models.AssignedProductAttributeValue.objects.filter(
-                            value__in=attribute_models.AttributeValue.objects.filter(
-                                reference_page=instance
-                            ),
-                            product_id=OuterRef("id"),
-                        )
+        product_ids = list(
+            Product.objects.filter(
+                Exists(
+                    attribute_models.AssignedProductAttributeValue.objects.filter(
+                        value__in=attribute_models.AttributeValue.objects.filter(
+                            reference_page=instance
+                        ),
+                        product_id=OuterRef("id"),
                     )
                 )
-                .values_list("id", flat=True)
-            )
-            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)
+            ).values_list("id", flat=True)
+        )
+        mark_products_search_vector_as_dirty.delay(product_ids)
 
     @staticmethod
     def delete_assigned_attribute_values(instance):

--- a/saleor/graphql/page/mutations/page_type_delete.py
+++ b/saleor/graphql/page/mutations/page_type_delete.py
@@ -7,7 +7,9 @@ from ....core.tracing import traced_atomic_transaction
 from ....page import models
 from ....permission.enums import PageTypePermissions
 from ....product.models import Product
-from ....product.tasks import mark_products_search_vector_as_dirty
+from ....product.utils.search_helpers import (
+    mark_products_search_vector_as_dirty_in_batches,
+)
 from ...core import ResolveInfo
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import PageError
@@ -55,7 +57,7 @@ class PageTypeDelete(ModelDeleteMutation):
                 )
             ).values_list("id", flat=True)
         )
-        mark_products_search_vector_as_dirty.delay(product_ids)
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
 
     @staticmethod
     def delete_assigned_attribute_values(instance_pk):

--- a/saleor/graphql/page/mutations/page_type_delete.py
+++ b/saleor/graphql/page/mutations/page_type_delete.py
@@ -1,5 +1,4 @@
 import graphene
-from django.db import transaction
 from django.db.models.expressions import Exists, OuterRef
 
 from ....attribute import AttributeInputType
@@ -7,8 +6,8 @@ from ....attribute import models as attribute_models
 from ....core.tracing import traced_atomic_transaction
 from ....page import models
 from ....permission.enums import PageTypePermissions
-from ....product.lock_objects import product_qs_select_for_update
 from ....product.models import Product
+from ....product.tasks import mark_products_search_vector_as_dirty
 from ...core import ResolveInfo
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import PageError
@@ -44,22 +43,19 @@ class PageTypeDelete(ModelDeleteMutation):
         page_ids = models.Page.objects.filter(page_type=instance).values_list(
             "id", flat=True
         )
-        with transaction.atomic():
-            locked_ids = (
-                product_qs_select_for_update()
-                .filter(
-                    Exists(
-                        attribute_models.AssignedProductAttributeValue.objects.filter(
-                            product_id=OuterRef("id"),
-                            value__in=attribute_models.AttributeValue.objects.filter(
-                                reference_page_id__in=page_ids
-                            ),
-                        )
+        product_ids = list(
+            Product.objects.filter(
+                Exists(
+                    attribute_models.AssignedProductAttributeValue.objects.filter(
+                        product_id=OuterRef("id"),
+                        value__in=attribute_models.AttributeValue.objects.filter(
+                            reference_page_id__in=page_ids
+                        ),
                     )
                 )
-                .values_list("id", flat=True)
-            )
-            Product.objects.filter(id__in=locked_ids).update(search_index_dirty=True)
+            ).values_list("id", flat=True)
+        )
+        mark_products_search_vector_as_dirty.delay(product_ids)
 
     @staticmethod
     def delete_assigned_attribute_values(instance_pk):

--- a/saleor/graphql/page/mutations/page_type_update.py
+++ b/saleor/graphql/page/mutations/page_type_update.py
@@ -20,7 +20,7 @@ from .page_type_create import PageTypeCreateInput, PageTypeMixin
 class PageTypeUpdateInput(PageTypeCreateInput):
     remove_attributes = NonNullList(
         graphene.ID,
-        description="List of attribute IDs to be assigned to the page type.",
+        description="List of attribute IDs to be unassigned from the page type.",
     )
 
     class Meta:
@@ -86,3 +86,14 @@ class PageTypeUpdate(PageTypeMixin, DeprecatedModelMutation):
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_type_updated, instance)
+        # Mark pages for search index update if page type structure or identification changed
+        should_update_search_index = (
+            cleaned_input.get("remove_attributes")
+            or "name" in cleaned_input
+            or "slug" in cleaned_input
+        )
+
+        if should_update_search_index:
+            models.Page.objects.filter(page_type_id=instance.pk).update(
+                search_index_dirty=True
+            )

--- a/saleor/graphql/page/mutations/page_type_update.py
+++ b/saleor/graphql/page/mutations/page_type_update.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 
 from ....page import models
 from ....page.error_codes import PageErrorCode
-from ....page.tasks import mark_pages_search_vector_as_dirty
+from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
 from ....permission.enums import PageTypePermissions
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_PAGES
@@ -100,4 +100,4 @@ class PageTypeUpdate(PageTypeMixin, DeprecatedModelMutation):
                     "pk", flat=True
                 )
             )
-            mark_pages_search_vector_as_dirty.delay(page_ids)
+            mark_pages_search_vector_as_dirty_in_batches(page_ids)

--- a/saleor/graphql/page/mutations/page_update.py
+++ b/saleor/graphql/page/mutations/page_update.py
@@ -6,7 +6,9 @@ from ....core.utils.update_mutation_manager import InstanceTracker
 from ....page import models
 from ....permission.enums import PagePermissions
 from ....product.models import Product
-from ....product.tasks import mark_products_search_vector_as_dirty
+from ....product.utils.search_helpers import (
+    mark_products_search_vector_as_dirty_in_batches,
+)
 from ...attribute.utils.attribute_assignment import AttributeAssignmentMixin
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
@@ -76,7 +78,7 @@ class PageUpdate(PageCreate):
                 )
             ).values_list("id", flat=True)
         )
-        mark_products_search_vector_as_dirty.delay(product_ids)
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
 
     @classmethod
     def success_response(cls, instance):

--- a/saleor/graphql/page/tests/mutations/test_page_attribute_assign.py
+++ b/saleor/graphql/page/tests/mutations/test_page_attribute_assign.py
@@ -35,6 +35,7 @@ def test_assign_attributes_to_page_type_by_staff(
     staff_api_client,
     permission_manage_page_types_and_attributes,
     page_type,
+    page,
     author_page_attribute,
 ):
     # given
@@ -42,6 +43,7 @@ def test_assign_attributes_to_page_type_by_staff(
     staff_user.user_permissions.add(permission_manage_page_types_and_attributes)
 
     page_type_attr_count = page_type.page_attributes.count()
+    assert page.search_index_dirty is False
 
     author_page_attr_id = graphene.Node.to_global_id(
         "Attribute", author_page_attribute.pk
@@ -65,12 +67,15 @@ def test_assign_attributes_to_page_type_by_staff(
     assert author_page_attr_id in {
         attr["id"] for attr in data["pageType"]["attributes"]
     }
+    page.refresh_from_db()
+    assert page.search_index_dirty is True
 
 
 def test_assign_attributes_to_page_type_by_app(
     app_api_client,
     permission_manage_page_types_and_attributes,
     page_type,
+    page,
     author_page_attribute,
 ):
     # given
@@ -78,6 +83,7 @@ def test_assign_attributes_to_page_type_by_app(
     app.permissions.add(permission_manage_page_types_and_attributes)
 
     page_type_attr_count = page_type.page_attributes.count()
+    assert page.search_index_dirty is False
 
     author_page_attr_id = graphene.Node.to_global_id(
         "Attribute", author_page_attribute.pk
@@ -101,6 +107,8 @@ def test_assign_attributes_to_page_type_by_app(
     assert author_page_attr_id in {
         attr["id"] for attr in data["pageType"]["attributes"]
     }
+    page.refresh_from_db()
+    assert page.search_index_dirty is True
 
 
 def test_assign_attributes_to_page_type_by_staff_no_perm(

--- a/saleor/graphql/page/tests/mutations/test_page_attribute_unassign.py
+++ b/saleor/graphql/page/tests/mutations/test_page_attribute_unassign.py
@@ -27,7 +27,7 @@ PAGE_UNASSIGN_ATTR_QUERY = """
 
 
 def test_unassign_attributes_from_page_type_by_staff(
-    staff_api_client, page_type, permission_manage_page_types_and_attributes
+    staff_api_client, page_type, page, permission_manage_page_types_and_attributes
 ):
     # given
     staff_user = staff_api_client.user
@@ -36,6 +36,7 @@ def test_unassign_attributes_from_page_type_by_staff(
     attr_count = page_type.page_attributes.count()
     attr_to_unassign = page_type.page_attributes.first()
     attr_to_unassign_id = graphene.Node.to_global_id("Attribute", attr_to_unassign.pk)
+    assert page.search_index_dirty is False
 
     variables = {
         "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
@@ -55,6 +56,8 @@ def test_unassign_attributes_from_page_type_by_staff(
     assert attr_to_unassign_id not in {
         attr["id"] for attr in data["pageType"]["attributes"]
     }
+    page.refresh_from_db()
+    assert page.search_index_dirty is True
 
 
 def test_unassign_attributes_from_page_type_by_staff_no_perm(
@@ -77,11 +80,12 @@ def test_unassign_attributes_from_page_type_by_staff_no_perm(
 
 
 def test_unassign_attributes_from_page_type_by_app(
-    app_api_client, page_type, permission_manage_page_types_and_attributes
+    app_api_client, page_type, page, permission_manage_page_types_and_attributes
 ):
     # given
     app = app_api_client.app
     app.permissions.add(permission_manage_page_types_and_attributes)
+    assert page.search_index_dirty is False
 
     attr_count = page_type.page_attributes.count()
     attr_to_unassign = page_type.page_attributes.first()
@@ -105,6 +109,8 @@ def test_unassign_attributes_from_page_type_by_app(
     assert attr_to_unassign_id not in {
         attr["id"] for attr in data["pageType"]["attributes"]
     }
+    page.refresh_from_db()
+    assert page.search_index_dirty is True
 
 
 def test_unassign_attributes_from_page_type_by_app_no_perm(app_api_client, page_type):

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -357,7 +357,7 @@ class ProductAttributeUnassign(BaseMutation):
         cls.save_field_values(product_type, "variant_attributes", attribute_pks)
 
         product_ids = list(
-            Product.objects.filter(product_type=product_type).values_list(
+            models.Product.objects.filter(product_type=product_type).values_list(
                 "id", flat=True
             )
         )

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -10,6 +10,9 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions, ProductTypePermissions
 from ....product import models
 from ....product.error_codes import ProductErrorCode
+from ....product.utils.search_helpers import (
+    mark_products_search_vector_as_dirty_in_batches,
+)
 from ...attribute.mutations import (
     BaseReorderAttributesMutation,
     BaseReorderAttributeValuesMutation,
@@ -353,7 +356,12 @@ class ProductAttributeUnassign(BaseMutation):
         cls.save_field_values(product_type, "product_attributes", attribute_pks)
         cls.save_field_values(product_type, "variant_attributes", attribute_pks)
 
-        product_type.products.all().update(search_index_dirty=True)
+        product_ids = list(
+            Product.objects.filter(product_type=product_type).values_list(
+                "id", flat=True
+            )
+        )
+        mark_products_search_vector_as_dirty_in_batches(product_ids)
 
         return cls(product_type=product_type)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -24400,7 +24400,7 @@ input PageTypeUpdateInput @doc(category: "Pages") {
   """List of attribute IDs to be assigned to the page type."""
   addAttributes: [ID!]
 
-  """List of attribute IDs to be assigned to the page type."""
+  """List of attribute IDs to be unassigned from the page type."""
   removeAttributes: [ID!]
 }
 

--- a/saleor/page/tasks.py
+++ b/saleor/page/tasks.py
@@ -1,15 +1,42 @@
 import logging
 
 from django.conf import settings
+from django.db import transaction
 
 from ..celeryconf import app
+from ..core.db.connection import allow_writer
+from .lock_objects import page_qs_select_for_update
 from .models import Page
 from .search import update_pages_search_vector
 
 logger = logging.getLogger(__name__)
 
 # TODO: validate the batch size
-PAGE_BATCH_SIZE = 200
+UPDATE_SEARCH_BATCH_SIZE = 200
+
+# Results in update time ~0.2s, consumes ~30 MB
+MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE = 1000
+
+
+@app.task
+@allow_writer()
+def mark_pages_search_vector_as_dirty(page_ids: list[int]):
+    """Mark pages as needing search index updates."""
+    page_ids_to_update = page_ids[:MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE]
+    if not page_ids_to_update:
+        return
+    with transaction.atomic():
+        _pages = list(
+            page_qs_select_for_update()
+            .filter(pk__in=page_ids_to_update)
+            .values_list("id", flat=True)
+        )
+        Page.objects.filter(id__in=page_ids_to_update).update(search_index_dirty=True)
+
+    if len(page_ids) > MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE:
+        mark_pages_search_vector_as_dirty.delay(
+            page_ids[MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE:]
+        )
 
 
 @app.task(
@@ -20,7 +47,7 @@ def update_pages_search_vector_task():
     pages = list(
         Page.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME).filter(
             search_index_dirty=True
-        )[:PAGE_BATCH_SIZE]
+        )[:UPDATE_SEARCH_BATCH_SIZE]
     )
     if not pages:
         return

--- a/saleor/page/tasks.py
+++ b/saleor/page/tasks.py
@@ -14,29 +14,20 @@ logger = logging.getLogger(__name__)
 # TODO: validate the batch size
 UPDATE_SEARCH_BATCH_SIZE = 200
 
-# Results in update time ~0.2s, consumes ~30 MB
-MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE = 1000
-
 
 @app.task
 @allow_writer()
 def mark_pages_search_vector_as_dirty(page_ids: list[int]):
     """Mark pages as needing search index updates."""
-    page_ids_to_update = page_ids[:MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE]
-    if not page_ids_to_update:
+    if not page_ids:
         return
     with transaction.atomic():
         _pages = list(
             page_qs_select_for_update()
-            .filter(pk__in=page_ids_to_update)
+            .filter(pk__in=page_ids)
             .values_list("id", flat=True)
         )
-        Page.objects.filter(id__in=page_ids_to_update).update(search_index_dirty=True)
-
-    if len(page_ids) > MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE:
-        mark_pages_search_vector_as_dirty.delay(
-            page_ids[MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE:]
-        )
+        Page.objects.filter(id__in=_pages).update(search_index_dirty=True)
 
 
 @app.task(

--- a/saleor/page/tasks.py
+++ b/saleor/page/tasks.py
@@ -22,12 +22,8 @@ def mark_pages_search_vector_as_dirty(page_ids: list[int]):
     if not page_ids:
         return
     with transaction.atomic():
-        _pages = list(
-            page_qs_select_for_update()
-            .filter(pk__in=page_ids)
-            .values_list("id", flat=True)
-        )
-        Page.objects.filter(id__in=_pages).update(search_index_dirty=True)
+        ids = page_qs_select_for_update().filter(pk__in=page_ids).values("id")
+        Page.objects.filter(id__in=ids).update(search_index_dirty=True)
 
 
 @app.task(

--- a/saleor/page/tests/fixtures/page.py
+++ b/saleor/page/tests/fixtures/page.py
@@ -13,6 +13,7 @@ def page(db, page_type, size_page_attribute):
         "content": dummy_editorjs("Test content."),
         "is_published": True,
         "page_type": page_type,
+        "search_index_dirty": False,
     }
     page = Page.objects.create(**data)
 

--- a/saleor/page/tests/fixtures/page.py
+++ b/saleor/page/tests/fixtures/page.py
@@ -3,6 +3,7 @@ import pytest
 from ....attribute.utils import associate_attribute_values_to_instance
 from ....tests.utils import dummy_editorjs
 from ...models import Page
+from ...search import update_pages_search_vector
 
 
 @pytest.fixture
@@ -22,6 +23,7 @@ def page(db, page_type, size_page_attribute):
     associate_attribute_values_to_instance(
         page, {size_page_attribute.pk: [page_attr_value]}
     )
+    update_pages_search_vector([page])
 
     return page
 

--- a/saleor/page/tests/test_tasks.py
+++ b/saleor/page/tests/test_tasks.py
@@ -46,20 +46,3 @@ def test_mark_pages_search_vector_as_dirty(page_list):
             "search_index_dirty", flat=True
         )
     )
-
-
-@patch("saleor.page.tasks.MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE", 1)
-def test_mark_pages_search_vector_as_dirty_batches(page_list):
-    # given
-    page_ids = [page.id for page in page_list]
-    Page.objects.all().update(search_index_dirty=False)
-
-    # when
-    mark_pages_search_vector_as_dirty(page_ids)
-
-    # then
-    assert all(
-        Page.objects.filter(id__in=page_ids).values_list(
-            "search_index_dirty", flat=True
-        )
-    )

--- a/saleor/page/tests/test_utils.py
+++ b/saleor/page/tests/test_utils.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+from ..models import Page
+from ..utils import mark_pages_search_vector_as_dirty_in_batches
+
+
+@patch("saleor.page.utils.MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE", 1)
+def test_mark_pages_search_vector_as_dirty_in_batches(page_list):
+    # given
+    page_ids = [page.id for page in page_list]
+    Page.objects.all().update(search_index_dirty=False)
+
+    # when
+    mark_pages_search_vector_as_dirty_in_batches(page_ids)
+
+    # then
+    assert all(
+        Page.objects.filter(id__in=page_ids).values_list(
+            "search_index_dirty", flat=True
+        )
+    )

--- a/saleor/page/utils.py
+++ b/saleor/page/utils.py
@@ -1,0 +1,11 @@
+from .tasks import mark_pages_search_vector_as_dirty
+
+# Results in update time ~0.2s, consumes ~30 MB
+MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE = 1000
+
+
+def mark_pages_search_vector_as_dirty_in_batches(page_ids: list[int]):
+    """Mark pages as needing search index updates."""
+    for i in range(0, len(page_ids), MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE):
+        batch_ids = page_ids[i : i + MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE]
+        mark_pages_search_vector_as_dirty.delay(batch_ids)

--- a/saleor/product/utils/search_helpers.py
+++ b/saleor/product/utils/search_helpers.py
@@ -1,0 +1,11 @@
+from ..tasks import mark_products_search_vector_as_dirty
+
+# Results in update time ~0.2s, consumes ~30 MB
+MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE = 1000
+
+
+def mark_products_search_vector_as_dirty_in_batches(product_ids: list[int]):
+    """Mark products as needing search index updates."""
+    for i in range(0, len(product_ids), MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE):
+        batch_ids = product_ids[i : i + MARK_SEARCH_VECTOR_DIRTY_BATCH_SIZE]
+        mark_products_search_vector_as_dirty.delay(batch_ids)


### PR DESCRIPTION
- Extend `Page` model with `search_vector` and `search_index_dirty`
- Mark search vectors as dirty on the following mutations (also update for `Product` in case it was missing):
  - `PageUpdate`
  - `PageTypeUpdate`
  - `PageAttributeUnassign`
  - `PageAttributeAssign`
  - `AttributeValueUpdate`
  - `AttributeValueDelete`
  - `AttributeUpdate`
  - `AttributeDelete`
  - `AttributeBulkUpdate`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
