### PR TITLE
Fix – Skip invalid span links in `TelemetryTaskContext`

### DIFF
--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -90,18 +90,21 @@ class TelemetryTaskContext:
     )
 
     def to_dict(self) -> dict:
+        # filter out links to invalid spans
+        links = [
+            {
+                "context": {
+                    "trace_id": link.context.trace_id,
+                    "span_id": link.context.span_id,
+                    "trace_flags": int(link.context.trace_flags),
+                },
+                "attributes": dict(link.attributes) if link.attributes else {},
+            }
+            for link in self.links or []
+            if link.context.is_valid
+        ]
         return {
-            "links": [
-                {
-                    "context": {
-                        "trace_id": link.context.trace_id,
-                        "span_id": link.context.span_id,
-                        "trace_flags": int(link.context.trace_flags),
-                    },
-                    "attributes": dict(link.attributes) if link.attributes else {},
-                }
-                for link in (self.links or [])
-            ],
+            "links": links,
             "global_attributes": dict(self.global_attributes),
         }
 
@@ -110,18 +113,18 @@ class TelemetryTaskContext:
         if not data:
             return cls(global_attributes={})
         try:
-            links = [
-                Link(
-                    context=SpanContext(
-                        trace_id=link["context"]["trace_id"],
-                        span_id=link["context"]["span_id"],
-                        is_remote=True,
-                        trace_flags=TraceFlags(link["context"]["trace_flags"]),
-                    ),
-                    attributes=link.get("attributes"),
+            links = []
+            for link in data.get("links", []):
+                context = SpanContext(
+                    trace_id=link["context"]["trace_id"],
+                    span_id=link["context"]["span_id"],
+                    is_remote=True,
+                    trace_flags=TraceFlags(link["context"]["trace_flags"]),
                 )
-                for link in data.get("links", [])
-            ]
+                if not context.is_valid:
+                    # filter out links to invalid spans
+                    continue
+                links.append(Link(context, attributes=link.get("attributes")))
             return cls(links=links, global_attributes=data.get("global_attributes", {}))
         except (KeyError, ValueError, TypeError) as e:
             raise ValueError(f"Invalid telemetry context data: {e}") from e

--- a/saleor/webhook/transport/asynchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_transport.py
@@ -178,3 +178,18 @@ def test_send_webhook_request_async_record_external_request_with_unknown_webhook
     assert external_request_content_length.attributes == attributes
     assert external_request_content_length.count == 1
     assert external_request_content_length.sum == payload_size
+
+
+@patch("saleor.webhook.transport.asynchronous.transport.webhooks_otel_trace")
+def test_send_webhook_request_async_fails_when_exception_raised_by_webhooks_otel_trace(
+    mock_webhooks_otel_trace,
+    event_delivery,
+):
+    # given
+    mock_webhooks_otel_trace.side_effect = ValueError("OTel error")
+
+    # when & then
+    with pytest.raises(ValueError, match="OTel error"):
+        send_webhook_request_async(
+            event_delivery_id=event_delivery.id, telemetry_context={}
+        )

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -597,13 +597,11 @@ def send_webhook_request_async(
     domain = get_domain()
     attempt = create_attempt(delivery, self.request.id)
     response = WebhookResponse(content="", status=EventDeliveryStatus.FAILED)
-    payload_size = 0
+    retry_on_failure = False
 
-    try:
-        if not delivery.payload:
-            raise ValueError(
-                f"Event delivery id: %{event_delivery_id}r has no payload."
-            )
+    if not delivery.payload:
+        response.content = f"Event delivery id: %{event_delivery_id}r has no payload."
+    else:
         data = delivery.payload.get_payload()
         # Covert payload to bytes if it's not already.
         data = data if isinstance(data, bytes) else data.encode("utf-8")
@@ -615,39 +613,38 @@ def send_webhook_request_async(
             app=webhook.app,
             span_links=telemetry_context.links,
         ) as span:
-            response = send_webhook_using_scheme_method(
-                webhook.target_url,
-                domain,
-                webhook.secret_key,
-                delivery.event_type,
-                data,
-                webhook.custom_headers,
-            )
+            try:
+                response = send_webhook_using_scheme_method(
+                    webhook.target_url,
+                    domain,
+                    webhook.secret_key,
+                    delivery.event_type,
+                    data,
+                    webhook.custom_headers,
+                )
+                retry_on_failure = True
+            except ValueError as e:
+                response.content = str(e)
             if response.status == EventDeliveryStatus.FAILED:
                 span.set_status(StatusCode.ERROR)
-
-        if response.status == EventDeliveryStatus.FAILED:
-            attempt_update(attempt, response)
-            handle_webhook_retry(self, webhook, response, delivery, attempt)
-            delivery_update(delivery, EventDeliveryStatus.FAILED)
-        elif response.status == EventDeliveryStatus.SUCCESS:
-            task_logger.info(
-                "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",
-                webhook.id,
-                sanitize_url_for_logging(webhook.target_url),
-                delivery.event_type,
-                delivery.id,
-            )
-            delivery.status = EventDeliveryStatus.SUCCESS
-            # update attempt without save to provide proper data in observability
-            attempt_update(attempt, response, with_save=False)
-    except ValueError as e:
-        response.content = str(e)
-        attempt_update(attempt, response)
-        delivery_update(delivery=delivery, status=EventDeliveryStatus.FAILED)
-    finally:
         record_external_request(webhook.target_url, response, payload_size)
 
+    if response.status == EventDeliveryStatus.FAILED:
+        attempt_update(attempt, response)
+        if retry_on_failure:
+            handle_webhook_retry(self, webhook, response, delivery, attempt)
+        delivery_update(delivery, EventDeliveryStatus.FAILED)
+    elif response.status == EventDeliveryStatus.SUCCESS:
+        task_logger.info(
+            "[Webhook ID:%r] Payload sent to %r for event %r. Delivery id: %r",
+            webhook.id,
+            sanitize_url_for_logging(webhook.target_url),
+            delivery.event_type,
+            delivery.id,
+        )
+        delivery.status = EventDeliveryStatus.SUCCESS
+        # update attempt without save to provide proper data in observability
+        attempt_update(attempt, response, with_save=False)
     observability.report_event_delivery_attempt(attempt)
     clear_successful_delivery(delivery)
 


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/18162
I want to merge this change because it prevents invalid span links from being assigned to the telemetry context passed to Celery tasks.

1. Invalid spans (trace and span ID set to 0) are commonly generated by the OTel SDK, for example when `NoOpTracer` is used (such as when OTel is disabled). The OTel SDK skips such links by default, but some third-party libraries (e.g., `ddtrace`, which integrates with OTel) may raise errors if they encounter them. To prevent this, I explicitly filter out invalid span links when passing `TelemetryTaskContext` to Celery tasks.
2. Additionally, I refactored `send_webhook_request_async` to reduce the scope of the `try...except` block, avoiding the risk of swallowing unexpected errors.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
