### PR TITLE
Release 3.21.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.21.21",
+  "version": "3.21.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.21.21",
+      "version": "3.21.22",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.21.21",
+  "version": "3.21.22",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ help = "Run tests with db reuse to speed up testing time"
 
 [tool.poetry]
 name = "saleor"
-version = "3.21.21"
+version = "3.21.22"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.21.21"
+__version__ = "3.21.22"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.21.22 (32db0992d8)
* Adjust retry backoffs policy (#18253) (4d24b195e9)
* Fix missing mime types the Docker image.  (#18246) (8522f0affc)
* Use postegres 15 instead of latest in CI jobs (#18243) (618929f54e)
* Improve celery logger (#18231) (4dc6606b3e)
