### PR TITLE
Fix missing mime types the Docker image.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,10 +16,8 @@ RUN apt-get update \
   libxml2 \
   libpq5 \
   shared-mime-info \
-  mime-support
-
-RUN echo 'image/webp webp' >> /etc/mime.types
-RUN echo 'image/avif avif' >> /etc/mime.types
+  # Required to allows to identify file types when handling file uploads
+  media-types
 
 WORKDIR /app
 RUN pip install poetry==1.7.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,11 @@ RUN apt-get update \
   libwebp7 \
   libxml2 \
   libpq5 \
-  shared-mime-info \
   libmagic1 \
+  # Required to allows to identify file types when handling file uploads
+  media-types \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-RUN echo 'image/webp webp' >> /etc/mime.types
-RUN echo 'image/avif avif' >> /etc/mime.types
 
 RUN mkdir -p /app/media /app/static \
   && chown -R saleor:saleor /app/

--- a/saleor/graphql/core/tests/test_file_validation.py
+++ b/saleor/graphql/core/tests/test_file_validation.py
@@ -11,6 +11,7 @@ from ....product.error_codes import ProductErrorCode
 from ..validators.file import (
     clean_image_file,
     is_image_mimetype,
+    is_image_url,
     is_supported_image_mimetype,
     validate_image_url,
 )
@@ -301,3 +302,29 @@ def test_clean_image_file_with_captialized_extension():
 
     # when & then
     clean_image_file({field: img}, field, ProductErrorCode)
+
+
+@pytest.mark.parametrize(
+    ("url", "is_valid"),
+    [
+        ("http://example.com/valid_image.jpg", True),
+        ("https://example.com/valid_image.png", True),
+        ("http://example.com/valid_image.jpeg", True),
+        ("http://example.com/valid_image.gif", True),
+        ("http://example.com/valid_image.bmp", True),
+        ("http://example.com/valid_image.tiff", True),
+        ("http://example.com/valid_image.webp", True),
+        ("https://example.com/valid_image.webp", True),
+        ("http://example.com/valid_image.avif", True),
+        ("http://example.com/invalid_image.pdf", False),
+        ("http://example.com/invalid_image.docx", False),
+        ("http://example.com/invalid_image.exe", False),
+        ("http://example.com/invalid_image.txt", False),
+    ],
+)
+def test_is_image_url(url, is_valid):
+    # when
+    result = is_image_url(url)
+
+    # then
+    assert result is is_valid


### PR DESCRIPTION
I want to merge this change because it fixes missing types in the Docker image.

Port #18246 

Tests:
https://github.com/saleor/saleor/pull/18246#issuecomment-3352227624

Clarifying comment:
https://github.com/saleor/saleor/pull/18246#issuecomment-3355459554

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
