### PR TITLE
deps: upgrade Django to fix CVE-2025-64459

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1165,14 +1165,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.15"
+version = "4.2.26"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "Django-4.2.15-py3-none-any.whl", hash = "sha256:61ee4a130efb8c451ef3467c67ca99fdce400fedd768634efc86a68c18d80d30"},
-    {file = "Django-4.2.15.tar.gz", hash = "sha256:c77f926b81129493961e19c0e02188f8d07c112a1162df69bfab178ae447f94a"},
+    {file = "django-4.2.26-py3-none-any.whl", hash = "sha256:c96e64fc3c359d051a6306871bd26243db1bd02317472a62ffdbe6c3cae14280"},
+    {file = "django-4.2.26.tar.gz", hash = "sha256:9398e487bcb55e3f142cb56d19fbd9a83e15bb03a97edc31f408361ee76d9d7a"},
 ]
 
 [package.dependencies]
@@ -5654,4 +5654,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12"
-content-hash = "359aa4bab0aadfdd88476ba777c3736a570003c315f514fadebebadd768d6b0c"
+content-hash = "8969568a73c4ee323791695fde9384b076803928ebec5bea3d0f56f4da9c2ae2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ documentation = "https://docs.saleor.io/"
     extras = [ "binary" ]
 
     [tool.poetry.dependencies.django]
-    version = "^4.2"
+    version = "^4.2.26"
     extras = [ "bcrypt" ]
 
     [tool.poetry.dependencies.uvicorn]


### PR DESCRIPTION
I want to merge this change because of a bump in the Django version.
Django changelog: https://www.djangoproject.com/weblog/2025/nov/05/security-releases/

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
