### PR TITLE
Clear caching stored payment methods in transactions api

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -25,6 +25,7 @@ from .....payment.utils import (
     create_failed_transaction_event,
     get_already_existing_event,
     get_transaction_event_amount,
+    invalidate_cache_for_stored_payment_methods_if_needed,
     process_order_or_checkout_with_transaction,
     truncate_transaction_event_message,
     update_transaction_item_with_payment_method_details,
@@ -371,6 +372,7 @@ class TransactionEventReport(DeprecatedModelMutation):
         transaction_event = cls.construct_instance(
             transaction_event, transaction_event_data
         )
+        source_object = transaction.order or transaction.checkout
 
         metadata_collection = cls.create_metadata_from_graphql_input(
             transaction_metadata, error_field_name="metadata"
@@ -473,6 +475,12 @@ class TransactionEventReport(DeprecatedModelMutation):
                 )
             if updated_fields:
                 transaction.save(update_fields=updated_fields)
+
+        app_identifier = app_identifier or transaction.app_identifier
+        if app_identifier and source_object:
+            invalidate_cache_for_stored_payment_methods_if_needed(
+                transaction_event, source_object, app_identifier
+            )
 
         return cls(
             already_processed=already_processed,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -29,6 +29,9 @@ from .....payment.lock_objects import (
 from .....payment.models import TransactionEvent
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....tests import race_condition
+from .....webhook.event_types import WebhookEventSyncType
+from .....webhook.models import Webhook
+from .....webhook.transport.utils import generate_cache_key_for_webhook
 from ....core.enums import TransactionEventReportErrorCode
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -4021,3 +4024,385 @@ def test_transaction_event_report_event_already_exists_updates_other_payment_met
     transaction.refresh_from_db()
     assert transaction.payment_method_type == PaymentMethodType.OTHER
     assert transaction.payment_method_name == payment_method_name
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_REQUEST,
+        TransactionEventType.CHARGE_SUCCESS,
+    ],
+)
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_invalidate_stored_payment_methods_for_order(
+    cache_delete_mock,
+    result,
+    customer_user,
+    app_api_client,
+    order_with_lines,
+    permission_manage_payments,
+    list_stored_payment_methods_app,
+    transaction_item_generator,
+):
+    # given
+    order = order_with_lines
+    order.user = customer_user
+    order.save(update_fields=["user_id"])
+
+    app = app_api_client.app
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, order_id=order.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    channel = order.channel
+    expected_payload = {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel.slug,
+    }
+    # cache key for transaction webhook
+    cache_key = generate_cache_key_for_webhook(
+        expected_payload,
+        webhook.target_url,
+        WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+        app.id,
+    )
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": result.upper(),
+        "amount": expected_amount,
+        "pspReference": expected_psp_reference,
+        "availableActions": [TransactionActionEnum.REFUND.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $availableActions: [TransactionActionEnum!]!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            availableActions: $availableActions
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+
+    # when
+    response = app_api_client.post_graphql(query, variables)
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["transaction"]
+
+    # ensure that only cache for result app identifier has been cleared
+    cache_delete_mock.assert_called_once_with(cache_key)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_REQUEST,
+        TransactionEventType.AUTHORIZATION_SUCCESS,
+        TransactionEventType.CHARGE_REQUEST,
+        TransactionEventType.CHARGE_SUCCESS,
+    ],
+)
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_invalidate_stored_payment_methods_for_checkout(
+    cache_delete_mock,
+    result,
+    customer_user,
+    app_api_client,
+    checkout_with_items,
+    permission_manage_payments,
+    list_stored_payment_methods_app,
+    transaction_item_generator,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_items
+    checkout.user = customer_user
+    checkout.save(update_fields=["user_id"])
+
+    # Fetch checkout lines and info to recalculate checkout total prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    app = app_api_client.app
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, checkout_id=checkout.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    channel = checkout.channel
+    expected_payload = {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel.slug,
+    }
+    # cache key for transaction webhook
+    cache_key = generate_cache_key_for_webhook(
+        expected_payload,
+        webhook.target_url,
+        WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+        app.id,
+    )
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": result.upper(),
+        "amount": expected_amount,
+        "pspReference": expected_psp_reference,
+        "availableActions": [TransactionActionEnum.REFUND.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $availableActions: [TransactionActionEnum!]!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            availableActions: $availableActions
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+
+    # when
+    response = app_api_client.post_graphql(query, variables)
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["transaction"]
+
+    # ensure that only cache for result app identifier has been cleared
+    cache_delete_mock.assert_called_once_with(cache_key)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_FAILURE,
+        TransactionEventType.CHARGE_ACTION_REQUIRED,
+        TransactionEventType.CHARGE_FAILURE,
+    ],
+)
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_stored_payment_methods_not_invalidated_for_order(
+    cache_delete_mock,
+    result,
+    customer_user,
+    app_api_client,
+    order_with_lines,
+    permission_manage_payments,
+    transaction_item_generator,
+):
+    # given
+    order = order_with_lines
+    order.user = customer_user
+    order.save(update_fields=["user_id"])
+
+    app = app_api_client.app
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, order_id=order.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": result.upper(),
+        "amount": expected_amount,
+        "pspReference": expected_psp_reference,
+        "availableActions": [TransactionActionEnum.REFUND.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $availableActions: [TransactionActionEnum!]!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            availableActions: $availableActions
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+
+    # when
+    response = app_api_client.post_graphql(query, variables)
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["transaction"]
+
+    # ensure that cache has not been cleared
+    cache_delete_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TransactionEventType.AUTHORIZATION_FAILURE,
+        TransactionEventType.CHARGE_ACTION_REQUIRED,
+        TransactionEventType.CHARGE_FAILURE,
+    ],
+)
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_stored_payment_methods_not_invalidated_for_checkout(
+    cache_delete_mock,
+    result,
+    customer_user,
+    app_api_client,
+    checkout_with_items,
+    permission_manage_payments,
+    transaction_item_generator,
+    plugins_manager,
+):
+    # given
+    checkout = checkout_with_items
+    checkout.user = customer_user
+    checkout.save(update_fields=["user_id"])
+
+    # Fetch checkout lines and info to recalculate checkout total prices
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, plugins_manager)
+    fetch_checkout_data(checkout_info, plugins_manager, lines)
+
+    app = app_api_client.app
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, checkout_id=checkout.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": result.upper(),
+        "amount": expected_amount,
+        "pspReference": expected_psp_reference,
+        "availableActions": [TransactionActionEnum.REFUND.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $availableActions: [TransactionActionEnum!]!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            availableActions: $availableActions
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+
+    # when
+    response = app_api_client.post_graphql(query, variables)
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["transaction"]
+
+    # ensure that cache has not been cleared
+    cache_delete_mock.assert_not_called()

--- a/saleor/payment/tests/test_utils/test_utils.py
+++ b/saleor/payment/tests/test_utils/test_utils.py
@@ -3,6 +3,7 @@ import logging
 from decimal import Decimal
 from unittest.mock import patch
 
+import graphene
 import pytest
 from freezegun import freeze_time
 
@@ -10,6 +11,9 @@ from ....checkout import CheckoutAuthorizeStatus, calculations
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....order import OrderChargeStatus, OrderGrantedRefundStatus
 from ....plugins.manager import get_plugins_manager
+from ....webhook.event_types import WebhookEventSyncType
+from ....webhook.models import Webhook
+from ....webhook.transport.utils import generate_cache_key_for_webhook
 from ... import TransactionEventType
 from ...interface import (
     PaymentLineData,
@@ -1815,6 +1819,249 @@ def test_create_transaction_event_from_request_and_webhook_updates_modified_at(
     checkout.refresh_from_db()
     assert transaction.modified_at == calculation_time
     assert checkout.last_transaction_modified_at == calculation_time
+
+
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_create_transaction_event_invalidate_stored_payment_methods_for_order(
+    cache_delete_mock,
+    customer_user,
+    app,
+    order_with_lines,
+    transaction_item_generator,
+    permission_manage_payments,
+):
+    # given
+    order = order_with_lines
+    order.user = customer_user
+    order.save(update_fields=["user_id"])
+
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, order_id=order.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=expected_amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+    channel = order.channel
+    expected_payload = {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel.slug,
+    }
+    cache_key = generate_cache_key_for_webhook(
+        expected_payload,
+        webhook.target_url,
+        WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+        app.id,
+    )
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": expected_amount,
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+        "actions": ["CHARGE", "REFUND"],
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    cache_delete_mock.assert_called_once_with(cache_key)
+
+
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_create_transaction_event_invalidate_stored_payment_methods_for_checkout(
+    cache_delete_mock,
+    customer_user,
+    app,
+    checkout_with_items,
+    transaction_item_generator,
+    permission_manage_payments,
+):
+    # given
+    checkout = checkout_with_items
+    checkout.user = customer_user
+    checkout.save(update_fields=["user_id"])
+
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, checkout_id=checkout.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=expected_amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    channel = checkout.channel
+    expected_payload = {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel.slug,
+    }
+    cache_key = generate_cache_key_for_webhook(
+        expected_payload,
+        webhook.target_url,
+        WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+        app.id,
+    )
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": expected_amount,
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+        "actions": ["CHARGE", "REFUND"],
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    cache_delete_mock.assert_called_once_with(cache_key)
+
+
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_create_transaction_event_stored_payment_methods_not_invalidated_for_order(
+    cache_delete_mock,
+    customer_user,
+    app,
+    order_with_lines,
+    transaction_item_generator,
+    permission_manage_payments,
+):
+    # given
+    order = order_with_lines
+    order.user = customer_user
+    order.save(update_fields=["user_id"])
+
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, order_id=order.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=expected_amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": expected_amount,
+        "result": TransactionEventType.CHARGE_FAILURE.upper(),
+        "actions": ["CHARGE", "REFUND"],
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    cache_delete_mock.assert_not_called()
+
+
+@patch("saleor.webhook.transport.list_stored_payment_methods.cache.delete")
+def test_create_transaction_event_stored_payment_methods_not_invalidated_for_checkout(
+    cache_delete_mock,
+    customer_user,
+    app,
+    checkout_with_items,
+    transaction_item_generator,
+    permission_manage_payments,
+):
+    # given
+    checkout = checkout_with_items
+    checkout.user = customer_user
+    checkout.save(update_fields=["user_id"])
+
+    expected_app_identifier = "webhook.app.identifier"
+    app.identifier = expected_app_identifier
+    app.save()
+
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+
+    transaction = transaction_item_generator(app=app, checkout_id=checkout.pk)
+    expected_amount = Decimal("11.00")
+    expected_psp_reference = "111-abc"
+
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=expected_amount,
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": expected_amount,
+        "result": TransactionEventType.CHARGE_FAILURE.upper(),
+        "actions": ["CHARGE", "REFUND"],
+    }
+
+    # when
+    create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    cache_delete_mock.assert_not_called()
 
 
 def test_recalculate_refundable_for_checkout_with_request_refund(


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/18362

Clear caching stored payment methods in transactions api for the following responses:
- `AUTHORIZATION_REQUEST`
- `AUTHORIZATION_SUCCESS`
- `CHARGE_REQUEST`
- `CHARGE_SUCCESS`


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
