### PR TITLE
Fix 3.22 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - `fulfillments` - Filter by fulfillment data (status, metadata, warehouse).
     - `lines` - Filter by line item data (metadata, product details, quantities).
     - `lines_count` - Filter by number of lines in the order.
-    - `transactions` - Filter by transaction data (payment method name and type, metadata). Note: Payment method filtering only works for transactions created after upgrading to this release: [see docs](https://docs.saleor.io/developer/payments/transactions#via-transaction-mutations).
+    - `transactions` - Filter by transaction data (payment method name and type, metadata). Note: Payment method filtering only works for transactions created after upgrading to this release: [see docs](https://docs.saleor.io/developer/payments/transactions#storing-payment-method-details).
     - `total_gross` - Filter by total gross amount.
     - `total_net` - Filter by total net amount.
     - `product_type_id` - Filter by the product type of related order lines.
@@ -165,6 +165,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - Via Transaction mutations: `transactionEventReport`, `transactionCreate`, `transactionUpdate`
     - Via Transaction webhooks: `TRANSACTION_INITIALIZE_SESSION`, `TRANSACTION_PROCESS_SESSION` (see [Transaction webhooks docs](https://docs.saleor.io/developer/extending/webhooks/synchronous-events/transaction#response-4))
   - Previously, payment apps often stored this information in transaction's `metadata` in an unstructured format defined by each app. This limited interoperability and search. With structured payment method details, this information is now standardized across all apps, which makes it type-safe and easily accessible for custom integrations and allows search on `orders` and `draftOrders` queries.
+  - For more details for implementing this change in apps [see Storing payment method details docs](https://docs.saleor.io/developer/payments/transactions#storing-payment-method-details)
 - Added `fractionalAmount` and `fractionDigits` fields to the `Money` type:
   - `fractionalAmount` - amount as an integer in the smallest currency unit (e.g., `1295` for $12.95 USD, `1234` for ¥1234 JPY)
   - `fractionDigits` - number of decimal places for the currency (e.g., `2` for USD, `0` for JPY)


### PR DESCRIPTION
I want to merge this change because it fixes Saleor 3.22 release notes with correct information and notes about features missing in Saleor Dashboard, but available via API

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
