### PR TITLE
Extend external_shipping_method_id to 1024

### DIFF
--- a/saleor/checkout/migrations/0082_checkout_shipping_methods_stale_at_checkoutdelivery_and_more.py
+++ b/saleor/checkout/migrations/0082_checkout_shipping_methods_stale_at_checkoutdelivery_and_more.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         db_index=True,
                         editable=False,
-                        max_length=512,
+                        max_length=1024,
                         null=True,
                     ),
                 ),

--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -43,7 +43,7 @@ class CheckoutDelivery(models.Model):
         on_delete=models.CASCADE,
     )
     external_shipping_method_id = models.CharField(
-        max_length=512, blank=True, null=True, editable=False, db_index=True
+        max_length=1024, blank=True, null=True, editable=False, db_index=True
     )
     built_in_shipping_method_id = models.IntegerField(
         blank=True, null=True, editable=False, db_index=True

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -390,8 +390,9 @@ def test_checkout_delivery_method_update_external_shipping_long_external_id(
     errors = data["errors"]
 
     assert not errors
-    assert checkout.external_shipping_method_id == method_id
-    assert len(checkout.external_shipping_method_id) > 900
+    assert checkout.assigned_delivery
+    assert checkout.assigned_delivery.external_shipping_method_id == method_id
+    assert len(checkout.assigned_delivery.external_shipping_method_id) > 900
 
 
 @mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")


### PR DESCRIPTION
I want to merge this change because it updates the new field from 512 to 1024

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
