### PR TITLE
Do not trigger order_charged webhooks for draft orders

### DIFF
--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -2219,7 +2219,7 @@ def test_transaction_event_report_for_order_triggers_webhooks_when_fully_paid(
 @patch("saleor.plugins.manager.PluginsManager.order_paid")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
-def test_transaction_event_report_for_draft_order_triggers_webhooks_when_fully_paid(
+def test_transaction_event_report_for_draft_order_does_not_trigger_webhooks_when_fully_paid(
     mock_order_fully_paid,
     mock_order_updated,
     mock_order_paid,
@@ -2273,9 +2273,9 @@ def test_transaction_event_report_for_draft_order_triggers_webhooks_when_fully_p
 
     assert order.status == OrderStatus.DRAFT
     assert order.charge_status == OrderChargeStatus.FULL
-    mock_order_fully_paid.assert_called_once_with(order, webhooks=set())
-    mock_order_updated.assert_called_once_with(order, webhooks=set())
-    mock_order_paid.assert_called_once_with(order, webhooks=set())
+    mock_order_fully_paid.assert_not_called()
+    mock_order_updated.assert_not_called()
+    mock_order_paid.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3049,7 +3049,7 @@ def test_transaction_update_for_order_triggers_webhooks_when_fully_paid(
 @patch("saleor.plugins.manager.PluginsManager.order_paid")
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.plugins.manager.PluginsManager.order_fully_paid")
-def test_transaction_update_for_draft_order_triggers_webhooks_when_fully_paid(
+def test_transaction_update_for_draft_order_does_not_trigger_webhooks_when_fully_paid(
     mock_order_fully_paid,
     mock_order_updated,
     mock_order_paid,
@@ -3094,9 +3094,9 @@ def test_transaction_update_for_draft_order_triggers_webhooks_when_fully_paid(
 
     assert order.status == OrderStatus.DRAFT
     assert order.charge_status == OrderChargeStatus.FULL
-    mock_order_fully_paid.assert_called_once_with(order, webhooks=set())
-    mock_order_updated.assert_called_once_with(order, webhooks=set())
-    mock_order_paid.assert_called_once_with(order, webhooks=set())
+    mock_order_fully_paid.assert_not_called()
+    mock_order_updated.assert_not_called()
+    mock_order_paid.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_paid")

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -651,6 +651,12 @@ def order_charged(
         events.payment_captured_event(
             order=order, user=user, app=app, amount=amount, payment=payment
         )
+
+    if order.status == OrderStatus.DRAFT:
+        # Skip charging events for draft orders
+        # They are going to be triggered when order is confirmed
+        return
+
     if webhook_event_map is None:
         webhook_event_map = get_webhooks_for_multiple_events(
             WEBHOOK_EVENTS_FOR_ORDER_CHARGED


### PR DESCRIPTION
I want to merge this change because we are sending duplicated order_fully_paid & order_paid when draft order is paid and then confirmed. Another issue is sending unexpected order_updated webhooks for order which is still draft.

Port of
- https://github.com/saleor/saleor/pull/18447 
- https://github.com/saleor/saleor/pull/18455

