### PR TITLE
Add custom scheduelrs for search tasks

### DIFF
--- a/saleor/core/schedules.py
+++ b/saleor/core/schedules.py
@@ -235,7 +235,70 @@ class checkout_automatic_completion_schedule(TimeBaseSchedule):
         return False
 
 
+class page_search_update_schedule(TimeBaseSchedule):
+    def __init__(self, initial_timedelta=60, nowfun=None, app=None):
+        # initial_timedelta defaults to 60 seconds, as referencing settings.py variables
+        # would require rebuilding the schedule. settings depends on this class instance,
+        # leading to a circular import if accessed directly.
+        import_path = "saleor.core.schedules.initiated_page_search_update_schedule"
+        super().__init__(import_path, initial_timedelta, nowfun, app)
+
+    def are_dirty(self) -> bool:
+        from django.conf import settings
+
+        from ..page.models import Page
+
+        return (
+            Page.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+            .filter(search_index_dirty=True)
+            .exists()
+        )
+
+
+class product_search_update_schedule(TimeBaseSchedule):
+    def __init__(self, initial_timedelta=60, nowfun=None, app=None):
+        # initial_timedelta defaults to 60 seconds, as referencing settings.py variables
+        # would require rebuilding the schedule. settings depends on this class instance,
+        # leading to a circular import if accessed directly.
+        import_path = "saleor.core.schedules.initiated_product_search_update_schedule"
+        super().__init__(import_path, initial_timedelta, nowfun, app)
+
+    def are_dirty(self) -> bool:
+        from django.conf import settings
+
+        from ..product.models import Product
+
+        return (
+            Product.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+            .filter(search_index_dirty=True)
+            .exists()
+        )
+
+
+class gift_card_search_update_schedule(TimeBaseSchedule):
+    def __init__(self, initial_timedelta=60, nowfun=None, app=None):
+        # initial_timedelta defaults to 60 seconds, as referencing settings.py variables
+        # would require rebuilding the schedule. settings depends on this class instance,
+        # leading to a circular import if accessed directly.
+        import_path = "saleor.core.schedules.initiated_gift_card_search_update_schedule"
+        super().__init__(import_path, initial_timedelta, nowfun, app)
+
+    def are_dirty(self) -> bool:
+        from django.conf import settings
+
+        from ..giftcard.models import GiftCard
+
+        return (
+            GiftCard.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+            .filter(search_index_dirty=True)
+            .exists()
+        )
+
+
 initiated_promotion_webhook_schedule = promotion_webhook_schedule()
 initiated_checkout_automatic_completion_schedule = (
     checkout_automatic_completion_schedule()
 )
+initiated_gift_card_search_update_schedule = gift_card_search_update_schedule()
+initiated_page_search_update_schedule = page_search_update_schedule()
+initiated_product_search_update_schedule = product_search_update_schedule()

--- a/saleor/core/tests/test_schedules.py
+++ b/saleor/core/tests/test_schedules.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytest
 from celery.schedules import BaseSchedule
 from django.utils import timezone
 from django.utils.module_loading import import_string
