### PR TITLE
Release 3.22.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.7",
+  "version": "3.22.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.7",
+      "version": "3.22.8",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.7",
+  "version": "3.22.8",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,4 +292,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.7"
+version = "3.22.8"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.7"
+__version__ = "3.22.8"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.22.8 (b2f9a10c5e)
* Fix voucher usage update for draft orders deletion (#18439) (0e7572ad2f)
* Fix validate_attribute_owns_values (#18437) (8c0bc5a7c0)
* Bump Django (#18440) (152b896d71)
* Update migration code to create proper locks (#18430) (27bb563cbf)
* Skip payload pregeneration when calling inside ASYNC webhooks (#18408) (d456f97ea4)
* Add TRANSLATIONS_MORE_ACTIONS app extension mount point (#18401) (a71e8aadfa)
