### PR TITLE
Allow fetching `privateMetadata` and `user` from `Checkout` and `Order` with `HANDLE_TAXES` permission

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -850,6 +850,7 @@ class Checkout(ModelObjectType[models.Checkout]):
             root.user,
             AccountPermissions.MANAGE_USERS,
             PaymentPermissions.HANDLE_PAYMENTS,
+            CheckoutPermissions.HANDLE_TAXES,
         )
         return root.user
 

--- a/saleor/graphql/meta/permissions.py
+++ b/saleor/graphql/meta/permissions.py
@@ -185,7 +185,7 @@ def product_type_permissions(
 
 
 def order_permissions(_info: ResolveInfo, _object_pk: Any) -> list[BasePermissionEnum]:
-    return [OrderPermissions.MANAGE_ORDERS]
+    return [OrderPermissions.MANAGE_ORDERS, CheckoutPermissions.HANDLE_TAXES]
 
 
 def invoice_permissions(
@@ -229,7 +229,7 @@ def channel_permissions(
 def checkout_permissions(
     _info: ResolveInfo, _object_pk: Any
 ) -> list[BasePermissionEnum]:
-    return [CheckoutPermissions.MANAGE_CHECKOUTS]
+    return [CheckoutPermissions.MANAGE_CHECKOUTS, CheckoutPermissions.HANDLE_TAXES]
 
 
 def page_permissions(_info: ResolveInfo, _object_pk: Any) -> list[BasePermissionEnum]:

--- a/saleor/graphql/meta/tests/queries/test_order.py
+++ b/saleor/graphql/meta/tests/queries/test_order.py
@@ -99,6 +99,30 @@ def test_query_public_meta_for_order_by_token_as_app(
     assert metadata["value"] == PUBLIC_VALUE
 
 
+def test_query_public_meta_for_order_by_token_as_app_with_handle_taxes(
+    app_api_client, order, customer_user, permission_handle_taxes
+):
+    # given
+    order.user = customer_user
+    order.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
+    order.save(update_fields=["user", "metadata"])
+    variables = {"token": order.id}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_ORDER_BY_TOKEN_PUBLIC_META,
+        variables,
+        [permission_handle_taxes],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    metadata = content["data"]["orderByToken"]["metadata"][0]
+    assert metadata["key"] == PUBLIC_KEY
+    assert metadata["value"] == PUBLIC_VALUE
+
+
 QUERY_ORDER_PUBLIC_META = """
     query orderMeta($id: ID!){
         order(id: $id){
@@ -551,6 +575,30 @@ def test_query_private_meta_for_order_as_app(
         QUERY_ORDER_PRIVATE_META,
         variables,
         [permission_manage_orders],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    metadata = content["data"]["order"]["privateMetadata"][0]
+    assert metadata["key"] == PRIVATE_KEY
+    assert metadata["value"] == PRIVATE_VALUE
+
+
+def test_query_private_meta_for_order_as_app_with_handle_taxes(
+    app_api_client, order, customer_user, permission_handle_taxes
+):
+    # given
+    order.user = customer_user
+    order.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
+    order.save(update_fields=["user", "private_metadata"])
+    variables = {"id": graphene.Node.to_global_id("Order", order.pk)}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_ORDER_PRIVATE_META,
+        variables,
+        [permission_handle_taxes],
         check_no_permissions=False,
     )
     content = get_graphql_content(response)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -39,6 +39,7 @@ from ...permission.auth_filters import AuthorizationFilters, is_app, is_staff_us
 from ...permission.enums import (
     AccountPermissions,
     AppPermission,
+    CheckoutPermissions,
     OrderPermissions,
     PaymentPermissions,
     ProductPermissions,
@@ -2118,6 +2119,7 @@ class Order(ModelObjectType[models.Order]):
                 AccountPermissions.MANAGE_USERS,
                 OrderPermissions.MANAGE_ORDERS,
                 PaymentPermissions.HANDLE_PAYMENTS,
+                CheckoutPermissions.HANDLE_TAXES,
             )
             return user
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -83,9 +83,31 @@ subscription {
           __typename
           ... on Checkout {
             id
-          }
+            metadata {
+              key
+              value
+            }
+            privateMetadata {
+              key
+              value
+            }
+            user {
+              id
+            }
+        }
           ... on Order {
             id
+            metadata {
+              key
+              value
+            }
+            privateMetadata {
+              key
+              value
+            }
+            user {
+              id
+            }
           }
         }
       }
@@ -108,15 +130,14 @@ def subscription_order_calculate_taxes(subscription_webhook):
 @pytest.mark.parametrize("charge_taxes", [True, False])
 def test_checkout_calculate_taxes(
     checkout_ready_to_complete,
-    webhook_app,
-    permission_handle_taxes,
+    tax_app,
     charge_taxes,
+    customer_user,
 ):
     # given
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -128,12 +149,17 @@ def test_checkout_calculate_taxes(
     tax_configuration.save(update_fields=["charge_taxes"])
     tax_configuration.country_exceptions.all().delete()
 
+    checkout_ready_to_complete.user = customer_user
+    checkout_ready_to_complete.save(update_fields=["user_id"])
+
     # when
     deliveries = create_delivery_for_subscription_sync_event(
         event_type, checkout_ready_to_complete, webhook
     )
 
     # then
+    metadata = checkout_ready_to_complete.metadata_storage.metadata
+    private_metadata = checkout_ready_to_complete.metadata_storage.private_metadata
     assert json.loads(deliveries.payload.get_payload()) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
@@ -165,6 +191,16 @@ def test_checkout_calculate_taxes(
             "sourceObject": {
                 "id": to_global_id_or_none(checkout_ready_to_complete),
                 "__typename": "Checkout",
+                "metadata": [
+                    {"key": key, "value": value} for key, value in metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in private_metadata.items()
+                ],
+                "user": {
+                    "id": to_global_id_or_none(customer_user),
+                },
             },
         },
     }
@@ -173,16 +209,14 @@ def test_checkout_calculate_taxes(
 @freeze_time("2020-03-18 12:00:00")
 def test_checkout_calculate_taxes_with_free_shipping_voucher(
     checkout_with_voucher_free_shipping,
-    webhook_app,
-    permission_handle_taxes,
+    tax_app,
     checkout_with_shipping_address,
 ):
     # given
     checkout = checkout_with_voucher_free_shipping
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -195,6 +229,8 @@ def test_checkout_calculate_taxes_with_free_shipping_voucher(
     )
 
     # then
+    metadata = checkout.metadata_storage.metadata
+    private_metadata = checkout.metadata_storage.private_metadata
     assert json.loads(deliveries.payload.get_payload()) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
@@ -208,6 +244,14 @@ def test_checkout_calculate_taxes_with_free_shipping_voucher(
             "sourceObject": {
                 "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
+                "metadata": [
+                    {"key": key, "value": value} for key, value in metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in private_metadata.items()
+                ],
+                "user": None,
             },
         },
     }
@@ -216,15 +260,13 @@ def test_checkout_calculate_taxes_with_free_shipping_voucher(
 @freeze_time("2020-03-18 12:00:00")
 def test_checkout_calculate_taxes_with_pregenerated_payload(
     checkout_with_voucher_free_shipping,
-    webhook_app,
-    permission_handle_taxes,
+    tax_app,
 ):
     # given
     checkout = checkout_with_voucher_free_shipping
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -247,8 +289,7 @@ def test_checkout_calculate_taxes_with_pregenerated_payload(
 @freeze_time("2020-03-18 12:00:00")
 def test_checkout_calculate_taxes_with_entire_order_voucher(
     checkout_with_voucher,
-    webhook_app,
-    permission_handle_taxes,
+    tax_app,
     address,
     shipping_method,
 ):
@@ -259,10 +300,9 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
     checkout.billing_address = address
     checkout.save()
 
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -275,6 +315,8 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
     )
 
     # then
+    metadata = checkout.metadata_storage.metadata
+    private_metadata = checkout.metadata_storage.private_metadata
     assert json.loads(deliveries.payload.get_payload()) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
@@ -304,6 +346,14 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
             "sourceObject": {
                 "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
+                "metadata": [
+                    {"key": key, "value": value} for key, value in metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in private_metadata.items()
+                ],
+                "user": None,
             },
         },
     }
@@ -313,14 +363,13 @@ def test_checkout_calculate_taxes_with_entire_order_voucher(
 def test_checkout_calculate_taxes_with_entire_order_voucher_once_per_order(
     voucher,
     checkout_with_voucher,
-    webhook_app,
+    tax_app,
     permission_handle_taxes,
 ):
     # given
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -335,6 +384,8 @@ def test_checkout_calculate_taxes_with_entire_order_voucher_once_per_order(
     )
 
     # then
+    metadata = checkout_with_voucher.metadata_storage.metadata
+    private_metadata = checkout_with_voucher.metadata_storage.private_metadata
     assert json.loads(deliveries.payload.get_payload()) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
@@ -362,6 +413,14 @@ def test_checkout_calculate_taxes_with_entire_order_voucher_once_per_order(
             "sourceObject": {
                 "id": to_global_id_or_none(checkout_with_voucher),
                 "__typename": "Checkout",
+                "metadata": [
+                    {"key": key, "value": value} for key, value in metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in private_metadata.items()
+                ],
+                "user": None,
             },
         },
     }
@@ -371,8 +430,7 @@ def test_checkout_calculate_taxes_with_entire_order_voucher_once_per_order(
 def test_checkout_calculate_taxes_with_shipping_voucher(
     checkout_with_item,
     voucher_free_shipping,
-    webhook_app,
-    permission_handle_taxes,
+    tax_app,
     address,
     shipping_method,
 ):
@@ -383,10 +441,9 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
     checkout.billing_address = address
     checkout.voucher_code = voucher_free_shipping.codes.first()
 
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -399,6 +456,8 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
     )
 
     # then
+    metadata = checkout.metadata_storage.metadata
+    private_metadata = checkout.metadata_storage.private_metadata
     assert json.loads(deliveries.payload.get_payload()) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
@@ -426,6 +485,14 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
             "sourceObject": {
                 "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
+                "metadata": [
+                    {"key": key, "value": value} for key, value in metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in private_metadata.items()
+                ],
+                "user": None,
             },
         },
     }
@@ -434,8 +501,7 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
 @freeze_time("2020-03-18 12:00:00")
 def test_checkout_calculate_taxes_with_order_promotion(
     checkout_with_item_and_order_discount,
-    webhook_app,
-    permission_handle_taxes,
+    tax_app,
 ):
     # given
     checkout = checkout_with_item_and_order_discount
@@ -444,10 +510,9 @@ def test_checkout_calculate_taxes_with_order_promotion(
         channel=checkout.channel
     ).price_amount
     channel_id = to_global_id_or_none(checkout.channel)
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -461,6 +526,8 @@ def test_checkout_calculate_taxes_with_order_promotion(
     )
 
     # then
+    metadata = checkout.metadata_storage.metadata
+    private_metadata = checkout.metadata_storage.private_metadata
     assert json.loads(deliveries.payload.get_payload()) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
@@ -493,6 +560,14 @@ def test_checkout_calculate_taxes_with_order_promotion(
             "sourceObject": {
                 "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
+                "metadata": [
+                    {"key": key, "value": value} for key, value in metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in private_metadata.items()
+                ],
+                "user": None,
             },
         },
     }
@@ -501,14 +576,12 @@ def test_checkout_calculate_taxes_with_order_promotion(
 @freeze_time("2020-03-18 12:00:00")
 def test_checkout_calculate_taxes_empty_checkout(
     checkout,
-    webhook_app,
-    permission_handle_taxes,
+    tax_app,
 ):
     # given
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -521,6 +594,8 @@ def test_checkout_calculate_taxes_empty_checkout(
     )
 
     # then
+    metadata = checkout.metadata_storage.metadata
+    private_metadata = checkout.metadata_storage.private_metadata
     assert json.loads(deliveries.payload.get_payload()) == {
         "__typename": "CalculateTaxes",
         "taxBase": {
@@ -534,6 +609,14 @@ def test_checkout_calculate_taxes_empty_checkout(
             "sourceObject": {
                 "id": to_global_id_or_none(checkout),
                 "__typename": "Checkout",
+                "metadata": [
+                    {"key": key, "value": value} for key, value in metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in private_metadata.items()
+                ],
+                "user": None,
             },
         },
     }
@@ -541,9 +624,7 @@ def test_checkout_calculate_taxes_empty_checkout(
 
 @freeze_time("2020-03-18 12:00:00")
 @pytest.mark.parametrize("charge_taxes", [True, False])
-def test_order_calculate_taxes(
-    order_line, webhook_app, permission_handle_taxes, shipping_zone, charge_taxes
-):
+def test_order_calculate_taxes(order_line, tax_app, shipping_zone, charge_taxes):
     # given
     order = order_line.order
     expected_shipping_price = Money("2.00", order.currency)
@@ -560,10 +641,9 @@ def test_order_calculate_taxes(
     )
     shipping_method = shipping_zone.shipping_methods.first()
     order.shipping_method = shipping_method
-    webhook_app.permissions.add(permission_handle_taxes)
     webhook = Webhook.objects.create(
         name="Webhook",
-        app=webhook_app,
+        app=tax_app,
         target_url="http://www.example.com/any",
         subscription_query=TAXES_SUBSCRIPTION_QUERY,
     )
@@ -611,6 +691,15 @@ def test_order_calculate_taxes(
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
             },
         },
     }
@@ -700,6 +789,15 @@ def test_draft_order_calculate_taxes_line_discount(
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
             },
         },
     }
@@ -791,6 +889,15 @@ def test_draft_order_calculate_taxes_entire_order_voucher(
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
             },
         },
     }
@@ -878,6 +985,15 @@ def test_draft_order_calculate_taxes_apply_once_per_order_voucher(
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
             },
         },
     }
@@ -974,6 +1090,15 @@ def test_order_calculate_taxes_specific_product_voucher(
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
             },
         },
     }
@@ -1015,6 +1140,15 @@ def test_draft_order_calculate_taxes_free_shipping_voucher(
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
             },
         },
     }
@@ -1113,7 +1247,19 @@ def test_order_calculate_taxes_with_manual_discount(
             ],
             "pricesEnteredWithTax": False,
             "shippingPrice": {"amount": float(shipping_price_amount)},
-            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
+            },
         },
     }
 
@@ -1151,6 +1297,15 @@ def test_order_calculate_taxes_empty_order(
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": None,
             },
         },
     }
@@ -1235,7 +1390,19 @@ def test_order_calculate_taxes_order_promotion(
             ],
             "pricesEnteredWithTax": False,
             "shippingPrice": {"amount": shipping_price_amount},
-            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
+            },
         },
     }
 
@@ -1336,7 +1503,19 @@ def test_order_calculate_taxes_order_voucher_and_manual_discount(
             ],
             "pricesEnteredWithTax": False,
             "shippingPrice": {"amount": shipping_price_amount},
-            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
+            },
         },
     }
 
@@ -1441,7 +1620,19 @@ def test_order_calculate_taxes_order_promotion_and_manual_discount(
             ],
             "pricesEnteredWithTax": False,
             "shippingPrice": {"amount": shipping_price_amount},
-            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
+            },
         },
     }
 
@@ -1536,7 +1727,19 @@ def test_order_calculate_taxes_free_shipping_voucher_and_manual_discount_fixed(
             ],
             "pricesEnteredWithTax": False,
             "shippingPrice": {"amount": 0},
-            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
+            },
         },
     }
 
@@ -1637,6 +1840,18 @@ def test_order_calculate_taxes_free_shipping_voucher_and_manual_discount_percent
             ],
             "pricesEnteredWithTax": False,
             "shippingPrice": {"amount": 0},
-            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+                "metadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.metadata.items()
+                ],
+                "privateMetadata": [
+                    {"key": key, "value": value}
+                    for key, value in order.private_metadata.items()
+                ],
+                "user": {"id": to_global_id_or_none(order.user)},
+            },
         },
     }


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/18374

Allow fetching `privateMetadata` and `user` from `Checkout` and `Order` with `HANDLE_TAXES` permission.
Apps with `HANDLE_TAXES` should have access to those fields.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
