### PR TITLE
Adjust the way images are downloaded. 

### DIFF
--- a/saleor/graphql/core/tests/test_file_validation.py
+++ b/saleor/graphql/core/tests/test_file_validation.py
@@ -5,7 +5,6 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from PIL import Image
-from requests_hardened import HTTPSession
 
 from ....product.error_codes import ProductErrorCode
 from ..validators.file import (
@@ -13,7 +12,7 @@ from ..validators.file import (
     is_image_mimetype,
     is_image_url,
     is_supported_image_mimetype,
-    validate_image_url,
+    is_valid_image_content_type,
 )
 
 
@@ -61,74 +60,28 @@ def test_is_supported_image_mimetype_invalid_mimetype():
     assert not result
 
 
-def test_validate_image_url_valid_image_response(monkeypatch):
-    # given
-    valid_image_response_mock = Mock()
-    valid_image_response_mock.headers = {"content-type": "image/jpeg"}
-    monkeypatch.setattr(
-        HTTPSession,
-        "request",
-        Mock(return_value=valid_image_response_mock),
-    )
-    field = "image"
-
+@pytest.mark.parametrize(
+    ("content_type", "is_valid"),
+    [
+        ("image/jpeg", True),
+        ("image/png", True),
+        ("image/gif", True),
+        ("image/bmp", True),
+        ("image/tiff", True),
+        ("image/webp", True),
+        ("image/avif", True),
+        ("application/json", False),
+        ("text/plain", False),
+        ("application/pdf", False),
+        (None, False),
+    ],
+)
+def test_is_valid_image_content_type(content_type, is_valid):
     # when
-    dummy_url = "http://example.com/valid_url.jpg"
+    result = is_valid_image_content_type(content_type)
 
     # then
-    validate_image_url(
-        dummy_url,
-        field,
-        ProductErrorCode.INVALID.value,
-    )
-
-
-def test_validate_image_url_invalid_mimetype_response(monkeypatch):
-    # given
-    invalid_response_mock = Mock()
-    invalid_response_mock.headers = {"content-type": "application/json"}
-    monkeypatch.setattr(
-        HTTPSession,
-        "request",
-        Mock(return_value=invalid_response_mock),
-    )
-    field = "image"
-    dummy_url = "http://example.com/invalid_url.json"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_url(
-            dummy_url,
-            field,
-            ProductErrorCode.INVALID.value,
-        )
-
-    # then
-    assert exc.value.args[0][field].message == "Invalid file type."
-
-
-def test_validate_image_url_response_without_content_headers(monkeypatch):
-    # given
-    invalid_response_mock = Mock()
-    invalid_response_mock.headers = {}
-    monkeypatch.setattr(
-        HTTPSession,
-        "request",
-        Mock(return_value=invalid_response_mock),
-    )
-    field = "image"
-    dummy_url = "http://example.com/broken_url"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_url(
-            dummy_url,
-            field,
-            ProductErrorCode.INVALID.value,
-        )
-
-    # then
-    assert exc.value.args[0][field].message == "Invalid file type."
+    assert result == is_valid
 
 
 def test_clean_image_file():

--- a/saleor/graphql/core/validators/file.py
+++ b/saleor/graphql/core/validators/file.py
@@ -4,7 +4,6 @@ import os
 from django.core.exceptions import ValidationError
 from PIL import Image, UnidentifiedImageError
 
-from ....core.http_client import HTTPClient
 from ....thumbnail import MIME_TYPE_TO_PIL_IDENTIFIER
 from ....thumbnail.utils import ProcessedImage
 from ..utils import add_hash_to_file_name
@@ -32,18 +31,9 @@ def is_image_url(url: str) -> bool:
     return filetype is not None and is_image_mimetype(filetype)
 
 
-def validate_image_url(url: str, field_name: str, error_code: str) -> None:
-    """Check if remote file has content type of image.
-
-    Instead of the whole file, only the headers are fetched.
-    """
-    head = HTTPClient.send_request("HEAD", url, allow_redirects=False)
-    header = head.headers
-    content_type = header.get("content-type")
-    if content_type is None or not is_supported_image_mimetype(content_type):
-        raise ValidationError(
-            {field_name: ValidationError("Invalid file type.", code=error_code)}
-        )
+def is_valid_image_content_type(content_type: str | None) -> bool:
+    """Check if content type is a valid image content type."""
+    return content_type is not None and is_supported_image_mimetype(content_type)
 
 
 def clean_image_file(cleaned_input, img_field_name, error_class):

--- a/saleor/graphql/product/mutations/product/product_media_create.py
+++ b/saleor/graphql/product/mutations/product/product_media_create.py
@@ -1,6 +1,5 @@
 import graphene
 from django.core.exceptions import ValidationError
-from django.core.files import File
 
 from .....core.exceptions import UnsupportedMediaProviderException
 from .....core.http_client import HTTPClient
@@ -14,7 +13,12 @@ from ....core.context import ChannelContext
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
 from ....core.mutations import BaseMutation
 from ....core.types import BaseInputObjectType, ProductError, Upload
-from ....core.validators.file import clean_image_file, is_image_url, validate_image_url
+from ....core.utils import create_file_from_response
+from ....core.validators.file import (
+    clean_image_file,
+    is_image_url,
+    is_valid_image_content_type,
+)
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Product, ProductMedia
 from ...utils import ALT_CHAR_LIMIT
@@ -119,14 +123,22 @@ class ProductMediaCreate(BaseMutation):
             # In case of images, file is downloaded. Otherwise we keep only
             # URL to remote media.
             if is_image_url(media_url):
-                validate_image_url(
-                    media_url, "media_url", ProductErrorCode.INVALID.value
-                )
-                filename = get_filename_from_url(media_url)
-                image_data = HTTPClient.send_request(
+                with HTTPClient.send_request(
                     "GET", media_url, stream=True, allow_redirects=False
-                )
-                image_file = File(image_data.raw, filename)
+                ) as image_data:
+                    content_type = image_data.headers.get("content-type")
+                    if is_valid_image_content_type(content_type):
+                        filename = get_filename_from_url(media_url)
+                        image_file = create_file_from_response(image_data, filename)
+                    else:
+                        raise ValidationError(
+                            {
+                                "media_url": ValidationError(
+                                    "Invalid file type.",
+                                    code=ProductErrorCode.INVALID.value,
+                                )
+                            }
+                        )
                 media = product.media.create(
                     image=image_file,
                     alt=alt,

--- a/saleor/graphql/product/tests/mutations/cassettes/test_product_bulk_create/test_product_bulk_create_with_media_image_file_is_fetched_only_once.yaml
+++ b/saleor/graphql/product/tests/mutations/cassettes/test_product_bulk_create/test_product_bulk_create_with_media_image_file_is_fetched_only_once.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Saleor/3.21
+    method: GET
+    uri: https://saleor.io/icon-dark.png
+  response:
+    body:
+      string: !!binary |
+        iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAPxklEQVR42uzdeWwUVRwH8KUFpBbk
+        7NvtznanpZSrHLWA4IFQLgVNCEGExCoR0Rjw5BBQYwRDDFFCUIwgHligFAJRiBIjopZyiBFpoxgD
+        pfAPBdI2tEBpl+32+X1NV8EAPdjZnZn9/pJPNqVA6Hvf/Hjz5nKwmlfOJG+s0LzdnJo3Tbi9oyAb
+        FsMa2AH5UASn4DxcAh/Ug2wUgCtQCeegGH6HvZAHK+FVmOZ0e+/HZwo+Oycm6TEOFqv14dVjEdwE
+        hCkToZoOS2ELHIBTUAG1wbCGWDD0ZXAcfoINsAimQLpT07u4k5IZctYtA5wotIbOOw9yoRDKwQ/S
+        JHxwFg7BepiNf/dQBLyby5PcxsGK3kII4hDg/gjFM7AB/oSLwa5rEQGogF/hA5iGnykFP1tbB8v+
+        JTS9AyY8o7EL74YzUAfSJnxQDBthpnAz3HbsxLGqa6n/nuErOB/swjbnh2LYAFMwDk58clli4W4c
+        jyCPbtyFOAF+kFGqBo7AUsgQHm97B8syQRaNW2q7oRIk/aseSiEHJkJHB8uchcnxwEtwGHyC4W3K
+        JfgWpgvN28XBMk2QNXgFCqFOMKgtdQX2wAwGO7IHewmYhDkMcsiDPRXBjnewwlNqsDHoj0MBXBUM
+        Yqhdhu3qJBO0c7AMW1rEYIBH4HMbVAsGz2hlsApj3quH18PtvhB3ZXfjllOpYNDCqR6OwWxc19LJ
+        wbq9wn5pOwzmo3AAAoIBi5Ra2A5DXTqvGWltV1a7F+/DBcFAmcVpeFGwWze/nB49BgM2BgrYlU3J
+        B3mQ7mA12ZU7YaAWwDnB4JjdMZjKnZCb72KkQA7P8lnKBViGa7K7OljXdeaRDRetMyBW5IdtkOaI
+        9sJ6uW3jhUSnBYNhdYdhZDQvMeJgCXcxbKUEpqlb2qJtidEVP/hqqBEMgd2UwRy4I1o6sxs2gF9w
+        8u2qGt6EDnYPsxd2Qr3gpNvdFVjh1PTOdg7zLsGJjiZ+WKuWmAwz2UVdMNQMM9kp1B+5NL2THQ4A
+        dwpOKOEMMCyHDlbemvtCcCLpP1fgdWSjvdXCfKfaZ+a9fnQDF+FZp1ePsdLp7CU8aUK3cB4mW2Xd
+        /ARPZ1MzHIfhZg/zSDglOFnUPAWQbNYw9+QloNQKObie+i4z3mmSIzg51HJXYbHTY5KDRKeeou4B
+        nM87Teg2lMEksyw1xvAeQAqB3yDVDI8ayBecDAqN9VhPx0XqITBqv3kFLwWlEKqGmZFaajwCFYKT
+        QKH1l3qZUySeNbdfcPDJGJ85NT08FzElpOht1IMTudQgA12Cx8LVne9reB0aB52Mdcjp9mrheNj4
+        VsHBJuMF4A2jDwSn82HjFEanIcPI16UVCA4yhdc6l0dvb0R3nstnaVAElGMtPdqIdwAeFRxcioxc
+        l1uPC2WgF/Dh4xRBlejS40PZnQsFB5UiKy8kXVq9bpjdmUzgArr0mFDsbPwiOJhkDp+7bucVGELz
+        ZvPCfTKRs+jSQ1ob5o74C3YLDiKZy7utDXSWOroUHEAyl2PgbdkVdcnJMfhDHwoOHpmPH2a1tDv3
+        bHgQCAePzOkbp6bHtyTQs/lcOjKxchjR3HsF4/gIXLKAZc3tzoPwm0sFB4zMfwNAt+acGXyBt1eR
+        BVRBVpPLDb4+gixkeVPLjQG8X5AsZL/TrXe+VaBncXeDLKQcht84zHg/M775peAgkbW8fJP1s56I
+        b/4hOEBkLVtdmt7uRsuNUQ0vdOEAkbX8DZ4bBXqe4OCQ9VyGcddfjORtWD/ngowmCYlJZLxwzOXC
+        /3fnBPzi0WgLc6++6XJAxhA5YDAZYeDdQ2XPtH7hmM/N2L6LvSbQembjFoiMBt2dmhz70CSZX7Bf
+        Fp88KU8UF1OInSwpkT/n75NZ4x+WPVweo+f0CE6D97j2dPeMaNl/VoM7dsJEWVhUJFnGVWlpqXzq
+        6dnhfJHnwGsD/Xa0dOYHs8bJo4UMs7FhPiuzZ84K1/pZ8cHk4P5zW3yRZ/8we+SwEQ/IAwcPSZZx
+        VV5RIZ97fm4wzOG0MHhA2B1fHLT7MiPznnvlnr0/SpZxVVlZJectWBSpef4kuNxIgxL7h3mvZBkZ
+        5kq54LUl0uVJjkR3Vr7DgWG8CvRoqLBrmAdlDpPf/8AwG1lVVVVy4SIVZj1SYVaKIFEFOhtq7Rjm
+        vumD5dc7d0mWcVVdXS3fWvpOJDtz0BkYqAK9COrtFua0fgPlptwtMhAISJYxVVtbK99buUpqemqk
+        w6xUwgQV6DV2DPPGzVtkXV2dZBkX5pWrVsuklDQzhFmphSdVoHfY6XR2au/+MmdTLsMcXWFWAjBf
+        BXqfXcLs7dlbfrxuvfT7GWajSjWKtRhjjHUwzGayQgW6yA5h9iT3aljP+Xw+yTKm1PHIZhyXpPZJ
+        N2OYlU9VoE9ZPcxJjWGuqamRLOPCnJu3VfbpPyh4sZEZ7fiHvTOBjaqIw/hQDiERq0Bnu320r8sl
+        sRIbxBI5IwpiQBQESgwgjRCCCipIiQEFROMRlSBRQFDUIJAKyh2JyiUKGiDcKohccpRWytlioR2/
+        ebhJI0V67Oy+t/t9yS+EHnv855fp7JvjaaFzvSyz/oT91tvvUmbDMi9YmON2mTWrtdAXvSqzvvb5
+        8qRXcC20UDHmsnTZCtXyznS3y6zZqIUu8qLMPstWo8eOc2apGHP5Futf7mqd4QWZNT86QntR5udf
+        yFYFBQWKMZc1a9epNm3be0VmzU5P9tDPjRlLmSlzeez1lNC6dx46fITKy89XjLls2vyTymjX0dkQ
+        gbpTaFNT2o8PGqKOHTuuGHPZsWOn6tylqxdl1mzzhNCN/MmQ+Ql15OhRxZjLzl27VNfuPYLDDC/y
+        gxb6nNt75gEDB1Pm8Mgc7Jm9yvda6BNu3tTaq3df9cfBg4oxl3379qvuPXp5XWbNKi30AZduakWP
+        0VPt2fuLYszl8JEjqk+/AU69UXevkyPceGJSw0Qtcw/nzyBjLhjG6c8mwYVG0cBMLfR3bhtmPPAg
+        ZQ6TzMEPgNHCFC30AjfJ3L7TfWrL1m2KMZeTublq0JAno03mEjBSC/2OW65m6JmpDThvjjGX05hh
+        feqZZ4PDjGiiCGRqoUeDEjfIrKdbGXMpgMxYA+OshUmILpk1f4HOWuj+oDCSMt+d0Y4yh0/maOyd
+        NYdx0ExLLXQ7kBcpmdNwjvCqr1crxlzOX7igsl8cH80ya7YAnxY6APZFQuYW2AGRs2ixKi0tVYyZ
+        FGGH9pTXXlf+5EA0y6xZnphk19VCx4O1kZB5/sIcHgRjUuaiS872NGwgjnaZNdOETsOUQBz+Mze8
+        MrfSGy4pM2UOJSPLHng+LlzrmQPNW6qPP/mMMhtMcXGxmjpteizJXAi6lxX6YXApHDK/P2MWTzUy
+        mCvoKOZ8NFelNrs9VmTWHMUVjhZlhb4DnDAtdM9H+qgvFn2plq1YqZYuX0FCzPKVq9Azv6daGDhu
+        wOVshNDxZYS2b8MXN5t+YnzSJoYJdh74N5b4MJDapIYIJiHQtAa+OFvyrqTEm4wQ/w2+OByUShaH
+        eIsCDDfuvVZoy85w5sNZIOIttvmS7ITyhG6Ab/4sWSDiLeYkNw7UEOUF35wuWSDiHa6ALIFcT+i+
+        4G/JQhFvcAykXV9oy1mo9LtkoYg3WInxcz1xvSQkp9bGD82XLBTxBtniRpGWPcQZm7BYxN3k43Jd
+        24oI3dy5TQULRtxM8FbIN4psnFrLWU7KghH3UgpGiooGP/wYuCRZOOLe1XVpFRfasn34pa2ShSPu
+        ZJ7fsmuLygS/NEmycMR9FKJ37i0qG/TSrZ010iwgcRebIHQjUdkkWHYd3bVLFpC4h1IwRlQ1ep8W
+        OCdZSOIO9qN3blZ1oS27vj5EWrKQxB28IaobaaUMcA7CYzFJZPkT6zbSRTUTXCe9VrKgJLJMt6xA
+        TRGK4MEGcqKFRJBj6J3biFAlwXJ2hX8jWVgSGaZaVpM4EcrIJFtPh1+QLC4JLwfRO7cSoY7Psm/G
+        gy+WLDAJH6VgojAVPHgncEqy0CQ8bEfvbAtT8V1dWjpVstDEPEUgSxhOcAPAbsmCE7N8hd65vghH
+        8GTDeBmPGOQ46CDCFVzGuwVPuEiy8CT0lICJSUlNa4hwBk96Dzgk2QAktKzBUEOKCERLPYoH05AQ
+        kgu6iEhFXh16LJBsCFJ9roCXEv2BOIFEUmp9+v8uyQYh1WMJhhoNhAsSPBPvtGSjkKrxK0gXbgmm
+        xfWEy2RwWbJxSOUoAJnCbfFdvU9LjmQDkYpzGUyGO7WEGyOtlBbOzYfYUKRizIPMtwo3RybZHfFC
+        D0g2Fvl/1gFbeCF4of1AnmSjkfLZjZ65tfBK/H7n/uFPc0MAKYdDoJvwWjCevgkvfAIolGxEAkAe
+        6C+8mgQrpR7EfhNvoliyMWOdfAwzshL9qXHCy5GWHY83M4N3BYhpzoChfgPT2pG8Rj2TUsckZ8Eo
+        PfkmgokiqT/g6ryYIh8MNS1zpFfnvQouSjZ2tJP375i5pojm4I3WBeN5qmlUcwhk+rXMsRBppeLs
+        aXsYj0SISvaAbiLWkpgUqIk3/ijYJylBtLDe/TOA5td+ZKAQG0CppBBepRh8DmzBCKELAT7lFRBP
+        cgZMQs8cL5iyUjtXQLI5rvYUv4FMX1JqbcFcGxRGj6sfAlskZXEzl8Ey50R9pkJDkACYzdV6ruQU
+        mOBsaGUqNQlTD4UbDPZKSuQGSsB6cH+i364pmCqPrVuiiHPAeUmpIsVJMAlt4RNMSNaB6NnFvmAz
+        KJEULFwUgSWgg8+fyl7ZwDDE0uM3cFhSNtPDi+0gyznSljG6EyYOYqej2LNAvqR8oeYgmAiRkwUT
+        1mFIHRS+M5gPzkqKWF1OgGmoa5r0p8QJ5p/27t8lgTiM4/jZL8rFIboz79TDFhEisKHGhAjHWppa
+        GhsySPoPinCuIUpoCYlqi8jaol9ESTQEQVtkUVRGhFNJ7yNbCgQpyB/PB164ntzHh+8jnP7brzY1
+        IczNWEVGlWIWI4c0Zilyp1M36xRJSS2OISziVpWyFvKOS8QYBh1S5BKOk6MI5Q5ys6ZxLr+39+Nb
+        i0OMU+Q2OVqU18Sugdt6BAgbeECuSqfxNZZYpgcocrMiKftztp1yd1nbOw7wUgVn43tsYUxzeQJO
+        w2xQJJUX9fNh3RAmsYunCpncb0hjE1FV9wStD7IiqarJ7eDGW5M7gmVc4LWMpnAGp4hjmPcTkBJL
+        vv4lt17TPQZ6KccEEkjhrkQePMjiBvuYxwhHiW6ut6XV8MpyJykc1TBrrQWKRaqdKd6fL/kCkjhD
+        Gs/5suf+aHnL4hFXOME6ZjDKNYQpsJ/rcWhun02RSH4b3euzaYbXTqlcGkXntY+yDSGKGOJYwzb2
+        cIzUN0fYQRIrmMMUIhhED/wssZrmNhsVSVH5AIu3xubrej5GAAAAAElFTkSuQmCC
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '16056'
+      Cache-Control:
+      - public, max-age=0, must-revalidate
+      Content-Disposition:
+      - inline; filename="icon-dark.png"
+      Content-Length:
+      - '4095'
+      Content-Type:
+      - image/png
+      Date:
+      - Thu, 16 Oct 2025 09:52:23 GMT
+      Etag:
+      - '"9c6ae8bbf0a6123a6c319a5f0b8b2620"'
+      Last-Modified:
+      - Thu, 16 Oct 2025 05:24:46 GMT
+      Permissions-Policy:
+      - camera=(), microphone=(), geolocation=(), interest-cohort=()
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Vercel
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Matched-Path:
+      - /icon-dark.png
+      X-Vercel-Cache:
+      - HIT
+      X-Vercel-Id:
+      - arn1::f7bwd-1760608343169-21563927c3a3
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/product/tests/mutations/cassettes/test_product_media_create/test_product_media_create_mutation_valid_image_file_is_fetched_once.yaml
+++ b/saleor/graphql/product/tests/mutations/cassettes/test_product_media_create/test_product_media_create_mutation_valid_image_file_is_fetched_once.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Saleor/3.21
+    method: GET
+    uri: https://saleor.io/icon-dark.png
+  response:
+    body:
+      string: !!binary |
+        iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAPxklEQVR42uzdeWwUVRwH8KUFpBbk
+        7NvtznanpZSrHLWA4IFQLgVNCEGExCoR0Rjw5BBQYwRDDFFCUIwgHligFAJRiBIjopZyiBFpoxgD
+        pfAPBdI2tEBpl+32+X1NV8EAPdjZnZn9/pJPNqVA6Hvf/Hjz5nKwmlfOJG+s0LzdnJo3Tbi9oyAb
+        FsMa2AH5UASn4DxcAh/Ug2wUgCtQCeegGH6HvZAHK+FVmOZ0e+/HZwo+Oycm6TEOFqv14dVjEdwE
+        hCkToZoOS2ELHIBTUAG1wbCGWDD0ZXAcfoINsAimQLpT07u4k5IZctYtA5wotIbOOw9yoRDKwQ/S
+        JHxwFg7BepiNf/dQBLyby5PcxsGK3kII4hDg/gjFM7AB/oSLwa5rEQGogF/hA5iGnykFP1tbB8v+
+        JTS9AyY8o7EL74YzUAfSJnxQDBthpnAz3HbsxLGqa6n/nuErOB/swjbnh2LYAFMwDk58clli4W4c
+        jyCPbtyFOAF+kFGqBo7AUsgQHm97B8syQRaNW2q7oRIk/aseSiEHJkJHB8uchcnxwEtwGHyC4W3K
+        JfgWpgvN28XBMk2QNXgFCqFOMKgtdQX2wAwGO7IHewmYhDkMcsiDPRXBjnewwlNqsDHoj0MBXBUM
+        Yqhdhu3qJBO0c7AMW1rEYIBH4HMbVAsGz2hlsApj3quH18PtvhB3ZXfjllOpYNDCqR6OwWxc19LJ
+        wbq9wn5pOwzmo3AAAoIBi5Ra2A5DXTqvGWltV1a7F+/DBcFAmcVpeFGwWze/nB49BgM2BgrYlU3J
+        B3mQ7mA12ZU7YaAWwDnB4JjdMZjKnZCb72KkQA7P8lnKBViGa7K7OljXdeaRDRetMyBW5IdtkOaI
+        9sJ6uW3jhUSnBYNhdYdhZDQvMeJgCXcxbKUEpqlb2qJtidEVP/hqqBEMgd2UwRy4I1o6sxs2gF9w
+        8u2qGt6EDnYPsxd2Qr3gpNvdFVjh1PTOdg7zLsGJjiZ+WKuWmAwz2UVdMNQMM9kp1B+5NL2THQ4A
+        dwpOKOEMMCyHDlbemvtCcCLpP1fgdWSjvdXCfKfaZ+a9fnQDF+FZp1ePsdLp7CU8aUK3cB4mW2Xd
+        /ARPZ1MzHIfhZg/zSDglOFnUPAWQbNYw9+QloNQKObie+i4z3mmSIzg51HJXYbHTY5KDRKeeou4B
+        nM87Teg2lMEksyw1xvAeQAqB3yDVDI8ayBecDAqN9VhPx0XqITBqv3kFLwWlEKqGmZFaajwCFYKT
+        QKH1l3qZUySeNbdfcPDJGJ85NT08FzElpOht1IMTudQgA12Cx8LVne9reB0aB52Mdcjp9mrheNj4
+        VsHBJuMF4A2jDwSn82HjFEanIcPI16UVCA4yhdc6l0dvb0R3nstnaVAElGMtPdqIdwAeFRxcioxc
+        l1uPC2WgF/Dh4xRBlejS40PZnQsFB5UiKy8kXVq9bpjdmUzgArr0mFDsbPwiOJhkDp+7bucVGELz
+        ZvPCfTKRs+jSQ1ob5o74C3YLDiKZy7utDXSWOroUHEAyl2PgbdkVdcnJMfhDHwoOHpmPH2a1tDv3
+        bHgQCAePzOkbp6bHtyTQs/lcOjKxchjR3HsF4/gIXLKAZc3tzoPwm0sFB4zMfwNAt+acGXyBt1eR
+        BVRBVpPLDb4+gixkeVPLjQG8X5AsZL/TrXe+VaBncXeDLKQcht84zHg/M775peAgkbW8fJP1s56I
+        b/4hOEBkLVtdmt7uRsuNUQ0vdOEAkbX8DZ4bBXqe4OCQ9VyGcddfjORtWD/ngowmCYlJZLxwzOXC
+        /3fnBPzi0WgLc6++6XJAxhA5YDAZYeDdQ2XPtH7hmM/N2L6LvSbQembjFoiMBt2dmhz70CSZX7Bf
+        Fp88KU8UF1OInSwpkT/n75NZ4x+WPVweo+f0CE6D97j2dPeMaNl/VoM7dsJEWVhUJFnGVWlpqXzq
+        6dnhfJHnwGsD/Xa0dOYHs8bJo4UMs7FhPiuzZ84K1/pZ8cHk4P5zW3yRZ/8we+SwEQ/IAwcPSZZx
+        VV5RIZ97fm4wzOG0MHhA2B1fHLT7MiPznnvlnr0/SpZxVVlZJectWBSpef4kuNxIgxL7h3mvZBkZ
+        5kq54LUl0uVJjkR3Vr7DgWG8CvRoqLBrmAdlDpPf/8AwG1lVVVVy4SIVZj1SYVaKIFEFOhtq7Rjm
+        vumD5dc7d0mWcVVdXS3fWvpOJDtz0BkYqAK9COrtFua0fgPlptwtMhAISJYxVVtbK99buUpqemqk
+        w6xUwgQV6DV2DPPGzVtkXV2dZBkX5pWrVsuklDQzhFmphSdVoHfY6XR2au/+MmdTLsMcXWFWAjBf
+        BXqfXcLs7dlbfrxuvfT7GWajSjWKtRhjjHUwzGayQgW6yA5h9iT3aljP+Xw+yTKm1PHIZhyXpPZJ
+        N2OYlU9VoE9ZPcxJjWGuqamRLOPCnJu3VfbpPyh4sZEZ7fiHvTOBjaqIw/hQDiERq0Bnu320r8sl
+        sRIbxBI5IwpiQBQESgwgjRCCCipIiQEFROMRlSBRQFDUIJAKyh2JyiUKGiDcKohccpRWytlioR2/
+        ebhJI0V67Oy+t/t9yS+EHnv855fp7JvjaaFzvSyz/oT91tvvUmbDMi9YmON2mTWrtdAXvSqzvvb5
+        8qRXcC20UDHmsnTZCtXyznS3y6zZqIUu8qLMPstWo8eOc2apGHP5Futf7mqd4QWZNT86QntR5udf
+        yFYFBQWKMZc1a9epNm3be0VmzU5P9tDPjRlLmSlzeez1lNC6dx46fITKy89XjLls2vyTymjX0dkQ
+        gbpTaFNT2o8PGqKOHTuuGHPZsWOn6tylqxdl1mzzhNCN/MmQ+Ql15OhRxZjLzl27VNfuPYLDDC/y
+        gxb6nNt75gEDB1Pm8Mgc7Jm9yvda6BNu3tTaq3df9cfBg4oxl3379qvuPXp5XWbNKi30AZduakWP
+        0VPt2fuLYszl8JEjqk+/AU69UXevkyPceGJSw0Qtcw/nzyBjLhjG6c8mwYVG0cBMLfR3bhtmPPAg
+        ZQ6TzMEPgNHCFC30AjfJ3L7TfWrL1m2KMZeTublq0JAno03mEjBSC/2OW65m6JmpDThvjjGX05hh
+        feqZZ4PDjGiiCGRqoUeDEjfIrKdbGXMpgMxYA+OshUmILpk1f4HOWuj+oDCSMt+d0Y4yh0/maOyd
+        NYdx0ExLLXQ7kBcpmdNwjvCqr1crxlzOX7igsl8cH80ya7YAnxY6APZFQuYW2AGRs2ixKi0tVYyZ
+        FGGH9pTXXlf+5EA0y6xZnphk19VCx4O1kZB5/sIcHgRjUuaiS872NGwgjnaZNdOETsOUQBz+Mze8
+        MrfSGy4pM2UOJSPLHng+LlzrmQPNW6qPP/mMMhtMcXGxmjpteizJXAi6lxX6YXApHDK/P2MWTzUy
+        mCvoKOZ8NFelNrs9VmTWHMUVjhZlhb4DnDAtdM9H+qgvFn2plq1YqZYuX0FCzPKVq9Azv6daGDhu
+        wOVshNDxZYS2b8MXN5t+YnzSJoYJdh74N5b4MJDapIYIJiHQtAa+OFvyrqTEm4wQ/w2+OByUShaH
+        eIsCDDfuvVZoy85w5sNZIOIttvmS7ITyhG6Ab/4sWSDiLeYkNw7UEOUF35wuWSDiHa6ALIFcT+i+
+        4G/JQhFvcAykXV9oy1mo9LtkoYg3WInxcz1xvSQkp9bGD82XLBTxBtniRpGWPcQZm7BYxN3k43Jd
+        24oI3dy5TQULRtxM8FbIN4psnFrLWU7KghH3UgpGiooGP/wYuCRZOOLe1XVpFRfasn34pa2ShSPu
+        ZJ7fsmuLygS/NEmycMR9FKJ37i0qG/TSrZ010iwgcRebIHQjUdkkWHYd3bVLFpC4h1IwRlQ1ep8W
+        OCdZSOIO9qN3blZ1oS27vj5EWrKQxB28IaobaaUMcA7CYzFJZPkT6zbSRTUTXCe9VrKgJLJMt6xA
+        TRGK4MEGcqKFRJBj6J3biFAlwXJ2hX8jWVgSGaZaVpM4EcrIJFtPh1+QLC4JLwfRO7cSoY7Psm/G
+        gy+WLDAJH6VgojAVPHgncEqy0CQ8bEfvbAtT8V1dWjpVstDEPEUgSxhOcAPAbsmCE7N8hd65vghH
+        8GTDeBmPGOQ46CDCFVzGuwVPuEiy8CT0lICJSUlNa4hwBk96Dzgk2QAktKzBUEOKCERLPYoH05AQ
+        kgu6iEhFXh16LJBsCFJ9roCXEv2BOIFEUmp9+v8uyQYh1WMJhhoNhAsSPBPvtGSjkKrxK0gXbgmm
+        xfWEy2RwWbJxSOUoAJnCbfFdvU9LjmQDkYpzGUyGO7WEGyOtlBbOzYfYUKRizIPMtwo3RybZHfFC
+        D0g2Fvl/1gFbeCF4of1AnmSjkfLZjZ65tfBK/H7n/uFPc0MAKYdDoJvwWjCevgkvfAIolGxEAkAe
+        6C+8mgQrpR7EfhNvoliyMWOdfAwzshL9qXHCy5GWHY83M4N3BYhpzoChfgPT2pG8Rj2TUsckZ8Eo
+        PfkmgokiqT/g6ryYIh8MNS1zpFfnvQouSjZ2tJP375i5pojm4I3WBeN5qmlUcwhk+rXMsRBppeLs
+        aXsYj0SISvaAbiLWkpgUqIk3/ijYJylBtLDe/TOA5td+ZKAQG0CppBBepRh8DmzBCKELAT7lFRBP
+        cgZMQs8cL5iyUjtXQLI5rvYUv4FMX1JqbcFcGxRGj6sfAlskZXEzl8Ey50R9pkJDkACYzdV6ruQU
+        mOBsaGUqNQlTD4UbDPZKSuQGSsB6cH+i364pmCqPrVuiiHPAeUmpIsVJMAlt4RNMSNaB6NnFvmAz
+        KJEULFwUgSWgg8+fyl7ZwDDE0uM3cFhSNtPDi+0gyznSljG6EyYOYqej2LNAvqR8oeYgmAiRkwUT
+        1mFIHRS+M5gPzkqKWF1OgGmoa5r0p8QJ5p/27t8lgTiM4/jZL8rFIboz79TDFhEisKHGhAjHWppa
+        GhsySPoPinCuIUpoCYlqi8jaol9ESTQEQVtkUVRGhFNJ7yNbCgQpyB/PB164ntzHh+8jnP7brzY1
+        IczNWEVGlWIWI4c0Zilyp1M36xRJSS2OISziVpWyFvKOS8QYBh1S5BKOk6MI5Q5ys6ZxLr+39+Nb
+        i0OMU+Q2OVqU18Sugdt6BAgbeECuSqfxNZZYpgcocrMiKftztp1yd1nbOw7wUgVn43tsYUxzeQJO
+        w2xQJJUX9fNh3RAmsYunCpncb0hjE1FV9wStD7IiqarJ7eDGW5M7gmVc4LWMpnAGp4hjmPcTkBJL
+        vv4lt17TPQZ6KccEEkjhrkQePMjiBvuYxwhHiW6ut6XV8MpyJykc1TBrrQWKRaqdKd6fL/kCkjhD
+        Gs/5suf+aHnL4hFXOME6ZjDKNYQpsJ/rcWhun02RSH4b3euzaYbXTqlcGkXntY+yDSGKGOJYwzb2
+        cIzUN0fYQRIrmMMUIhhED/wssZrmNhsVSVH5AIu3xubrej5GAAAAAElFTkSuQmCC
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '14774'
+      Cache-Control:
+      - public, max-age=0, must-revalidate
+      Content-Disposition:
+      - inline; filename="icon-dark.png"
+      Content-Length:
+      - '4095'
+      Content-Type:
+      - image/png
+      Date:
+      - Wed, 15 Oct 2025 12:50:01 GMT
+      Etag:
+      - '"9c6ae8bbf0a6123a6c319a5f0b8b2620"'
+      Last-Modified:
+      - Wed, 15 Oct 2025 08:43:47 GMT
+      Permissions-Policy:
+      - camera=(), microphone=(), geolocation=(), interest-cohort=()
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Vercel
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Matched-Path:
+      - /icon-dark.png
+      X-Vercel-Cache:
+      - HIT
+      X-Vercel-Id:
+      - arn1::hzs9t-1760532601984-b82cca2ef2a1
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -1145,7 +1145,7 @@ def test_product_bulk_create_with_media_with_media_url_invalid_provider(
     return_value=False,
 )
 @patch(
-    "saleor.graphql.core.validators.file.HTTPClient",
+    "saleor.graphql.product.bulk_mutations.product_bulk_create.HTTPClient",
 )
 def test_product_bulk_create_with_media_with_media_url_invalid_image_type(
     mocked_http_client,
@@ -1207,6 +1207,128 @@ def test_product_bulk_create_with_media_with_media_url_invalid_image_type(
     assert error_1[0]["path"] == "media.0.mediaUrl"
     assert error_1[0]["message"] == "Invalid file type."
     assert len(error_1) == 1
+
+
+@patch(
+    "saleor.graphql.product.bulk_mutations.product_bulk_create.HTTPClient",
+)
+def test_product_bulk_create_with_media_invalid_image_file_fetch_only_header(
+    mock_HTTPClient,
+    staff_api_client,
+    product_type,
+    category,
+    permission_manage_products,
+):
+    # given
+    mock_response = Mock()
+    mock_response.headers = Mock()
+    mock_response.headers.get = Mock(return_value="text/plain")
+    mock_response.raw = Mock()
+    mock_response.raw.read = Mock(return_value=b"fake_image_data")
+    mock_HTTPClient.send_request.return_value.__enter__.return_value = mock_response
+
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    category_id = graphene.Node.to_global_id("Category", category.pk)
+
+    product_name_1 = "test name 1"
+
+    alt = "Invalid_image"
+    url = "https://saleor.io/invalid.png"
+
+    media_1 = {
+        "alt": alt,
+        "mediaUrl": url,
+    }
+
+    products = [
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name_1,
+            "media": [media_1],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_BULK_CREATE_MUTATION, {"products": products}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["productBulkCreate"]
+    assert data["count"] == 0
+    error_1 = data["results"][0]["errors"]
+    assert error_1[0]["code"] == ProductBulkCreateErrorCode.INVALID.name
+    assert error_1[0]["path"] == "media.0.mediaUrl"
+    assert error_1[0]["message"] == "Invalid file type."
+    assert len(error_1) == 1
+
+
+@pytest.mark.vcr
+def test_product_bulk_create_with_media_image_file_is_fetched_only_once(
+    staff_api_client,
+    product_type,
+    category,
+    permission_manage_products,
+    media_root,
+):
+    # given
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    category_id = graphene.Node.to_global_id("Category", category.pk)
+
+    product_name_1 = "test name 1"
+
+    alt = "Invalid_image"
+    expected_file_name = "icon-dark.png"
+    url = f"https://saleor.io/{expected_file_name}"
+
+    media_1 = {
+        "alt": alt,
+        "mediaUrl": url,
+    }
+
+    products = [
+        {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name_1,
+            "media": [media_1],
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_BULK_CREATE_MUTATION, {"products": products}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["productBulkCreate"]
+    assert data["count"] == 1
+    assert not data["results"][0]["errors"]
+    assert data["results"][0]["product"]["media"][0]["type"] == "IMAGE"
+    assert data["results"][0]["product"]["media"][0]["alt"] == alt
+    assert data["results"][0]["product"]["media"][0]["url"] != url
+
+    # Validate the image file
+    product = Product.objects.first()
+    product_image = product.media.last()
+    assert product_image.image.file
+    img_name, format = os.path.splitext(expected_file_name)
+    file_name = product_image.image.name
+    assert file_name != expected_file_name
+    assert file_name.startswith(f"products/{img_name}")
+    assert file_name.endswith(format)
+
+    # Open the image and validate its content
+    image_path = product_image.image.path
+    with PIL.Image.open(image_path) as img:
+        assert img.format == "PNG"  # Ensure the image format is PNG
+        assert img.size[0] > 0  # Ensure the image has dimensions
+        assert img.size[1] > 0  # Ensure the image has dimensions
 
 
 def test_product_bulk_create_with_attributes(


### PR DESCRIPTION
I want to merge this change because it refactors the way Saleor downloads images via URL.

Port https://github.com/saleor/saleor/pull/18322

From now on, Saleor will use the stream=True parameter to fetch the header first. If the header passes validation, the file will be downloaded instead of the flow.

Fetch the HEAD query.
validate headers;
fetch the image.
This change allows to use of presigned URLs to upload files.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