@@ -10,8 +11,90 @@ from ...checkout.models import Checkout
 from ...discount.models import Promotion
 from ..schedules import (
     checkout_automatic_completion_schedule,
+    gift_card_search_update_schedule,
+    page_search_update_schedule,
+    product_search_update_schedule,
     promotion_webhook_schedule,
 )
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        page_search_update_schedule(),
+        product_search_update_schedule(),
+        gift_card_search_update_schedule(),
+    ],
+)
+@freeze_time("2020-10-10 12:00:00")
+def test_search_update_schedule_remaining_estimate_initial_state(schedule):
+    # when
+    remaining = schedule.remaining_estimate(last_run_at=timezone.now())
+
+    # then
+    assert remaining == schedule.initial_timedelta
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        page_search_update_schedule(),
+        product_search_update_schedule(),
+        gift_card_search_update_schedule(),
+    ],
+)
+@freeze_time("2020-10-10 12:00:00")
+def test_search_update_schedule_remaining_estimate(schedule):
+    # given
+    time_delta = datetime.timedelta(seconds=30)
+
+    # when
+    remaining = schedule.remaining_estimate(last_run_at=timezone.now() - time_delta)
+
+    # then
+    assert remaining == schedule.initial_timedelta - time_delta
+
+
+def test_gift_card_search_update_schedule_are_dirty(gift_card):
+    # given
+    schedule = gift_card_search_update_schedule()
+    gift_card.search_index_dirty = True
+    gift_card.save(update_fields=["search_index_dirty"])
+
+    # when
+    is_due, next_run = schedule.is_due(timezone.now() - datetime.timedelta(minutes=1))
+
+    # then
+    assert is_due is True
+    assert next_run == schedule.initial_timedelta.total_seconds()
+
+
+def test_page_search_update_schedule_are_dirty(page):
+    # given
+    schedule = page_search_update_schedule()
+    page.search_index_dirty = True
+    page.save(update_fields=["search_index_dirty"])
+
+    # when
+    is_due, next_run = schedule.is_due(timezone.now() - datetime.timedelta(minutes=1))
+
+    # then
+    assert is_due is True
+    assert next_run == schedule.initial_timedelta.total_seconds()
+
+
+def test_product_search_update_schedule_are_dirty(product):
+    # given
+    schedule = product_search_update_schedule()
+    product.search_index_dirty = True
+    product.save(update_fields=["search_index_dirty"])
+
+    # when
+    is_due, next_run = schedule.is_due(timezone.now() - datetime.timedelta(minutes=1))
+
+    # then
+    assert is_due is True
+    assert next_run == schedule.initial_timedelta.total_seconds()
 
 
 @freeze_time("2020-10-10 12:00:00")

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -33,6 +33,9 @@ from .core.languages import LANGUAGES as CORE_LANGUAGES
 from .core.rlimit import validate_and_set_rlimit
 from .core.schedules import (
     initiated_checkout_automatic_completion_schedule,
+    initiated_gift_card_search_update_schedule,
+    initiated_page_search_update_schedule,
+    initiated_product_search_update_schedule,
     initiated_promotion_webhook_schedule,
 )
 from .graphql.graphql_core import (
@@ -703,18 +706,21 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update-products-search-vectors": {
         "task": "saleor.product.tasks.update_products_search_vector_task",
-        "schedule": datetime.timedelta(seconds=BEAT_UPDATE_SEARCH_SEC),
-        "options": {"expires": BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC},
+        # Scheduled task that runs every 60 seconds to check for products
+        # requiring a search index rebuild.
+        "schedule": initiated_product_search_update_schedule,
     },
     "update-gift-cards-search-vectors": {
         "task": "saleor.giftcard.tasks.update_gift_cards_search_vector_task",
-        "schedule": datetime.timedelta(seconds=BEAT_UPDATE_SEARCH_SEC),
-        "options": {"expires": BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC},
+        # Scheduled task that runs every 60 seconds to check for gift cards
+        # requiring a search index rebuild.
+        "schedule": initiated_gift_card_search_update_schedule,
     },
     "update-pages-search-vectors": {
         "task": "saleor.page.tasks.update_pages_search_vector_task",
-        "schedule": datetime.timedelta(seconds=BEAT_UPDATE_SEARCH_SEC),
-        "options": {"expires": BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC},
+        # Scheduled task that runs every 60 seconds to check for pages
+        # requiring a search index rebuild.
+        "schedule": initiated_page_search_update_schedule,
     },
     "expire-orders": {
         "task": "saleor.order.tasks.expire_orders_task",


### PR DESCRIPTION
I want to merge this change because it adds custom schedulers for search tasks. Currently we're calling the task once per X seconds. With this change, tasks will be caleld only when we will have something to process. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
