### PR TITLE
Rebuild search index when new invoice object has been created

### DIFF
--- a/saleor/graphql/invoice/mutations/invoice_request.py
+++ b/saleor/graphql/invoice/mutations/invoice_request.py
@@ -5,6 +5,7 @@ from ....core import JobStatus
 from ....invoice import events, models
 from ....invoice.error_codes import InvoiceErrorCode
 from ....order import events as order_events
+from ....order.search import update_order_search_vector
 from ....permission.enums import OrderPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
@@ -109,6 +110,7 @@ class InvoiceRequest(DeprecatedModelMutation):
                 user=info.context.user, app=app, order=order
             )
 
+        update_order_search_vector(order)
         events.invoice_requested_event(
             user=info.context.user,
             app=app,

--- a/saleor/graphql/invoice/tests/test_invoice_request.py
+++ b/saleor/graphql/invoice/tests/test_invoice_request.py
@@ -54,6 +54,7 @@ def test_invoice_request(
     order,
 ):
     # given
+    assert not order.search_vector
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     dummy_invoice = Invoice.objects.create(order=order)
     plugin_mock.return_value = dummy_invoice
@@ -88,6 +89,9 @@ def test_invoice_request(
     assert invoice.order.events.filter(
         type=OrderEvents.INVOICE_REQUESTED, order=order, user=staff_api_client.user
     ).exists()
+
+    order.refresh_from_db()
+    assert order.search_vector
 
 
 def test_invoice_request_by_user_no_channel_access(


### PR DESCRIPTION
I want to merge this change because it adds missing index rebuild

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
