### PR TITLE
Adjust error message for checking permissions for customer price

### DIFF
--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -490,7 +490,10 @@ def check_permissions_for_custom_prices(app, lines):
     if any("price" in line for line in lines) and (
         not app or not app.has_perm(CheckoutPermissions.HANDLE_CHECKOUTS)
     ):
-        raise PermissionDenied(permissions=[CheckoutPermissions.HANDLE_CHECKOUTS])
+        raise PermissionDenied(
+            message="Setting the custom price is allowed only for apps with `MANAGE_CHECKOUTS` permission.",
+            permissions=[CheckoutPermissions.HANDLE_CHECKOUTS],
+        )
 
 
 def find_line_id_when_variant_parameter_used(


### PR DESCRIPTION
Return `Setting the custom price is allowed only for apps with MANAGE_CHECKOUTS permission.` instead
` To access this path, you need one of the following permissions: MANAGE_CHECKOUTS` . 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
