### PR TITLE
Adjust retry backoffs policy

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -79,40 +79,36 @@ def fetch_icon_image(
     *,
     max_file_size=MAX_ICON_FILE_SIZE,
     timeout=settings.COMMON_REQUESTS_TIMEOUT,
-) -> File:
+) -> File | None:
     filename = get_filename_from_url(url)
     size_error_msg = f"File too big. Maximal icon image file size is {max_file_size}."
     code = AppErrorCode.INVALID.value
     fetch_start = time.monotonic()
-    try:
-        with HTTPClient.send_request(
-            "GET", url, stream=True, timeout=timeout, allow_redirects=False
-        ) as res:
-            res.raise_for_status()
-            content_type = res.headers.get("content-type")
-            if content_type not in ICON_MIME_TYPES:
-                raise ValidationError("Invalid file type.", code=code)
-            try:
-                if int(res.headers.get("content-length", 0)) > max_file_size:
-                    raise ValidationError(size_error_msg, code=code)
-            except (ValueError, TypeError):
-                pass
-            content = BytesIO()
-            for chunk in res.iter_content(chunk_size=File.DEFAULT_CHUNK_SIZE):
-                content.write(chunk)
-                if content.tell() > max_file_size:
-                    raise ValidationError(size_error_msg, code=code)
-                timeout_in_secs = sum(timeout)
-                if (time.monotonic() - fetch_start) > timeout_in_secs:
-                    raise ValidationError(
-                        "Timeout occurred while reading image file.",
-                        code=AppErrorCode.MANIFEST_URL_CANT_CONNECT.value,
-                    )
-            content.seek(0)
-            image_file = File(content, filename)
-    except requests.RequestException:
-        code = AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
-        raise ValidationError("Unable to fetch image.", code=code)
+    with HTTPClient.send_request(
+        "GET", url, stream=True, timeout=timeout, allow_redirects=False
+    ) as res:
+        res.raise_for_status()
+        content_type = res.headers.get("content-type")
+        if content_type not in ICON_MIME_TYPES:
+            raise ValidationError("Invalid file type.", code=code)
+        try:
+            if int(res.headers.get("content-length", 0)) > max_file_size:
+                raise ValidationError(size_error_msg, code=code)
+        except (ValueError, TypeError):
+            pass
+        content = BytesIO()
+        for chunk in res.iter_content(chunk_size=File.DEFAULT_CHUNK_SIZE):
+            content.write(chunk)
+            if content.tell() > max_file_size:
+                raise ValidationError(size_error_msg, code=code)
+            timeout_in_secs = sum(timeout)
+            if (time.monotonic() - fetch_start) > timeout_in_secs:
+                raise ValidationError(
+                    "Timeout occurred while reading image file.",
+                    code=AppErrorCode.MANIFEST_URL_CANT_CONNECT.value,
+                )
+        content.seek(0)
+        image_file = File(content, filename)
 
     validate_icon_image(image_file, code)
     return image_file
@@ -126,9 +122,11 @@ def fetch_brand_data(manifest_data, timeout=settings.COMMON_REQUESTS_TIMEOUT):
         logo_url = brand_data["logo"]["default"]
         logo_file = fetch_icon_image(logo_url, timeout=timeout)
         brand_data["logo"]["default"] = logo_file
-    except ValidationError as error:
+    except (ValidationError, OSError) as error:
         msg = "Fetching brand data failed for app:%r error:%r"
-        logger.info(msg, manifest_data["id"], error, extra={"brand_data": brand_data})
+        logger.info(
+            msg, manifest_data["id"], str(error), extra={"brand_data": brand_data}
+        )
         brand_data = None
     return brand_data
 
@@ -149,7 +147,7 @@ def _set_brand_data(brand_obj: Optional[Union[App, AppInstallation]], logo: File
         default_storage.delete(brand_obj.brand_logo_default.name)
 
 
-@app.task(bind=True, retry_backoff=2700, retry_kwargs={"max_retries": 5})
+@app.task(bind=True, retry_backoff=30, retry_kwargs={"max_retries": 5})
 def fetch_brand_data_task(
     self, brand_data: dict, *, app_installation_id=None, app_id=None
 ):
@@ -162,15 +160,28 @@ def fetch_brand_data_task(
             return
     try:
         logo_img = fetch_icon_image(brand_data["logo"]["default"])
-        _set_brand_data(app_inst, logo_img)
-        _set_brand_data(app, logo_img)
+        if logo_img:
+            _set_brand_data(app_inst, logo_img)
+            _set_brand_data(app, logo_img)
     except ValidationError as error:
         extra = {
             "app_id": app_id,
             "app_installation_id": app_installation_id,
             "brand_data": brand_data,
         }
-        task_logger.info("Fetching brand data failed. Error: %r", error, extra=extra)
+        task_logger.warning(
+            "Fetching brand data failed. Error: %r", str(error), extra=extra
+        )
+        # Don't retry on validation errors image didn't pass validation when we tries again.
+    except OSError as error:
+        extra = {
+            "app_id": app_id,
+            "app_installation_id": app_installation_id,
+            "brand_data": brand_data,
+        }
+        task_logger.info(
+            "Fetching brand data failed. Error: %r", str(error), extra=extra
+        )
         try:
             countdown = self.retry_backoff * (2**self.request.retries)
             raise self.retry(countdown=countdown, **self.retry_kwargs)

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -701,14 +701,6 @@ def test_fetch_icon_image_file_too_big(mock_get_request, image_response_mock):
     assert "File too big. Maximal icon image file size is" in error.value.message
 
 
-@patch.object(HTTPSession, "request")
-def test_fetch_icon_image_network_error(mock_get_request):
-    mock_get_request.side_effect = requests.RequestException
-    with pytest.raises(ValidationError) as error:
-        fetch_icon_image("https://example.com/logo.png")
-    assert error.value.code == AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
-
-
 @pytest.mark.parametrize("app_object", ["app", "app_installation"])
 @patch("saleor.app.installation_utils.fetch_icon_image")
 def test_fetch_brand_data_task(
@@ -772,7 +764,9 @@ def test_fetch_brand_data_task_retry(
 ):
     # given
     brand_data = {"logo": {"default": "https://example.com/logo.png"}}
-    mock_fetch_icon_image.side_effect = ValidationError("Fetch image error")
+    mock_fetch_icon_image.side_effect = requests.exceptions.RequestException(
+        "Fetch image network error"
+    )
 
     # when
     with pytest.raises(Retry):

--- a/saleor/plugins/avatax/tasks.py
+++ b/saleor/plugins/avatax/tasks.py
@@ -13,7 +13,7 @@ task_logger = get_task_logger(__name__)
 
 @app.task(
     autoretry_for=(TaxError,),
-    retry_backoff=60,
+    retry_backoff=30,
     retry_kwargs={"max_retries": 5},
 )
 def api_post_request_task(transaction_url, data, config, order_id):

--- a/saleor/plugins/sendgrid/tasks.py
+++ b/saleor/plugins/sendgrid/tasks.py
@@ -14,7 +14,7 @@ from . import SendgridConfiguration
 
 logger = logging.getLogger(__name__)
 
-CELERY_RETRY_BACKOFF = 60
+CELERY_RETRY_BACKOFF = 30
 CELERY_RETRY_MAX = 5
 
 


### PR DESCRIPTION
I want to merge this change because:
- Adjust the retry backoffs so that they are more consistent.
- Task saleor.app.installation_utils.fetch_brand_data_task should be retried only in case of network errors. The situation remained the same when the image failed to pass validation the first time and was retried.

Port https://github.com/saleor/saleor/pull/18244

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
