### PR TITLE
Release 3.20.100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.20.99",
+  "version": "3.20.100",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.20.99",
+      "version": "3.20.100",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.20.99",
+  "version": "3.20.100",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "saleor"
-version = "3.20.99"
+version = "3.20.100"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.20.99"
+__version__ = "3.20.100"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Adjust retry backoffs policy (#18259) (8828714e2c)
* Fix missing mime types the Docker image.  (#18246) (#18251) (78b9fe015e)
* Prevent circular payload generation when listing shipping method for checkout (#18236) (26914cc677)
* Use postegres 15 instead of latest in CI jobs (#18242) (7a81e04afb)