### PR TITLE
Handle invalid provider exception for media url in product bulk mutation

### DIFF
--- a/saleor/core/exceptions.py
+++ b/saleor/core/exceptions.py
@@ -23,6 +23,12 @@ class InsufficientStockData:
     warehouse_pk: UUID | None = None
 
 
+class UnsupportedMediaProviderException(Exception):
+    def __init__(self, message: str = "Unsupported media provider or incorrect URL."):
+        self.message = message
+        super().__init__(message)
+
+
 class NonExistingCheckoutLines(Exception):
     def __init__(self, line_pks: set[UUID]):
         self.line_pks = line_pks

--- a/saleor/core/utils/validators.py
+++ b/saleor/core/utils/validators.py
@@ -2,10 +2,9 @@ import datetime
 from typing import Any
 
 import micawber
-from django.core.exceptions import ValidationError
 
 from ...product import ProductMediaTypes
-from ...product.error_codes import ProductErrorCode
+from ..exceptions import UnsupportedMediaProviderException
 
 SUPPORTED_MEDIA_TYPES = {
     "photo": ProductMediaTypes.IMAGE,
@@ -15,7 +14,7 @@ MEDIA_MAX_WIDTH = 1920
 MEDIA_MAX_HEIGHT = 1080
 
 
-def get_oembed_data(url: str, field_name: str) -> tuple[dict[str, Any], str]:
+def get_oembed_data(url: str) -> tuple[dict[str, Any], str]:
     """Get the oembed data from URL or raise an ValidationError."""
     providers = micawber.bootstrap_basic()
 
@@ -25,14 +24,7 @@ def get_oembed_data(url: str, field_name: str) -> tuple[dict[str, Any], str]:
         )
         return oembed_data, SUPPORTED_MEDIA_TYPES[oembed_data["type"]]
     except (micawber.exceptions.ProviderException, KeyError) as e:
-        raise ValidationError(
-            {
-                field_name: ValidationError(
-                    "Unsupported media provider or incorrect URL.",
-                    code=ProductErrorCode.UNSUPPORTED_MEDIA_PROVIDER.value,
-                )
-            }
-        ) from e
+        raise UnsupportedMediaProviderException() from e
 
 
 def is_date_in_future(given_date):

--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from graphene import InputField
 from micawber import ProviderException, ProviderRegistry
 
+from ....core.exceptions import UnsupportedMediaProviderException
 from ....core.utils.validators import get_oembed_data
 from ....product import ProductMediaTypes
 from ....product.models import Product, ProductChannelListing
@@ -269,7 +270,7 @@ def test_requestor_is_superuser_for_app(app):
     ],
 )
 def test_get_oembed_data(url, expected_media_type):
-    oembed_data, media_type = get_oembed_data(url, "media_url")
+    oembed_data, media_type = get_oembed_data(url)
 
     assert oembed_data != {}
     assert media_type == expected_media_type
@@ -289,9 +290,10 @@ def test_get_oembed_data(url, expected_media_type):
 def test_get_oembed_data_unsupported_media_provider(mocked_provider, url):
     mocked_provider.side_effect = ProviderException()
     with pytest.raises(
-        ValidationError, match="Unsupported media provider or incorrect URL."
+        UnsupportedMediaProviderException,
+        match="Unsupported media provider or incorrect URL.",
     ):
-        get_oembed_data(url, "media_url")
+        get_oembed_data(url)
 
 
 def test_add_hash_to_file_name(image, media_root):


### PR DESCRIPTION
I want to merge this change because handling invalid provider exception for media_url in product bulk mutation

Port #18284 

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
