### PR TITLE
Fix attribute values validation

### DIFF
--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 
 from ..page.models import Page
@@ -58,9 +57,7 @@ def validate_attribute_owns_values(attr_val_map: dict[int, list]) -> None:
         value_slugs = [value.slug for value in values]
         lookup |= Q(attribute_id=attribute_id, slug__in=value_slugs)
 
-    values = AttributeValue.objects.using(
-        settings.DATABASE_CONNECTION_REPLICA_NAME
-    ).filter(lookup)
+    values = AttributeValue.objects.filter(lookup)
 
     for value in values:
         attr_id = value.attribute_id


### PR DESCRIPTION
Previously the replica was used in `validate_attribute_owns_values`, as the new values were created just before reaching the function, replica does not know about new values and the validation fails. 

Tested locally.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
