### PR TITLE
Update CONTRIBUTING.md to match what actually works

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,19 +84,19 @@ You are ready to go 🎉.
 To start server:
 
 ```shell
-poe start
+uv run poe start
 ```
 
 to start Celery worker:
 
 ```
-poe worker
+uv run poe worker
 ```
 
 to start Celery Beat scheduler:
 
 ```shell
-poe scheduler
+uv run poe scheduler
 ```
 
 > [!NOTE]
@@ -105,13 +105,13 @@ poe scheduler
 To run database migrations:
 
 ```shell
-poe migrate
+uv run poe migrate
 ```
 
 To populate database with example data and create the admin user:
 
 ```shell
-poe populatedb
+uv run poe populatedb
 ```
 
 > [!NOTE]
@@ -120,13 +120,13 @@ poe populatedb
 To build `schema.graphql` file:
 
 ```shell
-poe build-schema
+uv run poe build-schema
 ```
 
 To run Django shell:
 
 ```
-poe shell
+uv run poe shell
 ```
 
 ## Managing dependencies
@@ -222,7 +222,7 @@ In the case of testing the `API`, we would like to split all tests into `mutatio
 To run tests, enter `poe test` in your terminal.
 
 ```bash
-poe test
+uv run poe test
 ```
 
 By default `poe test` is using the `--reuse-db` flag to speed up testing time.
@@ -230,20 +230,23 @@ By default `poe test` is using the `--reuse-db` flag to speed up testing time.
 > [!TIP]
 > If you need to ignore `--reuse-db` (e.g when testing Saleor on different versions that have different migrations) add `--create-db` argument: `poe test --create-db`
 
+> [!TIP]
+> Depending on your setup, you may want to run your Postgres on host (not inside container) to improve the test execution speed
+
 ### How to run particular tests?
 
 As running all tests is quite time-consuming, sometimes you want to run only tests from one dictionary or even just a particular test.
 You can use the following command for that. In the case of a particular directory or file, provide the path after the `pytest` command, like:
 
 ```bash
-poe test saleor/graphql/app/tests
+uv run poe test saleor/graphql/app/tests
 ```
 
 If you want to run a particular test, you need to provide the path to the file where the test is and the file name after the `::` sign. In the case of running a single test, it's also worth using the `-n0` flag to run the test only in one thread. It will significantly decrease time.
 See an example below:
 
 ```bash
-poe test saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0
+uv run poe test saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0
 ```
 
 ### Using pdb when testing
@@ -252,7 +255,7 @@ If you would like to use `pdb` in code when running a test, you need to use a fe
 So the previous example will look like this:
 
 ```bash
-poe test saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0 -s --allow-hosts=127.0.0.1
+uv run poe test saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_mutation -n0 -s --allow-hosts=127.0.0.1
 ```
 
 ### Recording cassettes
@@ -260,7 +263,7 @@ poe test saleor/graphql/app/tests/mutations/test_app_create.py::test_app_create_
 Some of our tests use `VCR.py` cassettes to record requests and responses from external APIs. To record one, you need to use the `vcr-record` flag and specify `allow-hosts`:
 
 ```bash
-poe test --vcr-record=once saleor/app/tests/test_app_commands.py --allow-hosts=127.0.0.1
+uv run poe test --vcr-record=once saleor/app/tests/test_app_commands.py --allow-hosts=127.0.0.1
 ```
 
 ### Writing benchmark tests
@@ -285,7 +288,7 @@ def test_apps_for_federation_query_count(
 To check the number of queries, run the benchmark test, and after that, call the following command in your terminal:
 
 ```bash
-django-queries show
+uv run django-queries show
 ```
 
 You will see the number of queries that were performed for each test
@@ -355,7 +358,7 @@ Use relative imports.
 ### Migrations
 
 Try to combine multiple migrations into one, but remember not to mix changes on the database with updating rows in migrations. In other words, operations that alter tables and use `RunPython` to run methods on existing data should be in separate files.
-Follow [zero-downtime policy](./developer/community/zero-downtime-migrations.mdx) when writing migrations.
+Follow [zero-downtime policy](https://docs.saleor.io/developer/community/zero-downtime-migrations) when writing migrations.
 
 ### Handling migrations between versions
 


### PR DESCRIPTION
I recently had to setup Saleor to start contributing and found `poe` commands will not work when not run through `uv` and the link to zero downtime migrations was broken. This is addressed here.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
