### PR TITLE
Make sure to have up-to-date deliveries on complete action

### DIFF
--- a/saleor/checkout/tests/fixtures/checkout.py
+++ b/saleor/checkout/tests/fixtures/checkout.py
@@ -155,7 +155,6 @@ def checkout_ready_to_complete(
     checkout_with_item,
     address,
     checkout_shipping_method,
-    gift_card,
 ):
     checkout = checkout_with_item
     checkout.shipping_address = address
@@ -165,7 +164,6 @@ def checkout_ready_to_complete(
     checkout.metadata_storage.store_value_in_private_metadata(
         items={"accepted": "false"}
     )
-    checkout_with_item.gift_cards.add(gift_card)
     checkout.save()
     checkout.metadata_storage.save()
     return checkout

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -13,6 +13,7 @@ from ....checkout.fetch import (
     CheckoutLineInfo,
     fetch_checkout_info,
     fetch_checkout_lines,
+    get_or_fetch_checkout_shipping_methods,
 )
 from ....checkout.utils import is_shipping_required
 from ....order import models as order_models
@@ -185,6 +186,8 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         billing_address = checkout_info.billing_address
 
         if is_shipping_required(lines):
+            # Refresh stale shipping if needed
+            get_or_fetch_checkout_shipping_methods(checkout_info)
             clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
             if shipping_address:
                 shipping_address_data = shipping_address.as_data()

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -3,7 +3,14 @@ from django.core.exceptions import ValidationError
 
 from ....checkout.checkout_cleaner import validate_checkout
 from ....checkout.complete_checkout import create_order_from_checkout
-from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from ....checkout.fetch import (
+    CheckoutInfo,
+    CheckoutLineInfo,
+    fetch_checkout_info,
+    fetch_checkout_lines,
+    get_or_fetch_checkout_shipping_methods,
+)
+from ....checkout.utils import is_shipping_required
 from ....core.exceptions import GiftCardNotApplicable, InsufficientStock
 from ....core.taxes import TaxDataError
 from ....discount.models import NotApplicable
@@ -147,6 +154,24 @@ class OrderCreateFromCheckout(BaseMutation):
         return False
 
     @classmethod
+    def validate_checkout(
+        cls,
+        checkout_info: CheckoutInfo,
+        checkout_lines: list[CheckoutLineInfo],
+        unavailable_variant_pks: list[int],
+        manager,
+    ):
+        if is_shipping_required(checkout_lines):
+            # Refresh stale shipping if needed
+            get_or_fetch_checkout_shipping_methods(checkout_info)
+        validate_checkout(
+            checkout_info=checkout_info,
+            lines=checkout_lines,
+            unavailable_variant_pks=unavailable_variant_pks,
+            manager=manager,
+        )
+
+    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls,
         _root,
@@ -182,11 +207,8 @@ class OrderCreateFromCheckout(BaseMutation):
         checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(checkout, checkout_lines, manager)
 
-        validate_checkout(
-            checkout_info=checkout_info,
-            lines=checkout_lines,
-            unavailable_variant_pks=unavailable_variant_pks,
-            manager=manager,
+        cls.validate_checkout(
+            checkout_info, checkout_lines, unavailable_variant_pks, manager
         )
         app = get_app_promise(info.context).get()
         try:

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -14,7 +14,12 @@ from .....account.models import Address
 from .....channel import MarkAsPaidStrategy
 from .....checkout import calculations
 from .....checkout.error_codes import CheckoutErrorCode
-from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from .....checkout.fetch import (
+    fetch_checkout_info,
+    fetch_checkout_lines,
+    fetch_shipping_methods_for_checkout,
+    get_or_fetch_checkout_shipping_methods,
+)
 from .....checkout.models import Checkout, CheckoutLine, CheckoutShippingMethod
 from .....checkout.payment_utils import update_checkout_payment_statuses
 from .....checkout.utils import PRIVATE_META_APP_SHIPPING_ID, add_voucher_to_checkout
@@ -39,6 +44,7 @@ from .....product.models import (
     ProductVariantChannelListing,
     VariantChannelListingPromotionRule,
 )
+from .....shipping.models import ShippingMethod
 from .....tests import race_condition
 from .....warehouse.models import Reservation, Stock, WarehouseClickAndCollectOption
 from .....warehouse.tests.utils import get_available_quantity_for_stock
@@ -5594,3 +5600,155 @@ def test_checkout_complete_sets_product_type_id_for_all_order_lines(
         assert (
             line.product_type_id == variant_id_to_product_type_id_map[line.variant_id]
         )
+
+
+@patch(
+    "saleor.graphql.checkout.mutations.checkout_complete."
+    "get_or_fetch_checkout_shipping_methods",
+    wraps=get_or_fetch_checkout_shipping_methods,
+)
+def test_complete_refreshes_shipping_methods_when_stale(
+    mocked_get_or_fetch_checkout_shipping_methods,
+    user_api_client,
+    checkout_ready_to_complete,
+    transaction_item_generator,
+    checkout_shipping_method,
+):
+    # given
+    checkout = checkout_ready_to_complete
+    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.gift_cards.all().delete()
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, None
+    )
+
+    transaction_item_generator(
+        checkout_id=checkout.pk, authorized_value=total.gross.amount
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+        checkout_has_lines=bool(lines),
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+
+    assert not data["errors"]
+    assert mocked_get_or_fetch_checkout_shipping_methods.called
+
+
+@patch(
+    "saleor.checkout.fetch.fetch_shipping_methods_for_checkout",
+    wraps=fetch_shipping_methods_for_checkout,
+)
+def test_complete_do_not_refresh_shipping_methods_when_not_stale(
+    mocked_fetch_checkout_shipping_methods,
+    user_api_client,
+    checkout_ready_to_complete,
+    transaction_item_generator,
+    checkout_shipping_method,
+):
+    # given
+    checkout = checkout_ready_to_complete
+    checkout.shipping_methods_stale_at = timezone.now() + datetime.timedelta(hours=1)
+    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.gift_cards.all().delete()
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, None
+    )
+
+    transaction_item_generator(
+        checkout_id=checkout.pk, authorized_value=total.gross.amount
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+        checkout_has_lines=bool(lines),
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+
+    assert not data["errors"]
+    assert not mocked_fetch_checkout_shipping_methods.called
+
+
+@patch(
+    "saleor.graphql.checkout.mutations.checkout_complete."
+    "get_or_fetch_checkout_shipping_methods",
+    wraps=get_or_fetch_checkout_shipping_methods,
+)
+def test_complete_refreshes_shipping_methods_when_stale_and_invalid(
+    mocked_get_or_fetch_checkout_shipping_methods,
+    user_api_client,
+    checkout_ready_to_complete,
+    transaction_item_generator,
+    checkout_shipping_method,
+):
+    # given
+    checkout = checkout_ready_to_complete
+    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.gift_cards.all().delete()
+
+    # Shipping is not available anymore
+    ShippingMethod.objects.all().delete()
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, None
+    )
+
+    transaction_item_generator(
+        checkout_id=checkout.pk, authorized_value=total.gross.amount
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+        checkout_has_lines=bool(lines),
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+
+    assert data["errors"]
+    assert data["errors"][0]["code"] == CheckoutErrorCode.INVALID_SHIPPING_METHOD.name
+
+    assert Order.objects.count() == 0
+    assert mocked_get_or_fetch_checkout_shipping_methods.called


### PR DESCRIPTION
I want to merge this change because it adds a fetch action on checkoutComplete, order create from checkout, when shipping methods are stale. It is required to confirm that that the current shipping methods are valid.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
