### PR TITLE
Adjust retry backoffs policy

### DIFF
--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -956,14 +956,6 @@ def test_fetch_icon_image_file_too_big(mock_get_request, image_response_mock):
     assert "File too big. Maximal icon image file size is" in error.value.message
 
 
-@patch.object(HTTPSession, "request")
-def test_fetch_icon_image_network_error(mock_get_request):
-    mock_get_request.side_effect = requests.RequestException
-    with pytest.raises(ValidationError) as error:
-        fetch_icon_image("https://example.com/logo.png")
-    assert error.value.code == AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
-
-
 @pytest.mark.parametrize("app_object", ["app", "app_installation"])
 @patch("saleor.app.installation_utils.fetch_icon_image")
 def test_fetch_brand_data_task(
@@ -1027,7 +1019,9 @@ def test_fetch_brand_data_task_retry(
 ):
     # given
     brand_data = {"logo": {"default": "https://example.com/logo.png"}}
-    mock_fetch_icon_image.side_effect = ValidationError("Fetch image error")
+    mock_fetch_icon_image.side_effect = requests.exceptions.RequestException(
+        "Fetch image network error"
+    )
 
     # when
     with pytest.raises(Retry):

--- a/saleor/plugins/avatax/tasks.py
+++ b/saleor/plugins/avatax/tasks.py
@@ -14,7 +14,7 @@ task_logger = get_task_logger(__name__)
 
 @app.task(
     autoretry_for=(TaxError,),
-    retry_backoff=60,
+    retry_backoff=30,
     retry_kwargs={"max_retries": 5},
 )
 @allow_writer()

--- a/saleor/plugins/sendgrid/tasks.py
+++ b/saleor/plugins/sendgrid/tasks.py
@@ -15,7 +15,7 @@ from . import SendgridConfiguration
 
 logger = logging.getLogger(__name__)
 
-CELERY_RETRY_BACKOFF = 60
+CELERY_RETRY_BACKOFF = 30
 CELERY_RETRY_MAX = 5
 
 


### PR DESCRIPTION
I want to merge this change because:
1. Adjust the retry backoffs so that they are more consistent. 
2. Task saleor.app.installation_utils.fetch_brand_data_task should be retried only in case of network errors. The situation remained the same when the image failed to pass validation the first time and was retried.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
