### PR TITLE
Use correct logger for subscription payload file

### DIFF
--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse
 
-from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db.models import Model
@@ -13,8 +12,6 @@ from text_unidecode import unidecode
 
 if TYPE_CHECKING:
     from ...attribute.models import Attribute
-
-task_logger = get_task_logger(__name__)
 
 
 if TYPE_CHECKING:

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -1,8 +1,8 @@
 import datetime
+import logging
 from collections.abc import Iterable
 from typing import Any
 
-from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
@@ -20,7 +20,7 @@ from ..core import SaleorContext
 from ..core.dataloaders import DataLoader
 from ..utils import format_error
 
-logger = get_task_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def initialize_request(


### PR DESCRIPTION
I want to merge this change because previously we were using `celery_task_logger` inside the uvicorn worker. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
