### PR TITLE
Keep PAYMENT_CAPTURED event createion for draft orders

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -642,15 +642,16 @@ def order_charged(
     webhook_event_map: dict[str, set["Webhook"]] | None = None,
 ):
     order = order_info.order
+    if payment and amount is not None:
+        events.payment_captured_event(
+            order=order, user=user, app=app, amount=amount, payment=payment
+        )
+
     if order.status == OrderStatus.DRAFT:
         # Skip charging events for draft orders
         # They are going to be triggered when order is confirmed
         return
 
-    if payment and amount is not None:
-        events.payment_captured_event(
-            order=order, user=user, app=app, amount=amount, payment=payment
-        )
     if webhook_event_map is None:
         webhook_event_map = get_webhooks_for_multiple_events(
             WEBHOOK_EVENTS_FOR_ORDER_CHARGED


### PR DESCRIPTION
I want to merge this change because we have dropped event creation in https://github.com/saleor/saleor/pull/18447
We need to restore it, so the draft order check has been moved another place.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
