### PR TITLE
Use postegres 15 instead of `latest` in CI jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: library/postgres:15-alpine
         env:
           POSTGRES_PASSWORD: saleor
           POSTGRES_USER: saleor

--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: library/postgres:15-alpine
         env:
           POSTGRES_PASSWORD: saleor
           POSTGRES_USER: saleor

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -41,7 +41,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: library/postgres:15-alpine
         env:
           POSTGRES_PASSWORD: saleor
           POSTGRES_USER: saleor


### PR DESCRIPTION
I want to merge this change because previously we were using `latest` image of postgres.  This could cause a missleading results.
This solves the failures on CI while running the tests on CI - like this [one](https://github.com/saleor/saleor/actions/runs/18083918999/job/51451476913)

Port of changes from: #18241

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
