### PR TITLE
Fix attributes migration task locks

### DIFF
--- a/saleor/attribute/migrations/0034_assignedpageattributevalue_page_data_migration.py
+++ b/saleor/attribute/migrations/0034_assignedpageattributevalue_page_data_migration.py
@@ -34,7 +34,7 @@ def update_page_assignment():
                 SELECT av.id
                 FROM attribute_assignedpageattributevalue AS av
                 WHERE av.page_id IS NULL
-                ORDER BY av.id DESC
+                ORDER BY av.sort_order, av.id DESC
                 LIMIT %s
                 FOR UPDATE
             )

--- a/saleor/attribute/migrations/0036_assignedproductattributevalue_product_data_migration.py
+++ b/saleor/attribute/migrations/0036_assignedproductattributevalue_product_data_migration.py
@@ -37,7 +37,7 @@ def update_product_assignment():
                 WHERE id IN (
                     SELECT ID FROM attribute_assignedproductattributevalue
                     WHERE product_id IS NULL
-                    ORDER BY ID DESC
+                    ORDER BY SORT_ORDER, ID DESC
                     FOR UPDATE
                     LIMIT %s
                 );

--- a/saleor/attribute/migrations/tasks/saleor3_22.py
+++ b/saleor/attribute/migrations/tasks/saleor3_22.py
@@ -59,7 +59,8 @@ def update_product_variant_assignment():
             )
             WHERE id IN (
                 SELECT ID FROM attribute_assignedvariantattributevalue
-                ORDER BY ID DESC
+                WHERE VARIANT_ID IS NULL
+                ORDER BY SORT_ORDER, ID DESC
                 FOR UPDATE
                 LIMIT %s
             );


### PR DESCRIPTION
I want to merge this change because it's fixing an issue found after #18394

What's changed:
- a missing where statement is added to the SQL running the update on assigned attribute values
- an ordering is added in the SQL on the same fields as normally used on the tables (that might have impacted lock order)
- the above is also added in historic migrations in case someone runs them from the start and has the same issue


Note:
I do not have a dataset where I could replicate the issue. I only tested on the data from `populatedb`

# Impact

- [x] Changed migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
