### PR TITLE
Release 3.21.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.21.23",
+  "version": "3.21.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.21.23",
+      "version": "3.21.24",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.21.23",
+  "version": "3.21.24",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ help = "Run tests with db reuse to speed up testing time"
 
 [tool.poetry]
 name = "saleor"
-version = "3.21.23"
+version = "3.21.24"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.21.23"
+__version__ = "3.21.24"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.21.24 (82a535acb8)
* Fix a bug where task deleting expired checkouts would end prematurely (#18324) (0e810fa48f)
* Optimize GraphQL metrics (#18314) (#18319) (44dc7ade19)
* Fix – Skip invalid span links in `TelemetryTaskContext` (#18162) (#18296) (5297f829a3)
