### PR TITLE
Prevent circular payload generation when listing shipping methods for checkout

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from collections import defaultdict
 from decimal import Decimal
 from unittest import mock
@@ -8,6 +9,7 @@ import graphene
 import pytest
 from django.core.exceptions import ValidationError
 from django.db.models import F
+from django.test import override_settings
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django_countries.fields import Country
@@ -40,7 +42,7 @@ from ....product.models import (
     ProductVariant,
     ProductVariantChannelListing,
 )
-from ....shipping.models import ShippingMethodTranslation
+from ....shipping.models import ShippingMethod, ShippingMethodTranslation
 from ....shipping.utils import convert_to_shipping_method_data
 from ....tests.utils import dummy_editorjs
 from ....warehouse import WarehouseClickAndCollectOption
@@ -524,6 +526,80 @@ def test_checkout_available_shipping_methods(
     assert data[field][0]["metadata"][0]["key"] == metadata_key
     assert data[field][0]["metadata"][0]["value"] == metadata_value
     assert data[field][0]["translation"]["name"] == translated_name
+
+
+GET_CHECKOUT_SHIPPING_METHODS_QUERY = """
+query getCheckout($id: ID) {
+    checkout(id: $id) {
+		shippingMethods {
+            id
+            name
+        }
+    }
+}
+"""
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_preventing_circular_payload_generation_when_listing_shipping_methods_for_checkout(
+    mock_send_webhook_request_sync,
+    api_client,
+    checkout_with_item,
+    address,
+    subscription_shipping_list_methods_for_checkout_webhook,
+    caplog,
+):
+    # This test ensures that the listing external shipping methods are resistant to circular webhooks calls.
+    # We call `shipping_methods` field inside `ShippingListMethodsForCheckout` subscription. This resolver should
+    # always return only internal shipping methods.
+    # given
+    checkout_with_item.shipping_address = address
+    checkout_with_item.save()
+    expected_external_shipping_name = "Provider - Economy"
+    mock_send_webhook_request_sync.return_value = [
+        {
+            "amount": "10",
+            "currency": checkout_with_item.currency,
+            "id": "abcd",
+            "name": expected_external_shipping_name,
+        },
+    ]
+
+    # when
+    variables = {"id": to_global_id_or_none(checkout_with_item)}
+    response = api_client.post_graphql(GET_CHECKOUT_SHIPPING_METHODS_QUERY, variables)
+
+    # then
+    shipping_method = ShippingMethod.objects.get()
+    content = get_graphql_content(response)
+    # Check if webhook was called with correct payload
+    assert mock_send_webhook_request_sync.call_count == 1
+    event_delivery = mock_send_webhook_request_sync.call_args[0][0]
+    payload = event_delivery.payload.get_payload()
+    assert json.loads(payload) == {
+        "checkout": {
+            "id": to_global_id_or_none(checkout_with_item),
+        },
+        "shippingMethods": [
+            {
+                "id": graphene.Node.to_global_id("ShippingMethod", shipping_method.id),
+                "name": shipping_method.name,
+            },
+        ],
+    }
+    # Check if shipping methods are correct
+    shipping_method_names = {
+        shipping_method_data["name"]
+        for shipping_method_data in content["data"]["checkout"]["shippingMethods"]
+    }
+    assert shipping_method_names == {
+        expected_external_shipping_name,
+        shipping_method.name,
+    }
+    # Ensure that any logs are generated via circular webhook calls. When webhooks are called in this way, they can
+    # generate the 'Subscription did not return a payload' log.
+    assert len(caplog.records) == 0
 
 
 @pytest.mark.parametrize("minimum_order_weight_value", [0, 2, None])

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -6,6 +6,7 @@ from ...checkout.fetch import (
     fetch_checkout_info,
     fetch_checkout_lines,
     get_all_shipping_methods_list,
+    get_valid_internal_shipping_method_list_for_checkout_info,
 )
 from ...core.exceptions import PermissionDenied
 from ...permission.enums import AppPermission
@@ -88,3 +89,30 @@ def resolve_shipping_methods_for_checkout(
         database_connection_name=database_connection_name,
     )
     return all_shipping_methods
+
+
+def resolve_only_internal_shipping_methods_for_checkout(
+    info: ResolveInfo,
+    checkout,
+    manager,
+    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+):
+    lines, _ = fetch_checkout_lines(
+        checkout, database_connection_name=database_connection_name
+    )
+    shipping_channel_listings = checkout.channel.shipping_method_listings.all()
+    checkout_info = fetch_checkout_info(
+        checkout,
+        lines,
+        manager,
+        shipping_channel_listings,
+        database_connection_name=database_connection_name,
+    )
+    address = checkout.shipping_address or checkout.billing_address
+    return get_valid_internal_shipping_method_list_for_checkout_info(
+        checkout_info,
+        address,
+        lines,
+        shipping_channel_listings,
+        database_connection_name,
+    )

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -90,7 +90,10 @@ from ..shipping.dataloaders import ShippingMethodChannelListingByChannelSlugLoad
 from ..shipping.types import ShippingMethod
 from ..translations import types as translation_types
 from ..warehouse.dataloaders import WarehouseByIdLoader
-from .resolvers import resolve_shipping_methods_for_checkout
+from .resolvers import (
+    resolve_only_internal_shipping_methods_for_checkout,
+    resolve_shipping_methods_for_checkout,
+)
 
 TRANSLATIONS_TYPES_MAP = {
     ProductTranslation: translation_types.ProductTranslation,
@@ -2573,9 +2576,11 @@ class ShippingListMethodsForCheckout(SubscriptionObjectType, CheckoutBase):
     @staticmethod
     @plugin_manager_promise_callback
     def resolve_shipping_methods(root, info: ResolveInfo, manager):
+        # We should only use internal shipping methods to prevent the generation of circular payloads.
+        # We aren't able to list shipping methods that are not internal for listing shipping methods webhook type.
         _, checkout = root
         database_connection_name = get_database_connection_name(info.context)
-        return resolve_shipping_methods_for_checkout(
+        return resolve_only_internal_shipping_methods_for_checkout(
             info, checkout, manager, database_connection_name
         )
 


### PR DESCRIPTION
I want to merge this change because it fixes circular payload generation when listing shipping methods for checkout.


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
