### PR TITLE
Update Sample DB: Brand model type and reference to products

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -263,6 +263,13 @@ def create_attributes_values(values_data):
         AttributeValue.objects.update_or_create(pk=pk, defaults=defaults)
 
 
+def assign_reference_page_types_to_attributes(relations: list):
+    for relation in relations:
+        fields = relation["fields"]
+        attribute = Attribute.objects.get(pk=fields["attribute"])
+        attribute.reference_page_types.add(fields["page_type"])
+
+
 def create_products(products_data, placeholder_dir, create_images):
     for product in products_data:
         pk = product["pk"]
@@ -445,6 +452,9 @@ def create_products_by_schema(placeholder_dir, create_images):
     )
     assign_attribute_values_to_variants(
         types["attribute.assignedvariantattributevalue"]
+    )
+    assign_reference_page_types_to_attributes(
+        types["attribute.attribute_reference_page_types"]
     )
     create_collections(
         data=types["product.collection"], placeholder_dir=placeholder_dir

--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -6847,7 +6847,7 @@
       "slug": "brand",
       "name": "Brand",
       "type": "product-type",
-      "input_type": "reference",
+      "input_type": "single-reference",
       "entity_type": "Page",
       "unit": null,
       "value_required": false,
@@ -9027,6 +9027,14 @@
       "attribute": 38,
       "product_type": 20,
       "variant_selection": true
+    }
+  },
+  {
+    "model": "attribute.attribute_reference_page_types",
+    "pk": 1,
+    "fields": {
+      "attribute": 44,
+      "page_type": 5
     }
   },
   {


### PR DESCRIPTION
I want to merge this change because...
I want to have more examples of attributes and show how to connect models with products.


Model type: `Brand`
Example Models: `Frutello` , `Saleor Loom`, `CozyNest`
Reference attribute `Brand` for products
Product type update with `Brand` attribute
Products updated with an attribute reference to the example brands

<img width="1471" height="302" alt="image" src="https://github.com/user-attachments/assets/78737db1-7bfd-4391-a7be-9a9b04356bb6" />

<img width="984" height="741" alt="image" src="https://github.com/user-attachments/assets/6af852d5-d0a1-4e22-a5a3-59ce8e58eedd" />

<img width="1458" height="442" alt="image" src="https://github.com/user-attachments/assets/2401f41a-e805-462a-b08f-232d6a913489" />


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
