### PR TITLE
Drop logic related to checkout & shipping method models

### DIFF
--- a/saleor/checkout/actions.py
+++ b/saleor/checkout/actions.py
@@ -19,6 +19,7 @@ from .fetch import (
     CheckoutLineInfo,
     fetch_checkout_info,
     fetch_checkout_lines,
+    get_or_fetch_checkout_shipping_methods,
 )
 from .models import Checkout
 from .payment_utils import (
@@ -89,8 +90,10 @@ def _trigger_checkout_sync_webhooks(
     webhook_event_map: dict[str, set["Webhook"]],
     address: Optional["Address"] = None,
 ):
-    _ = checkout_info.get_all_shipping_methods()
-
+    # FIXME: Maciek, What with this? We need it here, to trigger the webhooks
+    # for events lik fully paid. Without this, while building subscription
+    # we can try to make a request and it will fail.
+    get_or_fetch_checkout_shipping_methods(checkout_info)
     # + timedelta(seconds=10) to confirm that triggered webhooks will still have
     # valid prices. Triggered only when we have active sync tax webhook.
     if webhook_event_map.get(

--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -54,7 +54,9 @@ class CheckoutShippingMethod(models.Model):
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
     )
-    currency = models.CharField(max_length=3)
+    currency = models.CharField(
+        max_length=settings.DEFAULT_CURRENCY_CODE_LENGTH,
+    )
 
     maximum_delivery_days = models.PositiveIntegerField(null=True, blank=True)
     minimum_delivery_days = models.PositiveIntegerField(null=True, blank=True)

--- a/saleor/checkout/tests/fixtures/checkout_info.py
+++ b/saleor/checkout/tests/fixtures/checkout_info.py
@@ -1,7 +1,6 @@
 import pytest
 
 from ....plugins.manager import get_plugins_manager
-from ....shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ...fetch import CheckoutInfo, fetch_checkout_info, fetch_checkout_lines
 
 
@@ -17,15 +16,8 @@ def checkout_info(checkout_lines_info):
 def checkout_with_items_and_shipping_info(checkout_with_items_and_shipping):
     checkout = checkout_with_items_and_shipping
     channel = checkout.channel
-    shipping_method = ShippingMethod.objects.get(
-        id=checkout_with_items_and_shipping.assigned_shipping_method.original_id
-    )
     shipping_address = checkout.shipping_address
 
-    shipping_channel_listing = ShippingMethodChannelListing.objects.get(
-        channel=channel,
-        shipping_method=shipping_method,
-    )
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = CheckoutInfo(
@@ -34,8 +26,6 @@ def checkout_with_items_and_shipping_info(checkout_with_items_and_shipping):
         channel=channel,
         billing_address=checkout.billing_address,
         shipping_address=shipping_address,
-        shipping_method=shipping_method,
-        shipping_channel_listings=[shipping_channel_listing],
         tax_configuration=channel.tax_configuration,
         discounts=[],
         manager=manager,

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -202,7 +202,6 @@ def test_get_discount_for_checkout_value_entire_order_voucher(
         tax_configuration=channel_USD.tax_configuration,
         manager=manager,
         lines=lines,
-        shipping_channel_listings=[],
         discounts=[],
     )
 
@@ -369,7 +368,6 @@ def test_get_discount_for_checkout_value_specific_product_voucher(
         tax_configuration=channel_USD.tax_configuration,
         manager=manager,
         lines=lines,
-        shipping_channel_listings=[],
         discounts=[],
     )
 
@@ -471,7 +469,6 @@ def test_get_discount_for_checkout_entire_order_voucher_not_applicable(
         tax_configuration=channel_USD.tax_configuration,
         manager=manager,
         lines=[],
-        shipping_channel_listings=[],
         discounts=[],
     )
     with pytest.raises(NotApplicable):
@@ -650,7 +647,6 @@ def test_get_discount_for_checkout_specific_products_voucher_not_applicable(
         tax_configuration=channel_USD.tax_configuration,
         manager=manager,
         lines=[],
-        shipping_channel_listings=[],
         discounts=[],
     )
     with pytest.raises(NotApplicable):
@@ -824,7 +820,6 @@ def test_get_discount_for_checkout_shipping_voucher_limited_countries(
         tax_configuration=channel_USD.tax_configuration,
         manager=manager,
         lines=[],
-        shipping_channel_listings=[],
         discounts=[],
     )
     with pytest.raises(NotApplicable):
@@ -1530,7 +1525,6 @@ def test_change_address_in_checkout(checkout, address):
         address,
         store_shipping_address_in_user_addresses,
         lines,
-        checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(
         checkout, address, store_billing_address_in_user_addresses
@@ -1560,7 +1554,6 @@ def test_change_address_in_checkout_to_none(checkout, address):
         None,
         store_shipping_address_in_user_addresses,
         lines,
-        checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(
         checkout, None, store_billing_address_in_user_addresses
@@ -1592,7 +1585,6 @@ def test_change_address_in_checkout_to_same(checkout, address):
         address,
         store_shipping_address_in_user_addresses,
         lines,
-        checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(
         checkout, address, store_billing_address_in_user_addresses
@@ -1624,7 +1616,6 @@ def test_change_address_in_checkout_to_other(checkout, address):
         other_address,
         store_shipping_address_in_user_addresses,
         lines,
-        checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(
         checkout, other_address, store_billing_address_in_user_addresses
@@ -1660,7 +1651,6 @@ def test_change_address_in_checkout_from_user_address_to_other(
         other_address,
         store_shipping_address_in_user_addresses,
         lines,
-        checkout.channel.shipping_method_listings.all(),
     )
     billing_updated_fields = change_billing_address_in_checkout(
         checkout, other_address, store_billing_address_in_user_addresses
@@ -1674,46 +1664,6 @@ def test_change_address_in_checkout_from_user_address_to_other(
     assert checkout_info.shipping_address == other_address
     assert checkout.save_shipping_address == store_shipping_address_in_user_addresses
     assert checkout.save_billing_address == store_billing_address_in_user_addresses
-
-
-def test_change_address_in_checkout_invalidates_shipping_methods(
-    checkout_with_items, address, shipping_method, shipping_zone
-):
-    # given
-    checkout = checkout_with_items
-    store_address_in_user_addresses = True
-
-    manager = get_plugins_manager(allow_replica=False)
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(
-        checkout=checkout,
-        lines=lines,
-        manager=manager,
-        shipping_channel_listings=shipping_method.channel_listings.all(),
-    )
-
-    all_shipping_methods = checkout_info.get_all_shipping_methods()
-    assert all_shipping_methods == []
-
-    # when
-    shipping_updated_fields = change_shipping_address_in_checkout(
-        checkout_info,
-        address,
-        store_address_in_user_addresses,
-        lines,
-        checkout.channel.shipping_method_listings.all(),
-    )
-    billing_updated_fields = change_billing_address_in_checkout(
-        checkout, address, store_address_in_user_addresses
-    )
-    checkout.save(update_fields=shipping_updated_fields + billing_updated_fields)
-    checkout.refresh_from_db()
-
-    # then
-    assert checkout.shipping_address == address
-    assert checkout.billing_address == address
-    assert checkout_info.shipping_address == address
-    assert checkout_info.get_all_shipping_methods()
 
 
 def test_add_voucher_to_checkout(checkout_with_item, voucher):

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -50,7 +50,6 @@ def test_create_order_captured_payment_creates_expected_events(
     mock_notify,
     checkout_with_item,
     customer_user,
-    shipping_method,
     payment_txn_captured,
     channel_USD,
     site_settings,
@@ -67,7 +66,6 @@ def test_create_order_captured_payment_creates_expected_events(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_shipping_address
-    checkout.shipping_method = shipping_method
     checkout.payments.add(payment_txn_captured)
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
@@ -214,7 +212,6 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     mock_notify,
     checkout_with_item,
     customer_user,
-    shipping_method,
     payment_txn_captured,
     channel_USD,
     site_settings,
@@ -232,7 +229,6 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     checkout.email = "test@example.com"
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_shipping_address
-    checkout.shipping_method = shipping_method
     checkout.payments.add(payment_txn_captured)
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
@@ -375,7 +371,6 @@ def test_create_order_preauth_payment_creates_expected_events(
     mock_notify,
     checkout_with_item,
     customer_user,
-    shipping_method,
     payment_txn_preauth,
     channel_USD,
     site_settings,
@@ -392,7 +387,6 @@ def test_create_order_preauth_payment_creates_expected_events(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_shipping_address
-    checkout.shipping_method = shipping_method
     checkout.payments.add(payment_txn_preauth)
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
@@ -491,7 +485,6 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     mock_notify,
     checkout_with_item,
     customer_user,
-    shipping_method,
     payment_txn_preauth,
     channel_USD,
     site_settings,
@@ -509,7 +502,6 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     checkout.email = "test@example.com"
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_shipping_address
-    checkout.shipping_method = shipping_method
     checkout.payments.add(payment_txn_preauth)
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
@@ -622,13 +614,13 @@ def test_create_order_insufficient_stock(
 
 
 def test_create_order_doesnt_duplicate_order(
-    checkout_with_item, customer_user, shipping_method
+    checkout_with_item,
+    customer_user,
 ):
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -666,14 +658,13 @@ def test_create_order_doesnt_duplicate_order(
 
 @pytest.mark.parametrize("is_anonymous_user", [True, False])
 def test_create_order_with_gift_card(
-    checkout_with_gift_card, customer_user, shipping_method, is_anonymous_user
+    checkout_with_gift_card, customer_user, is_anonymous_user
 ):
     checkout_user = None if is_anonymous_user else customer_user
     checkout = checkout_with_gift_card
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -723,13 +714,14 @@ def test_create_order_with_gift_card(
 
 
 def test_create_order_with_gift_card_partial_use(
-    checkout_with_item, gift_card_used, customer_user, shipping_method
+    checkout_with_item,
+    gift_card_used,
+    customer_user,
 ):
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -782,13 +774,11 @@ def test_create_order_with_many_gift_cards(
     gift_card_created_by_staff,
     gift_card,
     customer_user,
-    shipping_method,
 ):
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -850,7 +840,6 @@ def test_create_order_gift_card_bought(
     checkout_with_gift_card_items,
     payment_txn_captured,
     customer_user,
-    shipping_method,
     is_anonymous_user,
     non_shippable_gift_card_product,
     django_capture_on_commit_callbacks,
@@ -861,7 +850,6 @@ def test_create_order_gift_card_bought(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -944,7 +932,6 @@ def test_create_order_gift_card_bought_order_not_captured_gift_cards_not_sent(
     send_notification_mock,
     checkout_with_gift_card_items,
     customer_user,
-    shipping_method,
     is_anonymous_user,
     django_capture_on_commit_callbacks,
 ):
@@ -955,7 +942,6 @@ def test_create_order_gift_card_bought_order_not_captured_gift_cards_not_sent(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -1007,7 +993,6 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     checkout,
     shippable_gift_card_product,
     customer_user,
-    shipping_method,
     is_anonymous_user,
 ):
     checkout_user = None if is_anonymous_user else customer_user
@@ -1020,7 +1005,6 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -1067,7 +1051,6 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     site_settings,
     checkout_with_gift_card_items,
     customer_user,
-    shipping_method,
     is_anonymous_user,
     non_shippable_gift_card_product,
 ):
@@ -1080,7 +1063,6 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -1181,7 +1163,8 @@ def test_create_order_with_variant_tracking_false(
 
 @override_settings(LANGUAGE_CODE="fr")
 def test_create_order_use_translations(
-    checkout_with_item, customer_user, shipping_method
+    checkout_with_item,
+    customer_user,
 ):
     translated_product_name = "French name"
     translated_variant_name = "French variant name"
@@ -1190,7 +1173,6 @@ def test_create_order_use_translations(
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
     checkout.language_code = "fr"
@@ -1837,7 +1819,9 @@ def test_complete_checkout_checkout_completed_in_the_meantime(
 
 
 def test_process_shipping_data_for_order_store_customer_shipping_address(
-    checkout_with_item, customer_user, address_usa, shipping_method
+    checkout_with_item,
+    customer_user,
+    address_usa,
 ):
     # given
     checkout = checkout_with_item
@@ -1845,7 +1829,6 @@ def test_process_shipping_data_for_order_store_customer_shipping_address(
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = address_usa
-    checkout.shipping_method = shipping_method
     checkout.save()
 
     user_address_count = customer_user.addresses.count()
@@ -1874,7 +1857,9 @@ def test_process_shipping_data_for_order_store_customer_shipping_address(
 
 
 def test_process_shipping_data_for_order_not_store_customer_shipping_address_saving_addresses_off(
-    checkout_with_item, customer_user, address_usa, shipping_method
+    checkout_with_item,
+    customer_user,
+    address_usa,
 ):
     # given
     checkout = checkout_with_item
@@ -1882,7 +1867,6 @@ def test_process_shipping_data_for_order_not_store_customer_shipping_address_sav
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = address_usa
-    checkout.shipping_method = shipping_method
     checkout.save_shipping_address = False
     checkout.save()
 
@@ -2043,14 +2027,12 @@ def test_create_order_update_display_gross_prices(checkout_with_item, customer_u
 
 
 def test_create_order_store_shipping_prices(
-    checkout_with_items_and_shipping, shipping_method, customer_user
+    checkout_with_items_and_shipping, customer_user
 ):
     # given
     checkout = checkout_with_items_and_shipping
 
-    expected_base_shipping_price = shipping_method.channel_listings.get(
-        channel=checkout.channel
-    ).price
+    expected_base_shipping_price = checkout.assigned_shipping_method.price
     expected_shipping_price = TaxedMoney(
         net=expected_base_shipping_price * Decimal("0.9"),
         gross=expected_base_shipping_price,
@@ -2102,16 +2084,13 @@ def test_create_order_store_shipping_prices(
 
 def test_create_order_store_shipping_prices_with_free_shipping_voucher(
     checkout_with_voucher_free_shipping,
-    shipping_method,
     customer_user,
 ):
     # given
     checkout = checkout_with_voucher_free_shipping
     manager = get_plugins_manager(allow_replica=False)
 
-    expected_undiscounted_shipping_price = shipping_method.channel_listings.get(
-        channel=checkout.channel
-    ).price
+    expected_undiscounted_shipping_price = checkout.assigned_shipping_method.price
     expected_base_shipping_price = zero_money(checkout.currency)
     expected_shipping_price = zero_taxed_money(checkout.currency)
     expected_shipping_tax_rate = Decimal("0.0")

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -58,14 +58,13 @@ def test_create_order_insufficient_stock(
 
 @pytest.mark.parametrize("is_anonymous_user", [True, False])
 def test_create_order_with_gift_card(
-    checkout_with_gift_card, customer_user, shipping_method, is_anonymous_user, app
+    checkout_with_gift_card, customer_user, is_anonymous_user, app
 ):
     checkout_user = None if is_anonymous_user else customer_user
     checkout = checkout_with_gift_card
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -108,13 +107,12 @@ def test_create_order_with_gift_card(
 
 
 def test_create_order_with_gift_card_partial_use(
-    checkout_with_item, gift_card_used, customer_user, shipping_method, app
+    checkout_with_item, gift_card_used, customer_user, app
 ):
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -163,7 +161,6 @@ def test_create_order_with_many_gift_cards_worth_more_than_total(
     gift_card_created_by_staff,
     gift_card,
     customer_user,
-    shipping_method,
     app,
 ):
     # given
@@ -231,14 +228,12 @@ def test_create_order_with_many_gift_cards(
     gift_card_created_by_staff,
     gift_card,
     customer_user,
-    shipping_method,
     app,
 ):
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -295,7 +290,6 @@ def test_create_order_gift_card_bought(
     send_notification_mock,
     checkout_with_gift_card_items,
     customer_user,
-    shipping_method,
     is_anonymous_user,
     non_shippable_gift_card_product,
     app,
@@ -308,7 +302,6 @@ def test_create_order_gift_card_bought(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -375,7 +368,6 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     checkout,
     shippable_gift_card_product,
     customer_user,
-    shipping_method,
     is_anonymous_user,
     app,
 ):
@@ -389,7 +381,6 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -429,7 +420,6 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     site_settings,
     checkout_with_gift_card_items,
     customer_user,
-    shipping_method,
     is_anonymous_user,
     non_shippable_gift_card_product,
     app,
@@ -443,7 +433,6 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     checkout.user = checkout_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -477,12 +466,9 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     assert not GiftCard.objects.all()
 
 
-def test_note_in_created_order(
-    checkout_with_item, address, customer_user, shipping_method, app
-):
+def test_note_in_created_order(checkout_with_item, address, customer_user, app):
     checkout_with_item.shipping_address = address
     checkout_with_item.billing_address = address
-    checkout_with_item.shipping_method = shipping_method
     checkout_with_item.note = "test_note"
     checkout_with_item.tracking_code = "tracking_code"
     checkout_with_item.redirect_url = "https://www.example.com"
@@ -502,9 +488,7 @@ def test_note_in_created_order(
 
 
 @override_settings(LANGUAGE_CODE="fr")
-def test_create_order_use_translations(
-    checkout_with_item, customer_user, shipping_method, app
-):
+def test_create_order_use_translations(checkout_with_item, customer_user, app):
     translated_product_name = "French name"
     translated_variant_name = "French variant name"
 
@@ -512,7 +496,6 @@ def test_create_order_use_translations(
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
     checkout.language_code = "fr"
@@ -548,12 +531,11 @@ def test_create_order_use_translations(
 
 
 def test_create_order_from_checkout_updates_total_authorized_amount(
-    checkout_with_item, address, customer_user, shipping_method, app
+    checkout_with_item, address, customer_user, app
 ):
     # given
     checkout_with_item.shipping_address = address
     checkout_with_item.billing_address = address
-    checkout_with_item.shipping_method = shipping_method
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
 
@@ -580,12 +562,11 @@ def test_create_order_from_checkout_updates_total_authorized_amount(
 
 
 def test_create_order_from_checkout_updates_total_charged_amount(
-    checkout_with_item, address, customer_user, shipping_method, app
+    checkout_with_item, address, customer_user, app
 ):
     # given
     checkout_with_item.shipping_address = address
     checkout_with_item.billing_address = address
-    checkout_with_item.shipping_method = shipping_method
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
 
@@ -695,7 +676,7 @@ def test_create_order_from_checkout_store_shipping_prices(
 
 
 def test_create_order_from_checkout_valid_undiscounted_prices(
-    checkout_with_items_and_shipping, shipping_method, customer_user, app
+    checkout_with_items_and_shipping, customer_user, app
 ):
     # given
     checkout = checkout_with_items_and_shipping
@@ -750,7 +731,6 @@ def test_create_order_from_checkout_valid_undiscounted_prices(
 
 def test_create_order_from_store_shipping_prices_with_free_shipping_voucher(
     checkout_with_voucher_free_shipping,
-    shipping_method,
     customer_user,
     voucher_free_shipping,
     app,
@@ -758,9 +738,7 @@ def test_create_order_from_store_shipping_prices_with_free_shipping_voucher(
     # given
     checkout = checkout_with_voucher_free_shipping
 
-    expected_undiscounted_shipping_price = shipping_method.channel_listings.get(
-        channel=checkout.channel
-    ).price
+    expected_undiscounted_shipping_price = checkout.assigned_shipping_method.price
     expected_base_shipping_price = zero_money(checkout.currency)
     expected_shipping_price = zero_taxed_money(checkout.currency)
     expected_shipping_tax_rate = Decimal("0.0")
@@ -804,13 +782,12 @@ def test_create_order_from_store_shipping_prices_with_free_shipping_voucher(
 
 
 def test_note_in_created_order_checkout_line_deleted_in_the_meantime(
-    checkout_with_item, address, shipping_method, app, voucher_percentage
+    checkout_with_item, address, app, voucher_percentage
 ):
     # given
     checkout_with_item.voucher_code = voucher_percentage.code
     checkout_with_item.shipping_address = address
     checkout_with_item.billing_address = address
-    checkout_with_item.shipping_method = shipping_method
     checkout_with_item.tracking_code = "tracking_code"
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
@@ -839,13 +816,12 @@ def test_note_in_created_order_checkout_line_deleted_in_the_meantime(
 
 
 def test_note_in_created_order_checkout_deleted_in_the_meantime(
-    checkout_with_item, address, shipping_method, app, voucher_percentage
+    checkout_with_item, address, app, voucher_percentage
 ):
     # given
     checkout_with_item.voucher_code = voucher_percentage.code
     checkout_with_item.shipping_address = address
     checkout_with_item.billing_address = address
-    checkout_with_item.shipping_method = shipping_method
     checkout_with_item.tracking_code = "tracking_code"
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
@@ -879,7 +855,6 @@ def test_create_order_from_checkout_update_undiscounted_prices_match(
     mock_unit,
     mock_total,
     checkout_with_items_and_shipping,
-    shipping_method,
     customer_user,
     app,
 ):
@@ -930,7 +905,6 @@ def test_create_order_from_checkout_update_undiscounted_prices_match(
 def test_create_order_product_on_promotion(
     checkout_with_item_on_promotion,
     customer_user,
-    shipping_method,
     app,
     catalogue_promotion_without_rules,
 ):
@@ -939,7 +913,6 @@ def test_create_order_product_on_promotion(
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -974,7 +947,6 @@ def test_create_order_product_on_promotion(
 def test_create_order_with_voucher_0_total(
     checkout_with_item,
     customer_user,
-    shipping_method,
     app,
     voucher_percentage,
     django_capture_on_commit_callbacks,
@@ -985,7 +957,6 @@ def test_create_order_with_voucher_0_total(
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
-    checkout.shipping_method = shipping_method
     checkout.tracking_code = "tracking_code"
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
@@ -993,10 +964,6 @@ def test_create_order_with_voucher_0_total(
     voucher_listing = voucher_percentage.channel_listings.get(channel=checkout.channel)
     voucher_listing.discount_value = 100
     voucher_listing.save(update_fields=["discount_value"])
-
-    shipping_listing = shipping_method.channel_listings.get(channel=checkout.channel)
-    shipping_listing.price_amount = 0
-    shipping_listing.save(update_fields=["price_amount"])
 
     manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -98,10 +98,7 @@ class CheckoutAddPromoCode(BaseMutation):
                 }
             )
 
-        shipping_channel_listings = checkout.channel.shipping_method_listings.all()
-        checkout_info = fetch_checkout_info(
-            checkout, lines, manager, shipping_channel_listings
-        )
+        checkout_info = fetch_checkout_info(checkout, lines, manager)
 
         add_promo_code_to_checkout(
             manager,

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -147,14 +147,12 @@ class CheckoutLinesAdd(BaseMutation):
                 ) from e
 
         lines, _ = fetch_checkout_lines(checkout)
-        shipping_channel_listings = checkout.channel.shipping_method_listings.all()
+
         update_delivery_method_lists_for_checkout_info(
             checkout_info=checkout_info,
-            shipping_method=checkout_info.checkout.shipping_method,
             collection_point=checkout_info.checkout.collection_point,
             shipping_address=checkout_info.shipping_address,
             lines=lines,
-            shipping_channel_listings=shipping_channel_listings,
         )
         return lines
 
@@ -237,10 +235,7 @@ class CheckoutLinesAdd(BaseMutation):
         checkout = get_checkout(cls, info, checkout_id=checkout_id, token=token, id=id)
         manager = get_plugin_manager_promise(info.context).get()
         variants = cls._get_variants_from_lines_input(lines)
-        shipping_channel_listings = checkout.channel.shipping_method_listings.all()
-        checkout_info = fetch_checkout_info(
-            checkout, [], manager, shipping_channel_listings
-        )
+        checkout_info = fetch_checkout_info(checkout, [], manager)
         existing_lines_info, _ = fetch_checkout_lines(
             checkout, skip_lines_with_unavailable_variants=False
         )

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -177,10 +177,7 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             ),
         )
         manager = get_plugin_manager_promise(info.context).get()
-        shipping_channel_listings = checkout.channel.shipping_method_listings.all()
-        checkout_info = fetch_checkout_info(
-            checkout, lines, manager, shipping_channel_listings
-        )
+        checkout_info = fetch_checkout_info(checkout, lines, manager)
 
         country = shipping_address_instance.country.code
         checkout.set_country(country, commit=True)
@@ -203,7 +200,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
                 shipping_address_instance,
                 save_address,
                 lines,
-                shipping_channel_listings,
             )
 
         shipping_update_fields = mark_checkout_shipping_methods_as_stale_if_needed(

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -419,7 +419,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(85):
+    with django_assert_num_queries(84):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -437,7 +437,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(85):
+    with django_assert_num_queries(84):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -825,7 +825,7 @@ def test_update_checkout_lines_with_reservations(
     )
 
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(106):
+    with django_assert_num_queries(103):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -839,7 +839,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(106):
+    with django_assert_num_queries(103):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -1101,7 +1101,7 @@ def test_add_checkout_lines_with_reservations(
 
     user_api_client.ensure_access_token()
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(103):
+    with django_assert_num_queries(100):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -1114,7 +1114,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(103):
+    with django_assert_num_queries(100):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,
@@ -1165,7 +1165,7 @@ def test_add_checkout_lines_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(94):
+    with django_assert_num_queries(91):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1251,7 +1251,7 @@ def test_add_checkout_lines_multiple_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(94):
+    with django_assert_num_queries(91):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1287,7 +1287,7 @@ def test_add_checkout_lines_order_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(100):
+    with django_assert_num_queries(97):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1322,7 +1322,7 @@ def test_add_checkout_lines_gift_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(127):
+    with django_assert_num_queries(124):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -202,7 +202,6 @@ def test_assign_delivery_method_to_checkout_delivery_method_to_none(
     # then
     assert checkout_with_delivery_method_for_cc.collection_point_id is None
     assert checkout_with_delivery_method_for_cc.shipping_address_id is None
-    assert checkout_info.shipping_method is None
     assert checkout_info.collection_point is None
 
 
@@ -243,7 +242,6 @@ def test_assign_delivery_method_to_checkout_delivery_method_to_external(
     assert checkout.shipping_method_name == app_shipping_name
     assert checkout.assigned_shipping_method.original_id == method_id
     assert checkout.assigned_shipping_method.name == app_shipping_name
-    assert checkout_info.shipping_method is None
     assert checkout_info.collection_point is None
 
 
@@ -275,4 +273,3 @@ def test_assign_delivery_method_to_checkout_delivery_method_to_cc(
     assert int(checkout.shipping_address_id) != int(collection_point.address.id)
     assert checkout.assigned_shipping_method is None
     assert checkout.shipping_method_name is None
-    assert checkout_info.shipping_method is None

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -49,7 +49,6 @@ from ....product.models import (
     ProductVariantChannelListing,
 )
 from ....shipping.models import ShippingMethodTranslation
-from ....shipping.utils import convert_to_shipping_method_data
 from ....tests import race_condition
 from ....tests.utils import dummy_editorjs
 from ....warehouse import WarehouseClickAndCollectOption
@@ -58,58 +57,6 @@ from ...core.utils import to_global_id_or_none
 from ...payment.enums import TokenizedPaymentFlowEnum
 from ...tests.utils import assert_no_permission, get_graphql_content
 from ..enums import CheckoutAuthorizeStatusEnum, CheckoutChargeStatusEnum
-from ..mutations.utils import (
-    clean_delivery_method,
-)
-
-
-def test_clean_delivery_method_after_shipping_address_changes_stay_the_same(
-    checkout_with_single_item, address, shipping_method, other_shipping_method
-):
-    """Ensure the current shipping method applies to new address.
-
-    If it does, then it doesn't need to be changed.
-    """
-
-    checkout = checkout_with_single_item
-    checkout.shipping_address = address
-
-    manager = get_plugins_manager(allow_replica=False)
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, manager)
-    delivery_method = convert_to_shipping_method_data(
-        shipping_method, shipping_method.channel_listings.first()
-    )
-    is_valid_method = clean_delivery_method(checkout_info, delivery_method)
-    assert is_valid_method is True
-
-
-def test_clean_delivery_method_with_preorder_is_valid_for_enabled_warehouse(
-    checkout_with_preorders_only, address, warehouses_for_cc
-):
-    checkout = checkout_with_preorders_only
-    checkout.shipping_address = address
-
-    manager = get_plugins_manager(allow_replica=False)
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, manager)
-    is_valid_method = clean_delivery_method(checkout_info, warehouses_for_cc[1])
-
-    assert is_valid_method is True
-
-
-def test_clean_delivery_method_does_nothing_if_no_shipping_method(
-    checkout_with_single_item, address, other_shipping_method
-):
-    """If no shipping method was selected, it shouldn't return an error."""
-
-    checkout = checkout_with_single_item
-    checkout.shipping_address = address
-    manager = get_plugins_manager(allow_replica=False)
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, manager)
-    is_valid_method = clean_delivery_method(checkout_info, None)
-    assert is_valid_method is True
 
 
 @pytest.fixture

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -70,12 +70,10 @@ def resolve_shipping_methods_for_checkout(
     lines, _ = fetch_checkout_lines(
         checkout, database_connection_name=database_connection_name
     )
-    shipping_channel_listings = checkout.channel.shipping_method_listings.all()
     checkout_info = fetch_checkout_info(
         checkout,
         lines,
         manager,
-        shipping_channel_listings,
         database_connection_name=database_connection_name,
     )
     all_shipping_methods = get_all_shipping_methods_list(

--- a/saleor/payment/tests/test_utils/test_utils.py
+++ b/saleor/payment/tests/test_utils/test_utils.py
@@ -122,14 +122,12 @@ def test_create_payment_lines_information_checkout_with_flat_rates(
     tax_configuration_flat_rates,
     default_tax_class,
     address,
-    shipping_method,
 ):
     # given
     tax_configuration_flat_rates.prices_entered_with_tax = False
     tax_configuration_flat_rates.save()
 
     checkout_with_items.shipping_address = address
-    checkout_with_items.shipping_method = shipping_method
     checkout_with_items.save()
 
     manager = get_plugins_manager(allow_replica=False)

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -3874,8 +3874,6 @@ def test_get_checkout_line_tax_rate(
         discounts=[],
         manager=manager,
         lines=lines,
-        shipping_method=shipping_method,
-        shipping_channel_listings=shipping_method.channel_listings.all(),
     )
     checkout_line_info = lines[0]
 
@@ -3942,8 +3940,6 @@ def test_get_checkout_line_tax_rate_for_product_with_charge_taxes_set_to_false(
         discounts=[],
         manager=manager,
         lines=lines,
-        shipping_method=shipping_method,
-        shipping_channel_listings=shipping_method.channel_listings.all(),
     )
     checkout_line_info = lines[0]
     product = checkout_line_info.product
@@ -4016,8 +4012,6 @@ def test_get_checkout_line_tax_rate_for_product_type_with_non_taxable_product(
         tax_configuration=checkout_with_item.channel.tax_configuration,
         discounts=[],
         manager=manager,
-        shipping_method=shipping_method,
-        shipping_channel_listings=shipping_method.channel_listings.all(),
         lines=lines,
     )
     add_variant_to_checkout(checkout_info, variant2, 1)


### PR DESCRIPTION
I want to merge this change because it:
-  removes the `shipping_channel_listing` and `shipping_method` from the CheckoutInfo.
- removes unused part of the code related to the shipping method
- clean up some tests
- adds usage of settings when providing max size of currency_code field

(There are some `FIXME`, they will be addressed separatly)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
