### PR TITLE
Fix a bug where task deleting expired checkouts would end prematurely (#18324)

### DIFF
--- a/saleor/checkout/tasks.py
+++ b/saleor/checkout/tasks.py
@@ -23,6 +23,7 @@ task_logger: logging.Logger = get_task_logger(__name__)
 
 
 @app.task
+@allow_writer()
 def delete_expired_checkouts(
     batch_size: int = 2000,
     batch_count: int = 5,


### PR DESCRIPTION
due to stale data being read from database replica.