### PR TITLE
Revert "Do not trigger order_charged webhooks for draft orders (#18447)"

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -6,13 +6,12 @@ from django.test import override_settings
 from .....core.models import EventDelivery
 from .....core.notify import NotifyEventType
 from .....core.tests.utils import get_site_context_payload
-from .....order import OrderOrigin, OrderStatus
+from .....order import OrderStatus
 from .....order import events as order_events
 from .....order.actions import call_order_event, order_charged
 from .....order.notifications import get_default_order_payload
 from .....payment import ChargeStatus
 from .....payment.models import Payment
-from .....warehouse.models import Allocation
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....payment.types import PaymentChargeStatusEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -280,67 +279,3 @@ def test_order_capture_triggers_webhooks(
     )
 
     assert wrapped_call_order_event.called
-
-
-@patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
-)
-@patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
-@patch(
-    "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
-)
-@override_settings(
-    PLUGINS=[
-        "saleor.plugins.webhook.plugin.WebhookPlugin",
-        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
-    ]
-)
-def test_draft_order_capture_dont_triggers_fully_paid_webhook(
-    mocked_send_webhook_request_async,
-    mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
-    setup_order_webhooks,
-    staff_api_client,
-    permission_group_manage_orders,
-    payment_txn_preauth,
-    staff_user,
-    settings,
-):
-    # given
-    mocked_send_webhook_request_sync.return_value = []
-    additional_order_webhook = setup_order_webhooks(
-        [
-            WebhookEventAsyncType.ORDER_PAID,
-            WebhookEventAsyncType.ORDER_UPDATED,
-            WebhookEventAsyncType.ORDER_FULLY_PAID,
-        ]
-    )[2]
-
-    permission_group_manage_orders.user_set.add(staff_api_client.user)
-    order = payment_txn_preauth.order
-
-    Allocation.objects.filter(order_line__order=order).delete()
-    order.status = OrderStatus.DRAFT
-    order.origin = OrderOrigin.DRAFT
-    order.should_refresh_prices = True
-    order.save(update_fields=["status", "origin", "should_refresh_prices"])
-
-    order_id = graphene.Node.to_global_id("Order", order.id)
-    amount = float(payment_txn_preauth.total)
-    variables = {"id": order_id, "amount": amount}
-
-    # when
-    response = staff_api_client.post_graphql(ORDER_CAPTURE_MUTATION, variables)
-
-    # then
-    content = get_graphql_content(response)
-    assert not content["data"]["orderCapture"]["errors"]
-
-    # confirm that no event deliveries were generated for order async webhook.
-    assert not EventDelivery.objects.filter(
-        webhook_id=additional_order_webhook.id
-    ).exists()
-
-    assert not mocked_send_webhook_request_async.called
-    assert not wrapped_call_order_event.called

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -2200,7 +2200,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_fully_paid(
 @patch("saleor.plugins.manager.PluginsManager.order_paid")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
-def test_transaction_event_report_for_draft_order_does_not_trigger_webhooks_when_fully_paid(
+def test_transaction_event_report_for_draft_order_triggers_webhooks_when_fully_paid(
     mock_order_fully_paid,
     mock_order_updated,
     mock_order_paid,
@@ -2254,9 +2254,9 @@ def test_transaction_event_report_for_draft_order_does_not_trigger_webhooks_when
 
     assert order.status == OrderStatus.DRAFT
     assert order.charge_status == OrderChargeStatus.FULL
-    mock_order_fully_paid.assert_not_called()
-    mock_order_updated.assert_not_called()
-    mock_order_paid.assert_not_called()
+    mock_order_fully_paid.assert_called_once_with(order, webhooks=set())
+    mock_order_updated.assert_called_once_with(order, webhooks=set())
+    mock_order_paid.assert_called_once_with(order, webhooks=set())
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3034,7 +3034,7 @@ def test_transaction_update_for_order_triggers_webhooks_when_fully_paid(
 @patch("saleor.plugins.manager.PluginsManager.order_paid")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
-def test_transaction_update_for_draft_order_does_not_trigger_webhooks_when_fully_paid(
+def test_transaction_update_for_draft_order_triggers_webhooks_when_fully_paid(
     mock_order_fully_paid,
     mock_order_updated,
     mock_order_paid,
@@ -3079,9 +3079,9 @@ def test_transaction_update_for_draft_order_does_not_trigger_webhooks_when_fully
 
     assert order.status == OrderStatus.DRAFT
     assert order.charge_status == OrderChargeStatus.FULL
-    mock_order_fully_paid.assert_not_called()
-    mock_order_updated.assert_not_called()
-    mock_order_paid.assert_not_called()
+    mock_order_fully_paid.assert_called_once_with(order, webhooks=set())
+    mock_order_updated.assert_called_once_with(order, webhooks=set())
+    mock_order_paid.assert_called_once_with(order, webhooks=set())
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_paid")

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -642,11 +642,6 @@ def order_charged(
     webhook_event_map: dict[str, set["Webhook"]] | None = None,
 ):
     order = order_info.order
-    if order.status == OrderStatus.DRAFT:
-        # Skip charging events for draft orders
-        # They are going to be triggered when order is confirmed
-        return
-
     if payment and amount is not None:
         events.payment_captured_event(
             order=order, user=user, app=app, amount=amount, payment=payment


### PR DESCRIPTION
This reverts commit d2ede52a55e231482dad57e88867a9e6ac24907f.

I want to merge this change because we need to restore `ORDER_UPDATED` events

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
